### PR TITLE
chore: retarget Dependabot updates to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/ui" # Location of package manifests
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "master"
     groups:
       npm-minor-patch:
         update-types:
@@ -20,11 +20,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "master"
 
   # This is actually for cargo crates
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "staging"
+    target-branch: "master"


### PR DESCRIPTION
## Summary
- change Dependabot `target-branch` from `staging` to `master` for npm, github-actions, and cargo
- align future Dependabot PRs with the branch you merge to mainline

## Why
Current Dependabot PRs keep defaulting back to `staging`, which prevents a stable merge flow into `master`.

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings so new update branches now target the main development branch instead of the staging branch.
  * Applied this change for app package updates, GitHub Actions, and Rust/Cargo dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->