### PR TITLE
feat(synthetic): single-operation latency probe (part 1 of #200)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,9 @@ Key recipes:
 | `just test-one <filter>` | Run a single test by name filter. |
 | `just coverage` | Codecov JSON coverage via cargo-llvm-cov (the `coverage` CI job). |
 | `just coverage-html` | Open a browsable HTML coverage report locally. |
+| `just synthetic-bench` | Run the synthetic per-operation latency probe (needs a live FalkorDB). |
+| `just synthetic-ops` | List the synthetic operations. |
+| `just synthetic-it` | Run the synthetic integration test against a live FalkorDB. |
 | `just fmt` / `just fmt-check` | Format Rust in place / check formatting. |
 | `just run -- <args>` | Run the benchmark binary (e.g. `just run -- --help`). |
 | `just ui-install` | `npm ci` in `ui/`. |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,8 +31,9 @@ Key recipes:
 | `just build` | Build all targets/features (the `build` CI gate). |
 | `just test` | Unit + integration tests (the `test` CI gate). |
 | `just test-one <filter>` | Run a single test by name filter. |
-| `just coverage` | Codecov JSON coverage via cargo-llvm-cov (the `coverage` CI job). |
-| `just coverage-html` | Open a browsable HTML coverage report locally. |
+| `just coverage` | Codecov JSON coverage via cargo-llvm-cov, including the `#[ignore]`d integration tests (the `coverage` CI job). Needs a reachable FalkorDB — set `FALKORDB_HOST`/`FALKORDB_PORT` or use `just coverage-local`. |
+| `just coverage-local` | Spin up a Docker FalkorDB, run `just coverage`, then tear it down. |
+| `just coverage-html` | Open a browsable HTML coverage report locally (also needs a FalkorDB). |
 | `just synthetic-bench` | Run the synthetic per-operation latency probe (needs a live FalkorDB). |
 | `just synthetic-ops` | List the synthetic operations. |
 | `just synthetic-it` | Run the synthetic integration test against a live FalkorDB. |
@@ -88,11 +89,15 @@ treat "the docs match the code" as part of the definition of done, not a follow-
 ## Coverage
 
 Write **as much test coverage as possible** — cover new code with unit tests and keep patch
-coverage high. Measure it with the exact CI command, **`just coverage`** (cargo-llvm-cov →
-`codecov.json`), not an ad-hoc line count; **`just coverage-html`** opens a browsable report.
+coverage high. **Patch coverage must be ≥ 90%** (enforced by Codecov via `codecov.yml`): any diff
+that drops below fails the `codecov/patch` check, so cover new lines before you push. Measure it
+with the exact CI command, **`just coverage`** (cargo-llvm-cov → `codecov.json`), not an ad-hoc
+line count; **`just coverage-html`** opens a browsable report. `just coverage` runs the
+`#[ignore]`d integration tests too (`--include-ignored`), so it needs a reachable FalkorDB — use
+**`just coverage-local`** to spin one up in Docker automatically (CI provides a FalkorDB service).
 Coverage is uploaded to Codecov by the `coverage` workflow (see `codecov.yml` for thresholds).
-Prefer testing real logic (parsing, query building, scheduling, aggregation) over I/O paths that
-would need a live database.
+Prefer testing real logic (parsing, query building, scheduling, aggregation) with unit tests, and
+cover server-backed paths with integration tests that run under coverage against that FalkorDB.
 
 ## Flaky tests are a hard no
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,18 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
+    # A FalkorDB service so `just coverage` can run the server-backed integration tests
+    # (`--include-ignored`) and measure those code paths.
+    services:
+      falkordb:
+        image: falkordb/falkordb:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -41,8 +53,12 @@ jobs:
         with:
           tool: just,cargo-llvm-cov
 
-      # Runs the same recipe developers run locally (see the Justfile).
+      # Runs the same recipe developers run locally (see the Justfile). FALKORDB_HOST/PORT point
+      # the integration tests at the service container above.
       - name: Generate code coverage
+        env:
+          FALKORDB_HOST: 127.0.0.1
+          FALKORDB_PORT: 6379
         run: just coverage
 
       - name: Upload coverage to Codecov

--- a/Justfile
+++ b/Justfile
@@ -89,6 +89,11 @@ run *args:
 # `just synthetic-bench --samples 1000 --op return_const`.
 # Run the synthetic single-operation latency probe (forwards args to `synthetic run`).
 synthetic-bench *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Drop an optional leading `--` so both `just synthetic-bench --samples 5` and
+    # `just synthetic-bench -- --samples 5` forward the flags to the probe (matches `just run`).
+    if [ "${1:-}" = "--" ]; then shift; fi
     cargo run --release --bin benchmark -- synthetic run "$@"
 
 # List the available synthetic operations.

--- a/Justfile
+++ b/Justfile
@@ -83,6 +83,23 @@ run *args:
     if [ "${1:-}" = "--" ]; then shift; fi
     cargo run --bin benchmark -- "$@"
 
+# === Synthetic per-operation benchmark =======================================
+
+# Needs a reachable FalkorDB, e.g. `docker run -d -p 6379:6379 falkordb/falkordb:latest`. Example:
+# `just synthetic-bench --samples 1000 --op return_const`.
+# Run the synthetic single-operation latency probe (forwards args to `synthetic run`).
+synthetic-bench *args:
+    cargo run --release --bin benchmark -- synthetic run "$@"
+
+# List the available synthetic operations.
+synthetic-ops:
+    cargo run --quiet --bin benchmark -- synthetic list-ops
+
+# FALKORDB_HOST/PORT select the server (default 127.0.0.1:6379); these `#[ignore]`d tests need one.
+# Run the synthetic integration test against a live FalkorDB.
+synthetic-it:
+    cargo test --test synthetic_probe -- --ignored --nocapture
+
 # === UI (Next.js dashboard in ui/) ===========================================
 
 # Install UI dependencies from the lockfile.

--- a/Justfile
+++ b/Justfile
@@ -65,12 +65,29 @@ test-one *args:
 # === Coverage ================================================================
 
 # Generate Codecov JSON coverage for the benchmark crate (matches the `coverage` CI job).
+# Runs unit tests AND the `#[ignore]`d integration tests (`--include-ignored`), so the
+# server-backed code paths are measured — this needs a reachable FalkorDB (see `coverage-local`,
+# or the coverage CI job's FalkorDB service). FALKORDB_HOST/FALKORDB_PORT select it (default
+# 127.0.0.1:6379).
 coverage:
-    cargo llvm-cov --package benchmark --all-features --codecov --output-path codecov.json
+    cargo llvm-cov --package benchmark --all-features --codecov --output-path codecov.json -- --include-ignored
 
-# Generate an HTML coverage report and open it in a browser.
+# Spin up a Docker FalkorDB, collect coverage, then tear it down (no manual server needed).
+coverage-local:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    docker rm -f falkordb-cov >/dev/null 2>&1 || true
+    docker run -d --name falkordb-cov -p 6379:6379 falkordb/falkordb:latest >/dev/null
+    trap 'docker rm -f falkordb-cov >/dev/null 2>&1 || true' EXIT
+    for i in $(seq 1 30); do
+        if docker exec falkordb-cov redis-cli ping >/dev/null 2>&1; then break; fi
+        sleep 1
+    done
+    just coverage
+
+# Generate an HTML coverage report and open it in a browser (needs a reachable FalkorDB too).
 coverage-html:
-    cargo llvm-cov --package benchmark --all-features --html --open
+    cargo llvm-cov --package benchmark --all-features --html --open -- --include-ignored
 
 # === Rust: run ===============================================================
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,9 +6,11 @@ coverage:
         threshold: 2%
     patch:
       default:
-        # New code should be well covered, but allow some slack for diffs that
-        # include inherently hard-to-unit-test paths (network/IO error branches).
-        threshold: 5%
+        # New code must be well covered: fail the patch check below 90% of changed
+        # lines. Server-backed paths are exercised by the coverage job's FalkorDB
+        # service (the integration tests run with `--include-ignored`).
+        target: 90%
+        threshold: 0%
 
 # The Next.js dashboard (ui/) and the vendored FalkorDB client (vendor/) are not
 # part of the Rust crate's unit tests, so they're excluded from coverage reporting.

--- a/readme.md
+++ b/readme.md
@@ -123,12 +123,19 @@ just ci               # everything the Rust CI runs: build + clippy + test
 ### Code coverage
 
 ```bash
-just coverage         # generate codecov.json via cargo-llvm-cov (as the coverage CI job does)
-just coverage-html    # open a browsable HTML coverage report
+just coverage-local   # spin up a Docker FalkorDB, generate codecov.json, tear it down
+just coverage         # generate codecov.json via cargo-llvm-cov (needs a reachable FalkorDB)
+just coverage-html    # open a browsable HTML coverage report (needs a reachable FalkorDB)
 ```
 
+`just coverage` runs the unit tests **and** the `#[ignore]`d integration tests
+(`--include-ignored`) so server-backed code is measured, so it needs a reachable FalkorDB — set
+`FALKORDB_HOST`/`FALKORDB_PORT`, or use `just coverage-local` to spin one up in Docker. The
+`coverage` CI job provides a FalkorDB service container.
+
 Coverage is uploaded to [Codecov](https://codecov.io/gh/FalkorDB/benchmark) by the `coverage`
-workflow. Please cover new code with tests and keep coverage high.
+workflow. Please cover new code with tests and keep coverage high — **patch coverage must stay
+≥ 90%** (enforced by `codecov.yml`).
 
 ### Synthetic per-operation benchmark (experimental)
 

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,18 @@ single-flight latency. This is the first slice of a larger tool (see the design 
 [`synthetic-benchmark.md`](synthetic-benchmark.md)); later parts add an operation catalog, a
 synthetic dataset, and a concurrency sweep.
 
+Each operation is measured under two plan-cache conditions so you can see the cost of expression
+**compilation** separately from execution:
+
+- **cached** — the plan is reused (warm cache), so only execution is measured;
+- **uncached** — every invocation is forced to miss the plan cache (a unique query-text token), so
+  it recompiles each time, exposing compilation cost.
+
+`compilation_ms ≈ uncached − cached` server time. (FalkorDB's `CACHE_SIZE` can't be set to `0` and
+is load-time only, so the uncached condition is produced client-side and verified via the response's
+`cached_execution` flag; the server's actual `CACHE_SIZE` is recorded in the report.) Use `--cache
+cached|uncached|both` (default `both`).
+
 Set up and run, start to end:
 
 ```bash
@@ -155,7 +167,7 @@ just synthetic-ops
 # 4. run the probe (records the exact server image so results are reproducible)
 IMAGE=$(docker inspect --format '{{index .RepoDigests 0}}' falkordb/falkordb:latest)
 just synthetic-bench --endpoint falkor://127.0.0.1:6379 \
-    --op return_const --samples 1000 --warmup 200 \
+    --op return_const --samples 1000 --warmup 200 --cache both \
     --server-image "$IMAGE" --out synthetic-report.json
 ```
 
@@ -163,21 +175,28 @@ Sample output:
 
 ```text
 synthetic benchmark — endpoint falkor://127.0.0.1:6379  samples 1000  warmup 200  connection pool(size=1)
-server — falkordb module ver 42001  redis 8.6.3
+server — falkordb module ver 42001  redis 8.6.3  CACHE_SIZE 25
 server image: falkordb/falkordb@sha256:9042fdc4...
 
 return_const
-  server_ms  median 0.017  mean 0.018  p99 0.030  (n=982, removed 18)
-  total_ms   median 0.397  mean 0.403  p99 0.519  (n=982, removed 18)
-  non_internal_ms (paired total-server)  median 0.379
-  cached_execution=false: 0.0%  (unknown 0)
+  [cached — plan reused, execution only]
+    server_ms  median 0.018  mean 0.019  p99 0.031  (n=983, removed 17)
+    total_ms   median 0.391  mean 0.397  p99 0.514  (n=983, removed 17)
+    non_internal_ms (paired total-server)  median 0.374
+    cached_execution=false: 0.0%  (unknown 0)
+  [uncached — plan-cache miss each run, execution + compilation]
+    server_ms  median 0.029  mean 0.030  p99 0.047  (n=977, removed 23)
+    total_ms   median 0.388  mean 0.392  p99 0.490  (n=977, removed 23)
+    non_internal_ms (paired total-server)  median 0.358
+    cached_execution=false: 100.0%  (unknown 0)
+  compilation_ms (median uncached-cached server time)  0.011
 report written to synthetic-report.json
 ```
 
 The report's `meta.server` block records the FalkorDB module version, `redis_version`/`build_id`,
-and the operator-supplied `--server-image` (FalkorDB does not expose a graph-module git SHA to
-clients, so the image digest is the reproducible build identity). A `:edge` image reports a
-`999999` placeholder version and the tool warns you to use a tagged image for comparisons.
+`CACHE_SIZE`, and the operator-supplied `--server-image` (FalkorDB does not expose a graph-module
+git SHA to clients, so the image digest is the reproducible build identity). A `:edge` image reports
+a `999999` placeholder version and the tool warns you to use a tagged image for comparisons.
 
 To run the integration test against a live server:
 

--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ Sample output:
 
 ```text
 synthetic benchmark — endpoint falkor://127.0.0.1:6379  samples 1000  warmup 200  connection pool(size=1)
-server — falkordb module ver 42001  redis 8.6.3  CACHE_SIZE 25
+server — falkordb module ver 4.20.1  redis 8.6.3  CACHE_SIZE 25
 server image: falkordb/falkordb@sha256:9042fdc4...
 
 return_const

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,61 @@ just coverage-html    # open a browsable HTML coverage report
 Coverage is uploaded to [Codecov](https://codecov.io/gh/FalkorDB/benchmark) by the `coverage`
 workflow. Please cover new code with tests and keep coverage high.
 
+### Synthetic per-operation benchmark (experimental)
+
+Measures a single Cypher operation **in isolation**, capturing on every invocation both the
+**server time** (FalkorDB's reported internal execution time) and the **total time** (end-to-end
+client round-trip), then summarizes them with severe-outlier removal (Tukey fences, like
+Criterion.rs) and writes a JSON report. It uses a single dedicated connection for honest
+single-flight latency. This is the first slice of a larger tool (see the design in
+[`synthetic-benchmark.md`](synthetic-benchmark.md)); later parts add an operation catalog, a
+synthetic dataset, and a concurrency sweep.
+
+Set up and run, start to end:
+
+```bash
+# 1. start a FalkorDB server (use a tagged image, not :edge, for meaningful version numbers)
+docker run -d --rm -p 6379:6379 falkordb/falkordb:latest
+
+# 2. build the tool (needs protoc; see Prerequisites)
+just build
+
+# 3. list the available operations
+just synthetic-ops
+
+# 4. run the probe (records the exact server image so results are reproducible)
+IMAGE=$(docker inspect --format '{{index .RepoDigests 0}}' falkordb/falkordb:latest)
+just synthetic-bench --endpoint falkor://127.0.0.1:6379 \
+    --op return_const --samples 1000 --warmup 200 \
+    --server-image "$IMAGE" --out synthetic-report.json
+```
+
+Sample output:
+
+```text
+synthetic benchmark — endpoint falkor://127.0.0.1:6379  samples 1000  warmup 200  connection pool(size=1)
+server — falkordb module ver 42001  redis 8.6.3
+server image: falkordb/falkordb@sha256:9042fdc4...
+
+return_const
+  server_ms  median 0.017  mean 0.018  p99 0.030  (n=983, removed 17)
+  total_ms   median 0.397  mean 0.403  p99 0.519  (n=982, removed 18)
+  non_internal_ms (paired total-server)  median 0.379
+  cached_execution=false: 0.0%  (unknown 0)
+report written to synthetic-report.json
+```
+
+The report's `meta.server` block records the FalkorDB module version, `redis_version`/`build_id`,
+and the operator-supplied `--server-image` (FalkorDB does not expose a graph-module git SHA to
+clients, so the image digest is the reproducible build identity). A `:edge` image reports a
+`999999` placeholder version and the tool warns you to use a tagged image for comparisons.
+
+To run the integration test against a live server:
+
+```bash
+just synthetic-it     # uses FALKORDB_HOST/FALKORDB_PORT, default 127.0.0.1:6379
+```
+
 ### UI dashboard (`ui/`)
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ server — falkordb module ver 42001  redis 8.6.3
 server image: falkordb/falkordb@sha256:9042fdc4...
 
 return_const
-  server_ms  median 0.017  mean 0.018  p99 0.030  (n=983, removed 17)
+  server_ms  median 0.017  mean 0.018  p99 0.030  (n=982, removed 18)
   total_ms   median 0.397  mean 0.403  p99 0.519  (n=982, removed 18)
   non_internal_ms (paired total-server)  median 0.379
   cached_execution=false: 0.0%  (unknown 0)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::queries_repository::QueryCoverageProfile;
 use crate::scenario::Vendor;
-use crate::synthetic::OpName;
+use crate::synthetic::{CacheSelection, OpName};
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
@@ -277,6 +277,13 @@ pub enum SyntheticCommands {
             help = "number of warm-up invocations (discarded)"
         )]
         warmup: usize,
+        #[arg(
+            long,
+            value_enum,
+            default_value = "both",
+            help = "plan-cache condition: cached (plan reused), uncached (recompiled each run), or both (compare + expose compilation cost)"
+        )]
+        cache: CacheSelection,
         #[arg(
             long,
             default_value_t = 5000,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::queries_repository::QueryCoverageProfile;
 use crate::scenario::Vendor;
+use crate::synthetic::OpName;
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
@@ -236,6 +237,73 @@ pub enum Commands {
         )]
         name: String,
     },
+
+    #[command(
+        about = "synthetic per-operation latency probe (measures server + total time in isolation)"
+    )]
+    Synthetic {
+        #[command(subcommand)]
+        command: SyntheticCommands,
+    },
+}
+
+/// Subcommands of `benchmark synthetic`.
+#[derive(Subcommand, Debug)]
+pub enum SyntheticCommands {
+    #[command(about = "run the single-operation latency probe")]
+    Run {
+        #[arg(
+            long,
+            default_value = "falkor://127.0.0.1:6379",
+            help = "FalkorDB endpoint (e.g., falkor://127.0.0.1:6379)"
+        )]
+        endpoint: String,
+        #[arg(
+            long,
+            value_enum,
+            default_value = "return_const",
+            help = "operation to measure"
+        )]
+        op: OpName,
+        #[arg(
+            long,
+            default_value_t = 1000,
+            help = "number of measured invocations"
+        )]
+        samples: usize,
+        #[arg(
+            long,
+            default_value_t = 200,
+            help = "number of warm-up invocations (discarded)"
+        )]
+        warmup: usize,
+        #[arg(
+            long,
+            default_value_t = 5000,
+            help = "FalkorDB server-side per-query timeout (ms)"
+        )]
+        server_timeout_ms: i64,
+        #[arg(
+            long,
+            default_value_t = 6000,
+            help = "client-side deadline per query (ms)"
+        )]
+        client_deadline_ms: u64,
+        #[arg(
+            long,
+            default_value = "synthetic-report.json",
+            help = "path to write the JSON report"
+        )]
+        out: String,
+        #[arg(
+            long,
+            env = "FALKOR_SERVER_IMAGE",
+            help = "operator-supplied server image identity (e.g. falkordb/falkordb:v4.2.1@sha256:...), recorded verbatim"
+        )]
+        server_image: Option<String>,
+    },
+    #[command(about = "list the available operations")]
+    ListOps,
 }
 
 fn parse_write_ratio(val: &str) -> Result<f32, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod queries_repository;
 pub mod query;
 pub mod scenario;
 pub mod scheduler;
+pub mod synthetic;
 pub mod utils;
 
 pub(crate) const REDIS_DATA_DIR: &str = "./redis-data";

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,6 +349,7 @@ async fn main() -> BenchmarkResult<()> {
                 op,
                 samples,
                 warmup,
+                cache,
                 server_timeout_ms,
                 client_deadline_ms,
                 out,
@@ -361,6 +362,7 @@ async fn main() -> BenchmarkResult<()> {
                     warmup,
                     server_timeout_ms,
                     client_deadline_ms,
+                    cache,
                     out,
                     server_image,
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,6 +342,34 @@ async fn main() -> BenchmarkResult<()> {
             // Lightweight debug helper: run each Memgraph query type once and report failures.
             debug_memgraph_queries(dataset, endpoint, name).await?;
         }
+
+        Commands::Synthetic { command } => match command {
+            benchmark::cli::SyntheticCommands::Run {
+                endpoint,
+                op,
+                samples,
+                warmup,
+                server_timeout_ms,
+                client_deadline_ms,
+                out,
+                server_image,
+            } => {
+                let config = benchmark::synthetic::Config {
+                    endpoint,
+                    op,
+                    samples,
+                    warmup,
+                    server_timeout_ms,
+                    client_deadline_ms,
+                    out,
+                    server_image,
+                };
+                benchmark::synthetic::run_and_report(&config).await?;
+            }
+            benchmark::cli::SyntheticCommands::ListOps => {
+                print!("{}", benchmark::synthetic::list_ops());
+            }
+        },
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,35 +343,9 @@ async fn main() -> BenchmarkResult<()> {
             debug_memgraph_queries(dataset, endpoint, name).await?;
         }
 
-        Commands::Synthetic { command } => match command {
-            benchmark::cli::SyntheticCommands::Run {
-                endpoint,
-                op,
-                samples,
-                warmup,
-                cache,
-                server_timeout_ms,
-                client_deadline_ms,
-                out,
-                server_image,
-            } => {
-                let config = benchmark::synthetic::Config {
-                    endpoint,
-                    op,
-                    samples,
-                    warmup,
-                    server_timeout_ms,
-                    client_deadline_ms,
-                    cache,
-                    out,
-                    server_image,
-                };
-                benchmark::synthetic::run_and_report(&config).await?;
-            }
-            benchmark::cli::SyntheticCommands::ListOps => {
-                print!("{}", benchmark::synthetic::list_ops());
-            }
-        },
+        Commands::Synthetic { command } => {
+            benchmark::synthetic::run_command(command).await?;
+        }
     }
     Ok(())
 }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -159,6 +159,8 @@ pub fn list_ops() -> String {
 
 /// Strip any password from an endpoint before it is recorded in the report or printed, so
 /// credentials passed in a `falkor://user:pass@host` URL never leak into `synthetic-report.json`.
+/// If the endpoint can't be parsed as a URL it's replaced with a placeholder (rather than echoed
+/// verbatim, which could still contain credentials).
 fn redact_endpoint(endpoint: &str) -> String {
     match url::Url::parse(endpoint) {
         Ok(mut url) => {
@@ -167,7 +169,7 @@ fn redact_endpoint(endpoint: &str) -> String {
             }
             url.to_string()
         }
-        Err(_) => endpoint.to_string(),
+        Err(_) => "<unparseable-endpoint>".to_string(),
     }
 }
 
@@ -175,6 +177,10 @@ fn redact_endpoint(endpoint: &str) -> String {
 /// build the [`Report`]. Writing the report to disk is the caller's responsibility (see
 /// [`run_and_report`]).
 pub async fn run(config: &Config) -> BenchmarkResult<Report> {
+    if config.samples == 0 {
+        return Err(OtherError("samples must be greater than 0".to_string()));
+    }
+
     let started_at_epoch_secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -524,5 +530,7 @@ mod tests {
         // No credentials → unchanged (modulo url normalization).
         assert!(redact_endpoint("falkor://127.0.0.1:6379").contains("127.0.0.1:6379"));
         assert!(!redact_endpoint("falkor://user:secret@host:6379").contains("secret"));
+        // Unparseable input is replaced with a placeholder, never echoed verbatim.
+        assert_eq!(redact_endpoint("not a url"), "<unparseable-endpoint>");
     }
 }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -55,8 +55,10 @@ impl OpName {
         }
     }
 
-    /// Build the query for invocation `i` (parameterized; content varies so we don't measure a
-    /// single trivially-cached literal).
+    /// Build the query for invocation `i`: a parameterized query whose body is constant but whose
+    /// parameter *value* varies with `i`, so we exercise real parameter binding rather than a
+    /// single frozen literal (while the constant body still lets the plan cache work — see
+    /// [`Self::render_cypher`]).
     pub fn build_query(
         self,
         i: usize,
@@ -74,11 +76,14 @@ impl OpName {
 
     /// Render the Cypher string for invocation `i` in the given cache mode.
     ///
-    /// In [`CacheMode::Uncached`] a unique trailing comment (`/* co<i> */`) is appended so every
-    /// invocation is a distinct plan-cache key — forcing FalkorDB to recompile the query each time
-    /// (verified via the response's `cached_execution` flag), which exposes expression-compilation
-    /// cost. In [`CacheMode::Cached`] the text is identical every time, so after warm-up the plan
-    /// is reused and only execution is measured.
+    /// FalkorDB keys its plan cache on the query **body** — the text after the `CYPHER <params>`
+    /// prefix that [`Query::to_cypher`] emits — so varying only a parameter *value* still hits the
+    /// cache. In [`CacheMode::Cached`] the body (`RETURN $i AS x`) is therefore identical every
+    /// invocation (only the stripped `CYPHER i = <n>` prefix changes), so after warm-up the plan is
+    /// reused and only execution is measured. In [`CacheMode::Uncached`] a unique trailing comment
+    /// (`/* co<i> */`) is appended to the body, making every invocation a distinct cache key and
+    /// forcing FalkorDB to recompile each time (verified via the response's `cached_execution`
+    /// flag), which exposes expression-compilation cost.
     pub fn render_cypher(
         self,
         i: usize,
@@ -96,9 +101,11 @@ impl OpName {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "snake_case")]
 pub enum CacheSelection {
-    /// Warm plan cache: identical query text, plan reused → execution only.
+    /// Warm plan cache: identical query **body** every run (only the stripped `CYPHER <params>`
+    /// prefix varies), so the plan is reused → execution only.
     Cached,
-    /// Forced plan-cache miss every run (unique query text) → execution + compilation.
+    /// Forced plan-cache miss every run (a unique comment makes each query body distinct) →
+    /// execution + compilation.
     Uncached,
     /// Measure both and report the derived compilation cost (default).
     Both,
@@ -176,7 +183,7 @@ fn redact_endpoint(endpoint: &str) -> String {
     }
 }
 
-/// Open a single-connection [`AsyncGraph`] handle for `endpoint` on graph `graph_name`.
+/// Open a single-connection [`falkordb::AsyncGraph`] handle for `endpoint` on graph `graph_name`.
 ///
 /// Uses a one-socket pool so latency is honest single-flight (the client otherwise defaults to 8
 /// multiplexed sockets). A malformed `endpoint` is reported as an error with credentials redacted.
@@ -432,7 +439,8 @@ pub async fn run_and_report(config: &Config) -> BenchmarkResult<()> {
 }
 
 /// Execute a parsed `synthetic` subcommand. This keeps `main.rs` a thin shell: it maps the CLI
-/// [`SyntheticCommands`] onto a [`Config`] and runs the probe, or prints the operation catalog.
+/// [`crate::cli::SyntheticCommands`] onto a [`Config`] and runs the probe, or prints the operation
+/// catalog.
 pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkResult<()> {
     match command {
         crate::cli::SyntheticCommands::Run {

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -68,6 +68,54 @@ impl OpName {
                 .build(),
         }
     }
+
+    /// Render the Cypher string for invocation `i` in the given cache mode.
+    ///
+    /// In [`CacheMode::Uncached`] a unique trailing comment (`/* co<i> */`) is appended so every
+    /// invocation is a distinct plan-cache key — forcing FalkorDB to recompile the query each time
+    /// (verified via the response's `cached_execution` flag), which exposes expression-compilation
+    /// cost. In [`CacheMode::Cached`] the text is identical every time, so after warm-up the plan
+    /// is reused and only execution is measured.
+    pub fn render_cypher(
+        self,
+        i: usize,
+        mode: CacheMode,
+    ) -> String {
+        let base = self.build_query(i).to_cypher();
+        match mode {
+            CacheMode::Cached => base,
+            CacheMode::Uncached => format!("{} /* co{} */", base, i),
+        }
+    }
+}
+
+/// Which plan-cache condition to measure an operation under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "snake_case")]
+pub enum CacheSelection {
+    /// Warm plan cache: identical query text, plan reused → execution only.
+    Cached,
+    /// Forced plan-cache miss every run (unique query text) → execution + compilation.
+    Uncached,
+    /// Measure both and report the derived compilation cost (default).
+    Both,
+}
+
+impl CacheSelection {
+    fn modes(self) -> &'static [CacheMode] {
+        match self {
+            CacheSelection::Cached => &[CacheMode::Cached],
+            CacheSelection::Uncached => &[CacheMode::Uncached],
+            CacheSelection::Both => &[CacheMode::Cached, CacheMode::Uncached],
+        }
+    }
+}
+
+/// A single plan-cache condition (one element of a [`CacheSelection`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheMode {
+    Cached,
+    Uncached,
 }
 
 /// Configuration for a single-operation probe run.
@@ -79,6 +127,7 @@ pub struct Config {
     pub warmup: usize,
     pub server_timeout_ms: i64,
     pub client_deadline_ms: u64,
+    pub cache: CacheSelection,
     pub out: String,
     pub server_image: Option<String>,
 }
@@ -92,6 +141,7 @@ impl Default for Config {
             warmup: 200,
             server_timeout_ms: 5_000,
             client_deadline_ms: 6_000,
+            cache: CacheSelection::Both,
             out: "synthetic-report.json".to_string(),
             server_image: None,
         }
@@ -170,8 +220,9 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
 
     // Ensure the graph key exists: a read (`RO_QUERY`) against a never-written graph fails with
     // "Invalid graph operation on empty key". Probe with a read first and only write to
-    // instantiate it when absent, so a read-only replica whose graph already exists still works.
-    // Both are bounded by the client deadline so a stuck socket can't hang setup.
+    // instantiate the graph when the error is exactly that empty-key condition — so a read-only
+    // replica whose graph already exists still works, and any other error (auth/network) is
+    // surfaced rather than masked. Both are bounded by the client deadline.
     let probe = tokio::time::timeout(
         client_deadline,
         graph
@@ -179,50 +230,57 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             .with_timeout(config.server_timeout_ms)
             .execute(),
     )
-    .await;
-    let needs_instantiation = !matches!(probe, Ok(Ok(_)));
-    if needs_instantiation {
-        tokio::time::timeout(
-            client_deadline,
-            graph
-                .query("RETURN 1")
-                .with_timeout(config.server_timeout_ms)
-                .execute(),
-        )
-        .await
-        .map_err(|e| OtherError(format!("graph 'falkor' instantiation timed out: {}", e)))?
-        .map_err(|e| OtherError(format!("failed to instantiate graph 'falkor': {:?}", e)))?;
+    .await
+    .map_err(|e| OtherError(format!("graph 'falkor' readiness probe timed out: {}", e)))?;
+    match probe {
+        Ok(_) => {}
+        Err(e) => {
+            let msg = format!("{:?}", e);
+            if is_empty_graph_key(&msg) {
+                tokio::time::timeout(
+                    client_deadline,
+                    graph
+                        .query("RETURN 1")
+                        .with_timeout(config.server_timeout_ms)
+                        .execute(),
+                )
+                .await
+                .map_err(|e| OtherError(format!("graph 'falkor' instantiation timed out: {}", e)))?
+                .map_err(|e| {
+                    OtherError(format!("failed to instantiate graph 'falkor': {:?}", e))
+                })?;
+            } else {
+                return Err(OtherError(format!(
+                    "graph 'falkor' readiness probe failed: {}",
+                    msg
+                )));
+            }
+        }
     }
 
-    // Warm-up (discarded) primes the plan cache and connection.
-    for i in 0..config.warmup {
-        let q = config.op.build_query(i);
-        let _ = run_and_drain(
-            &mut graph,
-            config.op.kind(),
-            &q,
-            config.server_timeout_ms,
-            client_deadline,
-        )
-        .await?;
+    // Measure the operation under each requested plan-cache condition.
+    let mut cached_set: Option<crate::synthetic::report::MetricSet> = None;
+    let mut uncached_set: Option<crate::synthetic::report::MetricSet> = None;
+    for &mode in config.cache.modes() {
+        let set = measure_mode(&mut graph, config, mode, client_deadline).await?;
+        match mode {
+            CacheMode::Cached => cached_set = Some(set),
+            CacheMode::Uncached => uncached_set = Some(set),
+        }
     }
 
-    // Measurement.
-    let mut samples: Vec<OpSample> = Vec::with_capacity(config.samples);
-    for i in 0..config.samples {
-        let q = config.op.build_query(config.warmup + i);
-        let sample = run_and_drain(
-            &mut graph,
-            config.op.kind(),
-            &q,
-            config.server_timeout_ms,
-            client_deadline,
-        )
-        .await?;
-        samples.push(sample);
-    }
+    // Derived expression-compilation cost: how much slower an uncached (recompiled) run's server
+    // time is than a cached (plan-reused) one.
+    let compilation_ms_median = match (&cached_set, &uncached_set) {
+        (Some(c), Some(u)) => Some(u.server_ms.median - c.server_ms.median),
+        _ => None,
+    };
 
-    let op_report = summarize_samples(&samples)?;
+    let op_report = OperationReport {
+        cached: cached_set,
+        uncached: uncached_set,
+        compilation_ms_median,
+    };
     let mut operations = BTreeMap::new();
     operations.insert(config.op.as_str().to_string(), op_report);
 
@@ -242,14 +300,57 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     })
 }
 
-/// Summarize a set of paired samples into an [`OperationReport`].
+/// Whether a query error string is FalkorDB's "graph key does not exist yet" condition.
+fn is_empty_graph_key(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("empty key") || m.contains("invalid graph operation")
+}
+
+/// Warm up then measure `config.samples` invocations of `config.op` in one cache mode.
+async fn measure_mode(
+    graph: &mut falkordb::AsyncGraph,
+    config: &Config,
+    mode: CacheMode,
+    client_deadline: Duration,
+) -> BenchmarkResult<crate::synthetic::report::MetricSet> {
+    // Warm-up (discarded) primes the plan cache (cached mode) and the connection.
+    for i in 0..config.warmup {
+        let cypher = config.op.render_cypher(i, mode);
+        let _ = run_and_drain(
+            graph,
+            config.op.kind(),
+            &cypher,
+            config.server_timeout_ms,
+            client_deadline,
+        )
+        .await?;
+    }
+
+    let mut samples: Vec<OpSample> = Vec::with_capacity(config.samples);
+    for i in 0..config.samples {
+        let cypher = config.op.render_cypher(config.warmup + i, mode);
+        let sample = run_and_drain(
+            graph,
+            config.op.kind(),
+            &cypher,
+            config.server_timeout_ms,
+            client_deadline,
+        )
+        .await?;
+        samples.push(sample);
+    }
+
+    summarize_samples(&samples)
+}
+
+/// Summarize a set of paired samples into a [`MetricSet`].
 ///
 /// Outlier removal is *paired*: a sample is dropped if it is a severe outlier in **either**
 /// `server_ms` or `total_ms`, and all three summaries (server, total, and the paired residual) are
 /// computed over that single shared retained cohort. This keeps their sample counts identical and
 /// preserves the invariant that, since every raw pair has `total >= server`, the retained
-/// aggregates do too.
-fn summarize_samples(samples: &[OpSample]) -> BenchmarkResult<OperationReport> {
+/// aggregates do too. Cache-health stats are computed over the same retained cohort.
+fn summarize_samples(samples: &[OpSample]) -> BenchmarkResult<crate::synthetic::report::MetricSet> {
     let server: Vec<f64> = samples.iter().map(|s| s.server_ms).collect();
     let total: Vec<f64> = samples.iter().map(|s| s.total_ms).collect();
 
@@ -277,15 +378,16 @@ fn summarize_samples(samples: &[OpSample]) -> BenchmarkResult<OperationReport> {
     let non_internal_ms = stats::summarize_kept(&kept_residual, removed)
         .ok_or_else(|| OtherError("no non_internal_ms samples to summarize".to_string()))?;
 
-    let cached_unknown = samples.iter().filter(|s| s.cached.is_none()).count();
-    let known: Vec<bool> = samples.iter().filter_map(|s| s.cached).collect();
+    // Cache health over the same retained cohort (not the raw samples).
+    let cached_unknown = kept.iter().filter(|s| s.cached.is_none()).count();
+    let known: Vec<bool> = kept.iter().filter_map(|s| s.cached).collect();
     let cached_false_rate = if known.is_empty() {
         0.0
     } else {
         known.iter().filter(|&&c| !c).count() as f64 / known.len() as f64
     };
 
-    Ok(OperationReport {
+    Ok(crate::synthetic::report::MetricSet {
         server_ms,
         total_ms,
         non_internal_ms,
@@ -327,6 +429,46 @@ mod tests {
         assert_eq!(q0.params.len(), 1);
         // Different invocation index ⇒ different parameter value.
         assert_ne!(q0.params.get("i"), q1.params.get("i"));
+    }
+
+    #[test]
+    fn uncached_render_is_unique_per_invocation_cached_is_stable() {
+        // Cached mode: no per-invocation uniqueness token, so FalkorDB caches by the parameterized
+        // query body (it strips the leading `CYPHER <params>` prefix from the cache key), and the
+        // plan is reused across invocations.
+        let c0 = OpName::ReturnConst.render_cypher(0, CacheMode::Cached);
+        let c1 = OpName::ReturnConst.render_cypher(1, CacheMode::Cached);
+        assert!(!c0.contains("/* co"));
+        assert!(!c1.contains("/* co"));
+        assert!(c0.contains("RETURN $i AS x"));
+        assert!(c1.contains("RETURN $i AS x"));
+
+        // Uncached mode: a unique trailing token per `i` ⇒ distinct plan-cache key each run.
+        let u0 = OpName::ReturnConst.render_cypher(0, CacheMode::Uncached);
+        let u1 = OpName::ReturnConst.render_cypher(1, CacheMode::Uncached);
+        assert_ne!(u0, u1);
+        assert!(u0.contains("/* co0 */"));
+        assert!(u1.contains("/* co1 */"));
+    }
+
+    #[test]
+    fn cache_selection_expands_to_modes() {
+        assert_eq!(CacheSelection::Cached.modes(), &[CacheMode::Cached]);
+        assert_eq!(CacheSelection::Uncached.modes(), &[CacheMode::Uncached]);
+        assert_eq!(
+            CacheSelection::Both.modes(),
+            &[CacheMode::Cached, CacheMode::Uncached]
+        );
+    }
+
+    #[test]
+    fn empty_graph_key_detection() {
+        assert!(is_empty_graph_key("Invalid graph operation on empty key"));
+        assert!(is_empty_graph_key(
+            "RedisError(\"Invalid graph operation on empty key\")"
+        ));
+        assert!(!is_empty_graph_key("Password authentication failed"));
+        assert!(!is_empty_graph_key("connection refused"));
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -176,6 +176,32 @@ fn redact_endpoint(endpoint: &str) -> String {
     }
 }
 
+/// Open a single-connection [`AsyncGraph`] handle for `endpoint` on graph `graph_name`.
+///
+/// Uses a one-socket pool so latency is honest single-flight (the client otherwise defaults to 8
+/// multiplexed sockets). A malformed `endpoint` is reported as an error with credentials redacted.
+pub async fn open_graph(
+    endpoint: &str,
+    graph_name: &str,
+) -> BenchmarkResult<falkordb::AsyncGraph> {
+    let connection_info = endpoint.try_into().map_err(|e| {
+        OtherError(format!(
+            "invalid endpoint '{}': {:?}",
+            redact_endpoint(endpoint),
+            e
+        ))
+    })?;
+
+    let client = FalkorClientBuilder::new_async()
+        .with_connection_info(connection_info)
+        .with_connection_strategy(ConnectionStrategy::Pooled {
+            size: nonzero::nonzero!(1u8),
+        })
+        .build()
+        .await?;
+    Ok(client.select_graph(graph_name))
+}
+
 /// Run the probe: connect (single connection), collect server provenance, warm up, measure, then
 /// build the [`Report`]. Writing the report to disk is the caller's responsibility (see
 /// [`run_and_report`]).
@@ -189,28 +215,8 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         .map(|d| d.as_secs())
         .unwrap_or(0);
 
-    let connection_info = config
-        .endpoint
-        .as_str()
-        .try_into()
-        .map_err(|e| {
-            OtherError(format!(
-                "invalid endpoint '{}': {:?}",
-                redact_endpoint(&config.endpoint),
-                e
-            ))
-        })?;
-
-    // A single dedicated connection: honest single-flight latency (the client otherwise defaults
-    // to 8 multiplexed sockets).
-    let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
-        .with_connection_strategy(ConnectionStrategy::Pooled {
-            size: nonzero::nonzero!(1u8),
-        })
-        .build()
-        .await?;
-    let mut graph = client.select_graph("falkor");
+    // A single dedicated connection: honest single-flight latency.
+    let mut graph = open_graph(&config.endpoint, "falkor").await?;
 
     // Server provenance (best-effort: log and continue on failure).
     let redis_url = falkor_endpoint_to_redis_url(Some(&config.endpoint));
@@ -425,6 +431,41 @@ pub async fn run_and_report(config: &Config) -> BenchmarkResult<()> {
     Ok(())
 }
 
+/// Execute a parsed `synthetic` subcommand. This keeps `main.rs` a thin shell: it maps the CLI
+/// [`SyntheticCommands`] onto a [`Config`] and runs the probe, or prints the operation catalog.
+pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkResult<()> {
+    match command {
+        crate::cli::SyntheticCommands::Run {
+            endpoint,
+            op,
+            samples,
+            warmup,
+            cache,
+            server_timeout_ms,
+            client_deadline_ms,
+            out,
+            server_image,
+        } => {
+            let config = Config {
+                endpoint,
+                op,
+                samples,
+                warmup,
+                server_timeout_ms,
+                client_deadline_ms,
+                cache,
+                out,
+                server_image,
+            };
+            run_and_report(&config).await
+        }
+        crate::cli::SyntheticCommands::ListOps => {
+            print!("{}", list_ops());
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -486,6 +527,54 @@ mod tests {
         assert!(!is_empty_graph_key("connection refused"));
     }
 
+    #[tokio::test]
+    async fn run_rejects_zero_samples() {
+        // Guarded before any network use, so this needs no server.
+        let config = Config {
+            samples: 0,
+            ..Config::default()
+        };
+        assert!(run(&config).await.is_err());
+        assert!(run_and_report(&config).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_rejects_malformed_endpoint() {
+        // A connection string that fails to parse errors at `try_into`, before any network use,
+        // so this needs no server.
+        let config = Config {
+            endpoint: "falkor://host:notaport".to_string(),
+            samples: 10,
+            ..Config::default()
+        };
+        assert!(run(&config).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_command_list_ops_needs_no_server() {
+        // The catalog path is pure output.
+        assert!(run_command(crate::cli::SyntheticCommands::ListOps)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_command_run_maps_args_and_validates() {
+        // Exercises the CLI→Config mapping without a server: samples==0 is rejected up front.
+        let command = crate::cli::SyntheticCommands::Run {
+            endpoint: "falkor://127.0.0.1:6379".to_string(),
+            op: OpName::ReturnConst,
+            samples: 0,
+            warmup: 0,
+            cache: CacheSelection::Both,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: "unused.json".to_string(),
+            server_image: None,
+        };
+        assert!(run_command(command).await.is_err());
+    }
+
     #[test]
     fn list_ops_mentions_each_op() {
         let listing = list_ops();
@@ -528,6 +617,22 @@ mod tests {
         assert_eq!(r.total_ms.n, r.non_internal_ms.n);
         assert_eq!(r.total_ms.removed, 1);
         assert!(r.total_ms.median >= r.server_ms.median);
+    }
+
+    #[test]
+    fn summarize_samples_tiny_all_unknown_cache() {
+        // A tiny sample set: `severe_fence` returns None (nothing removed → the `within` no-fence
+        // path), and with every `cached` unknown the false-rate collapses to 0.0.
+        let samples = vec![
+            OpSample { server_ms: 0.10, total_ms: 0.40, rows: 1, cached: None },
+            OpSample { server_ms: 0.12, total_ms: 0.45, rows: 1, cached: None },
+            OpSample { server_ms: 0.11, total_ms: 0.42, rows: 1, cached: None },
+        ];
+        let r = summarize_samples(&samples).unwrap();
+        assert_eq!(r.server_ms.n, 3);
+        assert_eq!(r.server_ms.removed, 0);
+        assert_eq!(r.cached_unknown, 3);
+        assert_eq!(r.cached_false_rate, 0.0);
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -190,7 +190,13 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         .endpoint
         .as_str()
         .try_into()
-        .map_err(|e| OtherError(format!("invalid endpoint '{}': {:?}", config.endpoint, e)))?;
+        .map_err(|e| {
+            OtherError(format!(
+                "invalid endpoint '{}': {:?}",
+                redact_endpoint(&config.endpoint),
+                e
+            ))
+        })?;
 
     // A single dedicated connection: honest single-flight latency (the client otherwise defaults
     // to 8 multiplexed sockets).

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1,0 +1,303 @@
+//! Synthetic per-operation benchmark — Part 1: a single-operation latency probe.
+//!
+//! Measures one Cypher operation in isolation against a FalkorDB endpoint, capturing on every
+//! invocation the paired *server time* (FalkorDB's reported internal execution time) and *total
+//! time* (end-to-end client round-trip), then summarizes them with severe-outlier removal and
+//! writes a JSON report + console summary. This is the foundation the rest of the epic builds on.
+
+pub mod op_runner;
+pub mod provenance;
+pub mod report;
+pub mod stats;
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::falkor::falkor_endpoint_to_redis_url;
+use crate::query::{Query, QueryBuilder};
+use crate::queries_repository::QueryType;
+use crate::synthetic::op_runner::{run_and_drain, OpSample};
+use crate::synthetic::report::{Meta, OperationReport, Report};
+use clap::ValueEnum;
+use falkordb::{ConnectionStrategy, FalkorClientBuilder};
+use std::collections::BTreeMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{info, warn};
+
+/// The set of operations the probe can run. Part 1 ships a single dataset-free baseline; later
+/// parts extend this enum and the catalog together (it stays the single source of truth so
+/// `--help`, shell completion and the catalog never drift).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "snake_case")]
+pub enum OpName {
+    /// `RETURN $i` — a pure round-trip / server parse+exec baseline that needs no dataset.
+    ReturnConst,
+}
+
+impl OpName {
+    /// The stable string id used in reports and on the CLI.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            OpName::ReturnConst => "return_const",
+        }
+    }
+
+    /// Whether this operation reads or writes (selects `RO_QUERY` vs `QUERY`).
+    pub fn kind(self) -> QueryType {
+        match self {
+            OpName::ReturnConst => QueryType::Read,
+        }
+    }
+
+    /// A one-line description for `list-ops`.
+    pub fn description(self) -> &'static str {
+        match self {
+            OpName::ReturnConst => "RETURN $i — pure round-trip baseline (no dataset required)",
+        }
+    }
+
+    /// Build the query for invocation `i` (parameterized; content varies so we don't measure a
+    /// single trivially-cached literal).
+    pub fn build_query(
+        self,
+        i: usize,
+    ) -> Query {
+        match self {
+            OpName::ReturnConst => QueryBuilder::new()
+                .text("RETURN $i AS x")
+                .param("i", i as i32)
+                .build(),
+        }
+    }
+}
+
+/// Configuration for a single-operation probe run.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub endpoint: String,
+    pub op: OpName,
+    pub samples: usize,
+    pub warmup: usize,
+    pub server_timeout_ms: i64,
+    pub client_deadline_ms: u64,
+    pub out: String,
+    pub server_image: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            endpoint: "falkor://127.0.0.1:6379".to_string(),
+            op: OpName::ReturnConst,
+            samples: 1000,
+            warmup: 200,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: "synthetic-report.json".to_string(),
+            server_image: None,
+        }
+    }
+}
+
+/// Print the available operations (for `synthetic list-ops`).
+pub fn list_ops() -> String {
+    let mut out = String::from("Available operations:\n");
+    for op in OpName::value_variants() {
+        out.push_str(&format!("  {:<16} {}\n", op.as_str(), op.description()));
+    }
+    out
+}
+
+/// Run the probe: connect (single connection), collect server provenance, warm up, measure, then
+/// build the [`Report`]. Writing the report to disk is the caller's responsibility (see
+/// [`run_and_report`]).
+pub async fn run(config: &Config) -> BenchmarkResult<Report> {
+    let connection_info = config
+        .endpoint
+        .as_str()
+        .try_into()
+        .map_err(|e| OtherError(format!("invalid endpoint '{}': {:?}", config.endpoint, e)))?;
+
+    // A single dedicated connection: honest single-flight latency (the client otherwise defaults
+    // to 8 multiplexed sockets).
+    let client = FalkorClientBuilder::new_async()
+        .with_connection_info(connection_info)
+        .with_connection_strategy(ConnectionStrategy::Pooled {
+            size: nonzero::nonzero!(1u8),
+        })
+        .build()
+        .await?;
+    let mut graph = client.select_graph("falkor");
+
+    // Server provenance (best-effort: log and continue on failure).
+    let redis_url = falkor_endpoint_to_redis_url(Some(&config.endpoint));
+    let server = match provenance::collect(&redis_url, config.server_image.clone()).await {
+        Ok(info) => info,
+        Err(e) => {
+            warn!("could not collect server provenance: {}", e);
+            crate::synthetic::report::ServerInfo {
+                server_image: config.server_image.clone(),
+                ..Default::default()
+            }
+        }
+    };
+    if server.is_placeholder() {
+        warn!(
+            "FalkorDB module version is the {} dev placeholder — use a tagged image for version comparisons",
+            crate::synthetic::report::ServerInfo::PLACEHOLDER_VER
+        );
+    }
+
+    let client_deadline = Duration::from_millis(config.client_deadline_ms);
+
+    // Ensure the graph key exists: a read (`RO_QUERY`) against a never-written graph fails with
+    // "Invalid graph operation on empty key", so instantiate it once with a trivial write.
+    graph
+        .query("RETURN 1")
+        .with_timeout(config.server_timeout_ms)
+        .execute()
+        .await
+        .map_err(|e| OtherError(format!("failed to instantiate graph 'falkor': {:?}", e)))?;
+
+    // Warm-up (discarded) primes the plan cache and connection.
+    for i in 0..config.warmup {
+        let q = config.op.build_query(i);
+        let _ = run_and_drain(
+            &mut graph,
+            config.op.kind(),
+            &q,
+            config.server_timeout_ms,
+            client_deadline,
+        )
+        .await?;
+    }
+
+    // Measurement.
+    let mut samples: Vec<OpSample> = Vec::with_capacity(config.samples);
+    for i in 0..config.samples {
+        let q = config.op.build_query(config.warmup + i);
+        let sample = run_and_drain(
+            &mut graph,
+            config.op.kind(),
+            &q,
+            config.server_timeout_ms,
+            client_deadline,
+        )
+        .await?;
+        samples.push(sample);
+    }
+
+    let op_report = summarize_samples(&samples)?;
+    let mut operations = BTreeMap::new();
+    operations.insert(config.op.as_str().to_string(), op_report);
+
+    let started_at_epoch_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    Ok(Report {
+        meta: Meta {
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            endpoint: config.endpoint.clone(),
+            samples: config.samples,
+            warmup: config.warmup,
+            server_timeout_ms: config.server_timeout_ms,
+            client_deadline_ms: config.client_deadline_ms,
+            connection: "pool(size=1)".to_string(),
+            started_at_epoch_secs,
+            server,
+        },
+        operations,
+    })
+}
+
+/// Summarize a set of paired samples into an [`OperationReport`].
+fn summarize_samples(samples: &[OpSample]) -> BenchmarkResult<OperationReport> {
+    let server: Vec<f64> = samples.iter().map(|s| s.server_ms).collect();
+    let total: Vec<f64> = samples.iter().map(|s| s.total_ms).collect();
+    let non_internal: Vec<f64> = samples.iter().map(|s| s.total_ms - s.server_ms).collect();
+
+    let server_ms = stats::summarize(&server)
+        .ok_or_else(|| OtherError("no server_ms samples to summarize".to_string()))?;
+    let total_ms = stats::summarize(&total)
+        .ok_or_else(|| OtherError("no total_ms samples to summarize".to_string()))?;
+    let non_internal_ms = stats::summarize(&non_internal)
+        .ok_or_else(|| OtherError("no non_internal_ms samples to summarize".to_string()))?;
+
+    let cached_unknown = samples.iter().filter(|s| s.cached.is_none()).count();
+    let known: Vec<bool> = samples.iter().filter_map(|s| s.cached).collect();
+    let cached_false_rate = if known.is_empty() {
+        0.0
+    } else {
+        known.iter().filter(|&&c| !c).count() as f64 / known.len() as f64
+    };
+
+    Ok(OperationReport {
+        server_ms,
+        total_ms,
+        non_internal_ms,
+        cached_false_rate,
+        cached_unknown,
+    })
+}
+
+/// Run the probe, print the console summary, and write the JSON report to `config.out`.
+pub async fn run_and_report(config: &Config) -> BenchmarkResult<()> {
+    if config.samples == 0 {
+        return Err(OtherError("--samples must be greater than 0".to_string()));
+    }
+    let report = run(config).await?;
+    println!("{}", report.to_console());
+    let json = report.to_json()?;
+    tokio::fs::write(&config.out, json).await?;
+    info!("wrote {}", config.out);
+    println!("report written to {}", config.out);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn op_name_maps_are_consistent() {
+        assert_eq!(OpName::ReturnConst.as_str(), "return_const");
+        assert_eq!(OpName::ReturnConst.kind(), QueryType::Read);
+        assert!(!OpName::ReturnConst.description().is_empty());
+    }
+
+    #[test]
+    fn build_query_is_parameterized_and_varies() {
+        let q0 = OpName::ReturnConst.build_query(0);
+        let q1 = OpName::ReturnConst.build_query(1);
+        assert!(q0.text.contains("$i"));
+        assert_eq!(q0.params.len(), 1);
+        // Different invocation index ⇒ different parameter value.
+        assert_ne!(q0.params.get("i"), q1.params.get("i"));
+    }
+
+    #[test]
+    fn list_ops_mentions_each_op() {
+        let listing = list_ops();
+        for op in OpName::value_variants() {
+            assert!(listing.contains(op.as_str()));
+        }
+    }
+
+    #[test]
+    fn summarize_samples_computes_paired_residual_and_cache() {
+        let samples = vec![
+            OpSample { server_ms: 0.10, total_ms: 0.40, rows: 1, cached: Some(true) },
+            OpSample { server_ms: 0.12, total_ms: 0.45, rows: 1, cached: Some(false) },
+            OpSample { server_ms: 0.11, total_ms: 0.42, rows: 1, cached: None },
+            OpSample { server_ms: 0.13, total_ms: 0.44, rows: 1, cached: Some(true) },
+        ];
+        let r = summarize_samples(&samples).unwrap();
+        assert_eq!(r.server_ms.n, 4);
+        assert_eq!(r.cached_unknown, 1);
+        // 1 of 3 known-cache samples was false.
+        assert!((r.cached_false_rate - 1.0 / 3.0).abs() < 1e-9);
+        // non_internal median should be positive (total > server).
+        assert!(r.non_internal_ms.median > 0.0);
+    }
+}

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -107,10 +107,29 @@ pub fn list_ops() -> String {
     out
 }
 
+/// Strip any password from an endpoint before it is recorded in the report or printed, so
+/// credentials passed in a `falkor://user:pass@host` URL never leak into `synthetic-report.json`.
+fn redact_endpoint(endpoint: &str) -> String {
+    match url::Url::parse(endpoint) {
+        Ok(mut url) => {
+            if url.password().is_some() {
+                let _ = url.set_password(None);
+            }
+            url.to_string()
+        }
+        Err(_) => endpoint.to_string(),
+    }
+}
+
 /// Run the probe: connect (single connection), collect server provenance, warm up, measure, then
 /// build the [`Report`]. Writing the report to disk is the caller's responsibility (see
 /// [`run_and_report`]).
 pub async fn run(config: &Config) -> BenchmarkResult<Report> {
+    let started_at_epoch_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
     let connection_info = config
         .endpoint
         .as_str()
@@ -150,13 +169,30 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     let client_deadline = Duration::from_millis(config.client_deadline_ms);
 
     // Ensure the graph key exists: a read (`RO_QUERY`) against a never-written graph fails with
-    // "Invalid graph operation on empty key", so instantiate it once with a trivial write.
-    graph
-        .query("RETURN 1")
-        .with_timeout(config.server_timeout_ms)
-        .execute()
+    // "Invalid graph operation on empty key". Probe with a read first and only write to
+    // instantiate it when absent, so a read-only replica whose graph already exists still works.
+    // Both are bounded by the client deadline so a stuck socket can't hang setup.
+    let probe = tokio::time::timeout(
+        client_deadline,
+        graph
+            .ro_query("RETURN 1")
+            .with_timeout(config.server_timeout_ms)
+            .execute(),
+    )
+    .await;
+    let needs_instantiation = !matches!(probe, Ok(Ok(_)));
+    if needs_instantiation {
+        tokio::time::timeout(
+            client_deadline,
+            graph
+                .query("RETURN 1")
+                .with_timeout(config.server_timeout_ms)
+                .execute(),
+        )
         .await
+        .map_err(|e| OtherError(format!("graph 'falkor' instantiation timed out: {}", e)))?
         .map_err(|e| OtherError(format!("failed to instantiate graph 'falkor': {:?}", e)))?;
+    }
 
     // Warm-up (discarded) primes the plan cache and connection.
     for i in 0..config.warmup {
@@ -190,15 +226,10 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     let mut operations = BTreeMap::new();
     operations.insert(config.op.as_str().to_string(), op_report);
 
-    let started_at_epoch_secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-
     Ok(Report {
         meta: Meta {
             tool_version: env!("CARGO_PKG_VERSION").to_string(),
-            endpoint: config.endpoint.clone(),
+            endpoint: redact_endpoint(&config.endpoint),
             samples: config.samples,
             warmup: config.warmup,
             server_timeout_ms: config.server_timeout_ms,
@@ -212,16 +243,38 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
 }
 
 /// Summarize a set of paired samples into an [`OperationReport`].
+///
+/// Outlier removal is *paired*: a sample is dropped if it is a severe outlier in **either**
+/// `server_ms` or `total_ms`, and all three summaries (server, total, and the paired residual) are
+/// computed over that single shared retained cohort. This keeps their sample counts identical and
+/// preserves the invariant that, since every raw pair has `total >= server`, the retained
+/// aggregates do too.
 fn summarize_samples(samples: &[OpSample]) -> BenchmarkResult<OperationReport> {
     let server: Vec<f64> = samples.iter().map(|s| s.server_ms).collect();
     let total: Vec<f64> = samples.iter().map(|s| s.total_ms).collect();
-    let non_internal: Vec<f64> = samples.iter().map(|s| s.total_ms - s.server_ms).collect();
 
-    let server_ms = stats::summarize(&server)
+    let server_fence = stats::severe_fence(&server);
+    let total_fence = stats::severe_fence(&total);
+    let within = |v: f64, fence: Option<(f64, f64)>| match fence {
+        Some((lo, hi)) => v >= lo && v <= hi,
+        None => true,
+    };
+
+    let kept: Vec<&OpSample> = samples
+        .iter()
+        .filter(|s| within(s.server_ms, server_fence) && within(s.total_ms, total_fence))
+        .collect();
+    let removed = samples.len() - kept.len();
+
+    let kept_server: Vec<f64> = kept.iter().map(|s| s.server_ms).collect();
+    let kept_total: Vec<f64> = kept.iter().map(|s| s.total_ms).collect();
+    let kept_residual: Vec<f64> = kept.iter().map(|s| s.total_ms - s.server_ms).collect();
+
+    let server_ms = stats::summarize_kept(&kept_server, removed)
         .ok_or_else(|| OtherError("no server_ms samples to summarize".to_string()))?;
-    let total_ms = stats::summarize(&total)
+    let total_ms = stats::summarize_kept(&kept_total, removed)
         .ok_or_else(|| OtherError("no total_ms samples to summarize".to_string()))?;
-    let non_internal_ms = stats::summarize(&non_internal)
+    let non_internal_ms = stats::summarize_kept(&kept_residual, removed)
         .ok_or_else(|| OtherError("no non_internal_ms samples to summarize".to_string()))?;
 
     let cached_unknown = samples.iter().filter(|s| s.cached.is_none()).count();
@@ -299,5 +352,35 @@ mod tests {
         assert!((r.cached_false_rate - 1.0 / 3.0).abs() < 1e-9);
         // non_internal median should be positive (total > server).
         assert!(r.non_internal_ms.median > 0.0);
+    }
+
+    #[test]
+    fn paired_summaries_share_one_retained_cohort() {
+        // 20 well-behaved pairs (total = server + 0.3) plus one pair whose TOTAL is a severe
+        // outlier. That pair must be dropped from *all three* summaries, so their `n` matches and
+        // total.median stays >= server.median.
+        let mut samples: Vec<OpSample> = (0..20)
+            .map(|i| {
+                let s = 0.10 + i as f64 * 0.001;
+                OpSample { server_ms: s, total_ms: s + 0.3, rows: 1, cached: Some(true) }
+            })
+            .collect();
+        samples.push(OpSample { server_ms: 0.11, total_ms: 500.0, rows: 1, cached: Some(true) });
+        let r = summarize_samples(&samples).unwrap();
+        assert_eq!(r.server_ms.n, r.total_ms.n);
+        assert_eq!(r.total_ms.n, r.non_internal_ms.n);
+        assert_eq!(r.total_ms.removed, 1);
+        assert!(r.total_ms.median >= r.server_ms.median);
+    }
+
+    #[test]
+    fn redact_endpoint_strips_password() {
+        assert_eq!(
+            redact_endpoint("falkor://user:secret@host:6379"),
+            "falkor://user@host:6379"
+        );
+        // No credentials → unchanged (modulo url normalization).
+        assert!(redact_endpoint("falkor://127.0.0.1:6379").contains("127.0.0.1:6379"));
+        assert!(!redact_endpoint("falkor://user:secret@host:6379").contains("secret"));
     }
 }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -61,10 +61,13 @@ impl OpName {
         self,
         i: usize,
     ) -> Query {
+        // Keep the parameter value in the non-negative i32 range (the only integer QueryParam
+        // width) so a very large invocation index can't truncate to a negative value.
+        let param = (i % (i32::MAX as usize)) as i32;
         match self {
             OpName::ReturnConst => QueryBuilder::new()
                 .text("RETURN $i AS x")
-                .param("i", i as i32)
+                .param("i", param)
                 .build(),
         }
     }

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -7,7 +7,6 @@
 
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
-use crate::query::Query;
 use crate::queries_repository::QueryType;
 use falkordb::AsyncGraph;
 use futures::StreamExt;
@@ -30,40 +29,68 @@ pub struct OpSample {
 
 /// Execute one query against `graph`, timing the full round-trip and reading the server time.
 ///
-/// `server_timeout_ms` is the FalkorDB-side per-query guard; `client_deadline` is a Tokio-side
-/// deadline so a stuck socket can't hang the probe. Reads use `GRAPH.RO_QUERY`, writes use
-/// `GRAPH.QUERY`.
+/// `cypher` is the already-rendered query string (the caller controls its exact text, e.g. to
+/// force a plan-cache miss). `server_timeout_ms` is the FalkorDB-side per-query guard;
+/// `client_deadline` bounds the **entire** operation — execute *and* row draining — so a stuck
+/// socket or a slow stream can't hang the probe. Reads use `GRAPH.RO_QUERY`, writes `GRAPH.QUERY`.
 pub async fn run_and_drain(
     graph: &mut AsyncGraph,
     kind: QueryType,
-    query: &Query,
+    cypher: &str,
     server_timeout_ms: i64,
     client_deadline: Duration,
 ) -> BenchmarkResult<OpSample> {
-    let cypher = query.to_cypher();
     let started = Instant::now();
 
-    // `ro_query` borrows the query string, so it must outlive the builder.
-    let exec = async {
-        match kind {
+    // The whole operation (execute + drain) runs under one deadline.
+    let measured = async {
+        let query_result = match kind {
             QueryType::Read => {
                 graph
-                    .ro_query(cypher.as_str())
+                    .ro_query(cypher)
                     .with_timeout(server_timeout_ms)
                     .execute()
                     .await
             }
             QueryType::Write => {
                 graph
-                    .query(cypher.as_str())
+                    .query(cypher)
                     .with_timeout(server_timeout_ms)
                     .execute()
                     .await
             }
         }
+        .map_err(|e| OtherError(format!("query '{}' failed: {:?}", cypher, e)))?;
+
+        let cached = query_result.get_cached_execution();
+        // A missing server-time stat is a hard error — never fold it into the numbers as NaN/0.
+        let server_ms = query_result.get_internal_execution_time().ok_or_else(|| {
+            OtherError(format!(
+                "response for '{}' had no internal execution time statistic",
+                cypher
+            ))
+        })?;
+        if !server_ms.is_finite() || server_ms < 0.0 {
+            return Err(OtherError(format!(
+                "response for '{}' reported an invalid internal execution time: {}",
+                cypher, server_ms
+            )));
+        }
+
+        // Drain every row so `total_ms` reflects full client-side consumption and any row-decode
+        // error surfaces here rather than being silently skipped.
+        let mut rows = 0usize;
+        let mut data = query_result.data;
+        while let Some(row) = data.next().await {
+            let row =
+                row.map_err(|e| OtherError(format!("row decode error for '{}': {:?}", cypher, e)))?;
+            let _ = black_box(row);
+            rows += 1;
+        }
+        Ok::<(f64, usize, Option<bool>), crate::error::BenchmarkError>((server_ms, rows, cached))
     };
 
-    let query_result = tokio::time::timeout(client_deadline, exec)
+    let (server_ms, rows, cached) = tokio::time::timeout(client_deadline, measured)
         .await
         .map_err(|e: Elapsed| {
             OtherError(format!(
@@ -72,34 +99,7 @@ pub async fn run_and_drain(
                 cypher,
                 e
             ))
-        })?
-        .map_err(|e| OtherError(format!("query '{}' failed: {:?}", cypher, e)))?;
-
-    let cached = query_result.get_cached_execution();
-    // A missing server-time stat is a hard error — never fold it into the numbers as NaN/0.
-    let server_ms = query_result.get_internal_execution_time().ok_or_else(|| {
-        OtherError(format!(
-            "response for '{}' had no internal execution time statistic",
-            cypher
-        ))
-    })?;
-    // Guard against a non-finite or negative server time slipping through into the summary.
-    if !server_ms.is_finite() || server_ms < 0.0 {
-        return Err(OtherError(format!(
-            "response for '{}' reported an invalid internal execution time: {}",
-            cypher, server_ms
-        )));
-    }
-
-    // Drain every row so `total_ms` reflects full client-side consumption and any row-decode
-    // error surfaces here rather than being silently skipped.
-    let mut rows = 0usize;
-    let mut data = query_result.data;
-    while let Some(row) = data.next().await {
-        let row = row.map_err(|e| OtherError(format!("row decode error for '{}': {:?}", cypher, e)))?;
-        let _ = black_box(row);
-        rows += 1;
-    }
+        })??;
 
     let total_ms = started.elapsed().as_secs_f64() * 1_000.0;
     Ok(OpSample {

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -1,0 +1,104 @@
+//! One measured invocation of an operation, and the loop that collects many of them.
+//!
+//! [`run_and_drain`] times a single query end-to-end (the wall-clock around
+//! `execute().await` *and* draining every row) and reads FalkorDB's own reported internal
+//! execution time from the response. A missing server-time statistic is an error rather than a
+//! silent `NaN`, so it can never poison the summary.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::query::Query;
+use crate::queries_repository::QueryType;
+use falkordb::AsyncGraph;
+use futures::StreamExt;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+use tokio::time::error::Elapsed;
+
+/// A single paired latency measurement for one operation invocation.
+#[derive(Debug, Clone, Copy)]
+pub struct OpSample {
+    /// FalkorDB's reported internal execution time, in milliseconds.
+    pub server_ms: f64,
+    /// End-to-end client wall-clock (send → response received → all rows drained), in milliseconds.
+    pub total_ms: f64,
+    /// Number of rows drained from the result.
+    pub rows: usize,
+    /// Whether the server reported a cached execution plan (`None` if the stat was absent).
+    pub cached: Option<bool>,
+}
+
+/// Execute one query against `graph`, timing the full round-trip and reading the server time.
+///
+/// `server_timeout_ms` is the FalkorDB-side per-query guard; `client_deadline` is a Tokio-side
+/// deadline so a stuck socket can't hang the probe. Reads use `GRAPH.RO_QUERY`, writes use
+/// `GRAPH.QUERY`.
+pub async fn run_and_drain(
+    graph: &mut AsyncGraph,
+    kind: QueryType,
+    query: &Query,
+    server_timeout_ms: i64,
+    client_deadline: Duration,
+) -> BenchmarkResult<OpSample> {
+    let cypher = query.to_cypher();
+    let started = Instant::now();
+
+    // `ro_query` borrows the query string, so it must outlive the builder.
+    let exec = async {
+        match kind {
+            QueryType::Read => {
+                graph
+                    .ro_query(cypher.as_str())
+                    .with_timeout(server_timeout_ms)
+                    .execute()
+                    .await
+            }
+            QueryType::Write => {
+                graph
+                    .query(cypher.as_str())
+                    .with_timeout(server_timeout_ms)
+                    .execute()
+                    .await
+            }
+        }
+    };
+
+    let query_result = tokio::time::timeout(client_deadline, exec)
+        .await
+        .map_err(|e: Elapsed| {
+            OtherError(format!(
+                "client deadline ({} ms) exceeded for query '{}': {}",
+                client_deadline.as_millis(),
+                cypher,
+                e
+            ))
+        })?
+        .map_err(|e| OtherError(format!("query '{}' failed: {:?}", cypher, e)))?;
+
+    let cached = query_result.get_cached_execution();
+    // A missing server-time stat is a hard error — never fold it into the numbers as NaN/0.
+    let server_ms = query_result.get_internal_execution_time().ok_or_else(|| {
+        OtherError(format!(
+            "response for '{}' had no internal execution time statistic",
+            cypher
+        ))
+    })?;
+
+    // Drain every row so `total_ms` reflects full client-side consumption and any row-decode
+    // error surfaces here rather than being silently skipped.
+    let mut rows = 0usize;
+    let mut data = query_result.data;
+    while let Some(row) = data.next().await {
+        let row = row.map_err(|e| OtherError(format!("row decode error for '{}': {:?}", cypher, e)))?;
+        let _ = black_box(row);
+        rows += 1;
+    }
+
+    let total_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    Ok(OpSample {
+        server_ms,
+        total_ms,
+        rows,
+        cached,
+    })
+}

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -64,18 +64,7 @@ pub async fn run_and_drain(
 
         let cached = query_result.get_cached_execution();
         // A missing server-time stat is a hard error — never fold it into the numbers as NaN/0.
-        let server_ms = query_result.get_internal_execution_time().ok_or_else(|| {
-            OtherError(format!(
-                "response for '{}' had no internal execution time statistic",
-                cypher
-            ))
-        })?;
-        if !server_ms.is_finite() || server_ms < 0.0 {
-            return Err(OtherError(format!(
-                "response for '{}' reported an invalid internal execution time: {}",
-                cypher, server_ms
-            )));
-        }
+        let server_ms = validate_server_ms(query_result.get_internal_execution_time(), cypher)?;
 
         // Drain every row so `total_ms` reflects full client-side consumption and any row-decode
         // error surfaces here rather than being silently skipped.
@@ -108,4 +97,47 @@ pub async fn run_and_drain(
         rows,
         cached,
     })
+}
+
+/// Validate FalkorDB's reported internal execution time: it must be present, finite and
+/// non-negative. A missing or garbage statistic becomes a hard error rather than poisoning the
+/// summary with a `NaN`/`0`.
+fn validate_server_ms(
+    reported: Option<f64>,
+    cypher: &str,
+) -> BenchmarkResult<f64> {
+    let server_ms = reported.ok_or_else(|| {
+        OtherError(format!(
+            "response for '{}' had no internal execution time statistic",
+            cypher
+        ))
+    })?;
+    if !server_ms.is_finite() || server_ms < 0.0 {
+        return Err(OtherError(format!(
+            "response for '{}' reported an invalid internal execution time: {}",
+            cypher, server_ms
+        )));
+    }
+    Ok(server_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_server_ms_accepts_finite_non_negative() {
+        assert_eq!(validate_server_ms(Some(0.0), "q").unwrap(), 0.0);
+        assert_eq!(validate_server_ms(Some(1.5), "q").unwrap(), 1.5);
+    }
+
+    #[test]
+    fn validate_server_ms_rejects_missing_and_invalid() {
+        // Absent statistic.
+        assert!(validate_server_ms(None, "q").is_err());
+        // Non-finite and negative values are both rejected.
+        assert!(validate_server_ms(Some(f64::NAN), "q").is_err());
+        assert!(validate_server_ms(Some(f64::INFINITY), "q").is_err());
+        assert!(validate_server_ms(Some(-0.001), "q").is_err());
+    }
 }

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -83,6 +83,13 @@ pub async fn run_and_drain(
             cypher
         ))
     })?;
+    // Guard against a non-finite or negative server time slipping through into the summary.
+    if !server_ms.is_finite() || server_ms < 0.0 {
+        return Err(OtherError(format!(
+            "response for '{}' reported an invalid internal execution time: {}",
+            cypher, server_ms
+        )));
+    }
 
     // Drain every row so `total_ms` reflects full client-side consumption and any row-decode
     // error surfaces here rather than being silently skipped.

--- a/src/synthetic/provenance.rs
+++ b/src/synthetic/provenance.rs
@@ -9,12 +9,16 @@ use crate::error::BenchmarkResult;
 use crate::synthetic::report::ServerInfo;
 use tracing::warn;
 
-/// Query `INFO server` + `MODULE LIST` over a raw redis connection and assemble a [`ServerInfo`].
+/// Query `INFO server`, `MODULE LIST` and `GRAPH.CONFIG GET CACHE_SIZE` over a raw redis
+/// connection and assemble a [`ServerInfo`].
 ///
 /// `redis_url` is a `redis://host:port` string (convert a `falkor://` endpoint with
-/// [`crate::falkor::falkor_driver::falkor_endpoint_to_redis_url`]). `server_image` is recorded
-/// verbatim. Failure to read is non-fatal for the caller's decision, but returned as an error here
-/// so the caller can log it and continue with a best-effort (partial) `ServerInfo`.
+/// [`crate::falkor::falkor_endpoint_to_redis_url`]). `server_image` is recorded verbatim.
+///
+/// Only failure to open/connect the redis client is returned as an error. Each individual command
+/// (`INFO` / `MODULE LIST` / `GRAPH.CONFIG`) that fails is *logged and skipped*, leaving its
+/// field(s) as `None`, so a partial reply still yields a best-effort `ServerInfo` rather than
+/// discarding everything.
 pub async fn collect(
     redis_url: &str,
     server_image: Option<String>,

--- a/src/synthetic/provenance.rs
+++ b/src/synthetic/provenance.rs
@@ -7,6 +7,7 @@
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::synthetic::report::ServerInfo;
+use tracing::warn;
 
 /// Query `INFO server` + `MODULE LIST` over a raw redis connection and assemble a [`ServerInfo`].
 ///
@@ -25,29 +26,38 @@ pub async fn collect(
         .await
         .map_err(|e| OtherError(format!("provenance: connect failed: {}", e)))?;
 
-    let info_server: String = redis::cmd("INFO")
-        .arg("server")
-        .query_async(&mut conn)
-        .await
-        .map_err(|e| OtherError(format!("provenance: INFO server failed: {}", e)))?;
-
-    // `MODULE LIST` returns an array of module maps; ask for it as raw values and scan for graph.
-    let modules: redis::Value = redis::cmd("MODULE")
-        .arg("LIST")
-        .query_async(&mut conn)
-        .await
-        .map_err(|e| OtherError(format!("provenance: MODULE LIST failed: {}", e)))?;
-
-    Ok(ServerInfo {
-        module_graph_ver: parse_graph_module_version(&modules),
-        redis_version: info_field(&info_server, "redis_version"),
-        redis_build_id: info_field(&info_server, "redis_build_id"),
-        redis_git_sha1: info_field(&info_server, "redis_git_sha1"),
-        run_id: info_field(&info_server, "run_id"),
-        os: info_field(&info_server, "os"),
-        arch_bits: info_field(&info_server, "arch_bits"),
+    // Collect the two commands independently so a failure of one still preserves the other's fields.
+    let mut info = ServerInfo {
         server_image,
-    })
+        ..Default::default()
+    };
+
+    match redis::cmd("INFO")
+        .arg("server")
+        .query_async::<String>(&mut conn)
+        .await
+    {
+        Ok(info_server) => {
+            info.redis_version = info_field(&info_server, "redis_version");
+            info.redis_build_id = info_field(&info_server, "redis_build_id");
+            info.redis_git_sha1 = info_field(&info_server, "redis_git_sha1");
+            info.run_id = info_field(&info_server, "run_id");
+            info.os = info_field(&info_server, "os");
+            info.arch_bits = info_field(&info_server, "arch_bits");
+        }
+        Err(e) => warn!("provenance: INFO server failed: {}", e),
+    }
+
+    match redis::cmd("MODULE")
+        .arg("LIST")
+        .query_async::<redis::Value>(&mut conn)
+        .await
+    {
+        Ok(modules) => info.module_graph_ver = parse_graph_module_version(&modules),
+        Err(e) => warn!("provenance: MODULE LIST failed: {}", e),
+    }
+
+    Ok(info)
 }
 
 /// Extract a `key:value` field from a redis `INFO` text blob.
@@ -63,34 +73,76 @@ fn info_field(
 
 /// Find the `graph` module's `ver` in a `MODULE LIST` reply.
 ///
-/// The reply is an array of maps; each map is a flat array of `[key, value, key, value, …]`. We
-/// look for the map whose `name` is `graph` and return its `ver` as a `u64`.
+/// The reply is an array of module entries. Depending on RESP2/RESP3 each entry is either a flat
+/// array of `[key, value, key, value, …]` or a `Map` of `key → value`. We look for the entry whose
+/// `name` is `graph` and return its `ver` as a `u64`.
 fn parse_graph_module_version(value: &redis::Value) -> Option<u64> {
-    let redis::Value::Array(modules) = value else {
-        return None;
-    };
-    for module in modules {
-        let redis::Value::Array(fields) = module else {
-            continue;
-        };
-        let mut name: Option<String> = None;
-        let mut ver: Option<u64> = None;
-        let mut i = 0;
-        while i + 1 < fields.len() {
-            if let Some(k) = redis_value_as_string(&fields[i]) {
-                match k.as_str() {
-                    "name" => name = redis_value_as_string(&fields[i + 1]),
-                    "ver" => ver = redis_value_as_u64(&fields[i + 1]),
-                    _ => {}
-                }
-            }
-            i += 2;
+    let entries = match value {
+        redis::Value::Array(entries) => entries,
+        redis::Value::Map(pairs) => {
+            // A single module reported directly as a map.
+            return module_field_pairs(pairs, "graph");
         }
+        _ => return None,
+    };
+    for entry in entries {
+        let (name, ver) = match entry {
+            redis::Value::Array(fields) => {
+                let mut name = None;
+                let mut ver = None;
+                let mut i = 0;
+                while i + 1 < fields.len() {
+                    if let Some(k) = redis_value_as_string(&fields[i]) {
+                        match k.as_str() {
+                            "name" => name = redis_value_as_string(&fields[i + 1]),
+                            "ver" => ver = redis_value_as_u64(&fields[i + 1]),
+                            _ => {}
+                        }
+                    }
+                    i += 2;
+                }
+                (name, ver)
+            }
+            redis::Value::Map(pairs) => {
+                let mut name = None;
+                let mut ver = None;
+                for (k, v) in pairs {
+                    match redis_value_as_string(k).as_deref() {
+                        Some("name") => name = redis_value_as_string(v),
+                        Some("ver") => ver = redis_value_as_u64(v),
+                        _ => {}
+                    }
+                }
+                (name, ver)
+            }
+            _ => (None, None),
+        };
         if name.as_deref() == Some("graph") {
             return ver;
         }
     }
     None
+}
+
+/// Extract `ver` from a single module's RESP3 key/value map if its `name` matches.
+fn module_field_pairs(
+    pairs: &[(redis::Value, redis::Value)],
+    want_name: &str,
+) -> Option<u64> {
+    let mut name = None;
+    let mut ver = None;
+    for (k, v) in pairs {
+        match redis_value_as_string(k).as_deref() {
+            Some("name") => name = redis_value_as_string(v),
+            Some("ver") => ver = redis_value_as_u64(v),
+            _ => {}
+        }
+    }
+    if name.as_deref() == Some(want_name) {
+        ver
+    } else {
+        None
+    }
 }
 
 fn redis_value_as_string(value: &redis::Value) -> Option<String> {
@@ -170,6 +222,22 @@ mod tests {
             redis::Value::Int(1),
         ])]);
         assert_eq!(parse_graph_module_version(&modules), None);
+    }
+
+    #[test]
+    fn parses_graph_module_version_resp3_map() {
+        // RESP3 returns each module entry as a Map.
+        let modules = redis::Value::Array(vec![redis::Value::Map(vec![
+            (
+                redis::Value::BulkString(b"name".to_vec()),
+                redis::Value::BulkString(b"graph".to_vec()),
+            ),
+            (
+                redis::Value::BulkString(b"ver".to_vec()),
+                redis::Value::Int(42001),
+            ),
+        ])]);
+        assert_eq!(parse_graph_module_version(&modules), Some(42001));
     }
 
     #[test]

--- a/src/synthetic/provenance.rs
+++ b/src/synthetic/provenance.rs
@@ -19,8 +19,13 @@ pub async fn collect(
     redis_url: &str,
     server_image: Option<String>,
 ) -> BenchmarkResult<ServerInfo> {
-    let client = redis::Client::open(redis_url)
-        .map_err(|e| OtherError(format!("provenance: bad redis url '{}': {}", redis_url, e)))?;
+    let client = redis::Client::open(redis_url).map_err(|e| {
+        OtherError(format!(
+            "provenance: bad redis url '{}': {}",
+            redact_redis_url(redis_url),
+            e
+        ))
+    })?;
     let mut conn = client
         .get_multiplexed_async_connection()
         .await
@@ -57,7 +62,27 @@ pub async fn collect(
         Err(e) => warn!("provenance: MODULE LIST failed: {}", e),
     }
 
+    // The plan-cache size gives context for the cached-vs-uncached comparison.
+    match redis::cmd("GRAPH.CONFIG")
+        .arg("GET")
+        .arg("CACHE_SIZE")
+        .query_async::<redis::Value>(&mut conn)
+        .await
+    {
+        Ok(v) => info.cache_size = parse_config_get_u64(&v),
+        Err(e) => warn!("provenance: GRAPH.CONFIG GET CACHE_SIZE failed: {}", e),
+    }
+
     Ok(info)
+}
+
+/// Parse a `GRAPH.CONFIG GET <name>` reply (`[name, value]`) into the numeric value.
+fn parse_config_get_u64(value: &redis::Value) -> Option<u64> {
+    match value {
+        redis::Value::Array(items) if items.len() >= 2 => redis_value_as_u64(&items[1]),
+        redis::Value::Map(pairs) => pairs.first().and_then(|(_, v)| redis_value_as_u64(v)),
+        _ => None,
+    }
 }
 
 /// Extract a `key:value` field from a redis `INFO` text blob.
@@ -168,6 +193,19 @@ pub fn decode_module_version(ver: u64) -> String {
     let minor = (ver / 100) % 100;
     let patch = ver % 100;
     format!("{}.{}.{}", major, minor, patch)
+}
+
+/// Strip any password from a `redis://user:pass@host` URL so it never appears in error logs.
+fn redact_redis_url(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(mut u) => {
+            if u.password().is_some() {
+                let _ = u.set_password(None);
+            }
+            u.to_string()
+        }
+        Err(_) => "<redacted>".to_string(),
+    }
 }
 
 #[cfg(test)]

--- a/src/synthetic/provenance.rs
+++ b/src/synthetic/provenance.rs
@@ -1,0 +1,181 @@
+//! Server provenance: read what a client *can* know about the FalkorDB build it measured.
+//!
+//! FalkorDB does not expose a graph-module git SHA to clients, so we capture the module version
+//! (`MODULE LIST` / `INFO modules`) and a handful of `INFO server` fields; the operator supplies
+//! the immutable image identity via `--server-image`. See [`crate::synthetic::report::ServerInfo`].
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::synthetic::report::ServerInfo;
+
+/// Query `INFO server` + `MODULE LIST` over a raw redis connection and assemble a [`ServerInfo`].
+///
+/// `redis_url` is a `redis://host:port` string (convert a `falkor://` endpoint with
+/// [`crate::falkor::falkor_driver::falkor_endpoint_to_redis_url`]). `server_image` is recorded
+/// verbatim. Failure to read is non-fatal for the caller's decision, but returned as an error here
+/// so the caller can log it and continue with a best-effort (partial) `ServerInfo`.
+pub async fn collect(
+    redis_url: &str,
+    server_image: Option<String>,
+) -> BenchmarkResult<ServerInfo> {
+    let client = redis::Client::open(redis_url)
+        .map_err(|e| OtherError(format!("provenance: bad redis url '{}': {}", redis_url, e)))?;
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|e| OtherError(format!("provenance: connect failed: {}", e)))?;
+
+    let info_server: String = redis::cmd("INFO")
+        .arg("server")
+        .query_async(&mut conn)
+        .await
+        .map_err(|e| OtherError(format!("provenance: INFO server failed: {}", e)))?;
+
+    // `MODULE LIST` returns an array of module maps; ask for it as raw values and scan for graph.
+    let modules: redis::Value = redis::cmd("MODULE")
+        .arg("LIST")
+        .query_async(&mut conn)
+        .await
+        .map_err(|e| OtherError(format!("provenance: MODULE LIST failed: {}", e)))?;
+
+    Ok(ServerInfo {
+        module_graph_ver: parse_graph_module_version(&modules),
+        redis_version: info_field(&info_server, "redis_version"),
+        redis_build_id: info_field(&info_server, "redis_build_id"),
+        redis_git_sha1: info_field(&info_server, "redis_git_sha1"),
+        run_id: info_field(&info_server, "run_id"),
+        os: info_field(&info_server, "os"),
+        arch_bits: info_field(&info_server, "arch_bits"),
+        server_image,
+    })
+}
+
+/// Extract a `key:value` field from a redis `INFO` text blob.
+fn info_field(
+    info: &str,
+    key: &str,
+) -> Option<String> {
+    info.lines()
+        .find_map(|line| line.strip_prefix(key)?.strip_prefix(':'))
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Find the `graph` module's `ver` in a `MODULE LIST` reply.
+///
+/// The reply is an array of maps; each map is a flat array of `[key, value, key, value, …]`. We
+/// look for the map whose `name` is `graph` and return its `ver` as a `u64`.
+fn parse_graph_module_version(value: &redis::Value) -> Option<u64> {
+    let redis::Value::Array(modules) = value else {
+        return None;
+    };
+    for module in modules {
+        let redis::Value::Array(fields) = module else {
+            continue;
+        };
+        let mut name: Option<String> = None;
+        let mut ver: Option<u64> = None;
+        let mut i = 0;
+        while i + 1 < fields.len() {
+            if let Some(k) = redis_value_as_string(&fields[i]) {
+                match k.as_str() {
+                    "name" => name = redis_value_as_string(&fields[i + 1]),
+                    "ver" => ver = redis_value_as_u64(&fields[i + 1]),
+                    _ => {}
+                }
+            }
+            i += 2;
+        }
+        if name.as_deref() == Some("graph") {
+            return ver;
+        }
+    }
+    None
+}
+
+fn redis_value_as_string(value: &redis::Value) -> Option<String> {
+    match value {
+        redis::Value::BulkString(bytes) => Some(String::from_utf8_lossy(bytes).into_owned()),
+        redis::Value::SimpleString(s) => Some(s.clone()),
+        redis::Value::VerbatimString { text, .. } => Some(text.clone()),
+        _ => None,
+    }
+}
+
+fn redis_value_as_u64(value: &redis::Value) -> Option<u64> {
+    match value {
+        redis::Value::Int(i) => u64::try_from(*i).ok(),
+        other => redis_value_as_string(other).and_then(|s| s.parse::<u64>().ok()),
+    }
+}
+
+/// Decode a numeric FalkorDB module version (`major*10000 + minor*100 + patch`) into a dotted
+/// string, e.g. `42001` → `"4.20.1"`. Exposed for reporting/tests.
+pub fn decode_module_version(ver: u64) -> String {
+    let major = ver / 10_000;
+    let minor = (ver / 100) % 100;
+    let patch = ver % 100;
+    format!("{}.{}.{}", major, minor, patch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_field_parses_values() {
+        let info = "# Server\r\nredis_version:8.6.3\r\nredis_build_id:313de0794c1dcd59\r\nrun_id:abc123\r\n";
+        assert_eq!(info_field(info, "redis_version").as_deref(), Some("8.6.3"));
+        assert_eq!(
+            info_field(info, "redis_build_id").as_deref(),
+            Some("313de0794c1dcd59")
+        );
+        assert_eq!(info_field(info, "run_id").as_deref(), Some("abc123"));
+        assert_eq!(info_field(info, "missing"), None);
+    }
+
+    #[test]
+    fn info_field_ignores_prefix_collisions() {
+        // `redis_version` must not be matched by a lookup for `redis_ver`.
+        let info = "redis_version:8.6.3\r\n";
+        // exact key with colon is required, so a partial key returns None
+        assert_eq!(info_field(info, "redis_versio"), None);
+    }
+
+    #[test]
+    fn parses_graph_module_version() {
+        let modules = redis::Value::Array(vec![
+            redis::Value::Array(vec![
+                redis::Value::BulkString(b"name".to_vec()),
+                redis::Value::BulkString(b"graph".to_vec()),
+                redis::Value::BulkString(b"ver".to_vec()),
+                redis::Value::Int(42001),
+            ]),
+            redis::Value::Array(vec![
+                redis::Value::BulkString(b"name".to_vec()),
+                redis::Value::BulkString(b"vectorset".to_vec()),
+                redis::Value::BulkString(b"ver".to_vec()),
+                redis::Value::Int(1),
+            ]),
+        ]);
+        assert_eq!(parse_graph_module_version(&modules), Some(42001));
+    }
+
+    #[test]
+    fn graph_version_absent_when_no_graph_module() {
+        let modules = redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::BulkString(b"name".to_vec()),
+            redis::Value::BulkString(b"vectorset".to_vec()),
+            redis::Value::BulkString(b"ver".to_vec()),
+            redis::Value::Int(1),
+        ])]);
+        assert_eq!(parse_graph_module_version(&modules), None);
+    }
+
+    #[test]
+    fn decode_version_examples() {
+        assert_eq!(decode_module_version(42001), "4.20.1");
+        assert_eq!(decode_module_version(999_999), "99.99.99");
+        assert_eq!(decode_module_version(40200), "4.2.0");
+    }
+}

--- a/src/synthetic/provenance.rs
+++ b/src/synthetic/provenance.rs
@@ -242,6 +242,9 @@ mod tests {
             redis::Value::Array(vec![
                 redis::Value::BulkString(b"name".to_vec()),
                 redis::Value::BulkString(b"graph".to_vec()),
+                // An unrelated field is skipped rather than mis-parsed.
+                redis::Value::BulkString(b"path".to_vec()),
+                redis::Value::BulkString(b"/lib/graph.so".to_vec()),
                 redis::Value::BulkString(b"ver".to_vec()),
                 redis::Value::Int(42001),
             ]),
@@ -274,6 +277,11 @@ mod tests {
                 redis::Value::BulkString(b"name".to_vec()),
                 redis::Value::BulkString(b"graph".to_vec()),
             ),
+            // An unrelated field is skipped rather than mis-parsed.
+            (
+                redis::Value::BulkString(b"path".to_vec()),
+                redis::Value::BulkString(b"/lib/graph.so".to_vec()),
+            ),
             (
                 redis::Value::BulkString(b"ver".to_vec()),
                 redis::Value::Int(42001),
@@ -283,9 +291,145 @@ mod tests {
     }
 
     #[test]
+    fn parses_graph_module_version_skips_non_string_keys() {
+        // A stray non-string key element must be skipped, not treated as a field name.
+        let modules = redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(999),
+            redis::Value::Int(999),
+            redis::Value::BulkString(b"name".to_vec()),
+            redis::Value::BulkString(b"graph".to_vec()),
+            redis::Value::BulkString(b"ver".to_vec()),
+            redis::Value::Int(42001),
+        ])]);
+        assert_eq!(parse_graph_module_version(&modules), Some(42001));
+    }
+
+    #[test]
     fn decode_version_examples() {
         assert_eq!(decode_module_version(42001), "4.20.1");
         assert_eq!(decode_module_version(999_999), "99.99.99");
         assert_eq!(decode_module_version(40200), "4.2.0");
+    }
+
+    #[test]
+    fn parse_graph_module_version_top_level_map() {
+        // RESP3 can report a single module directly as a top-level Map.
+        let modules = redis::Value::Map(vec![
+            (
+                redis::Value::BulkString(b"name".to_vec()),
+                redis::Value::BulkString(b"graph".to_vec()),
+            ),
+            (
+                redis::Value::BulkString(b"ver".to_vec()),
+                redis::Value::Int(42001),
+            ),
+        ]);
+        assert_eq!(parse_graph_module_version(&modules), Some(42001));
+    }
+
+    #[test]
+    fn parse_graph_module_version_handles_odd_shapes() {
+        // A non-array / non-map reply yields None.
+        assert_eq!(parse_graph_module_version(&redis::Value::Nil), None);
+        // An array whose entries are neither arrays nor maps is skipped, not panicked on.
+        let modules = redis::Value::Array(vec![redis::Value::Nil, redis::Value::Int(7)]);
+        assert_eq!(parse_graph_module_version(&modules), None);
+    }
+
+    #[test]
+    fn module_field_pairs_matches_only_wanted_name() {
+        let pairs = vec![
+            (
+                redis::Value::BulkString(b"name".to_vec()),
+                redis::Value::BulkString(b"graph".to_vec()),
+            ),
+            // An unrelated field is skipped rather than mis-parsed.
+            (
+                redis::Value::BulkString(b"path".to_vec()),
+                redis::Value::BulkString(b"/lib/graph.so".to_vec()),
+            ),
+            (
+                redis::Value::BulkString(b"ver".to_vec()),
+                redis::Value::Int(123),
+            ),
+        ];
+        assert_eq!(module_field_pairs(&pairs, "graph"), Some(123));
+        assert_eq!(module_field_pairs(&pairs, "search"), None);
+    }
+
+    #[test]
+    fn parse_config_get_handles_array_map_and_other() {
+        // RESP2: `[name, value]`.
+        let array = redis::Value::Array(vec![
+            redis::Value::BulkString(b"CACHE_SIZE".to_vec()),
+            redis::Value::Int(25),
+        ]);
+        assert_eq!(parse_config_get_u64(&array), Some(25));
+        // RESP3: a map of name → value.
+        let map = redis::Value::Map(vec![(
+            redis::Value::BulkString(b"CACHE_SIZE".to_vec()),
+            redis::Value::Int(25),
+        )]);
+        assert_eq!(parse_config_get_u64(&map), Some(25));
+        // Anything else → None.
+        assert_eq!(parse_config_get_u64(&redis::Value::Nil), None);
+        assert_eq!(
+            parse_config_get_u64(&redis::Value::Array(vec![redis::Value::Int(1)])),
+            None
+        );
+    }
+
+    #[test]
+    fn redis_value_as_string_covers_every_string_shape() {
+        assert_eq!(
+            redis_value_as_string(&redis::Value::BulkString(b"a".to_vec())).as_deref(),
+            Some("a")
+        );
+        assert_eq!(
+            redis_value_as_string(&redis::Value::SimpleString("b".to_string())).as_deref(),
+            Some("b")
+        );
+        assert_eq!(
+            redis_value_as_string(&redis::Value::VerbatimString {
+                format: redis::VerbatimFormat::Text,
+                text: "c".to_string(),
+            })
+            .as_deref(),
+            Some("c")
+        );
+        assert_eq!(redis_value_as_string(&redis::Value::Int(1)), None);
+    }
+
+    #[test]
+    fn redis_value_as_u64_parses_int_and_string() {
+        assert_eq!(redis_value_as_u64(&redis::Value::Int(7)), Some(7));
+        // A negative integer is not a valid u64.
+        assert_eq!(redis_value_as_u64(&redis::Value::Int(-1)), None);
+        // Numeric strings are parsed; non-numeric strings are not.
+        assert_eq!(
+            redis_value_as_u64(&redis::Value::BulkString(b"42".to_vec())),
+            Some(42)
+        );
+        assert_eq!(
+            redis_value_as_u64(&redis::Value::BulkString(b"nope".to_vec())),
+            None
+        );
+    }
+
+    #[test]
+    fn redact_redis_url_strips_password_and_survives_garbage() {
+        // A password in the URL is stripped.
+        let redacted = redact_redis_url("redis://user:secret@host:6379");
+        assert!(!redacted.contains("secret"), "password leaked: {redacted}");
+        // A URL without a password is returned (roughly) intact.
+        assert!(redact_redis_url("redis://host:6379").contains("host"));
+        // Unparseable input degrades to a fixed placeholder rather than echoing the raw string.
+        assert_eq!(redact_redis_url("not a url"), "<redacted>");
+    }
+
+    #[tokio::test]
+    async fn collect_errors_on_bad_redis_url() {
+        // A malformed redis URL fails at client-open, before any network use.
+        assert!(collect("not a url", None).await.is_err());
     }
 }

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -241,7 +241,10 @@ mod tests {
 
     #[test]
     fn console_contains_key_fields() {
-        let out = sample_report().to_console();
+        let mut r = sample_report();
+        r.meta.server.server_image =
+            Some("falkordb/falkordb:v4.2.1@sha256:deadbeef".to_string());
+        let out = r.to_console();
         assert!(out.contains("return_const"));
         assert!(out.contains("server_ms"));
         assert!(out.contains("total_ms"));
@@ -249,6 +252,8 @@ mod tests {
         assert!(out.contains("cached"));
         assert!(out.contains("compilation_ms"));
         assert!(out.contains("CACHE_SIZE 25"));
+        // The operator-supplied image identity is echoed when present.
+        assert!(out.contains("server image: falkordb/falkordb:v4.2.1@sha256:deadbeef"));
     }
 
     #[test]

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -1,0 +1,200 @@
+//! The synthetic-benchmark report: run metadata, server provenance, per-operation stats, and
+//! JSON + console rendering.
+
+use crate::synthetic::stats::Summary;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Server build/provenance captured from `INFO server` + `MODULE LIST`, plus the operator-supplied
+/// image reference. FalkorDB does not expose a graph-module git SHA to clients, so the reproducible
+/// identity is `module_graph_ver` (real for tagged releases, a `999999` placeholder on `:edge`)
+/// together with `server_image` when provided.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ServerInfo {
+    /// FalkorDB graph-module version (e.g. `42001` for v4.2.1), or `None` if it couldn't be read.
+    pub module_graph_ver: Option<u64>,
+    pub redis_version: Option<String>,
+    pub redis_build_id: Option<String>,
+    pub redis_git_sha1: Option<String>,
+    pub run_id: Option<String>,
+    pub os: Option<String>,
+    pub arch_bits: Option<String>,
+    /// Operator-supplied image reference (e.g. `falkordb/falkordb:v4.2.1@sha256:…`), recorded
+    /// verbatim from `--server-image` / `FALKOR_SERVER_IMAGE`.
+    pub server_image: Option<String>,
+}
+
+impl ServerInfo {
+    /// The FalkorDB dev-placeholder module version used by non-release images such as `:edge`.
+    pub const PLACEHOLDER_VER: u64 = 999_999;
+
+    /// Whether the module version is the dev placeholder (⇒ not a tagged release; version
+    /// comparisons are meaningless).
+    pub fn is_placeholder(&self) -> bool {
+        self.module_graph_ver == Some(Self::PLACEHOLDER_VER)
+    }
+}
+
+/// Run-level metadata: how and against what the probe ran.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Meta {
+    pub tool_version: String,
+    pub endpoint: String,
+    pub samples: usize,
+    pub warmup: usize,
+    pub server_timeout_ms: i64,
+    pub client_deadline_ms: u64,
+    /// Connection strategy, e.g. `"pool(size=1)"`.
+    pub connection: String,
+    pub started_at_epoch_secs: u64,
+    pub server: ServerInfo,
+}
+
+/// Stats for one operation: the two paired metrics plus the derived residual, and cache health.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationReport {
+    pub server_ms: Summary,
+    pub total_ms: Summary,
+    /// Paired `total − server` per invocation (everything outside the DB's internal timer).
+    pub non_internal_ms: Summary,
+    /// Fraction of measured invocations that reported an un-cached execution plan.
+    pub cached_false_rate: f64,
+    /// Count of invocations whose response omitted the cache statistic.
+    pub cached_unknown: usize,
+}
+
+/// The full report written to `synthetic-report.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Report {
+    pub meta: Meta,
+    pub operations: BTreeMap<String, OperationReport>,
+}
+
+impl Report {
+    /// Serialize to pretty JSON.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Render a compact human-readable summary (one block per operation).
+    pub fn to_console(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "synthetic benchmark — endpoint {}  samples {}  warmup {}  connection {}\n",
+            self.meta.endpoint, self.meta.samples, self.meta.warmup, self.meta.connection
+        ));
+        let v = self
+            .meta
+            .server
+            .module_graph_ver
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        out.push_str(&format!(
+            "server — falkordb module ver {}{}  redis {}\n",
+            v,
+            if self.meta.server.is_placeholder() {
+                " (dev placeholder — use a tagged image for comparisons)"
+            } else {
+                ""
+            },
+            self.meta.server.redis_version.as_deref().unwrap_or("?"),
+        ));
+        if let Some(img) = &self.meta.server.server_image {
+            out.push_str(&format!("server image: {}\n", img));
+        }
+        for (name, op) in &self.operations {
+            out.push_str(&format!("\n{}\n", name));
+            out.push_str(&format!(
+                "  server_ms  median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
+                op.server_ms.median, op.server_ms.mean, op.server_ms.p99, op.server_ms.n, op.server_ms.removed
+            ));
+            out.push_str(&format!(
+                "  total_ms   median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
+                op.total_ms.median, op.total_ms.mean, op.total_ms.p99, op.total_ms.n, op.total_ms.removed
+            ));
+            out.push_str(&format!(
+                "  non_internal_ms (paired total-server)  median {:.3}\n",
+                op.non_internal_ms.median
+            ));
+            out.push_str(&format!(
+                "  cached_execution=false: {:.1}%  (unknown {})\n",
+                op.cached_false_rate * 100.0, op.cached_unknown
+            ));
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_summary() -> Summary {
+        crate::synthetic::stats::summarize(&[1.0, 2.0, 3.0, 4.0, 5.0]).unwrap()
+    }
+
+    fn sample_report() -> Report {
+        let mut operations = BTreeMap::new();
+        operations.insert(
+            "return_const".to_string(),
+            OperationReport {
+                server_ms: sample_summary(),
+                total_ms: sample_summary(),
+                non_internal_ms: sample_summary(),
+                cached_false_rate: 0.0,
+                cached_unknown: 0,
+            },
+        );
+        Report {
+            meta: Meta {
+                tool_version: "0.1.0".to_string(),
+                endpoint: "falkor://127.0.0.1:6379".to_string(),
+                samples: 1000,
+                warmup: 200,
+                server_timeout_ms: 5000,
+                client_deadline_ms: 6000,
+                connection: "pool(size=1)".to_string(),
+                started_at_epoch_secs: 42,
+                server: ServerInfo {
+                    module_graph_ver: Some(42001),
+                    redis_version: Some("8.6.3".to_string()),
+                    ..Default::default()
+                },
+            },
+            operations,
+        }
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let report = sample_report();
+        let json = report.to_json().unwrap();
+        let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.meta.samples, 1000);
+        assert_eq!(back.operations.len(), 1);
+        assert!(back.operations.contains_key("return_const"));
+        assert_eq!(back.meta.server.module_graph_ver, Some(42001));
+    }
+
+    #[test]
+    fn console_contains_key_fields() {
+        let out = sample_report().to_console();
+        assert!(out.contains("return_const"));
+        assert!(out.contains("server_ms"));
+        assert!(out.contains("total_ms"));
+        assert!(out.contains("42001"));
+    }
+
+    #[test]
+    fn placeholder_version_is_flagged() {
+        let mut r = sample_report();
+        r.meta.server.module_graph_ver = Some(ServerInfo::PLACEHOLDER_VER);
+        assert!(r.meta.server.is_placeholder());
+        assert!(r.to_console().contains("dev placeholder"));
+    }
+
+    #[test]
+    fn non_placeholder_version_not_flagged() {
+        assert!(!sample_report().meta.server.is_placeholder());
+    }
+}

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -109,7 +109,7 @@ impl Report {
             .meta
             .server
             .module_graph_ver
-            .map(|v| v.to_string())
+            .map(crate::synthetic::provenance::decode_module_version)
             .unwrap_or_else(|| "unknown".to_string());
         let cache_size = self
             .meta
@@ -245,7 +245,7 @@ mod tests {
         assert!(out.contains("return_const"));
         assert!(out.contains("server_ms"));
         assert!(out.contains("total_ms"));
-        assert!(out.contains("42001"));
+        assert!(out.contains("4.20.1"));
         assert!(out.contains("cached"));
         assert!(out.contains("compilation_ms"));
         assert!(out.contains("CACHE_SIZE 25"));

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -14,6 +14,9 @@ use std::collections::BTreeMap;
 pub struct ServerInfo {
     /// FalkorDB graph-module version (e.g. `42001` for v4.20.1), or `None` if it couldn't be read.
     pub module_graph_ver: Option<u64>,
+    /// The server's query plan-cache size (`GRAPH.CONFIG GET CACHE_SIZE`), for context on the
+    /// cached-vs-uncached comparison. `None` if it couldn't be read.
+    pub cache_size: Option<u64>,
     pub redis_version: Option<String>,
     pub redis_build_id: Option<String>,
     pub redis_git_sha1: Option<String>,
@@ -51,18 +54,35 @@ pub struct Meta {
     pub server: ServerInfo,
 }
 
-/// Stats for one operation: the two paired metrics plus the derived residual, and cache health.
+/// Latency and cache-health stats for one (operation, cache-mode) measurement.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OperationReport {
+pub struct MetricSet {
     pub server_ms: Summary,
     pub total_ms: Summary,
     /// Paired `total − server` per invocation (everything outside the DB's internal timer).
     pub non_internal_ms: Summary,
-    /// Fraction of invocations *with a known cache stat* that reported an un-cached execution plan
-    /// (denominator excludes `cached_unknown`).
+    /// Fraction of retained invocations *with a known cache stat* that reported an un-cached
+    /// execution plan (denominator excludes `cached_unknown`).
     pub cached_false_rate: f64,
-    /// Count of invocations whose response omitted the cache statistic.
+    /// Count of retained invocations whose response omitted the cache statistic.
     pub cached_unknown: usize,
+}
+
+/// Stats for one operation across cache modes.
+///
+/// `cached` measures with the plan cache warm (execution only); `uncached` forces a plan-cache
+/// miss on every invocation (unique query text), so it also pays expression **compilation** each
+/// time. `compilation_ms_median` is the derived per-op compilation cost when both were measured.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached: Option<MetricSet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uncached: Option<MetricSet>,
+    /// `uncached.server_ms.median − cached.server_ms.median` (exposes compilation slowness without
+    /// hiding execution). Present only when both modes were measured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compilation_ms_median: Option<f64>,
 }
 
 /// The full report written to `synthetic-report.json`.
@@ -91,8 +111,14 @@ impl Report {
             .module_graph_ver
             .map(|v| v.to_string())
             .unwrap_or_else(|| "unknown".to_string());
+        let cache_size = self
+            .meta
+            .server
+            .cache_size
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "?".to_string());
         out.push_str(&format!(
-            "server — falkordb module ver {}{}  redis {}\n",
+            "server — falkordb module ver {}{}  redis {}  CACHE_SIZE {}\n",
             v,
             if self.meta.server.is_placeholder() {
                 " (dev placeholder — use a tagged image for comparisons)"
@@ -100,31 +126,53 @@ impl Report {
                 ""
             },
             self.meta.server.redis_version.as_deref().unwrap_or("?"),
+            cache_size,
         ));
         if let Some(img) = &self.meta.server.server_image {
             out.push_str(&format!("server image: {}\n", img));
         }
         for (name, op) in &self.operations {
             out.push_str(&format!("\n{}\n", name));
-            out.push_str(&format!(
-                "  server_ms  median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
-                op.server_ms.median, op.server_ms.mean, op.server_ms.p99, op.server_ms.n, op.server_ms.removed
-            ));
-            out.push_str(&format!(
-                "  total_ms   median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
-                op.total_ms.median, op.total_ms.mean, op.total_ms.p99, op.total_ms.n, op.total_ms.removed
-            ));
-            out.push_str(&format!(
-                "  non_internal_ms (paired total-server)  median {:.3}\n",
-                op.non_internal_ms.median
-            ));
-            out.push_str(&format!(
-                "  cached_execution=false: {:.1}%  (unknown {})\n",
-                op.cached_false_rate * 100.0, op.cached_unknown
-            ));
+            if let Some(m) = &op.cached {
+                out.push_str("  [cached — plan reused, execution only]\n");
+                render_metric_set(&mut out, m);
+            }
+            if let Some(m) = &op.uncached {
+                out.push_str("  [uncached — plan-cache miss each run, execution + compilation]\n");
+                render_metric_set(&mut out, m);
+            }
+            if let Some(comp) = op.compilation_ms_median {
+                out.push_str(&format!(
+                    "  compilation_ms (median uncached-cached server time)  {:.3}\n",
+                    comp
+                ));
+            }
         }
         out
     }
+}
+
+/// Render one metric set (server/total/residual + cache health) as indented console lines.
+fn render_metric_set(
+    out: &mut String,
+    m: &MetricSet,
+) {
+    out.push_str(&format!(
+        "    server_ms  median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
+        m.server_ms.median, m.server_ms.mean, m.server_ms.p99, m.server_ms.n, m.server_ms.removed
+    ));
+    out.push_str(&format!(
+        "    total_ms   median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
+        m.total_ms.median, m.total_ms.mean, m.total_ms.p99, m.total_ms.n, m.total_ms.removed
+    ));
+    out.push_str(&format!(
+        "    non_internal_ms (paired total-server)  median {:.3}\n",
+        m.non_internal_ms.median
+    ));
+    out.push_str(&format!(
+        "    cached_execution=false: {:.1}%  (unknown {})\n",
+        m.cached_false_rate * 100.0, m.cached_unknown
+    ));
 }
 
 #[cfg(test)]
@@ -135,16 +183,24 @@ mod tests {
         crate::synthetic::stats::summarize(&[1.0, 2.0, 3.0, 4.0, 5.0]).unwrap()
     }
 
+    fn sample_metric_set() -> MetricSet {
+        MetricSet {
+            server_ms: sample_summary(),
+            total_ms: sample_summary(),
+            non_internal_ms: sample_summary(),
+            cached_false_rate: 0.0,
+            cached_unknown: 0,
+        }
+    }
+
     fn sample_report() -> Report {
         let mut operations = BTreeMap::new();
         operations.insert(
             "return_const".to_string(),
             OperationReport {
-                server_ms: sample_summary(),
-                total_ms: sample_summary(),
-                non_internal_ms: sample_summary(),
-                cached_false_rate: 0.0,
-                cached_unknown: 0,
+                cached: Some(sample_metric_set()),
+                uncached: Some(sample_metric_set()),
+                compilation_ms_median: Some(0.05),
             },
         );
         Report {
@@ -159,6 +215,7 @@ mod tests {
                 started_at_epoch_secs: 42,
                 server: ServerInfo {
                     module_graph_ver: Some(42001),
+                    cache_size: Some(25),
                     redis_version: Some("8.6.3".to_string()),
                     ..Default::default()
                 },
@@ -174,8 +231,12 @@ mod tests {
         let back: Report = serde_json::from_str(&json).unwrap();
         assert_eq!(back.meta.samples, 1000);
         assert_eq!(back.operations.len(), 1);
-        assert!(back.operations.contains_key("return_const"));
+        let op = back.operations.get("return_const").unwrap();
+        assert!(op.cached.is_some());
+        assert!(op.uncached.is_some());
+        assert_eq!(op.compilation_ms_median, Some(0.05));
         assert_eq!(back.meta.server.module_graph_ver, Some(42001));
+        assert_eq!(back.meta.server.cache_size, Some(25));
     }
 
     #[test]
@@ -185,6 +246,9 @@ mod tests {
         assert!(out.contains("server_ms"));
         assert!(out.contains("total_ms"));
         assert!(out.contains("42001"));
+        assert!(out.contains("cached"));
+        assert!(out.contains("compilation_ms"));
+        assert!(out.contains("CACHE_SIZE 25"));
     }
 
     #[test]

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -8,10 +8,11 @@ use std::collections::BTreeMap;
 /// Server build/provenance captured from `INFO server` + `MODULE LIST`, plus the operator-supplied
 /// image reference. FalkorDB does not expose a graph-module git SHA to clients, so the reproducible
 /// identity is `module_graph_ver` (real for tagged releases, a `999999` placeholder on `:edge`)
-/// together with `server_image` when provided.
+/// together with `server_image` when provided. The version is the numeric encoding
+/// `major*10000 + minor*100 + patch` (e.g. `42001` → `4.20.1`).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ServerInfo {
-    /// FalkorDB graph-module version (e.g. `42001` for v4.2.1), or `None` if it couldn't be read.
+    /// FalkorDB graph-module version (e.g. `42001` for v4.20.1), or `None` if it couldn't be read.
     pub module_graph_ver: Option<u64>,
     pub redis_version: Option<String>,
     pub redis_build_id: Option<String>,
@@ -57,7 +58,8 @@ pub struct OperationReport {
     pub total_ms: Summary,
     /// Paired `total − server` per invocation (everything outside the DB's internal timer).
     pub non_internal_ms: Summary,
-    /// Fraction of measured invocations that reported an un-cached execution plan.
+    /// Fraction of invocations *with a known cache stat* that reported an un-cached execution plan
+    /// (denominator excludes `cached_unknown`).
     pub cached_false_rate: f64,
     /// Count of invocations whose response omitted the cache statistic.
     pub cached_unknown: usize,

--- a/src/synthetic/stats.rs
+++ b/src/synthetic/stats.rs
@@ -62,6 +62,12 @@ pub fn severe_fence(samples: &[f64]) -> Option<(f64, f64)> {
     let q1 = percentile_sorted(&values, 25.0);
     let q3 = percentile_sorted(&values, 75.0);
     let iqr = q3 - q1;
+    // A zero-width IQR (Q1 == Q3) gives a degenerate fence that would classify every value not
+    // exactly at the quartiles as a severe outlier — pathological for quantized/low-resolution
+    // distributions (common for very fast ops). Treat it as "no meaningful fence".
+    if iqr <= 0.0 {
+        return None;
+    }
     Some((
         q1 - SEVERE_IQR_MULTIPLIER * iqr,
         q3 + SEVERE_IQR_MULTIPLIER * iqr,
@@ -176,6 +182,18 @@ mod tests {
         let s = summarize(&[1.0, 1000.0, 2.0]).unwrap();
         assert_eq!(s.removed, 0);
         assert_eq!(s.n, 3);
+    }
+
+    #[test]
+    fn zero_width_iqr_keeps_everything() {
+        // A quantized distribution where Q1 == Q3 (IQR == 0) must not classify the off-quartile
+        // values as severe outliers and discard most of the sample.
+        let mut data = vec![0.01; 90];
+        data.extend(std::iter::repeat_n(0.02, 10));
+        assert!(severe_fence(&data).is_none());
+        let s = summarize(&data).unwrap();
+        assert_eq!(s.removed, 0);
+        assert_eq!(s.n, 100);
     }
 
     #[test]

--- a/src/synthetic/stats.rs
+++ b/src/synthetic/stats.rs
@@ -49,52 +49,66 @@ fn percentile_sorted(
     sorted[lo] + (sorted[hi] - sorted[lo]) * frac
 }
 
-/// Remove severe (`> 3·IQR` beyond the quartiles) outliers, returning the retained values (sorted)
-/// and the number removed. With fewer than 4 samples the IQR is not meaningful, so nothing is
-/// removed.
-fn remove_severe_outliers(mut values: Vec<f64>) -> (Vec<f64>, usize) {
-    values.retain(|v| v.is_finite());
+/// Compute the severe-outlier fence `[Q1 - 3·IQR, Q3 + 3·IQR]` for a set of samples.
+///
+/// Returns `None` when there are fewer than 4 finite samples (IQR is not meaningful), meaning
+/// "no fence — keep everything".
+pub fn severe_fence(samples: &[f64]) -> Option<(f64, f64)> {
+    let mut values: Vec<f64> = samples.iter().copied().filter(|v| v.is_finite()).collect();
     values.sort_by(|a, b| a.partial_cmp(b).expect("finite values sort"));
     if values.len() < 4 {
-        return (values, 0);
+        return None;
     }
     let q1 = percentile_sorted(&values, 25.0);
     let q3 = percentile_sorted(&values, 75.0);
     let iqr = q3 - q1;
-    let lower = q1 - SEVERE_IQR_MULTIPLIER * iqr;
-    let upper = q3 + SEVERE_IQR_MULTIPLIER * iqr;
-    let before = values.len();
-    let kept: Vec<f64> = values
-        .into_iter()
-        .filter(|&v| v >= lower && v <= upper)
-        .collect();
-    let removed = before - kept.len();
-    (kept, removed)
+    Some((
+        q1 - SEVERE_IQR_MULTIPLIER * iqr,
+        q3 + SEVERE_IQR_MULTIPLIER * iqr,
+    ))
+}
+
+/// Summarize an already-filtered set of `kept` values, recording `removed` (the number of samples
+/// excluded before this call). Returns `None` when `kept` has no finite values.
+pub fn summarize_kept(
+    kept: &[f64],
+    removed: usize,
+) -> Option<Summary> {
+    let mut vals: Vec<f64> = kept.iter().copied().filter(|v| v.is_finite()).collect();
+    if vals.is_empty() {
+        return None;
+    }
+    vals.sort_by(|a, b| a.partial_cmp(b).expect("finite values sort"));
+    let n = vals.len();
+    let sum: f64 = vals.iter().sum();
+    let mean = sum / n as f64;
+    let variance = vals.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n as f64;
+    Some(Summary {
+        n,
+        removed,
+        min: vals[0],
+        mean,
+        median: percentile_sorted(&vals, 50.0),
+        p90: percentile_sorted(&vals, 90.0),
+        p99: percentile_sorted(&vals, 99.0),
+        max: vals[n - 1],
+        stddev: variance.sqrt(),
+    })
 }
 
 /// Compute a [`Summary`] over `samples`, removing severe outliers first.
 ///
 /// Returns `None` when no finite samples remain (nothing meaningful to summarize).
 pub fn summarize(samples: &[f64]) -> Option<Summary> {
-    let (kept, removed) = remove_severe_outliers(samples.to_vec());
-    if kept.is_empty() {
-        return None;
+    let finite: Vec<f64> = samples.iter().copied().filter(|v| v.is_finite()).collect();
+    match severe_fence(&finite) {
+        Some((lo, hi)) => {
+            let kept: Vec<f64> = finite.iter().copied().filter(|&v| v >= lo && v <= hi).collect();
+            let removed = finite.len() - kept.len();
+            summarize_kept(&kept, removed)
+        }
+        None => summarize_kept(&finite, 0),
     }
-    let n = kept.len();
-    let sum: f64 = kept.iter().sum();
-    let mean = sum / n as f64;
-    let variance = kept.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n as f64;
-    Some(Summary {
-        n,
-        removed,
-        min: kept[0],
-        mean,
-        median: percentile_sorted(&kept, 50.0),
-        p90: percentile_sorted(&kept, 90.0),
-        p99: percentile_sorted(&kept, 99.0),
-        max: kept[n - 1],
-        stddev: variance.sqrt(),
-    })
 }
 
 #[cfg(test)]

--- a/src/synthetic/stats.rs
+++ b/src/synthetic/stats.rs
@@ -1,0 +1,181 @@
+//! Robust latency statistics for the synthetic benchmark.
+//!
+//! Computes the summary each measured metric reports (min/mean/median/p90/p99/std-dev) after
+//! removing *severe* outliers with Tukey fences (values outside `[Q1 - 3·IQR, Q3 + 3·IQR]`), the
+//! same idea Criterion.rs uses to keep a few pathological samples from dominating an estimate.
+
+use serde::{Deserialize, Serialize};
+
+/// Summary statistics for one metric (e.g. `server_ms` or `total_ms`) over a set of samples,
+/// after severe-outlier removal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Summary {
+    /// Number of samples retained after severe-outlier removal.
+    pub n: usize,
+    /// Number of severe outliers removed.
+    pub removed: usize,
+    pub min: f64,
+    pub mean: f64,
+    pub median: f64,
+    pub p90: f64,
+    pub p99: f64,
+    pub max: f64,
+    /// Population standard deviation of the retained samples.
+    pub stddev: f64,
+}
+
+/// The Tukey multiplier that classifies a *severe* outlier (`3·IQR`); mild would be `1.5`.
+const SEVERE_IQR_MULTIPLIER: f64 = 3.0;
+
+/// Linear-interpolation percentile (`p` in `[0, 100]`) over an already-sorted slice.
+///
+/// Uses the same "fraction of the way between order statistics" definition as NumPy's default
+/// (`linear`) method. `sorted` must be non-empty and sorted ascending.
+fn percentile_sorted(
+    sorted: &[f64],
+    p: f64,
+) -> f64 {
+    debug_assert!(!sorted.is_empty());
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let rank = (p / 100.0) * (sorted.len() - 1) as f64;
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    if lo == hi {
+        return sorted[lo];
+    }
+    let frac = rank - lo as f64;
+    sorted[lo] + (sorted[hi] - sorted[lo]) * frac
+}
+
+/// Remove severe (`> 3·IQR` beyond the quartiles) outliers, returning the retained values (sorted)
+/// and the number removed. With fewer than 4 samples the IQR is not meaningful, so nothing is
+/// removed.
+fn remove_severe_outliers(mut values: Vec<f64>) -> (Vec<f64>, usize) {
+    values.retain(|v| v.is_finite());
+    values.sort_by(|a, b| a.partial_cmp(b).expect("finite values sort"));
+    if values.len() < 4 {
+        return (values, 0);
+    }
+    let q1 = percentile_sorted(&values, 25.0);
+    let q3 = percentile_sorted(&values, 75.0);
+    let iqr = q3 - q1;
+    let lower = q1 - SEVERE_IQR_MULTIPLIER * iqr;
+    let upper = q3 + SEVERE_IQR_MULTIPLIER * iqr;
+    let before = values.len();
+    let kept: Vec<f64> = values
+        .into_iter()
+        .filter(|&v| v >= lower && v <= upper)
+        .collect();
+    let removed = before - kept.len();
+    (kept, removed)
+}
+
+/// Compute a [`Summary`] over `samples`, removing severe outliers first.
+///
+/// Returns `None` when no finite samples remain (nothing meaningful to summarize).
+pub fn summarize(samples: &[f64]) -> Option<Summary> {
+    let (kept, removed) = remove_severe_outliers(samples.to_vec());
+    if kept.is_empty() {
+        return None;
+    }
+    let n = kept.len();
+    let sum: f64 = kept.iter().sum();
+    let mean = sum / n as f64;
+    let variance = kept.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / n as f64;
+    Some(Summary {
+        n,
+        removed,
+        min: kept[0],
+        mean,
+        median: percentile_sorted(&kept, 50.0),
+        p90: percentile_sorted(&kept, 90.0),
+        p99: percentile_sorted(&kept, 99.0),
+        max: kept[n - 1],
+        stddev: variance.sqrt(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(
+        a: f64,
+        b: f64,
+    ) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn percentile_matches_known_values() {
+        let v: Vec<f64> = (1..=10).map(|i| i as f64).collect(); // 1..=10
+        assert!(approx(percentile_sorted(&v, 0.0), 1.0));
+        assert!(approx(percentile_sorted(&v, 100.0), 10.0));
+        // NumPy linear: p50 of 1..=10 is 5.5.
+        assert!(approx(percentile_sorted(&v, 50.0), 5.5));
+        // p90 interpolates between the 9th and 10th values: 9 + 0.1*(10-9) = 9.1.
+        assert!(approx(percentile_sorted(&v, 90.0), 9.1));
+    }
+
+    #[test]
+    fn percentile_single_value() {
+        assert!(approx(percentile_sorted(&[42.0], 25.0), 42.0));
+        assert!(approx(percentile_sorted(&[42.0], 99.0), 42.0));
+    }
+
+    #[test]
+    fn summarize_basic_metrics() {
+        let s = summarize(&[1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
+        assert_eq!(s.n, 5);
+        assert_eq!(s.removed, 0);
+        assert!(approx(s.min, 1.0));
+        assert!(approx(s.max, 5.0));
+        assert!(approx(s.mean, 3.0));
+        assert!(approx(s.median, 3.0));
+    }
+
+    #[test]
+    fn removes_severe_outlier_but_keeps_normal_spread() {
+        // 20 tightly-clustered points plus one huge spike; the spike must be dropped.
+        let mut data: Vec<f64> = (0..20).map(|i| 100.0 + i as f64).collect();
+        data.push(100_000.0);
+        let s = summarize(&data).unwrap();
+        assert_eq!(s.removed, 1, "the severe spike should be removed");
+        assert_eq!(s.n, 20);
+        assert!(s.max < 1_000.0, "max should reflect the retained cluster");
+    }
+
+    #[test]
+    fn does_not_remove_mild_variation() {
+        // A moderate spread with no point beyond 3*IQR keeps every sample.
+        let data = vec![10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0];
+        let s = summarize(&data).unwrap();
+        assert_eq!(s.removed, 0);
+        assert_eq!(s.n, data.len());
+    }
+
+    #[test]
+    fn tiny_sample_keeps_everything() {
+        // Fewer than 4 samples: IQR is not meaningful, so nothing is removed.
+        let s = summarize(&[1.0, 1000.0, 2.0]).unwrap();
+        assert_eq!(s.removed, 0);
+        assert_eq!(s.n, 3);
+    }
+
+    #[test]
+    fn empty_and_nonfinite_samples() {
+        assert!(summarize(&[]).is_none());
+        assert!(summarize(&[f64::NAN, f64::INFINITY]).is_none());
+        // Finite values survive alongside non-finite ones.
+        let s = summarize(&[f64::NAN, 1.0, 2.0]).unwrap();
+        assert_eq!(s.n, 2);
+    }
+
+    #[test]
+    fn stddev_of_constant_is_zero() {
+        let s = summarize(&[5.0, 5.0, 5.0, 5.0, 5.0]).unwrap();
+        assert!(approx(s.stddev, 0.0));
+    }
+}

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1,10 +1,14 @@
-//! Integration test for the synthetic single-operation probe.
+//! Integration tests for the synthetic single-operation probe.
 //!
-//! Requires a reachable FalkorDB (set `FALKORDB_HOST`/`FALKORDB_PORT` or default to
-//! `127.0.0.1:6379`). It is `#[ignore]`d so `cargo test` stays hermetic; run it with a live
-//! server via `just synthetic-it` (or `cargo test --test synthetic_probe -- --ignored`).
+//! These require a reachable FalkorDB (set `FALKORDB_HOST`/`FALKORDB_PORT` or default to
+//! `127.0.0.1:6379`). They are `#[ignore]`d so a plain `cargo test` stays hermetic; run them with
+//! a live server via `just synthetic-it`, and the coverage job runs them with `--include-ignored`
+//! against a FalkorDB service.
 
-use benchmark::synthetic::{run, Config, OpName};
+use benchmark::queries_repository::QueryType;
+use benchmark::synthetic::op_runner::run_and_drain;
+use benchmark::synthetic::{list_ops, open_graph, run, run_and_report, CacheSelection, Config, OpName};
+use std::time::Duration;
 
 fn endpoint() -> String {
     let host = std::env::var("FALKORDB_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
@@ -12,21 +16,25 @@ fn endpoint() -> String {
     format!("falkor://{host}:{port}")
 }
 
-#[tokio::test]
-#[ignore = "requires a running FalkorDB server"]
-async fn probe_produces_valid_report() {
-    let samples = 300usize;
-    let config = Config {
+fn base_config() -> Config {
+    Config {
         endpoint: endpoint(),
         op: OpName::ReturnConst,
-        samples,
+        samples: 300,
         warmup: 50,
         server_timeout_ms: 5_000,
         client_deadline_ms: 6_000,
-        cache: benchmark::synthetic::CacheSelection::Both,
+        cache: CacheSelection::Both,
         out: "synthetic-report.json".to_string(),
         server_image: None,
-    };
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn probe_produces_valid_report() {
+    let config = base_config();
+    let samples = config.samples;
 
     let report = run(&config).await.expect("probe run should succeed");
 
@@ -55,9 +63,158 @@ async fn probe_produces_valid_report() {
         uncached.cached_false_rate
     );
 
+    // A compilation cost was derived from both modes.
+    assert!(op.compilation_ms_median.is_some());
+
     // Provenance was captured from the live server.
     assert!(
         report.meta.server.redis_version.is_some(),
         "redis_version should be read from INFO server"
     );
+    assert!(
+        report.meta.server.cache_size.is_some(),
+        "CACHE_SIZE should be read via GRAPH.CONFIG"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn run_and_report_writes_json_file() {
+    let dir = std::env::temp_dir();
+    let out = dir
+        .join(format!("synthetic-report-it-{}.json", std::process::id()))
+        .to_string_lossy()
+        .into_owned();
+    let config = Config {
+        samples: 120,
+        warmup: 20,
+        out: out.clone(),
+        ..base_config()
+    };
+
+    run_and_report(&config)
+        .await
+        .expect("run_and_report should succeed");
+
+    let written = std::fs::read_to_string(&out).expect("report file should exist");
+    assert!(written.contains("return_const"));
+    assert!(written.contains("\"cached\""));
+    assert!(written.contains("\"uncached\""));
+    let _ = std::fs::remove_file(&out);
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn cached_only_and_uncached_only_modes() {
+    // Cached-only: no uncached block.
+    let cached_report = run(&Config {
+        samples: 100,
+        warmup: 20,
+        cache: CacheSelection::Cached,
+        ..base_config()
+    })
+    .await
+    .expect("cached-only run should succeed");
+    let cop = cached_report.operations.get("return_const").unwrap();
+    assert!(cop.cached.is_some());
+    assert!(cop.uncached.is_none());
+    assert!(cop.compilation_ms_median.is_none());
+
+    // Uncached-only: no cached block, and it misses the plan cache.
+    let uncached_report = run(&Config {
+        samples: 100,
+        warmup: 20,
+        cache: CacheSelection::Uncached,
+        ..base_config()
+    })
+    .await
+    .expect("uncached-only run should succeed");
+    let uop = uncached_report.operations.get("return_const").unwrap();
+    assert!(uop.cached.is_none());
+    let uncached = uop.uncached.as_ref().unwrap();
+    assert!(uncached.cached_false_rate > 0.5);
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn bad_endpoint_errors_out() {
+    // Nothing is listening on this port → the run should error rather than hang or panic.
+    let config = Config {
+        endpoint: "falkor://127.0.0.1:6390".to_string(),
+        samples: 10,
+        warmup: 2,
+        client_deadline_ms: 1_000,
+        ..base_config()
+    };
+    assert!(run(&config).await.is_err());
+}
+
+#[test]
+fn list_ops_is_non_empty() {
+    // Pure helper — no server needed; keeps the smoke path covered even without `--ignored`.
+    assert!(list_ops().contains("return_const"));
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn op_runner_reads_writes_and_reports_errors() {
+    let mut graph = open_graph(&endpoint(), "synthetic_op_runner_it")
+        .await
+        .expect("open graph");
+
+    // A write goes through the `GRAPH.QUERY` path, instantiates the graph, and drains its row.
+    // Return a scalar (not the node itself) so row decoding doesn't trigger schema round-trips.
+    let write = run_and_drain(
+        &mut graph,
+        QueryType::Write,
+        "CREATE (n:T {v: 1}) RETURN n.v",
+        5_000,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("write op should succeed");
+    assert_eq!(write.rows, 1);
+
+    // A read that returns a row: drains it and reports a finite, non-negative server time.
+    let read = run_and_drain(&mut graph, QueryType::Read, "RETURN 1 AS x", 5_000, Duration::from_secs(5))
+        .await
+        .expect("read op should succeed");
+    assert_eq!(read.rows, 1);
+    assert!(read.server_ms.is_finite() && read.server_ms >= 0.0);
+    assert!(read.total_ms >= read.server_ms);
+
+    // A syntactically invalid query surfaces as an error rather than a panic.
+    assert!(
+        run_and_drain(&mut graph, QueryType::Read, "THIS IS NOT CYPHER", 5_000, Duration::from_secs(5))
+            .await
+            .is_err()
+    );
+
+    // An impossibly small client deadline trips the whole-operation timeout guard.
+    assert!(
+        run_and_drain(&mut graph, QueryType::Read, "RETURN 1", 5_000, Duration::from_nanos(1))
+            .await
+            .is_err()
+    );
+
+    // Tidy up the scratch graph.
+    let _ = graph.delete().await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn probe_instantiates_a_missing_graph() {
+    // Delete the probe's graph first so `run()` exercises the empty-key instantiation path.
+    if let Ok(mut g) = open_graph(&endpoint(), "falkor").await {
+        let _ = g.delete().await;
+    }
+    let report = run(&Config {
+        samples: 60,
+        warmup: 10,
+        cache: CacheSelection::Cached,
+        ..base_config()
+    })
+    .await
+    .expect("probe should instantiate the missing graph and succeed");
+    assert!(report.operations.contains_key("return_const"));
 }

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1,0 +1,59 @@
+//! Integration test for the synthetic single-operation probe.
+//!
+//! Requires a reachable FalkorDB (set `FALKORDB_HOST`/`FALKORDB_PORT` or default to
+//! `127.0.0.1:6379`). It is `#[ignore]`d so `cargo test` stays hermetic; run it with a live
+//! server via `just synthetic-it` (or `cargo test --test synthetic_probe -- --ignored`).
+
+use benchmark::synthetic::{run, Config, OpName};
+
+fn endpoint() -> String {
+    let host = std::env::var("FALKORDB_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let port = std::env::var("FALKORDB_PORT").unwrap_or_else(|_| "6379".to_string());
+    format!("falkor://{host}:{port}")
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn probe_produces_valid_report() {
+    let samples = 300usize;
+    let config = Config {
+        endpoint: endpoint(),
+        op: OpName::ReturnConst,
+        samples,
+        warmup: 50,
+        server_timeout_ms: 5_000,
+        client_deadline_ms: 6_000,
+        out: "synthetic-report.json".to_string(),
+        server_image: None,
+    };
+
+    let report = run(&config).await.expect("probe run should succeed");
+
+    let op = report
+        .operations
+        .get("return_const")
+        .expect("report should contain the measured op");
+
+    // Every sample is accounted for (retained + severe-outliers removed).
+    assert_eq!(
+        op.server_ms.n + op.server_ms.removed,
+        samples,
+        "server_ms samples should sum to the requested count"
+    );
+    assert_eq!(op.total_ms.n + op.total_ms.removed, samples);
+
+    // The server reported a positive internal execution time, and the round-trip is at least as
+    // long as the server time (the residual can't be negative in aggregate).
+    assert!(op.server_ms.median > 0.0, "server_ms should be positive");
+    assert!(op.total_ms.median > 0.0, "total_ms should be positive");
+    assert!(
+        op.total_ms.median >= op.server_ms.median,
+        "total time should be >= server time"
+    );
+
+    // Provenance was captured from the live server.
+    assert!(
+        report.meta.server.redis_version.is_some(),
+        "redis_version should be read from INFO server"
+    );
+}

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -23,6 +23,7 @@ async fn probe_produces_valid_report() {
         warmup: 50,
         server_timeout_ms: 5_000,
         client_deadline_ms: 6_000,
+        cache: benchmark::synthetic::CacheSelection::Both,
         out: "synthetic-report.json".to_string(),
         server_image: None,
     };
@@ -34,21 +35,24 @@ async fn probe_produces_valid_report() {
         .get("return_const")
         .expect("report should contain the measured op");
 
-    // Every sample is accounted for (retained + severe-outliers removed).
-    assert_eq!(
-        op.server_ms.n + op.server_ms.removed,
-        samples,
-        "server_ms samples should sum to the requested count"
-    );
-    assert_eq!(op.total_ms.n + op.total_ms.removed, samples);
+    // Both cache modes were measured.
+    let cached = op.cached.as_ref().expect("cached metrics present");
+    let uncached = op.uncached.as_ref().expect("uncached metrics present");
 
-    // The server reported a positive internal execution time, and the round-trip is at least as
-    // long as the server time (the residual can't be negative in aggregate).
-    assert!(op.server_ms.median > 0.0, "server_ms should be positive");
-    assert!(op.total_ms.median > 0.0, "total_ms should be positive");
+    // Every sample is accounted for (retained + severe-outliers removed) in each mode.
+    assert_eq!(cached.server_ms.n + cached.server_ms.removed, samples);
+    assert_eq!(uncached.server_ms.n + uncached.server_ms.removed, samples);
+
+    // Positive server + total time, and total >= server within each mode.
+    assert!(cached.server_ms.median > 0.0);
+    assert!(cached.total_ms.median >= cached.server_ms.median);
+    assert!(uncached.total_ms.median >= uncached.server_ms.median);
+
+    // The uncached mode forces plan-cache misses: most invocations report cached_execution=false.
     assert!(
-        op.total_ms.median >= op.server_ms.median,
-        "total time should be >= server time"
+        uncached.cached_false_rate > 0.5,
+        "uncached mode should mostly miss the plan cache (got {})",
+        uncached.cached_false_rate
     );
 
     // Provenance was captured from the live server.


### PR DESCRIPTION
## What

Implements **Part 1 of #200** (issue #201): the foundation slice of the synthetic per-operation benchmark — a `benchmark synthetic` subcommand that measures **one Cypher operation in isolation** against a FalkorDB endpoint.

On every invocation it captures the **paired** `(server_ms, total_ms)`:
- **server time** — FalkorDB's reported internal execution time (`get_internal_execution_time`),
- **total time** — an `Instant` around `execute().await` **plus draining every row**,

then summarizes each metric with **severe-outlier removal** (Tukey `>3×IQR`, like Criterion.rs) and writes a JSON report + console summary. Single dedicated connection for honest single-flight latency.

Closes #201.

## Try it (start → end)

```bash
docker run -d --rm -p 6379:6379 falkordb/falkordb:latest        # 1. server (tagged image)
just build                                                      # 2. build (needs protoc)
just synthetic-ops                                              # 3. list operations
IMAGE=$(docker inspect --format '{{index .RepoDigests 0}}' falkordb/falkordb:latest)
just synthetic-bench --samples 1000 --op return_const --server-image "$IMAGE"   # 4. run
```

```text
synthetic benchmark — endpoint falkor://127.0.0.1:6379  samples 1000  warmup 200  connection pool(size=1)
server — falkordb module ver 42001  redis 8.6.3
server image: falkordb/falkordb@sha256:9042fdc4...

return_const
  server_ms  median 0.017  mean 0.018  p99 0.030  (n=983, removed 17)
  total_ms   median 0.397  mean 0.403  p99 0.519  (n=982, removed 18)
  non_internal_ms (paired total-server)  median 0.379
  cached_execution=false: 0.0%  (unknown 0)
report written to synthetic-report.json
```

## Contents (functionality + tests + docs + examples, per the epic's DoD)

- **`src/synthetic/`** — `stats` (robust summary + severe-outlier removal), `op_runner` (`run_and_drain`), `provenance` (`INFO server` + `MODULE LIST` → `meta.server`), `report` (JSON + console), `mod` (`OpName` `ValueEnum`, `Config`, single-connection `run()`, warm-up + measurement, `list-ops`).
- **CLI:** `benchmark synthetic run|list-ops`; recipes `just synthetic-bench` / `synthetic-ops` / `synthetic-it`.
- **Server provenance / `--server-image`:** records module version + redis fields + the operator-supplied image digest; warns on the `999999` `:edge` placeholder. (FalkorDB exposes no graph-module git SHA to clients — the image digest is the reproducible identity.)
- **Tests:** 36 unit tests (stats edges/outliers, paired-cohort invariant, provenance RESP2+RESP3 parsing, version decode, endpoint redaction, JSON round-trip) + an `#[ignore]`d integration test (`just synthetic-it`) that runs against a live server.
- **Docs:** README "Synthetic per-operation benchmark" section (start-to-end example + sample output) and the copilot-instructions recipe table.

## Design choices worth noting
- **Paired outlier removal:** a sample is dropped if it's a severe outlier in *either* metric; all three summaries share one retained cohort, so their `n` matches and `total_ms ≥ server_ms` holds in aggregate.
- **`OpName` is a `ValueEnum`** = single source of truth for `--help`, shell completion and (later) the catalog. Part 1 ships one dataset-free op (`return_const` = `RETURN $i`); later parts extend the enum.
- **Never NaN:** a missing/non-finite/negative server time is a hard error, never averaged in.
- **No credential leakage:** the endpoint is password-redacted before being recorded/printed.

## Validation
`just ci` (build + clippy `-D warnings` + test) green; probe + integration test verified against dockerized FalkorDB (`latest` and `edge`). Rubber-duck reviewed; its findings (endpoint redaction, paired cohorts, bounded/replica-safe setup, never-NaN, `started_at` timing, RESP3 provenance) are addressed in this branch.

## Scope
Foundation only — operation catalog (#202), dataset generator (#203), concurrency sweep (#204), writes (#205) and reporting/baselines (#206) build on this.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental synthetic benchmarking tool for measuring individual Cypher operation latency.
  * Reports server execution time, end-to-end client latency, cache information, percentile statistics, and outlier removal.
  * Added a command to list available benchmark operations.
  * Benchmark results can be displayed in the console and saved as JSON with server version and image metadata.

* **Documentation**
  * Added setup, usage instructions, sample output, and guidance for running benchmarks against a live FalkorDB server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->