### PR TITLE
Add columnar-fast-path query shapes

### DIFF
--- a/src/queries_repository.rs
+++ b/src/queries_repository.rs
@@ -581,6 +581,69 @@ impl UsersQueriesRepository {
                     .text("MATCH (n {id: $id}) RETURN n")
                     .param("id", random.random_vertex())
                     .build()
+            })
+            // Value hash join: bind one user by id, scan all users, join on age
+            .add_query("value_join", QueryType::Read, |random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (a:User {id: $id}), (b:User) WHERE a.age = b.age RETURN b.id")
+                    .param("id", random.random_vertex())
+                    .build()
+            })
+            .add_query("value_join_cnt", QueryType::Read, |random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (a:User {id: $id}), (b:User) WHERE a.age = b.age RETURN count(b)")
+                    .param("id", random.random_vertex())
+                    .build()
+            })
+            // Full sort over every user
+            .add_query("order_by_age", QueryType::Read, |_random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (n:User) RETURN n.id, n.age ORDER BY n.age, n.id")
+                    .build()
+            })
+            // UNWIND of a per-row list literal
+            .add_query("unwind_rows", QueryType::Read, |random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (n:User {id: $id}) UNWIND [n.id, n.id + 1, n.id + 2] AS x RETURN x")
+                    .param("id", random.random_vertex())
+                    .build()
+            })
+            // Variable-length expansion from one user
+            .add_query("var_len_friends", QueryType::Read, |random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (a:User {id: $id})-[*1..2]->(b:User) RETURN b.id")
+                    .param("id", random.random_vertex())
+                    .build()
+            })
+            // OPTIONAL MATCH (correlated expansion)
+            .add_query("optional_friend", QueryType::Read, |random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (a:User {id: $id}) OPTIONAL MATCH (a)-->(b:User) RETURN a.id, b.id")
+                    .param("id", random.random_vertex())
+                    .build()
+            })
+            // CALL {} subquery (correlated)
+            .add_query("call_subquery", QueryType::Read, |random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (a:User {id: $id}) CALL { WITH a MATCH (a)-->(b:User) RETURN b.id AS bid } RETURN bid")
+                    .param("id", random.random_vertex())
+                    .build()
+            })
+            // Node lookup by internal id
+            .add_query("id_seek", QueryType::Read, |random, _flavour| {
+                QueryBuilder::new()
+                    .text("MATCH (n) WHERE id(n) = $id RETURN n.id")
+                    .param("id", random.random_vertex())
+                    .build()
+            })
+            // Node scan over an internal-id range (columnar fan-out)
+            .add_query("id_range_scan", QueryType::Read, |random, _flavour| {
+                let start = random.random_vertex();
+                QueryBuilder::new()
+                    .text("MATCH (n) WHERE id(n) >= $start AND id(n) < $end RETURN n.id")
+                    .param("start", start)
+                    .param("end", start + 100)
+                    .build()
             });
         if algorithm_selection.pagerank {
             queries_builder = queries_builder.add_query(


### PR DESCRIPTION
## Summary

Adds nine read queries that exercise query shapes optimized by FalkorDB's columnar batch execution fast paths. The existing catalog didn't cover any of these shapes, so they were invisible to the benchmark.

| query | shape | exercises |
|---|---|---|
| `value_join` | `MATCH (a:User {id:$id}),(b:User) WHERE a.age=b.age RETURN b.id` | Value Hash Join (cartesian + equality) |
| `value_join_cnt` | same, `RETURN count(b)` | Value Hash Join + aggregation |
| `order_by_age` | `MATCH (n:User) RETURN n.id,n.age ORDER BY n.age,n.id` | full sort over every user |
| `unwind_rows` | `... UNWIND [n.id,n.id+1,n.id+2] AS x RETURN x` | UNWIND of a per-row list literal |
| `var_len_friends` | `MATCH (a:User {id:$id})-[*1..2]->(b:User) RETURN b.id` | variable-length expansion |
| `optional_friend` | `... OPTIONAL MATCH (a)-->(b:User) RETURN a.id,b.id` | OPTIONAL MATCH correlated expansion |
| `call_subquery` | `... CALL { WITH a MATCH (a)-->(b:User) RETURN b.id AS bid } RETURN bid` | CALL {} correlated subquery |
| `id_seek` | `MATCH (n) WHERE id(n)=$id RETURN n.id` | node lookup by internal id |
| `id_range_scan` | `MATCH (n) WHERE id(n)>=$start AND id(n)<$end RETURN n.id` | node scan over internal-id range |

## Validation

- All nine return **identical row counts** across the C (`falkordb:edge`) and Rust (`edge-rs`) engines, loaded with the `small` Pokec dataset.
- All nine **parse and execute** on both engines (CALL {} and OPTIONAL MATCH included).
- `value_join` confirmed to produce a `Value Hash Join` plan.
- Uses the existing `add_query` builder conventions and `random.random_vertex()` for parameters; no harness changes.

## Notes

- Queries are label-agnostic where possible (untyped `-->` / `-[*1..2]->`) to match the existing read queries and avoid edge-label assumptions.
- No changes to the committed `queries.jsonl`; it is regenerated by `generate-queries`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded query support for more complex data retrieval patterns, including ordered results, variable-length relationships, optional relationships, subqueries, and internal ID lookups.
  * Improved handling of joins, row expansion, and range-based access for richer query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->