### PR TITLE
UI: hide telemetry breakdown in public single view

### DIFF
--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -976,7 +976,7 @@ export default function DashBoard({
                   Better performance, lower overall costs
                 </p>
 
-                {telemetryBreakdownPerRun.length > 0 && (
+                {!hideHardware && telemetryBreakdownPerRun.length > 0 && (
                   <div className="w-full pb-2">
                     <p className="text-xs text-gray-600 text-center font-fira pb-1">
                       Telemetry breakdown for {telemetryBreakdownPerRun[0].query} (wait / exec / report)


### PR DESCRIPTION
## Summary
- Hide the single-workload telemetry breakdown table when the dashboard is in public mode (`hideHardware=true`).
- Keeps telemetry visible for non-public/internal views.

## Notes
- This is a stacked PR on top of #135.

## Validation
- `npm --prefix ui run lint`

## Artifacts
- Conversation: https://app.warp.dev/conversation/9279c5b4-e302-4643-8f09-d9d6097b3e83

Co-Authored-By: Oz <oz-agent@warp.dev>