### PR TITLE
ci(workflows): pin GitHub Actions dependencies to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Rust
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
 
@@ -38,7 +38,7 @@ jobs:
           npx playwright test --reporter=dot,list
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ always() }}
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to their full commit SHA for supply-chain security.

## Changes

- Pin 4 action references across 2 workflow files to commit SHAs
- Version tags preserved in comments for readability

### Changed Files
- `.github/workflows/ci.yml`
- `.github/workflows/playwright.yml`

## Testing

- Workflow syntax is unchanged; only the `@ref` portion of `uses:` directives is modified
- All pinned SHAs correspond to the exact same code as the original version tags

## Memory / Performance Impact

N/A - CI configuration only.

## Related Issues

Closes #128
