### PR TITLE
UI: public dashboard consistency fixes and neo4j summary restore

### DIFF
--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -58,6 +58,8 @@ export default function DashBoard({
       baseDatasetBytes?: number;
     }[]
   >([]);
+  const [didInitFromData, setDidInitFromData] = useState(false);
+  const [loadedDataUrl, setLoadedDataUrl] = useState<string | null>(null);
 
   const [manifest, setManifest] = useState<Record<string, { filename: string; timestamp: number }[]>>({});
 
@@ -78,6 +80,8 @@ export default function DashBoard({
 
   useEffect(() => {
     setActiveUrl(dataUrl);
+    setData(null);
+    setLoadedDataUrl(null);
     setDidInitFromData(false);
   }, [dataUrl]);
 
@@ -112,42 +116,53 @@ export default function DashBoard({
     return next;
   });
 
-  const [didInitFromData, setDidInitFromData] = useState(false);
-
-  const fetchData = useCallback(async () => {
-    try {
-      const response = await fetch(activeUrl);
-      if (!response.ok)
-        throw new Error(`HTTP error! status: ${response.status}`);
-
-      const json = (await response.json()) as BenchmarkData;
-
-      if (allowedVendors?.length) {
-        const filtered: BenchmarkData = {
-          ...json,
-          runs: (json.runs ?? []).filter((r) =>
-            allowedVendors.includes(r.vendor?.toLowerCase())
-          ),
-          unrealstic: (json.unrealstic ?? []).filter((u) =>
-            allowedVendors.includes(u.vendor?.toLowerCase())
-          ),
-        };
-        setData(filtered);
-      } else {
-        setData(json);
-      }
-    } catch (error) {
-      toast({
-        title: "Error fetching data",
-        description: error instanceof Error ? error.message : "Unknown error",
-        variant: "destructive",
-      });
-    }
-  }, [toast, activeUrl, allowedVendors]);
 
   useEffect(() => {
+    let cancelled = false;
+    const urlForRequest = activeUrl;
+
+    const fetchData = async () => {
+      try {
+        const response = await fetch(urlForRequest);
+        if (!response.ok)
+          throw new Error(`HTTP error! status: ${response.status}`);
+
+        const json = (await response.json()) as BenchmarkData;
+
+        if (cancelled) return;
+
+        if (allowedVendors?.length) {
+          const filtered: BenchmarkData = {
+            ...json,
+            runs: (json.runs ?? []).filter((r) =>
+              allowedVendors.includes(r.vendor?.toLowerCase())
+            ),
+            unrealstic: (json.unrealstic ?? []).filter((u) =>
+              allowedVendors.includes(u.vendor?.toLowerCase())
+            ),
+          };
+          setData(filtered);
+        } else {
+          setData(json);
+        }
+        setLoadedDataUrl(urlForRequest);
+      } catch (error) {
+        if (cancelled) return;
+        setLoadedDataUrl(null);
+        toast({
+          title: "Error fetching data",
+          description: error instanceof Error ? error.message : "Unknown error",
+          variant: "destructive",
+        });
+      }
+    };
+
     fetchData();
-  }, [fetchData]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeUrl, allowedVendors, toast]);
 
   const availableQueries = useMemo(() => {
     if (!data) return [];
@@ -167,7 +182,7 @@ export default function DashBoard({
 
   // On first load of a summary file, auto-pick filters that match the data.
   useEffect(() => {
-    if (didInitFromData || !data?.runs?.length) return;
+    if (didInitFromData || loadedDataUrl !== activeUrl || !data?.runs?.length) return;
 
     const vendors = allowedVendors?.length
       ? allowedVendors
@@ -245,7 +260,7 @@ export default function DashBoard({
     });
 
     setDidInitFromData(true);
-  }, [data, didInitFromData, allowedVendors, availableQueries, hideHardware]);
+  }, [data, didInitFromData, loadedDataUrl, activeUrl, allowedVendors, availableQueries, hideHardware]);
 
   const handleSideBarSelection = (groupTitle: string, optionId: string) => {
     setSelectedOptions((prev) => {
@@ -380,6 +395,20 @@ export default function DashBoard({
         isVendorMatch && isClientMatch && isThroughputMatch && isHardwareMatch
       );
     });
+    const shouldDeduplicateConcurrentPublicRuns =
+      hideHardware &&
+      selectedOptions["Workload Type"]?.includes("concurrent");
+
+    if (shouldDeduplicateConcurrentPublicRuns) {
+      const byVendor = new Map<string, Run>();
+      for (const run of results) {
+        const vendorKey = (run.vendor ?? "").toString().toLowerCase();
+        if (!vendorKey || byVendor.has(vendorKey)) continue;
+        byVendor.set(vendorKey, run);
+      }
+      setFilteredResults(Array.from(byVendor.values()));
+      return;
+    }
 
     setFilteredResults(results);
   }, [data, selectedOptions, hideHardware]);
@@ -700,7 +729,7 @@ export default function DashBoard({
   const workloadType = selectedOptions["Workload Type"];
   useEffect(() => {
     setGridKey((prevKey) => prevKey + 1);
-  }, [workloadType]);
+  }, [workloadType, activeUrl]);
 
   //saving data to window.allChartData
   /* eslint-disable */
@@ -805,6 +834,8 @@ export default function DashBoard({
                     } else {
                       setActiveUrl(`/summaries/${val}`);
                     }
+                    setData(null);
+                    setLoadedDataUrl(null);
                     setDidInitFromData(false);
                   }}
                   className="bg-white border border-gray-200/80 text-gray-800 text-sm rounded-lg px-3 py-2 font-fira shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary cursor-pointer min-w-[280px]"


### PR DESCRIPTION
## Summary
- Stabilize dashboard state updates when switching summary files so selecting another JSON reliably re-renders charts.
- Deduplicate concurrent public-view runs to one run per vendor to avoid duplicated product series.
- Hide public-view run history dropdown and single-view telemetry panel in public mode.
- Restore `ui/public/summaries/neo4j_vs_falkordb.json` to the pre-PR-134 dataset (including the ~496x single-query P99 ratio baseline).

## Changed files
- `ui/app/components/dashboard.tsx`
- `ui/public/summaries/neo4j_vs_falkordb.json`

## Validation
- `npm --prefix ui run lint`

## Artifacts
- Conversation: https://app.warp.dev/conversation/9279c5b4-e302-4643-8f09-d9d6097b3e83

Co-Authored-By: Oz <oz-agent@warp.dev>