### PR TITLE
UI: default public FalkorDB vs Neo4j to single 4L filtered

### DIFF
--- a/ui/app/neo4j/page.tsx
+++ b/ui/app/neo4j/page.tsx
@@ -10,8 +10,9 @@ export default function Neo4jVsFalkor() {
         comparisonVendors={["falkordb", "neo4j"]}
         hideHardware
         initialSelectedOptions={{
-          "Workload Type": ["concurrent"],
+          "Workload Type": ["single"],
           Vendors: ["falkordb", "neo4j"],
+          Queries: ["aggregate_expansion_4_with_filter"],
         }}
       />
     </main>

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -11,8 +11,9 @@ export default function Home() {
         comparisonVendors={["falkordb", "neo4j"]}
         hideHardware
         initialSelectedOptions={{
-          "Workload Type": ["concurrent"],
+          "Workload Type": ["single"],
           Vendors: ["falkordb", "neo4j"],
+          Queries: ["aggregate_expansion_4_with_filter"],
         }}
       />
     </main>


### PR DESCRIPTION
## Summary
- Change the default public FalkorDB vs Neo4j view to load in `single` mode.
- Set the default query to `aggregate_expansion_4_with_filter` (Expand 4L filtered).

## Changed files
- `ui/app/page.tsx`
- `ui/app/neo4j/page.tsx`

## Artifacts
- Conversation: https://app.warp.dev/conversation/9279c5b4-e302-4643-8f09-d9d6097b3e83

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default comparison setup to start with a single workload type instead of concurrent.
  * Added a default query selection for the benchmark view, while keeping the vendor comparison unchanged.

* **Bug Fixes**
  * Improved the initial dashboard state on both the home page and Neo4j vs Falkor page for a more consistent starting experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->