### PR TITLE
UI: hide telemetry breakdown in public single view

### DIFF
--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -976,7 +976,7 @@ export default function DashBoard({
                   Better performance, lower overall costs
                 </p>
 
-                {telemetryBreakdownPerRun.length > 0 && (
+                {!hideHardware && telemetryBreakdownPerRun.length > 0 && (
                   <div className="w-full pb-2">
                     <p className="text-xs text-gray-600 text-center font-fira pb-1">
                       Telemetry breakdown for {telemetryBreakdownPerRun[0].query} (wait / exec / report)


### PR DESCRIPTION
## Summary
- Hide the single-workload telemetry breakdown table in public view mode.
- This applies when `hideHardware=true` (the public FalkorDB vs Neo4j pages).

## Why this PR
- PR #136 was merged into `shahar-memgraph` (stacked), so this follow-up is a direct PR to `master` for production deployment.

## Validation
- `npm --prefix ui run lint`

## Artifacts
- Conversation: https://app.warp.dev/conversation/9279c5b4-e302-4643-8f09-d9d6097b3e83

Co-Authored-By: Oz <oz-agent@warp.dev>