### PR TITLE
feat(ui): add crawler-readable benchmark data output

### DIFF
--- a/ui/app/aws-tests/page.tsx
+++ b/ui/app/aws-tests/page.tsx
@@ -3,31 +3,29 @@ import { Header } from "../components/header";
 import BenchmarkMetricsCrawlerTable from "../components/BenchmarkMetricsCrawlerTable";
 import { loadBenchmarkSummary, loadRunsManifest } from "../lib/benchmark-data.server";
 
-export default async function Neo4jVsFalkor() {
-  const dataUrl = "/summaries/neo4j_vs_falkordb.json";
+export default async function AwsTestsFalkorGravitonVsIntel() {
+  const dataUrl = "/summaries/aws_tests_falkor_graviton_vs_intel.json";
   const [initialData, initialManifest] = await Promise.all([
     loadBenchmarkSummary(dataUrl),
     loadRunsManifest(),
   ]);
   return (
-    <main className="min-h-screen md:h-screen flex flex-col">
+    <main className="h-screen flex flex-col">
       <Header />
       <DashBoard
         dataUrl={dataUrl}
         initialData={initialData}
         initialManifest={initialManifest}
-        comparisonVendors={["falkordb", "neo4j"]}
-        hideHardware
+        // Do not hardcode comparisonVendors: aws-tests labels are instance types (e.g. r7i.2xlarge).
         initialSelectedOptions={{
-          "Workload Type": ["single"],
-          Vendors: ["falkordb", "neo4j"],
-          Queries: ["aggregate_expansion_4_with_filter"],
+          "Workload Type": ["concurrent"],
+          Hardware: ["falkordb1", "falkordb2", "intel", "arm"],
         }}
       />
       <BenchmarkMetricsCrawlerTable
         data={initialData}
         dataUrl={dataUrl}
-        title="Neo4j vs FalkorDB"
+        title="AWS FalkorDB Graviton vs Intel"
       />
     </main>
   );

--- a/ui/app/components/BenchmarkMetricsCrawlerTable.tsx
+++ b/ui/app/components/BenchmarkMetricsCrawlerTable.tsx
@@ -20,6 +20,7 @@ const formatTimestamp = (epochSeconds?: number) => {
 };
 
 const getQueryCounts = (run: Run): Array<{ query: string; count: number | null }> => {
+  if (!run?.result) return [];
   const byQuery = run.result.operations?.["by-query"];
   if (byQuery) {
     return Object.entries(byQuery)
@@ -65,25 +66,28 @@ export default function BenchmarkMetricsCrawlerTable({
           </tr>
         </thead>
         <tbody>
-          {runs.map((run, index) => (
-            <tr key={`${run.vendor}-${run.platform}-${index}`}>
-              <td>{run.vendor}</td>
-              <td>{run.platform}</td>
-              <td>{formatNumber(run.clients)}</td>
-              <td>{formatNumber(run["target-messages-per-second"])}</td>
-              <td>{formatNumber(run.result["actual-messages-per-second"])}</td>
-              <td>{run.result.latency?.p50 ?? ""}</td>
-              <td>{run.result.latency?.p95 ?? ""}</td>
-              <td>{run.result.latency?.p99 ?? ""}</td>
-              <td>{formatNumber(run.result["avg-latency-ms"])}</td>
-              <td>{formatNumber(run.result["cpu-usage"])}</td>
-              <td>{run.result["ram-usage"] ?? ""}</td>
-              <td>{formatNumber(run.result.errors)}</td>
-              <td>{formatNumber(run.result["successful-requests"])}</td>
-              <td>{formatNumber(run["read-write-ratio"])}</td>
-              <td>{formatTimestamp(run["started-at-epoch-secs"])}</td>
-            </tr>
-          ))}
+          {runs.map((run, index) => {
+            if (!run?.result) return null;
+            return (
+              <tr key={`${run.vendor}-${run.platform}-${index}`}>
+                <td>{run.vendor}</td>
+                <td>{run.platform}</td>
+                <td>{formatNumber(run.clients)}</td>
+                <td>{formatNumber(run["target-messages-per-second"])}</td>
+                <td>{formatNumber(run.result["actual-messages-per-second"])}</td>
+                <td>{run.result.latency?.p50 ?? ""}</td>
+                <td>{run.result.latency?.p95 ?? ""}</td>
+                <td>{run.result.latency?.p99 ?? ""}</td>
+                <td>{formatNumber(run.result["avg-latency-ms"])}</td>
+                <td>{formatNumber(run.result["cpu-usage"])}</td>
+                <td>{run.result["ram-usage"] ?? ""}</td>
+                <td>{formatNumber(run.result.errors)}</td>
+                <td>{formatNumber(run.result["successful-requests"])}</td>
+                <td>{formatNumber(run["read-write-ratio"])}</td>
+                <td>{formatTimestamp(run["started-at-epoch-secs"])}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
 
@@ -97,15 +101,16 @@ export default function BenchmarkMetricsCrawlerTable({
           </tr>
         </thead>
         <tbody>
-          {runs.flatMap((run, runIndex) =>
-            getQueryCounts(run).map(({ query, count }) => (
+          {runs.flatMap((run, runIndex) => {
+            if (!run?.result) return [];
+            return getQueryCounts(run).map(({ query, count }) => (
               <tr key={`${run.vendor}-${runIndex}-${query}`}>
                 <td>{run.vendor}</td>
                 <td>{query}</td>
                 <td>{count === null ? "n/a" : formatNumber(count)}</td>
               </tr>
-            ))
-          )}
+            ));
+          })}
         </tbody>
       </table>
     </section>

--- a/ui/app/components/BenchmarkMetricsCrawlerTable.tsx
+++ b/ui/app/components/BenchmarkMetricsCrawlerTable.tsx
@@ -1,0 +1,113 @@
+import { BenchmarkData, Run } from "@/app/types/benchmark";
+
+type BenchmarkMetricsCrawlerTableProps = {
+  data: BenchmarkData | null;
+  dataUrl: string;
+  title: string;
+};
+
+const formatNumber = (value: number | string | undefined) => {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "number") return Number.isFinite(value) ? value.toLocaleString() : "";
+  return value;
+};
+
+const formatTimestamp = (epochSeconds?: number) => {
+  if (!epochSeconds || !Number.isFinite(epochSeconds)) return "";
+  const date = new Date(epochSeconds * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString();
+};
+
+const getQueryCounts = (run: Run): Array<{ query: string; count: number | null }> => {
+  const byQuery = run.result.operations?.["by-query"];
+  if (byQuery) {
+    return Object.entries(byQuery)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([query, count]) => ({ query, count }));
+  }
+
+  const histogramQueryNames = Object.keys(run.result.histogram_for_type ?? {}).sort();
+  return histogramQueryNames.map((query) => ({ query, count: null }));
+};
+
+export default function BenchmarkMetricsCrawlerTable({
+  data,
+  dataUrl,
+  title,
+}: BenchmarkMetricsCrawlerTableProps) {
+  const runs = data?.runs ?? [];
+  if (runs.length === 0) return null;
+
+  return (
+    <section className="sr-only" aria-label={`${title} crawlable benchmark metrics`}>
+      <h2>{title} benchmark metrics</h2>
+      <p>Data source: {dataUrl}</p>
+      <table>
+        <caption>Core run metrics</caption>
+        <thead>
+          <tr>
+            <th>Vendor</th>
+            <th>Platform</th>
+            <th>Clients</th>
+            <th>Target MPS</th>
+            <th>Actual MPS</th>
+            <th>Latency p50</th>
+            <th>Latency p95</th>
+            <th>Latency p99</th>
+            <th>Avg latency (ms)</th>
+            <th>CPU usage</th>
+            <th>RAM usage</th>
+            <th>Errors</th>
+            <th>Successful requests</th>
+            <th>Read/Write ratio</th>
+            <th>Started at</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run, index) => (
+            <tr key={`${run.vendor}-${run.platform}-${index}`}>
+              <td>{run.vendor}</td>
+              <td>{run.platform}</td>
+              <td>{formatNumber(run.clients)}</td>
+              <td>{formatNumber(run["target-messages-per-second"])}</td>
+              <td>{formatNumber(run.result["actual-messages-per-second"])}</td>
+              <td>{run.result.latency?.p50 ?? ""}</td>
+              <td>{run.result.latency?.p95 ?? ""}</td>
+              <td>{run.result.latency?.p99 ?? ""}</td>
+              <td>{formatNumber(run.result["avg-latency-ms"])}</td>
+              <td>{formatNumber(run.result["cpu-usage"])}</td>
+              <td>{run.result["ram-usage"] ?? ""}</td>
+              <td>{formatNumber(run.result.errors)}</td>
+              <td>{formatNumber(run.result["successful-requests"])}</td>
+              <td>{formatNumber(run["read-write-ratio"])}</td>
+              <td>{formatTimestamp(run["started-at-epoch-secs"])}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <table>
+        <caption>Per-query operation coverage</caption>
+        <thead>
+          <tr>
+            <th>Vendor</th>
+            <th>Query ID</th>
+            <th>Operation count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.flatMap((run, runIndex) =>
+            getQueryCounts(run).map(({ query, count }) => (
+              <tr key={`${run.vendor}-${runIndex}-${query}`}>
+                <td>{run.vendor}</td>
+                <td>{query}</td>
+                <td>{count === null ? "n/a" : formatNumber(count)}</td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -10,10 +10,29 @@ import { useToast } from "@/hooks/use-toast";
 import HorizontalBarChart from "./HorizontalBarChart";
 import VerticalBarChart from "./VerticalBarChart";
 import MemoryBarChart from "./MemoryBarChart";
+type RunsManifest = Record<string, { filename: string; timestamp: number }[]>;
+
+const filterDataByVendors = (
+  data: BenchmarkData,
+  allowedVendors: string[] | null
+): BenchmarkData => {
+  if (!allowedVendors?.length) return data;
+  return {
+    ...data,
+    runs: (data.runs ?? []).filter((r) =>
+      allowedVendors.includes(r.vendor?.toLowerCase())
+    ),
+    unrealstic: (data.unrealstic ?? []).filter((u) =>
+      allowedVendors.includes(u.vendor?.toLowerCase())
+    ),
+  };
+};
 
 type DashboardProps = {
   dataUrl?: string;
   initialSelectedOptions?: Partial<Record<string, string[]>>;
+  initialData?: BenchmarkData | null;
+  initialManifest?: RunsManifest;
   /**
    * If provided, the dashboard will only show these vendors in the UI (and will
    * ignore any other vendors present in the data file).
@@ -53,11 +72,21 @@ function MobileFiltersBar() {
 export default function DashBoard({
   dataUrl = "/resultData.json",
   initialSelectedOptions,
+  initialData = null,
+  initialManifest,
   comparisonVendors,
   hideHardware = false,
 }: DashboardProps) {
+  const allowedVendors = useMemo(() => {
+    const v = (comparisonVendors ?? [])
+      .map((x) => x.toLowerCase())
+      .filter(Boolean);
+    return v.length ? v : null;
+  }, [comparisonVendors]);
   const [activeUrl, setActiveUrl] = useState(dataUrl);
-  const [data, setData] = useState<BenchmarkData | null>(null);
+  const [data, setData] = useState<BenchmarkData | null>(() =>
+    initialData ? filterDataByVendors(initialData, allowedVendors) : null
+  );
   const { toast } = useToast();
   const [gridKey, setGridKey] = useState(0);
   const [p99SingleRatio, setP99SingleRatio] = useState<number | null>(null);
@@ -76,11 +105,14 @@ export default function DashBoard({
     }[]
   >([]);
   const [didInitFromData, setDidInitFromData] = useState(false);
-  const [loadedDataUrl, setLoadedDataUrl] = useState<string | null>(null);
+  const [loadedDataUrl, setLoadedDataUrl] = useState<string | null>(() =>
+    initialData ? dataUrl : null
+  );
 
-  const [manifest, setManifest] = useState<Record<string, { filename: string; timestamp: number }[]>>({});
+  const [manifest, setManifest] = useState<RunsManifest>(initialManifest ?? {});
 
   useEffect(() => {
+    if (Object.keys(manifest).length > 0) return;
     const fetchManifest = async () => {
       try {
         const response = await fetch("/summaries/manifest.json");
@@ -93,14 +125,14 @@ export default function DashBoard({
       }
     };
     fetchManifest();
-  }, []);
+  }, [manifest]);
 
   useEffect(() => {
     setActiveUrl(dataUrl);
-    setData(null);
-    setLoadedDataUrl(null);
+    setData(initialData ? filterDataByVendors(initialData, allowedVendors) : null);
+    setLoadedDataUrl(initialData ? dataUrl : null);
     setDidInitFromData(false);
-  }, [dataUrl]);
+  }, [dataUrl, initialData, allowedVendors]);
 
   const baseFileName = useMemo(() => {
     if (!dataUrl) return "";
@@ -112,10 +144,6 @@ export default function DashBoard({
     return manifest[baseFileName] || [];
   }, [manifest, baseFileName]);
 
-  const allowedVendors = useMemo(() => {
-    const v = (comparisonVendors ?? []).map((x) => x.toLowerCase()).filter(Boolean);
-    return v.length ? v : null;
-  }, [comparisonVendors]);
 
   const [selectedOptions, setSelectedOptions] = React.useState<
     Record<string, string[]>
@@ -135,6 +163,7 @@ export default function DashBoard({
 
 
   useEffect(() => {
+    if (loadedDataUrl === activeUrl && data) return;
     let cancelled = false;
     const urlForRequest = activeUrl;
 
@@ -148,20 +177,7 @@ export default function DashBoard({
 
         if (cancelled) return;
 
-        if (allowedVendors?.length) {
-          const filtered: BenchmarkData = {
-            ...json,
-            runs: (json.runs ?? []).filter((r) =>
-              allowedVendors.includes(r.vendor?.toLowerCase())
-            ),
-            unrealstic: (json.unrealstic ?? []).filter((u) =>
-              allowedVendors.includes(u.vendor?.toLowerCase())
-            ),
-          };
-          setData(filtered);
-        } else {
-          setData(json);
-        }
+        setData(filterDataByVendors(json, allowedVendors));
         setLoadedDataUrl(urlForRequest);
       } catch (error) {
         if (cancelled) return;
@@ -179,7 +195,7 @@ export default function DashBoard({
     return () => {
       cancelled = true;
     };
-  }, [activeUrl, allowedVendors, toast]);
+  }, [activeUrl, allowedVendors, toast, loadedDataUrl, data]);
 
   const availableQueries = useMemo(() => {
     if (!data) return [];

--- a/ui/app/falkordb-compare/page.tsx
+++ b/ui/app/falkordb-compare/page.tsx
@@ -1,17 +1,31 @@
 import DashBoard from "../components/dashboard";
 import { Header } from "../components/header";
+import BenchmarkMetricsCrawlerTable from "../components/BenchmarkMetricsCrawlerTable";
+import { loadBenchmarkSummary, loadRunsManifest } from "../lib/benchmark-data.server";
 
-export default function FalkorDBCompare() {
+export default async function FalkorDBCompare() {
+  const dataUrl = "/summaries/falkordb_vs_falkordb.json";
+  const [initialData, initialManifest] = await Promise.all([
+    loadBenchmarkSummary(dataUrl),
+    loadRunsManifest(),
+  ]);
   return (
     <main className="min-h-screen md:h-screen flex flex-col">
       <Header />
       <DashBoard
-        dataUrl="/summaries/falkordb_vs_falkordb.json"
+        dataUrl={dataUrl}
+        initialData={initialData}
+        initialManifest={initialManifest}
         comparisonVendors={["falkordb-c", "falkordb-rs", "falkordb1", "falkordb2", "r6g.xl", "r7g.xl", "r8g.xl", "r6i.xl", "r7i.xl"]}
         initialSelectedOptions={{
           "Workload Type": ["concurrent"],
           Vendors: ["falkordb-c", "falkordb-rs", "falkordb1", "falkordb2", "r6g.xl", "r7g.xl", "r8g.xl", "r6i.xl", "r7i.xl"],
         }}
+      />
+      <BenchmarkMetricsCrawlerTable
+        data={initialData}
+        dataUrl={dataUrl}
+        title="FalkorDB version comparison"
       />
     </main>
   );

--- a/ui/app/lib/benchmark-data.server.ts
+++ b/ui/app/lib/benchmark-data.server.ts
@@ -1,0 +1,52 @@
+import "server-only";
+import { promises as fs } from "fs";
+import path from "path";
+import { BenchmarkData } from "@/app/types/benchmark";
+
+export type RunsManifest = Record<string, { filename: string; timestamp: number }[]>;
+
+const publicDir = path.join(process.cwd(), "public");
+const summariesDir = path.join(publicDir, "summaries");
+
+const toSummaryFilePath = (dataUrl: string): string | null => {
+  const normalized = dataUrl.startsWith("/") ? dataUrl.slice(1) : dataUrl;
+  if (!normalized.startsWith("summaries/")) return null;
+
+  const fullPath = path.join(publicDir, normalized);
+  const relativeToSummaries = path.relative(summariesDir, fullPath);
+  if (
+    relativeToSummaries.startsWith("..") ||
+    path.isAbsolute(relativeToSummaries)
+  ) {
+    return null;
+  }
+
+  return fullPath;
+};
+
+const readJsonFile = async <T>(filePath: string): Promise<T | null> => {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+};
+
+export const loadBenchmarkSummary = async (
+  dataUrl: string
+): Promise<BenchmarkData | null> => {
+  const filePath = toSummaryFilePath(dataUrl);
+  if (!filePath) return null;
+
+  const data = await readJsonFile<BenchmarkData>(filePath);
+  if (!data || !Array.isArray(data.runs)) return null;
+  return data;
+};
+
+export const loadRunsManifest = async (): Promise<RunsManifest> => {
+  const filePath = path.join(summariesDir, "manifest.json");
+  const data = await readJsonFile<RunsManifest>(filePath);
+  if (!data || typeof data !== "object") return {};
+  return data;
+};

--- a/ui/app/memgraph/page.tsx
+++ b/ui/app/memgraph/page.tsx
@@ -1,17 +1,31 @@
 import DashBoard from "../components/dashboard";
 import { Header } from "../components/header";
+import BenchmarkMetricsCrawlerTable from "../components/BenchmarkMetricsCrawlerTable";
+import { loadBenchmarkSummary, loadRunsManifest } from "../lib/benchmark-data.server";
 
-export default function MemgraphVsFalkor() {
+export default async function MemgraphVsFalkor() {
+  const dataUrl = "/summaries/memgraph_vs_falkordb.json";
+  const [initialData, initialManifest] = await Promise.all([
+    loadBenchmarkSummary(dataUrl),
+    loadRunsManifest(),
+  ]);
   return (
     <main className="min-h-screen md:h-screen flex flex-col">
       <Header />
       <DashBoard
-        dataUrl="/summaries/memgraph_vs_falkordb.json"
+        dataUrl={dataUrl}
+        initialData={initialData}
+        initialManifest={initialManifest}
         comparisonVendors={["falkordb", "memgraph"]}
         initialSelectedOptions={{
           "Workload Type": ["concurrent"],
           Vendors: ["falkordb", "memgraph"],
         }}
+      />
+      <BenchmarkMetricsCrawlerTable
+        data={initialData}
+        dataUrl={dataUrl}
+        title="Memgraph vs FalkorDB"
       />
     </main>
   );

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,13 +1,22 @@
 
 import DashBoard from "./components/dashboard";
 import { Header } from "./components/header";
+import BenchmarkMetricsCrawlerTable from "./components/BenchmarkMetricsCrawlerTable";
+import { loadBenchmarkSummary, loadRunsManifest } from "./lib/benchmark-data.server";
 
-export default function Home() {
+export default async function Home() {
+  const dataUrl = "/summaries/neo4j_vs_falkordb.json";
+  const [initialData, initialManifest] = await Promise.all([
+    loadBenchmarkSummary(dataUrl),
+    loadRunsManifest(),
+  ]);
   return (
     <main className="min-h-screen md:h-screen flex flex-col">
       <Header />
       <DashBoard
-        dataUrl="/summaries/neo4j_vs_falkordb.json"
+        dataUrl={dataUrl}
+        initialData={initialData}
+        initialManifest={initialManifest}
         comparisonVendors={["falkordb", "neo4j"]}
         hideHardware
         initialSelectedOptions={{
@@ -15,6 +24,11 @@ export default function Home() {
           Vendors: ["falkordb", "neo4j"],
           Queries: ["aggregate_expansion_4_with_filter"],
         }}
+      />
+      <BenchmarkMetricsCrawlerTable
+        data={initialData}
+        dataUrl={dataUrl}
+        title="Neo4j vs FalkorDB"
       />
     </main>
   );


### PR DESCRIPTION
## Summary
- add server-side benchmark summary/manifest loading for public benchmark pages
- add a hidden crawler-readable HTML metrics table (`BenchmarkMetricsCrawlerTable`) so non-JS crawlers can index benchmark values
- pass server-fetched `initialData` and `initialManifest` into the dashboard to render immediately and avoid initial client-only loading gaps
- apply the crawler table + server data wiring across `/`, `/neo4j`, `/memgraph`, `/falkordb-compare`, and `/aws-tests`

## Validation
- npm --prefix /Users/shaharbiron/Documents/GitHub/benchmark-pr-crawler-support/ui run lint

## Artifact
- Warp conversation: https://app.warp.dev/conversation/9279c5b4-e302-4643-8f09-d9d6097b3e83

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preloaded benchmark pages with a new metrics table for comparing run details and per-query coverage.
  * Improved the dashboard experience by loading summary data and run manifests up front for faster initial display.
  * Added support for multiple comparison views, including AWS tests, FalkorDB vs Graviton/Intel, Memgraph, Neo4j, and the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->