### PR TITLE
UI: hide run-history dropdown in public view

### DIFF
--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -789,7 +789,7 @@ export default function DashBoard({
           datasetSummary={datasetSummary}
         />
         <SidebarInset className="flex-grow h-full min-h-0 overflow-y-auto">
-          {pastRuns.length > 0 && (
+          {!hideHardware && pastRuns.length > 0 && (
             <div className="bg-muted/30 border-b border-gray-200/40 p-4 flex flex-wrap items-center justify-between gap-4 font-space">
               <div className="flex flex-col">
                 <span className="text-xs text-gray-500 font-medium">Select Run History</span>


### PR DESCRIPTION
## Summary
- Hide the run-history dropdown in public view mode.
- Public pages now always show the latest run only.
- Internal/non-public views keep the history selector.

## Validation
- `npm --prefix ui run lint`

## Artifacts
- Conversation: https://app.warp.dev/conversation/9279c5b4-e302-4643-8f09-d9d6097b3e83

Co-Authored-By: Oz <oz-agent@warp.dev>