### PR TITLE
UI: simplify public FalkorDB vs Neo4j benchmark view

### DIFF
--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -18,6 +18,10 @@ type DashboardProps = {
    * ignore any other vendors present in the data file).
    */
   comparisonVendors?: string[];
+  /**
+   * Hides hardware controls/indicators and ignores hardware filtering when true.
+   */
+  hideHardware?: boolean;
 };
 
 const DEFAULT_SELECTED_OPTIONS: Record<string, string[]> = {
@@ -33,6 +37,7 @@ export default function DashBoard({
   dataUrl = "/resultData.json",
   initialSelectedOptions,
   comparisonVendors,
+  hideHardware = false,
 }: DashboardProps) {
   const [activeUrl, setActiveUrl] = useState(dataUrl);
   const [data, setData] = useState<BenchmarkData | null>(null);
@@ -183,9 +188,11 @@ export default function DashBoard({
           .filter(Boolean)
       )
     );
-    const hardware = Array.from(
-      new Set(data.runs.map((r) => r.platform?.toLowerCase()).filter(Boolean))
-    );
+    const hardware = hideHardware
+      ? []
+      : Array.from(
+          new Set(data.runs.map((r) => r.platform?.toLowerCase()).filter(Boolean))
+        );
 
     const queries = availableQueries;
 
@@ -221,22 +228,24 @@ export default function DashBoard({
       replaceIfNoMatch("Clients", clients);
       replaceIfNoMatch("Throughput", throughputs);
       
-      // For hardware selection, default to showing *all* hardwares present in the file if no match.
-      if (hardware.length) {
-        const current = next["Hardware"] ?? [];
-        const hasMatch = current.some((c) => hardware.some((a) => a === c));
-        if (!hasMatch) {
-          next["Hardware"] = hardware;
+      if (!hideHardware) {
+        // For hardware selection, default to showing *all* hardwares present in the file if no match.
+        if (hardware.length) {
+          const current = next["Hardware"] ?? [];
+          const hasMatch = current.some((c) => hardware.some((a) => a === c));
+          if (!hasMatch) {
+            next["Hardware"] = hardware;
+          }
+        } else {
+          replaceIfNoMatch("Hardware", hardware);
         }
-      } else {
-        replaceIfNoMatch("Hardware", hardware);
       }
 
       return next;
     });
 
     setDidInitFromData(true);
-  }, [data, didInitFromData, allowedVendors, availableQueries]);
+  }, [data, didInitFromData, allowedVendors, availableQueries, hideHardware]);
 
   const handleSideBarSelection = (groupTitle: string, optionId: string) => {
     setSelectedOptions((prev) => {
@@ -339,7 +348,9 @@ export default function DashBoard({
     }
 
     const results = data.runs.filter((run) => {
-      const isHardwareMatch = selectedOptions.Hardware?.length
+      const isHardwareMatch = hideHardware
+        ? true
+        : selectedOptions.Hardware?.length
         ? run.platform &&
           selectedOptions.Hardware.some((hardware) =>
             run.platform.toLowerCase().includes(hardware.toLowerCase())
@@ -371,7 +382,7 @@ export default function DashBoard({
     });
 
     setFilteredResults(results);
-  }, [data, selectedOptions]);
+  }, [data, selectedOptions, hideHardware]);
 
   const latencyDataForRealistic = useMemo(() => {
     const convertToMilliseconds = (value: string): number => {
@@ -732,6 +743,18 @@ export default function DashBoard({
     return Array.from(byVendor.values());
   }, [filteredResults]);
 
+  const hasConcurrentRunDetails = useMemo(() => {
+    return concurrentRuns.some((r) => {
+      const elapsedMs = Number(r?.result?.["elapsed-ms"] ?? 0);
+      const avgLatency = Number(r?.result?.["avg-latency-ms"] ?? 0);
+      const stats = r?.result?.["spawn-stats"];
+      const ratio = Number(stats?.["max-min-ratio"] ?? 0);
+      const cv = Number(stats?.cv ?? 0);
+
+      return elapsedMs > 0 || avgLatency > 0 || ratio > 0 || cv > 0;
+    });
+  }, [concurrentRuns]);
+
   return (
     <SidebarProvider className="h-screen w-screen overflow-hidden">
       <div className="flex h-full w-full">
@@ -739,6 +762,7 @@ export default function DashBoard({
           selectedOptions={selectedOptions}
           handleSideBarSelection={handleSideBarSelection}
           platform={data?.platforms}
+          hideHardware={hideHardware}
           allowedVendors={
             data?.runs?.length
               ? Array.from(
@@ -786,25 +810,11 @@ export default function DashBoard({
                   className="bg-white border border-gray-200/80 text-gray-800 text-sm rounded-lg px-3 py-2 font-fira shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary cursor-pointer min-w-[280px]"
                 >
                   <option value={baseFileName}>Latest Run (Default)</option>
-                  {pastRuns.map((run) => {
-                    const date = new Date(run.timestamp * 1000);
-                    const formatted = date.toLocaleString("en-US", {
-                      timeZone: "UTC",
-                      year: "numeric",
-                      month: "short",
-                      day: "2-digit",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      second: "2-digit",
-                      hour12: false,
-                    }) + " UTC";
-                    
-                    return (
-                      <option key={run.filename} value={run.filename}>
-                        {formatted}
-                      </option>
-                    );
-                  })}
+                  {pastRuns.map((run) => (
+                    <option key={run.filename} value={run.filename}>
+                      {run.filename}
+                    </option>
+                  ))}
                 </select>
               </div>
             </div>
@@ -837,48 +847,50 @@ export default function DashBoard({
                 </div>
               </div>
 
-              <div className="bg-muted/50 rounded-xl p-4 w-full flex flex-col min-h-[180px]">
-                <h2 className="text-2xl font-bold text-center font-space">
-                  RUN DETAILS
-                </h2>
-                <p className="pb-2 text-gray-600 text-center font-fira">
-                  Duration, mean latency, and worker fairness
-                </p>
-                <div className="w-full overflow-x-auto">
-                  <table className="w-full text-sm font-fira">
-                    <thead>
-                      <tr className="text-left text-gray-600">
-                        <th className="py-1 pr-4">Vendor</th>
-                        <th className="py-1 pr-4">Duration</th>
-                        <th className="py-1 pr-4">Avg latency</th>
-                        <th className="py-1 pr-4">Worker imbalance</th>
-                        <th className="py-1 pr-4">Worker CV</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {concurrentRuns.map((r) => {
-                        const elapsedMs = Number(r?.result?.["elapsed-ms"] ?? 0);
-                        const avgLatency = Number(r?.result?.["avg-latency-ms"] ?? 0);
-                        const stats = r?.result?.["spawn-stats"];
-                        const ratio = Number(stats?.["max-min-ratio"] ?? 0);
-                        const cv = Number(stats?.cv ?? 0);
+              {hasConcurrentRunDetails && (
+                <div className="bg-muted/50 rounded-xl p-4 w-full flex flex-col min-h-[180px]">
+                  <h2 className="text-2xl font-bold text-center font-space">
+                    RUN DETAILS
+                  </h2>
+                  <p className="pb-2 text-gray-600 text-center font-fira">
+                    Duration, mean latency, and worker fairness
+                  </p>
+                  <div className="w-full overflow-x-auto">
+                    <table className="w-full text-sm font-fira">
+                      <thead>
+                        <tr className="text-left text-gray-600">
+                          <th className="py-1 pr-4">Vendor</th>
+                          <th className="py-1 pr-4">Duration</th>
+                          <th className="py-1 pr-4">Avg latency</th>
+                          <th className="py-1 pr-4">Worker imbalance</th>
+                          <th className="py-1 pr-4">Worker CV</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {concurrentRuns.map((r) => {
+                          const elapsedMs = Number(r?.result?.["elapsed-ms"] ?? 0);
+                          const avgLatency = Number(r?.result?.["avg-latency-ms"] ?? 0);
+                          const stats = r?.result?.["spawn-stats"];
+                          const ratio = Number(stats?.["max-min-ratio"] ?? 0);
+                          const cv = Number(stats?.cv ?? 0);
 
-                        return (
-                          <tr key={r.vendor} className="border-t border-gray-200/60">
-                            <td className="py-2 pr-4 font-semibold">{r.vendor}</td>
-                            <td className="py-2 pr-4">{formatDuration(elapsedMs)}</td>
-                            <td className="py-2 pr-4">{avgLatency.toFixed(2)} ms</td>
-                            <td className="py-2 pr-4">
-                              {ratio > 0 ? `${ratio.toFixed(2)}x (max/min)` : "—"}
-                            </td>
-                            <td className="py-2 pr-4">{cv > 0 ? cv.toFixed(3) : "—"}</td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
+                          return (
+                            <tr key={r.vendor} className="border-t border-gray-200/60">
+                              <td className="py-2 pr-4 font-semibold">{r.vendor}</td>
+                              <td className="py-2 pr-4">{formatDuration(elapsedMs)}</td>
+                              <td className="py-2 pr-4">{avgLatency.toFixed(2)} ms</td>
+                              <td className="py-2 pr-4">
+                                {ratio > 0 ? `${ratio.toFixed(2)}x (max/min)` : "—"}
+                              </td>
+                              <td className="py-2 pr-4">{cv > 0 ? cv.toFixed(3) : "—"}</td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
-              </div>
+              )}
 
               <div
                 className="bg-muted/50 rounded-xl p-4 w-full flex flex-col items-center justify-between min-h-[420px]"

--- a/ui/app/neo4j/page.tsx
+++ b/ui/app/neo4j/page.tsx
@@ -8,6 +8,7 @@ export default function Neo4jVsFalkor() {
       <DashBoard
         dataUrl="/summaries/neo4j_vs_falkordb.json"
         comparisonVendors={["falkordb", "neo4j"]}
+        hideHardware
         initialSelectedOptions={{
           "Workload Type": ["concurrent"],
           Vendors: ["falkordb", "neo4j"],

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -6,7 +6,15 @@ export default function Home() {
   return (
     <main className="h-screen flex flex-col">
       <Header />
-      <DashBoard comparisonVendors={["falkordb", "neo4j"]} />
+      <DashBoard
+        dataUrl="/summaries/neo4j_vs_falkordb.json"
+        comparisonVendors={["falkordb", "neo4j"]}
+        hideHardware
+        initialSelectedOptions={{
+          "Workload Type": ["concurrent"],
+          Vendors: ["falkordb", "neo4j"],
+        }}
+      />
     </main>
   );
 }

--- a/ui/components/ui/SidebarNavigation.tsx
+++ b/ui/components/ui/SidebarNavigation.tsx
@@ -127,6 +127,7 @@ export function NavMain({
   selectedOptions,
   handleSideBarSelection,
   platform,
+  hideHardware,
   datasetSummary,
 }: {
   items: {
@@ -139,6 +140,7 @@ export function NavMain({
   selectedOptions: Record<string, string[]>;
   handleSideBarSelection: (groupTitle: string, optionId: string) => void;
   platform?: Platforms;
+  hideHardware?: boolean;
   datasetSummary?: {
     nodes: number;
     edges: number;
@@ -154,6 +156,7 @@ export function NavMain({
 
   const filteredItems = items.filter((group) => {
     if (group.title === "Queries" && isRealisticWorkloadOn) return false;
+    if (group.title === "Hardware" && hideHardware) return false;
     if (
       (group.title === "Clients" ||
         group.title === "Throughput" ||
@@ -186,24 +189,6 @@ export function NavMain({
               <div className="flex flex-col">
                 <h2 className="text-lg font-semibold mb-1">Dataset &amp; workload</h2>
                 <div className="mt-0.5 flex flex-col gap-0.5 text-xs text-gray-700 font-medium">
-                  {datasetSummary.startedAtEpochSecs && (
-                    <div className="flex justify-between gap-4 pb-1 mb-1 border-b border-gray-200/40">
-                      <span className="text-gray-500">Date &amp; time</span>
-                      <span className="tabular-nums text-right">
-                        {(() => {
-                          const date = new Date(datasetSummary.startedAtEpochSecs * 1000);
-                          const pad = (num: number) => String(num).padStart(2, "0");
-                          const yyyy = date.getUTCFullYear();
-                          const mm = pad(date.getUTCMonth() + 1);
-                          const dd = pad(date.getUTCDate());
-                          const hh = pad(date.getUTCHours());
-                          const min = pad(date.getUTCMinutes());
-                          const ss = pad(date.getUTCSeconds());
-                          return `${yyyy}-${mm}-${dd} ${hh}:${min}:${ss} UTC`;
-                        })()}
-                      </span>
-                    </div>
-                  )}
                   <div className="flex justify-between gap-4">
                     <span className="text-gray-500">Nodes</span>
                     <span className="tabular-nums">

--- a/ui/components/ui/app-sidebar.tsx
+++ b/ui/components/ui/app-sidebar.tsx
@@ -24,6 +24,7 @@ export function AppSidebar({
   selectedOptions,
   handleSideBarSelection,
   platform,
+  hideHardware,
   allowedVendors,
   throughputOptions,
   queryOptions,
@@ -33,6 +34,7 @@ export function AppSidebar({
   selectedOptions: Record<string, string[]>;
   handleSideBarSelection: (groupTitle: string, optionId: string) => void;
   platform?: Platforms;
+  hideHardware?: boolean;
   allowedVendors?: string[];
   throughputOptions?: Array<string | number>;
   queryOptions?: string[];
@@ -82,7 +84,9 @@ export function AppSidebar({
         .join(" ");
     };
 
-    return sidebarConfig.sidebarData.map((group) => {
+    return sidebarConfig.sidebarData
+      .filter((group) => !(hideHardware && group.title === "Hardware"))
+      .map((group) => {
       if (group.title === "Vendors" && allowed.length) {
         return {
           ...group,
@@ -106,7 +110,7 @@ export function AppSidebar({
 
       return group;
     });
-  }, [allowedVendors, throughputOptions, queryOptions]);
+  }, [allowedVendors, throughputOptions, queryOptions, hideHardware]);
 
   return (
     <Sidebar
@@ -124,6 +128,7 @@ export function AppSidebar({
           selectedOptions={selectedOptions}
           handleSideBarSelection={handleSideBarSelection}
           platform={platform}
+          hideHardware={hideHardware}
           datasetSummary={datasetSummary}
         />
       </SidebarContent>


### PR DESCRIPTION
## Summary
- Switch the public dashboard route to the curated `/summaries/neo4j_vs_falkordb.json` comparison.
- Hide hardware controls/indicators for the public FalkorDB vs Neo4j view.
- Remove date/time presentation from run selectors and dataset summary.
- Hide the concurrent run-details panel when detail fields are missing.

## Validation
- `npm --prefix ui run lint`
- `npm --prefix ui run build`

## Artifacts
- Conversation: https://app.warp.dev/conversation/9279c5b4-e302-4643-8f09-d9d6097b3e83

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to hide hardware-related filters and sidebar sections in supported views.
  * Updated the dashboard to show run details only when concurrent metrics are meaningful.
  * Simplified run history labels to display cleaner filenames.

* **Bug Fixes**
  * Improved filtering behavior so hardware constraints are ignored when hardware is hidden.
  * Updated the home and Neo4j dashboard views to use the new configuration consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->