### PR TITLE
ci: drive automation via just and add AI agent settings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+language: en-US
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - master
+  # Don't review vendored code or large generated/data artifacts — they aren't hand-maintained
+  # here (the FalkorDB Rust client lives in vendor/ via a Cargo [patch]; *.rdb/*.jsonl are fixtures).
+  path_filters:
+    - "!vendor/**"
+    - "!**/*.rdb"
+    - "!**/*.jsonl"
+    - "!Cargo.lock"
+    - "!ui/package-lock.json"
+  pre_merge_checks:
+    # Disable the docstring-coverage check: this repo has no docstring-coverage convention, so the
+    # check only produces false positives. Docs are enforced by review, not this pre-merge gate.
+    docstrings:
+      mode: "off"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,10 +15,10 @@ The default branch is **`master`**. The FalkorDB Rust client is pulled in from
 
 ## Golden rule: drive everything through `just`
 
-For **any** check that CI performs — Rust `build`, `clippy`, `test`, and the Playwright UI smoke
-test — run the **exact same `just` recipe CI uses**, never a raw `cargo …` / `npm …` command
-(`just fmt-check`, `just ui-lint` and `just ui-build` are recommended local recipes but not CI
-gates). If a check needs changing, update the `just` recipe **and** the CI workflow together so
+For **any** check that CI performs — Rust `build`, `clippy`, `test`, `coverage`, and the Playwright
+UI smoke test — run the **exact same `just` recipe CI uses**, never a raw `cargo …` / `npm …`
+command (`just fmt-check`, `just ui-lint` and `just ui-build` are recommended local recipes but not
+CI gates). If a check needs changing, update the `just` recipe **and** the CI workflow together so
 they stay identical. Run `just --list` to see every recipe.
 
 Key recipes:
@@ -30,6 +30,9 @@ Key recipes:
 | `just clippy` | Strict clippy, warnings denied, scoped to the `benchmark` package (the `clippy` CI gate). |
 | `just build` | Build all targets/features (the `build` CI gate). |
 | `just test` | Unit + integration tests (the `test` CI gate). |
+| `just test-one <filter>` | Run a single test by name filter. |
+| `just coverage` | Codecov JSON coverage via cargo-llvm-cov (the `coverage` CI job). |
+| `just coverage-html` | Open a browsable HTML coverage report locally. |
 | `just fmt` / `just fmt-check` | Format Rust in place / check formatting. |
 | `just run -- <args>` | Run the benchmark binary (e.g. `just run -- --help`). |
 | `just ui-install` | `npm ci` in `ui/`. |
@@ -37,10 +40,10 @@ Key recipes:
 | `just ui-smoke` | The Playwright CI smoke test (the `Playwright Tests` gate). |
 | `just bench-small` / `bench-medium` / `bench-large` | Run the dataset benchmark pipelines in `scripts/`. |
 
-Each **CI job only adds environment setup (protobuf / Node) then installs `just` and runs one
-recipe per check step** — so whatever CI checks, you can reproduce locally with the identical
-recipe. If you add or change a CI check, add or change the recipe and wire the workflow to call
-it; never inline a bare command in a workflow.
+Each **CI job only adds environment setup (protobuf / Node / coverage tooling) then installs
+`just` and runs one recipe per check step** — so whatever CI checks, you can reproduce locally with
+the identical recipe. If you add or change a CI check, add or change the recipe and wire the
+workflow to call it; never inline a bare command in a workflow.
 
 ## Working on the UI (`ui/`)
 
@@ -52,10 +55,12 @@ own dev server, runs the smoke spec and tears the server down; run `just ui-inst
 ## Definition of done for a change
 
 1. **Design first** for non-trivial work, and **rubber-duck review** the design before coding.
-2. **Implement** the change with code **+ tests + docs**. On every change, **check and align the
-   documentation** (README, recipe docs, this file) so it never drifts from the code.
-3. **Validate locally via `just`** — all relevant gates green (`just ci`, plus `just ui-lint` /
-   `just ui-build` / `just ui-smoke` when the UI changed).
+2. **Implement** the change with code **+ tests + docs**. Cover new code with tests (see
+   **Coverage** below). On every change, **check and align all documentation** (the README, recipe
+   doc-comments, this file) so it never drifts from the code — see **Keep documentation in sync**.
+3. **Run all validations locally before committing** — never commit without a green local run.
+   Run `just ci` (build, clippy, test) **and** `just coverage`, plus `just ui-lint` /
+   `just ui-build` / `just ui-smoke` when the UI changed.
 4. Open a PR on a feature branch (prefix with your username, e.g. `barakb/…`) targeting `master`.
 5. **Resolve every AI review thread** (Copilot **and** CodeRabbit) — reply *and* mark it resolved —
    before merge. Copilot's reviewer does not reliably re-review new commits; re-request it (POST
@@ -63,6 +68,28 @@ own dev server, runs the smoke spec and tears the server down; run `just ui-inst
 6. **Never merge to `master` yourself — wait for explicit human approval.** Do **not** run any
    `gh pr merge …` variant to self-merge, even when every check is green and all AI threads are
    resolved. Open the PR, get it green, and **stop** until the maintainer approves the merge.
+
+## Keep documentation in sync
+
+On **every** change, check and align **all** documentation so it never drifts from the code —
+treat "the docs match the code" as part of the definition of done, not a follow-up:
+
+- Update **`readme.md`** whenever behavior, commands, CLI flags, `just` recipes, or setup steps
+  change — keep the **Development** (just recipes for tests/coverage) section and any examples
+  current.
+- Update the **recipe doc-comments** in the `Justfile` and the recipe tables in this file
+  (`.github/copilot-instructions.md`) whenever you add, rename, or change a recipe or a workflow.
+- Keep the other docs (`ui/README.md`, `QUERY_EXPLANATIONS_AND_SAMPLES.md`, …) accurate when the
+  code they describe changes.
+
+## Coverage
+
+Write **as much test coverage as possible** — cover new code with unit tests and keep patch
+coverage high. Measure it with the exact CI command, **`just coverage`** (cargo-llvm-cov →
+`codecov.json`), not an ad-hoc line count; **`just coverage-html`** opens a browsable report.
+Coverage is uploaded to Codecov by the `coverage` workflow (see `codecov.yml` for thresholds).
+Prefer testing real logic (parsing, query building, scheduling, aggregation) over I/O paths that
+would need a live database.
 
 ## Flaky tests are a hard no
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,90 @@
+# Copilot / AI agent instructions for `FalkorDB/benchmark`
+
+Guidance for GitHub Copilot and other AI agents working in this repository. It encodes the
+team's engineering conventions so changes land clean on the first try. Human contributors
+should follow it too.
+
+`benchmark` is FalkorDB's benchmarking tool. It has two parts:
+
+- a **Rust CLI** (`src/`, the `benchmark` binary) that loads data into and drives workloads
+  against **FalkorDB**, **Neo4j** and **Memgraph**, exposing Prometheus metrics; and
+- a **Next.js dashboard** in **`ui/`** that renders the results, with Playwright smoke tests.
+
+The default branch is **`master`**. The FalkorDB Rust client is pulled in from
+`vendor/falkordb-rs` via a Cargo `[patch]`, so keep it out of lint/format passes.
+
+## Golden rule: drive everything through `just`
+
+For **any** check that CI performs — Rust `build`, `clippy`, `test`, and the Playwright UI smoke
+test — run the **exact same `just` recipe CI uses**, never a raw `cargo …` / `npm …` command
+(`just fmt-check`, `just ui-lint` and `just ui-build` are recommended local recipes but not CI
+gates). If a check needs changing, update the `just` recipe **and** the CI workflow together so
+they stay identical. Run `just --list` to see every recipe.
+
+Key recipes:
+
+| Recipe | Purpose |
+| --- | --- |
+| `just check` | Fast pre-commit loop for Rust: `fmt clippy build`. |
+| `just ci` | Every Rust CI gate, in the same order CI runs them: `build clippy test`. |
+| `just clippy` | Strict clippy, warnings denied, scoped to the `benchmark` package (the `clippy` CI gate). |
+| `just build` | Build all targets/features (the `build` CI gate). |
+| `just test` | Unit + integration tests (the `test` CI gate). |
+| `just fmt` / `just fmt-check` | Format Rust in place / check formatting. |
+| `just run -- <args>` | Run the benchmark binary (e.g. `just run -- --help`). |
+| `just ui-install` | `npm ci` in `ui/`. |
+| `just ui-lint` / `just ui-build` | Lint / production-build the dashboard. |
+| `just ui-smoke` | The Playwright CI smoke test (the `Playwright Tests` gate). |
+| `just bench-small` / `bench-medium` / `bench-large` | Run the dataset benchmark pipelines in `scripts/`. |
+
+Each **CI job only adds environment setup (protobuf / Node) then installs `just` and runs one
+recipe per check step** — so whatever CI checks, you can reproduce locally with the identical
+recipe. If you add or change a CI check, add or change the recipe and wire the workflow to call
+it; never inline a bare command in a workflow.
+
+## Working on the UI (`ui/`)
+
+`just ui-*` recipes wrap `npm` in `ui/`. **Never run `just ui-build` (or `next build`/`next start`)
+while `just ui-dev` (`next dev`) is live** — both write `ui/.next` and corrupt it (ENOENT
+manifest/rename errors). If that happens, `rm -rf ui/.next` and restart. `just ui-smoke` starts its
+own dev server, runs the smoke spec and tears the server down; run `just ui-install` first.
+
+## Definition of done for a change
+
+1. **Design first** for non-trivial work, and **rubber-duck review** the design before coding.
+2. **Implement** the change with code **+ tests + docs**. On every change, **check and align the
+   documentation** (README, recipe docs, this file) so it never drifts from the code.
+3. **Validate locally via `just`** — all relevant gates green (`just ci`, plus `just ui-lint` /
+   `just ui-build` / `just ui-smoke` when the UI changed).
+4. Open a PR on a feature branch (prefix with your username, e.g. `barakb/…`) targeting `master`.
+5. **Resolve every AI review thread** (Copilot **and** CodeRabbit) — reply *and* mark it resolved —
+   before merge. Copilot's reviewer does not reliably re-review new commits; re-request it (POST
+   `pulls/{n}/requested_reviewers`) after pushing. CodeRabbit auto-reviews each push.
+6. **Never merge to `master` yourself — wait for explicit human approval.** Do **not** run any
+   `gh pr merge …` variant to self-merge, even when every check is green and all AI threads are
+   resolved. Open the PR, get it green, and **stop** until the maintainer approves the merge.
+
+## Flaky tests are a hard no
+
+Fix a flaky test **immediately, as top priority**, regardless of the current task or whether the
+flake is pre-existing. Find the root cause (retry only the genuinely transient error and fail fast
+on everything else) rather than papering over it.
+
+## Feature flags over deletion
+
+When temporarily disabling a feature (e.g. because of an upstream bug), gate it behind a flag so it
+is non-accessible from the API and the UI rather than deleting the code — so it can be re-enabled
+easily once fixed.
+
+## Commits & PRs
+
+- Use clear, imperative commit subjects. Prefer **Conventional Commits** (`feat`, `fix`, `ci`,
+  `docs`, `chore`, `refactor`, `perf`, `test`, `build`) where it helps.
+- Include a `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer on
+  agent-authored commits.
+- Keep PRs focused; don't reformat or refactor unrelated code in the same change.
+
+## Code style
+
+Keep code **tidy, simple, and efficient**. Comment only what genuinely needs clarification — not
+the obvious. Match the surrounding style; prefer the smallest change that fully solves the problem.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,22 @@ jobs:
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
 
       - name: Install protobuf compiler
-        # Kept explicit to ensure protoc is always available in CI.
+        # Kept explicit to ensure protoc is always available in CI (the prometheus crate's
+        # build script needs it).
         run: sudo apt-get install -y protobuf-compiler
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      # Every step runs a single `just` recipe so the exact command can be reproduced locally
+      # (see the Justfile / .github/copilot-instructions.md).
       - name: Build
-        run: cargo build --verbose --all-targets --all-features
+        run: just build
 
       - name: Run Clippy
-        run: cargo clippy --package benchmark --all-targets --all-features -- -D warnings
+        run: just clippy
 
       - name: Test
-        run: cargo test --verbose
+        run: just test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
 
       - name: Install just
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
         with:
           tool: just
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,50 @@
+name: Code Coverage
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+# Generate code coverage with cargo-llvm-cov and upload it to Codecov.
+jobs:
+  coverage:
+    name: Code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Rust
+        run: rustup update stable && rustup default stable
+
+      - name: Install protobuf compiler
+        # The prometheus crate's build script needs protoc.
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Install just and cargo-llvm-cov
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
+        with:
+          tool: just,cargo-llvm-cov
+
+      # Runs the same recipe developers run locally (see the Justfile).
+      - name: Generate code coverage
+        run: just coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        with:
+          files: codecov.json
+          # Don't fail the build on a transient Codecov upload/token hiccup.
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,10 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Least privilege: the job only checks out code and uploads a coverage report.
+permissions:
+  contents: read
+
 # Generate code coverage with cargo-llvm-cov and upload it to Codecov.
 jobs:
   coverage:
@@ -42,7 +46,7 @@ jobs:
         run: just coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: codecov.json
           # Don't fail the build on a transient Codecov upload/token hiccup.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
           cache: npm
           cache-dependency-path: ui/package-lock.json
       - name: Install just
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
         with:
           tool: just
       # Both steps run a single `just` recipe so the exact command can be reproduced locally

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,9 +13,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]' || contains(github.head_ref, '/ui/') }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./ui
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -25,36 +22,22 @@ jobs:
           node-version: lts/*
           cache: npm
           cache-dependency-path: ui/package-lock.json
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      # Both steps run a single `just` recipe so the exact command can be reproduced locally
+      # (see the Justfile / .github/copilot-instructions.md).
       - name: Install dependencies
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-        run: npm ci
-      - name: Set up environment and run minimal Playwright smoke test
+        run: just ui-install
+      - name: Run minimal Playwright smoke test
         env:
           NEXT_PUBLIC_HUBSPOT_PORTAL_ID: ${{ secrets.NEXT_PUBLIC_HUBSPOT_PORTAL_ID }}
           NEXT_PUBLIC_HUBSPOT_FORM_ID: ${{ secrets.NEXT_PUBLIC_HUBSPOT_FORM_ID }}
           PORT: 3000
-        run: |
-          if command -v google-chrome >/dev/null 2>&1; then
-            export PLAYWRIGHT_CHROMIUM_CHANNEL=chrome
-            google-chrome --version
-          elif command -v google-chrome-stable >/dev/null 2>&1; then
-            export PLAYWRIGHT_CHROMIUM_CHANNEL=chrome
-            google-chrome-stable --version
-          else
-            echo "System Chrome not found; installing Playwright Chromium headless shell fallback."
-            npx playwright install --only-shell chromium
-          fi
-          npm run dev &
-          echo "Waiting for Next.js to be ready on http://localhost:3000 ..."
-          for i in {1..120}; do
-            if curl -fsS http://localhost:3000/ >/dev/null; then
-              echo "Next.js is up."
-              break
-            fi
-            sleep 1
-          done
-          npx playwright test tests/tests/ci-smoke.spec.ts --project=chromium --retries=0 --workers=1 --reporter=dot
+        run: just ui-smoke
       - name: Upload Playwright report
         uses: actions/upload-artifact@v6
         if: ${{ always() }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .idea
 downloads
 cache
+# code coverage output (`just coverage` / cargo-llvm-cov)
+codecov.json
 backups
 *.so
 redis-data

--- a/Justfile
+++ b/Justfile
@@ -108,15 +108,21 @@ ui-smoke:
     fi
     PORT="$port" npm run dev &
     dev_pid=$!
-    trap 'kill "$dev_pid" 2>/dev/null || true' EXIT
+    trap 'kill "$dev_pid" 2>/dev/null || true; wait "$dev_pid" 2>/dev/null || true' EXIT
     echo "Waiting for Next.js to be ready on http://localhost:${port}/ ..."
+    ready=0
     for i in $(seq 1 120); do
-        if curl -fsS "http://localhost:${port}/" >/dev/null; then
+        if curl -fsS "http://localhost:${port}/" >/dev/null 2>&1; then
             echo "Next.js is up."
+            ready=1
             break
         fi
         sleep 1
     done
+    if [ "$ready" -ne 1 ]; then
+        echo "Next.js did not become ready on http://localhost:${port}/ within 120s" >&2
+        exit 1
+    fi
     npx playwright test tests/tests/ci-smoke.spec.ts --project=chromium --retries=0 --workers=1 --reporter=dot
 
 # === Benchmarks (helper-script wrappers) =====================================

--- a/Justfile
+++ b/Justfile
@@ -127,7 +127,7 @@ ui-smoke:
     echo "Waiting for Next.js to be ready on http://localhost:${port}/ ..."
     ready=0
     for i in $(seq 1 120); do
-        if curl -fsS "http://localhost:${port}/" >/dev/null 2>&1; then
+        if curl -fsS --connect-timeout 2 --max-time 5 "http://localhost:${port}/" >/dev/null 2>&1; then
             echo "Next.js is up."
             ready=1
             break

--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,7 @@ clippy:
 
 # Build every target with all features (matches the `build` CI gate).
 build:
-    cargo build --all-targets --all-features
+    cargo build --verbose --all-targets --all-features
 
 # Build the optimized release binary.
 build-release:
@@ -56,7 +56,7 @@ doc:
 
 # Run the unit + integration test suite (matches the `test` CI gate).
 test:
-    cargo test
+    cargo test --verbose
 
 # Run a single test by name filter, e.g. `just test-one aggregator`.
 test-one *args:

--- a/Justfile
+++ b/Justfile
@@ -1,8 +1,8 @@
 # Justfile — dev-cycle automation for the FalkorDB benchmark.
 #
-# Run `just` (or `just --list`) to see every available recipe. Every check CI performs
-# is a recipe here, so the exact command can be reproduced locally and CI and local stay
-# identical (see .github/workflows/ and .github/copilot-instructions.md).
+# Run `just` (or `just --list`) to see every available recipe. Every check CI performs is a
+# recipe here, so CI and local runs use the exact same command (see .github/workflows/ and
+# .github/copilot-instructions.md).
 #
 # This repo has two parts, each with its own recipes:
 #   * the Rust benchmark binary  -> `fmt`, `clippy`, `build`, `test`, `run`, …
@@ -33,7 +33,7 @@ fmt-check:
 
 # === Rust: lint ==============================================================
 
-# `--package benchmark` keeps the patched-in falkordb-rs vendor copy out of the lint.
+# `--package benchmark` selects this crate explicitly, exactly as the CI invocation does.
 # Strict clippy over all targets/features, warnings denied (matches the `clippy` CI gate).
 clippy:
     cargo clippy --package benchmark --all-targets --all-features -- -D warnings
@@ -91,8 +91,8 @@ ui-build:
 ui-dev:
     cd ui && PORT={{PORT}} npm run dev
 
-# Set the NEXT_PUBLIC_HUBSPOT_* env vars (as CI does) if the smoke path needs them. Run `just
-# ui-install` first. Mirrors the `playwright.yml` workflow.
+# Run `just ui-install` first. Set the NEXT_PUBLIC_HUBSPOT_* env vars (as CI does) if the
+# smoke path needs them. Mirrors the `playwright.yml` workflow.
 # Playwright CI smoke test: start the dev server, wait for it, run the smoke spec, tear it down.
 ui-smoke:
     #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -66,7 +66,12 @@ test-one *args:
 
 # Run the benchmark binary, forwarding args, e.g. `just run -- --help` or `just run load ...`.
 run *args:
-    cargo run --bin benchmark "$@"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Drop an optional leading `--` so both `just run --help` and `just run -- --help` forward
+    # the flags to the binary (not to cargo).
+    if [ "${1:-}" = "--" ]; then shift; fi
+    cargo run --bin benchmark -- "$@"
 
 # === UI (Next.js dashboard in ui/) ===========================================
 

--- a/Justfile
+++ b/Justfile
@@ -62,6 +62,16 @@ test:
 test-one *args:
     cargo test "$@"
 
+# === Coverage ================================================================
+
+# Generate Codecov JSON coverage for the benchmark crate (matches the `coverage` CI job).
+coverage:
+    cargo llvm-cov --package benchmark --all-features --codecov --output-path codecov.json
+
+# Generate an HTML coverage report and open it in a browser.
+coverage-html:
+    cargo llvm-cov --package benchmark --all-features --html --open
+
 # === Rust: run ===============================================================
 
 # Run the benchmark binary, forwarding args, e.g. `just run -- --help` or `just run load ...`.
@@ -89,7 +99,7 @@ ui-build:
 
 # Start the UI dev server on {{PORT}}.
 ui-dev:
-    cd ui && PORT={{PORT}} npm run dev
+    cd ui && PORT="{{PORT}}" npm run dev
 
 # Run `just ui-install` first. Set the NEXT_PUBLIC_HUBSPOT_* env vars (as CI does) if the
 # smoke path needs them. Mirrors the `playwright.yml` workflow.
@@ -157,7 +167,8 @@ ci: build clippy test
 
 # === Housekeeping ============================================================
 
-# Remove Rust build artifacts and the UI build/test output.
+# Remove Rust build artifacts, coverage output, and the UI build/test output.
 clean:
     cargo clean
+    rm -f codecov.json
     rm -rf ui/.next ui/playwright-report ui/test-results

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,152 @@
+# Justfile — dev-cycle automation for the FalkorDB benchmark.
+#
+# Run `just` (or `just --list`) to see every available recipe. Every check CI performs
+# is a recipe here, so the exact command can be reproduced locally and CI and local stay
+# identical (see .github/workflows/ and .github/copilot-instructions.md).
+#
+# This repo has two parts, each with its own recipes:
+#   * the Rust benchmark binary  -> `fmt`, `clippy`, `build`, `test`, `run`, …
+#   * the Next.js dashboard in ui/ -> `ui-*`
+
+set shell := ["bash", "-uc"]
+set positional-arguments
+
+# --- Configuration (override on the CLI, e.g. `just PORT=3005 ui-dev`) --------
+
+# Port for the UI dev server (`ui-dev`). The Playwright smoke test always targets 3000
+# (see ui/tests/config/urls.json), so `ui-smoke` pins its own server to 3000.
+PORT := env_var_or_default("PORT", "3000")
+
+# Default recipe: list everything.
+default:
+    @just --list
+
+# === Rust: format ============================================================
+
+# Format all Rust code in place.
+fmt:
+    cargo fmt --all
+
+# Check Rust formatting without modifying files.
+fmt-check:
+    cargo fmt --all --check
+
+# === Rust: lint ==============================================================
+
+# `--package benchmark` keeps the patched-in falkordb-rs vendor copy out of the lint.
+# Strict clippy over all targets/features, warnings denied (matches the `clippy` CI gate).
+clippy:
+    cargo clippy --package benchmark --all-targets --all-features -- -D warnings
+
+# === Rust: build =============================================================
+
+# Build every target with all features (matches the `build` CI gate).
+build:
+    cargo build --all-targets --all-features
+
+# Build the optimized release binary.
+build-release:
+    cargo build --release
+
+# Build the API docs.
+doc:
+    cargo doc --no-deps
+
+# === Rust: test ==============================================================
+
+# Run the unit + integration test suite (matches the `test` CI gate).
+test:
+    cargo test
+
+# Run a single test by name filter, e.g. `just test-one aggregator`.
+test-one *args:
+    cargo test "$@"
+
+# === Rust: run ===============================================================
+
+# Run the benchmark binary, forwarding args, e.g. `just run -- --help` or `just run load ...`.
+run *args:
+    cargo run --bin benchmark "$@"
+
+# === UI (Next.js dashboard in ui/) ===========================================
+
+# Install UI dependencies from the lockfile.
+ui-install:
+    cd ui && npm ci
+
+# Lint the UI.
+ui-lint:
+    cd ui && npm run lint
+
+# Production build of the UI. Do NOT run while `ui-dev` is live — both write ui/.next.
+ui-build:
+    cd ui && npm run build
+
+# Start the UI dev server on {{PORT}}.
+ui-dev:
+    cd ui && PORT={{PORT}} npm run dev
+
+# Set the NEXT_PUBLIC_HUBSPOT_* env vars (as CI does) if the smoke path needs them. Run `just
+# ui-install` first. Mirrors the `playwright.yml` workflow.
+# Playwright CI smoke test: start the dev server, wait for it, run the smoke spec, tear it down.
+ui-smoke:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ui
+    # The smoke spec targets http://localhost:3000 (ui/tests/config/urls.json), so pin the
+    # dev server to 3000 regardless of any outer PORT.
+    port=3000
+    if command -v google-chrome >/dev/null 2>&1; then
+        export PLAYWRIGHT_CHROMIUM_CHANNEL=chrome
+        google-chrome --version
+    elif command -v google-chrome-stable >/dev/null 2>&1; then
+        export PLAYWRIGHT_CHROMIUM_CHANNEL=chrome
+        google-chrome-stable --version
+    else
+        echo "System Chrome not found; installing Playwright Chromium headless shell fallback."
+        npx playwright install --only-shell chromium
+    fi
+    PORT="$port" npm run dev &
+    dev_pid=$!
+    trap 'kill "$dev_pid" 2>/dev/null || true' EXIT
+    echo "Waiting for Next.js to be ready on http://localhost:${port}/ ..."
+    for i in $(seq 1 120); do
+        if curl -fsS "http://localhost:${port}/" >/dev/null; then
+            echo "Next.js is up."
+            break
+        fi
+        sleep 1
+    done
+    npx playwright test tests/tests/ci-smoke.spec.ts --project=chromium --retries=0 --workers=1 --reporter=dot
+
+# === Benchmarks (helper-script wrappers) =====================================
+# Thin pass-throughs to scripts/. Configure via env vars (see the README and each script's
+# header), e.g. `RUN_NEO4J=0 QUERIES_COUNT=25000 just bench-small`.
+
+# Run the small-dataset benchmark pipeline.
+bench-small:
+    ./scripts/run_small_benchmark.sh
+
+# Run the medium-dataset benchmark pipeline.
+bench-medium:
+    ./scripts/run_medium_benchmark.sh
+
+# Run the large-dataset benchmark pipeline.
+bench-large:
+    ./scripts/run_large_benchmark.sh
+
+# === Aggregates ==============================================================
+
+# Fast pre-commit loop for Rust: format, lint, build.
+check: fmt clippy build
+
+# Must be green before declaring a task done.
+# Every Rust CI gate, in the same order CI runs them: build, clippy, test.
+ci: build clippy test
+
+# === Housekeeping ============================================================
+
+# Remove Rust build artifacts and the UI build/test output.
+clean:
+    cargo clean
+    rm -rf ui/.next ui/playwright-report ui/test-results

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        # Allow small dips in overall coverage between runs.
+        threshold: 2%
+    patch:
+      default:
+        # New code should be well covered, but allow some slack for diffs that
+        # include inherently hard-to-unit-test paths (network/IO error branches).
+        threshold: 5%
+
+# The Next.js dashboard (ui/) and the vendored FalkorDB client (vendor/) are not
+# part of the Rust crate's unit tests, so they're excluded from coverage reporting.
+ignore:
+  - "ui"
+  - "vendor"
+  - "scripts"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 [![Cargo Build & Test](https://github.com/FalkorDB/benchmark/actions/workflows/ci.yml/badge.svg)](https://github.com/FalkorDB/benchmark/actions/workflows/ci.yml)
 [![Code Coverage](https://github.com/FalkorDB/benchmark/actions/workflows/coverage.yml/badge.svg)](https://github.com/FalkorDB/benchmark/actions/workflows/coverage.yml)
 [![codecov](https://codecov.io/gh/FalkorDB/benchmark/graph/badge.svg)](https://codecov.io/gh/FalkorDB/benchmark)
-[![License](https://img.shields.io/github/license/falkordb/benchmark.svg)](https://github.com/falkordb/benchmark/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/falkordb/benchmark.svg)](https://github.com/falkordb/benchmark/blob/master/LICENSE)
 [![Discord](https://img.shields.io/discord/1146782921294884966.svg?style=social&logo=discord)](https://discord.com/invite/99y2Ubh6tg)
 [![Twitter](https://img.shields.io/twitter/follow/falkordb?style=social)](https://twitter.com/falkordb)
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
 [![Cargo Build & Test](https://github.com/FalkorDB/benchmark/actions/workflows/ci.yml/badge.svg)](https://github.com/FalkorDB/benchmark/actions/workflows/ci.yml)
+[![Code Coverage](https://github.com/FalkorDB/benchmark/actions/workflows/coverage.yml/badge.svg)](https://github.com/FalkorDB/benchmark/actions/workflows/coverage.yml)
+[![codecov](https://codecov.io/gh/FalkorDB/benchmark/graph/badge.svg)](https://codecov.io/gh/FalkorDB/benchmark)
 [![License](https://img.shields.io/github/license/falkordb/benchmark.svg)](https://github.com/falkordb/benchmark/blob/main/LICENSE)
 [![Discord](https://img.shields.io/discord/1146782921294884966.svg?style=social&logo=discord)](https://discord.com/invite/99y2Ubh6tg)
 [![Twitter](https://img.shields.io/twitter/follow/falkordb?style=social)](https://twitter.com/falkordb)
@@ -10,6 +12,7 @@
 - [System Requirements](#system-requirements)
   - [Prerequisites](#prerequisites)
   - [Installation Steps](#installation-steps)
+- [Development](#development)
 - [Run the benchmark](#run-the-benchmark)
   - [Run via helper scripts](#run-via-helper-scripts)
   - [CLI workflow](#cli-workflow)
@@ -95,6 +98,47 @@ from `~/`
 - build the benchmark `cargo build --release`
 - enable autocomplete `source <(./target/release/benchmark generate-auto-complete bash)`
 - copy the falkor shared lib to `cp ~/FalkorDB/bin/linux-x64-release/src/falkordb.so .`
+
+## Development
+
+Automation for this repo is driven by [`just`](https://github.com/casey/just) — run `just --list`
+to see every recipe. CI installs `just` and runs these same recipes, so whatever CI checks you can
+reproduce locally with the identical command.
+
+Install `just` (`cargo install just` or `brew install just`) and, for coverage,
+[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) (`cargo install cargo-llvm-cov`).
+Building the Rust crate also needs `protoc` (`sudo apt-get install -y protobuf-compiler` or
+`brew install protobuf`).
+
+### Build, lint and test
+
+```bash
+just build            # build all targets/features
+just clippy           # strict clippy (warnings denied)
+just test             # run the unit + integration test suite
+just test-one <name>  # run a single test by name filter
+just ci               # everything the Rust CI runs: build + clippy + test
+```
+
+### Code coverage
+
+```bash
+just coverage         # generate codecov.json via cargo-llvm-cov (as the coverage CI job does)
+just coverage-html    # open a browsable HTML coverage report
+```
+
+Coverage is uploaded to [Codecov](https://codecov.io/gh/FalkorDB/benchmark) by the `coverage`
+workflow. Please cover new code with tests and keep coverage high.
+
+### UI dashboard (`ui/`)
+
+```bash
+just ui-install       # npm ci
+just ui-lint          # lint
+just ui-build         # production build
+just ui-dev           # start the dev server
+just ui-smoke         # Playwright smoke test (starts its own dev server)
+```
 
 #### run the benchmark
 ##### run via helper scripts


### PR DESCRIPTION
## What & why

Makes this repo mirror [`FalkorDB/falkordb-rs`](https://github.com/FalkorDB/falkordb-rs) from the standpoint of **AI/agent settings** and **just-driven automation**: a single `Justfile` is the source of truth for every dev/CI action, and each CI job installs `just` and runs one recipe per check step instead of raw `cargo`/`npm` commands. It also adds **code coverage** (cargo-llvm-cov + Codecov) like the `-rs` project.

## Changes

- **`Justfile`** (new) — the single automation entrypoint (`just --list`):
  - Rust: `fmt`, `fmt-check`, `clippy`, `build`, `build-release`, `doc`, `test`, `test-one`, `run`.
  - Coverage: `coverage` (Codecov JSON via cargo-llvm-cov) and `coverage-html`.
  - UI (`ui/`): `ui-install`, `ui-lint`, `ui-build`, `ui-dev`, `ui-smoke`.
  - Benchmarks: `bench-small` / `bench-medium` / `bench-large` wrappers for `scripts/`.
  - Aggregates: `check` (fmt+clippy+build), `ci` (build+clippy+test), `clean`.
- **`.github/copilot-instructions.md`** (new) — AI-agent guide adapted for this repo: drive everything through `just`, keep docs/README in sync, run all validations locally before commit, maximize coverage, resolve Copilot+CodeRabbit threads, never self-merge to `master`.
- **`.coderabbit.yaml`** (new) — auto-review on `master`, path filters skip `vendor/` + large `*.rdb`/`*.jsonl`, docstring pre-merge check off.
- **`.github/workflows/ci.yml`** — installs `just` (pinned SHA) and runs `just build` / `just clippy` / `just test`.
- **`.github/workflows/playwright.yml`** — installs `just` and runs `just ui-install` + `just ui-smoke`.
- **`.github/workflows/coverage.yml`** (new) + **`codecov.yml`** (new) — runs `just coverage` and uploads to Codecov (`contents: read` least-privilege).
- **`readme.md`** — a **Development** section documenting the `just` recipes for build/test/coverage/UI, plus build + coverage badges.

## Notes / scope

- The pre-existing Rust gates (build/clippy/test) and the Playwright smoke test are **unchanged** — only routed through `just` (identical flags, including `--verbose`). This PR **adds one new gate**, the `coverage` job.
- `fmt-check` is intentionally **not** a CI gate: the tree isn't rustfmt-clean under stable rustfmt, and reformatting it is out of scope.
- No `release-plz` / `llms.txt` / spellcheck machinery from `-rs` was copied — not applicable to a benchmark binary + dashboard.

## Validation

Ran locally: `just ci` (build+clippy+test, 10 tests, no DB), `just coverage` (codecov.json), `just ui-install`, `just ui-lint`. CI is green including the new Code coverage job and `codecov/patch` + `codecov/project`. All Copilot, CodeRabbit and CodeQL review threads addressed (reply + resolve).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
