### PR TITLE
feat(synthetic): operation catalog + read primitives (part 2 of #200)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -103,8 +103,9 @@ run *args:
 # === Synthetic per-operation benchmark =======================================
 
 # Needs a reachable FalkorDB, e.g. `docker run -d -p 6379:6379 falkordb/falkordb:latest`. Example:
-# `just synthetic-bench --samples 1000 --op return_const`.
-# Run the synthetic single-operation latency probe (forwards args to `synthetic run`).
+# `just synthetic-bench --graph demo --op match_by_index,expand_1_hop --samples 500` (or --all-reads).
+# Read primitives need a `:User {id}` / `:Friend` dataset in --graph; see the README catalog.
+# Run the synthetic per-operation latency probe (forwards args to `synthetic run`).
 synthetic-bench *args:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/readme.md
+++ b/readme.md
@@ -172,12 +172,12 @@ parameterized; the corpus is seeded (`--seed`) so the same seed yields an identi
 |---|---|---|
 | `return_const` | round-trip / parse+exec baseline (no dataset) | `RETURN $i AS x` |
 | `match_by_index` | point lookup on the `:User(id)` index | `MATCH (n:User {id: $id}) RETURN n.id` |
-| `match_by_label_scan` | full `:User` label scan (non-indexable predicate) | `MATCH (n:User) WHERE n.id % $modulus = 0 RETURN count(n)` |
+| `match_by_label_scan` | full `:User` label scan (non-indexable predicate) | `MATCH (n:User) WHERE n.id % $modulus = 0 RETURN count(n) AS c` |
 | `expand_1_hop` | 1-hop `:Friend` expansion | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.id` |
 | `expand_hops_5` | fixed 5-hop `:Friend` expansion | `MATCH (s:User {id: $id})-[:Friend*5..5]->(n:User) RETURN DISTINCT n.id LIMIT 100` |
-| `aggregate_count` | count a node's 1-hop neighbours | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN count(n)` |
+| `aggregate_count` | count a node's 1-hop neighbours | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN count(n) AS c` |
 | `aggregate_group` | group neighbours by age with counts | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.age AS age, count(*) AS c ORDER BY c DESC LIMIT 10` |
-| `shortest_path` | bounded shortest `:Friend` path between two nodes | `MATCH (s:User {id: $from}),(t:User {id: $to}) WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1)` |
+| `shortest_path` | bounded shortest `:Friend` path between two nodes | `MATCH (s:User {id: $from}),(t:User {id: $to}) WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1) AS len` |
 | `property_projection` | project scalar properties of an indexed node | `MATCH (n:User {id: $id}) RETURN n.id, n.age` |
 
 Because `OpName` is a clap `ValueEnum`, `--op <TAB>` completes the operation names once you've

--- a/readme.md
+++ b/readme.md
@@ -163,9 +163,11 @@ cached|uncached|both` (default `both`).
 
 Select operations with `--op <name>` (repeatable and comma-separated) or `--all-reads`. All read
 ops except `return_const` target the benchmark's `:User {id, age}` / `(:User)-[:Friend]->(:User)`
-schema (with an index on `:User(id)`); their parameter corpora are seeded from ids sampled out of
-`--graph` (a reproducible generated dataset arrives in Part 3, so for now point `--graph` at a graph
-that already holds that schema). Every query projects **scalars** (never whole nodes) and is
+schema (with an index on `:User(id)`). Most draw their parameters from `:User` ids sampled out of
+`--graph` (`shortest_path` needs two, `match_by_index`/`expand_*`/`aggregate_*`/`property_projection`
+one); `return_const` and `match_by_label_scan` need no seed ids (they vary a constant / a scan
+modulus). A reproducible generated dataset arrives in Part 3, so for now point `--graph` at a graph
+that already holds that schema. Every query projects **scalars** (never whole nodes) and is
 parameterized; the corpus is seeded (`--seed`) so the same seed yields an identical corpus.
 
 | Operation | What it measures | Cypher (body) |

--- a/readme.md
+++ b/readme.md
@@ -179,7 +179,7 @@ parameterized; the corpus is seeded (`--seed`) so the same seed yields an identi
 | `expand_hops_5` | fixed 5-hop `:Friend` expansion | `MATCH (s:User {id: $id})-[:Friend*5..5]->(n:User) RETURN DISTINCT n.id LIMIT 100` |
 | `aggregate_count` | count a node's 1-hop neighbours | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN count(n) AS c` |
 | `aggregate_group` | group neighbours by age with counts | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.age AS age, count(*) AS c ORDER BY c DESC LIMIT 10` |
-| `shortest_path` | bounded shortest `:Friend` path between two nodes | `MATCH (s:User {id: $from}),(t:User {id: $to}) WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1) AS len` |
+| `shortest_path` | bounded shortest `:Friend` path between two nodes | `MATCH (s:User {id: $from}), (t:User {id: $to}) WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1) AS len` |
 | `property_projection` | project scalar properties of an indexed node | `MATCH (n:User {id: $id}) RETURN n.id, n.age` |
 
 Because `OpName` is a clap `ValueEnum`, `--op <TAB>` completes the operation names once you've
@@ -222,6 +222,8 @@ match_by_index
     cached_execution=false: 0.0%  (unknown 0)
   [uncached — plan-cache miss each run, execution + compilation]
     server_ms  median 0.058  mean 0.063  p99 0.093  (n=497, removed 3)
+    total_ms   median 0.452  mean 0.461  p99 0.604  (n=497, removed 3)
+    non_internal_ms (paired total-server)  median 0.391
     cached_execution=false: 100.0%  (unknown 0)
   compilation_ms (median uncached-cached server time)  0.025
 

--- a/readme.md
+++ b/readme.md
@@ -139,13 +139,13 @@ workflow. Please cover new code with tests and keep coverage high — **patch co
 
 ### Synthetic per-operation benchmark (experimental)
 
-Measures a single Cypher operation **in isolation**, capturing on every invocation both the
-**server time** (FalkorDB's reported internal execution time) and the **total time** (end-to-end
-client round-trip), then summarizes them with severe-outlier removal (Tukey fences, like
-Criterion.rs) and writes a JSON report. It uses a single dedicated connection for honest
-single-flight latency. This is the first slice of a larger tool (see the design in
-[`synthetic-benchmark.md`](synthetic-benchmark.md)); later parts add an operation catalog, a
-synthetic dataset, and a concurrency sweep.
+Measures a curated suite of **read operations in isolation** — one at a time, selectable — capturing
+on every invocation both the **server time** (FalkorDB's reported internal execution time) and the
+**total time** (end-to-end client round-trip), then summarizing them with severe-outlier removal
+(Tukey fences, like Criterion.rs) and writing a JSON report with one block per operation. It uses a
+single dedicated connection for honest single-flight latency. This is Part 2 of a larger tool (see
+[`synthetic-benchmark.md`](synthetic-benchmark.md)); later parts add a generated synthetic dataset,
+a concurrency sweep, and write operations.
 
 Each operation is measured under two plan-cache conditions so you can see the cost of expression
 **compilation** separately from execution:
@@ -159,6 +159,31 @@ is load-time only, so the uncached condition is produced client-side and verifie
 `cached_execution` flag; the server's actual `CACHE_SIZE` is recorded in the report.) Use `--cache
 cached|uncached|both` (default `both`).
 
+#### Operation catalog
+
+Select operations with `--op <name>` (repeatable and comma-separated) or `--all-reads`. All read
+ops except `return_const` target the benchmark's `:User {id, age}` / `(:User)-[:Friend]->(:User)`
+schema (with an index on `:User(id)`); their parameter corpora are seeded from ids sampled out of
+`--graph` (a reproducible generated dataset arrives in Part 3, so for now point `--graph` at a graph
+that already holds that schema). Every query projects **scalars** (never whole nodes) and is
+parameterized; the corpus is seeded (`--seed`) so the same seed yields an identical corpus.
+
+| Operation | What it measures | Cypher (body) |
+|---|---|---|
+| `return_const` | round-trip / parse+exec baseline (no dataset) | `RETURN $i AS x` |
+| `match_by_index` | point lookup on the `:User(id)` index | `MATCH (n:User {id: $id}) RETURN n.id` |
+| `match_by_label_scan` | full `:User` label scan (non-indexable predicate) | `MATCH (n:User) WHERE n.id % $modulus = 0 RETURN count(n)` |
+| `expand_1_hop` | 1-hop `:Friend` expansion | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.id` |
+| `expand_hops_5` | fixed 5-hop `:Friend` expansion | `MATCH (s:User {id: $id})-[:Friend*5..5]->(n:User) RETURN DISTINCT n.id LIMIT 100` |
+| `aggregate_count` | count a node's 1-hop neighbours | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN count(n)` |
+| `aggregate_group` | group neighbours by age with counts | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.age AS age, count(*) AS c ORDER BY c DESC LIMIT 10` |
+| `shortest_path` | bounded shortest `:Friend` path between two nodes | `MATCH (s:User {id: $from}),(t:User {id: $to}) WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1)` |
+| `property_projection` | project scalar properties of an indexed node | `MATCH (n:User {id: $id}) RETURN n.id, n.age` |
+
+Because `OpName` is a clap `ValueEnum`, `--op <TAB>` completes the operation names once you've
+installed completion (`benchmark generate-auto-complete <shell>`), and `just synthetic-ops` (or
+`benchmark synthetic list-ops`) prints the catalog.
+
 Set up and run, start to end:
 
 ```bash
@@ -171,32 +196,35 @@ just build
 # 3. list the available operations
 just synthetic-ops
 
-# 4. run the probe (records the exact server image so results are reproducible)
+# 4. run the probe over several ops (records the exact server image so results are reproducible)
 IMAGE=$(docker inspect --format '{{index .RepoDigests 0}}' falkordb/falkordb:latest)
-just synthetic-bench --endpoint falkor://127.0.0.1:6379 \
-    --op return_const --samples 1000 --warmup 200 --cache both \
-    --server-image "$IMAGE" --out synthetic-report.json
+just synthetic-bench --endpoint falkor://127.0.0.1:6379 --graph main \
+    --op match_by_index,expand_1_hop,aggregate_count --samples 500 --warmup 100 \
+    --cache both --seed 42 --server-image "$IMAGE" --out synthetic-report.json
+# ...or measure the whole read catalog at once:
+just synthetic-bench --graph main --all-reads --samples 500
 ```
 
-Sample output:
+Sample output (one block per selected op):
 
 ```text
-synthetic benchmark — endpoint falkor://127.0.0.1:6379  samples 1000  warmup 200  connection pool(size=1)
+synthetic benchmark — endpoint falkor://127.0.0.1:6379  graph main  samples 500  warmup 100  seed 42  connection pool(size=1)
 server — falkordb module ver 4.20.1  redis 8.6.3  CACHE_SIZE 25
 server image: falkordb/falkordb@sha256:9042fdc4...
 
-return_const
+match_by_index
   [cached — plan reused, execution only]
-    server_ms  median 0.018  mean 0.019  p99 0.031  (n=983, removed 17)
-    total_ms   median 0.391  mean 0.397  p99 0.514  (n=983, removed 17)
-    non_internal_ms (paired total-server)  median 0.374
+    server_ms  median 0.033  mean 0.034  p99 0.059  (n=487, removed 13)
+    total_ms   median 0.427  mean 0.440  p99 0.596  (n=487, removed 13)
+    non_internal_ms (paired total-server)  median 0.394
     cached_execution=false: 0.0%  (unknown 0)
   [uncached — plan-cache miss each run, execution + compilation]
-    server_ms  median 0.029  mean 0.030  p99 0.047  (n=977, removed 23)
-    total_ms   median 0.388  mean 0.392  p99 0.490  (n=977, removed 23)
-    non_internal_ms (paired total-server)  median 0.358
+    server_ms  median 0.058  mean 0.063  p99 0.093  (n=497, removed 3)
     cached_execution=false: 100.0%  (unknown 0)
-  compilation_ms (median uncached-cached server time)  0.011
+  compilation_ms (median uncached-cached server time)  0.025
+
+expand_1_hop
+  ...
 report written to synthetic-report.json
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -250,7 +250,7 @@ pub enum Commands {
 /// Subcommands of `benchmark synthetic`.
 #[derive(Subcommand, Debug)]
 pub enum SyntheticCommands {
-    #[command(about = "run the single-operation latency probe")]
+    #[command(about = "run the per-operation latency probe over one or more read operations")]
     Run {
         #[arg(
             long,
@@ -260,11 +260,24 @@ pub enum SyntheticCommands {
         endpoint: String,
         #[arg(
             long,
-            value_enum,
-            default_value = "return_const",
-            help = "operation to measure"
+            default_value = "falkor",
+            help = "graph key to measure against"
         )]
-        op: OpName,
+        graph: String,
+        #[arg(
+            long = "op",
+            value_enum,
+            value_delimiter = ',',
+            num_args = 1..,
+            help = "operation(s) to measure; repeatable and comma-separated (e.g. --op match_by_index --op expand_1_hop or --op match_by_index,expand_1_hop)"
+        )]
+        ops: Vec<OpName>,
+        #[arg(
+            long,
+            conflicts_with = "ops",
+            help = "measure every read operation (mutually exclusive with --op)"
+        )]
+        all_reads: bool,
         #[arg(
             long,
             default_value_t = 1000,
@@ -277,6 +290,12 @@ pub enum SyntheticCommands {
             help = "number of warm-up invocations (discarded)"
         )]
         warmup: usize,
+        #[arg(
+            long,
+            default_value_t = 0,
+            help = "seed for the per-operation parameter corpora (same seed ⇒ identical corpora)"
+        )]
+        seed: u64,
         #[arg(
             long,
             value_enum,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -269,6 +269,7 @@ pub enum SyntheticCommands {
             value_enum,
             value_delimiter = ',',
             num_args = 1..,
+            required_unless_present = "all_reads",
             help = "operation(s) to measure; repeatable and comma-separated (e.g. --op match_by_index --op expand_1_hop or --op match_by_index,expand_1_hop)"
         )]
         ops: Vec<OpName>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::queries_repository::QueryCoverageProfile;
 use crate::scenario::Vendor;
-use crate::synthetic::{CacheSelection, OpName};
+use crate::synthetic::{CacheSelection, OpName, DEFAULT_GRAPH};
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
@@ -260,7 +260,7 @@ pub enum SyntheticCommands {
         endpoint: String,
         #[arg(
             long,
-            default_value = "falkor",
+            default_value_t = DEFAULT_GRAPH.to_string(),
             help = "graph key to measure against"
         )]
         graph: String,

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -1,0 +1,412 @@
+//! The read-operation catalog: the corpus of Cypher operations the probe can measure, plus the
+//! minimal dataset handle their parameter corpora are drawn from.
+//!
+//! Each [`OpName`] maps to exactly one [`OperationSpec`] via [`spec`] (an exhaustive match, so a
+//! new variant won't compile until it has a corpus). A spec's [`CorpusFn`] pre-generates a fixed
+//! set of *parameterized* queries from a seeded RNG and a [`DatasetHandle`], so the same seed
+//! yields a byte-identical corpus (determinism is unit-tested). Every query projects **scalars**
+//! (never whole nodes/edges) so draining a row never triggers FalkorDB schema-resolution
+//! round-trips on the single probe connection.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::queries_repository::QueryType;
+use crate::query::{Query, QueryBuilder};
+use crate::synthetic::OpName;
+use rand::{Rng, RngExt};
+
+/// Number of distinct parameterizations pre-generated per operation. The measured loop cycles
+/// through this corpus, so varying parameter *values* exercise real binding while the query
+/// **body** stays constant (keeping the plan cache warm in cached mode).
+pub const CORPUS_SIZE: usize = 256;
+
+/// A minimal, seed-independent snapshot of the live graph that operation corpora draw from.
+///
+/// Part 2 reads this from whatever graph the endpoint already has (Part 3 will generate a
+/// reproducible dataset). `node_ids` is sorted ascending for a stable, reproducible sample.
+#[derive(Debug, Clone, Default)]
+pub struct DatasetHandle {
+    /// A sample of existing `:User` ids, ascending. Empty if the graph has no `:User` nodes.
+    pub node_ids: Vec<i32>,
+}
+
+impl DatasetHandle {
+    /// The sampled ids, or a clear error naming the op that needs seed data when the graph has
+    /// none (so a user pointed at an empty/foreign graph gets an actionable message instead of a
+    /// panic).
+    fn ids(
+        &self,
+        op: &str,
+        need: usize,
+    ) -> BenchmarkResult<&[i32]> {
+        if self.node_ids.len() < need {
+            return Err(OtherError(format!(
+                "operation '{}' needs at least {} seed :User id(s) but the graph sample has {} — \
+                 load a dataset (see Part 3) or point --graph at a populated graph",
+                op,
+                need,
+                self.node_ids.len()
+            )));
+        }
+        Ok(&self.node_ids)
+    }
+}
+
+/// What seed data an operation's corpus requires from the [`DatasetHandle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatasetRequirement {
+    /// Needs no seed ids (self-contained or full-scan).
+    None,
+    /// Needs at least one existing `:User` id.
+    OneId,
+    /// Needs at least two existing `:User` ids (e.g. shortest-path endpoints).
+    TwoIds,
+}
+
+impl DatasetRequirement {
+    fn min_ids(self) -> usize {
+        match self {
+            DatasetRequirement::None => 0,
+            DatasetRequirement::OneId => 1,
+            DatasetRequirement::TwoIds => 2,
+        }
+    }
+}
+
+/// Object-safe corpus builder: given a seeded RNG, the dataset sample, and this worker's index of
+/// `workers` total (both `0`/`1` at concurrency 1; reserved for the Part 4 concurrency sweep), it
+/// returns a fixed-size vector of parameterized queries that all share one query body.
+pub type CorpusFn =
+    fn(&mut dyn Rng, &DatasetHandle, usize, usize) -> BenchmarkResult<Vec<Query>>;
+
+/// One catalog entry: an operation's identity, its read/write kind, a one-line description, the
+/// seed data it needs, and its corpus builder. `OpName` stays the single source of truth; this
+/// spec is what the runner and `--help`/completion all agree on.
+#[derive(Clone, Copy)]
+pub struct OperationSpec {
+    pub name: OpName,
+    pub kind: QueryType,
+    pub description: &'static str,
+    pub requirement: DatasetRequirement,
+    pub corpus: CorpusFn,
+}
+
+impl OperationSpec {
+    /// Build this operation's parameter corpus, first validating that the dataset satisfies the
+    /// operation's [`DatasetRequirement`] so the error names the op rather than panicking deep in
+    /// a corpus closure.
+    pub fn build_corpus(
+        &self,
+        rng: &mut dyn Rng,
+        dataset: &DatasetHandle,
+        worker: usize,
+        workers: usize,
+    ) -> BenchmarkResult<Vec<Query>> {
+        let _ = dataset.ids(self.name.as_str(), self.requirement.min_ids())?;
+        let corpus = (self.corpus)(rng, dataset, worker, workers)?;
+        if corpus.is_empty() {
+            return Err(OtherError(format!(
+                "operation '{}' produced an empty corpus",
+                self.name.as_str()
+            )));
+        }
+        Ok(corpus)
+    }
+}
+
+/// The full read-operation catalog, in `OpName` declaration order.
+pub fn catalog() -> Vec<OperationSpec> {
+    OpName::all().iter().map(|&op| spec(op)).collect()
+}
+
+/// The [`OperationSpec`] for one operation. Exhaustive over [`OpName`] — adding a variant forces a
+/// corpus here.
+pub fn spec(op: OpName) -> OperationSpec {
+    match op {
+        OpName::ReturnConst => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "RETURN $i — pure round-trip baseline (no dataset required)",
+            requirement: DatasetRequirement::None,
+            corpus: corpus_return_const,
+        },
+        OpName::MatchByIndex => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "point lookup on the :User(id) index",
+            requirement: DatasetRequirement::OneId,
+            corpus: corpus_match_by_index,
+        },
+        OpName::MatchByLabelScan => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "full :User label scan with a non-indexable predicate",
+            requirement: DatasetRequirement::None,
+            corpus: corpus_match_by_label_scan,
+        },
+        OpName::Expand1Hop => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "1-hop :Friend expansion from a seed node",
+            requirement: DatasetRequirement::OneId,
+            corpus: corpus_expand_1_hop,
+        },
+        OpName::ExpandHops5 => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "fixed 5-hop :Friend expansion from a seed node",
+            requirement: DatasetRequirement::OneId,
+            corpus: corpus_expand_hops_5,
+        },
+        OpName::AggregateCount => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "count a seed node's 1-hop :Friend neighbours",
+            requirement: DatasetRequirement::OneId,
+            corpus: corpus_aggregate_count,
+        },
+        OpName::AggregateGroup => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "group a seed node's neighbours by age with counts",
+            requirement: DatasetRequirement::OneId,
+            corpus: corpus_aggregate_group,
+        },
+        OpName::ShortestPath => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "bounded shortest :Friend path between two seed nodes",
+            requirement: DatasetRequirement::TwoIds,
+            corpus: corpus_shortest_path,
+        },
+        OpName::PropertyProjection => OperationSpec {
+            name: op,
+            kind: QueryType::Read,
+            description: "project scalar properties of an indexed node",
+            requirement: DatasetRequirement::OneId,
+            corpus: corpus_property_projection,
+        },
+    }
+}
+
+/// Pick a uniformly-random id from the sample.
+fn pick_id(
+    rng: &mut dyn Rng,
+    ids: &[i32],
+) -> i32 {
+    ids[rng.random_range(0..ids.len())]
+}
+
+/// Build `CORPUS_SIZE` queries that share one body, parameterized by one random seed id each.
+fn one_id_corpus(
+    rng: &mut dyn Rng,
+    ids: &[i32],
+    text: &'static str,
+) -> Vec<Query> {
+    (0..CORPUS_SIZE)
+        .map(|_| {
+            QueryBuilder::new()
+                .text(text)
+                .param("id", pick_id(rng, ids))
+                .build()
+        })
+        .collect()
+}
+
+fn corpus_return_const(
+    rng: &mut dyn Rng,
+    _dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    Ok((0..CORPUS_SIZE)
+        .map(|_| {
+            QueryBuilder::new()
+                .text("RETURN $i AS x")
+                .param("i", rng.random_range(0..i32::MAX))
+                .build()
+        })
+        .collect())
+}
+
+fn corpus_match_by_index(
+    rng: &mut dyn Rng,
+    dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    let ids = dataset.ids("match_by_index", 1)?;
+    Ok(one_id_corpus(
+        rng,
+        ids,
+        "MATCH (n:User {id: $id}) RETURN n.id",
+    ))
+}
+
+fn corpus_match_by_label_scan(
+    rng: &mut dyn Rng,
+    _dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    // `n.id % $modulus` is a computed predicate the id index can't satisfy, forcing a full label
+    // scan. `count(n)` keeps the payload one row while still doing the server-side scan work.
+    Ok((0..CORPUS_SIZE)
+        .map(|_| {
+            QueryBuilder::new()
+                .text("MATCH (n:User) WHERE n.id % $modulus = 0 RETURN count(n) AS c")
+                .param("modulus", rng.random_range(2..=97))
+                .build()
+        })
+        .collect())
+}
+
+fn corpus_expand_1_hop(
+    rng: &mut dyn Rng,
+    dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    let ids = dataset.ids("expand_1_hop", 1)?;
+    Ok(one_id_corpus(
+        rng,
+        ids,
+        "MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.id",
+    ))
+}
+
+fn corpus_expand_hops_5(
+    rng: &mut dyn Rng,
+    dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    let ids = dataset.ids("expand_hops_5", 1)?;
+    // Exactly five typed hops; `DISTINCT` + `LIMIT` bound the fan-out payload.
+    Ok(one_id_corpus(
+        rng,
+        ids,
+        "MATCH (s:User {id: $id})-[:Friend*5..5]->(n:User) RETURN DISTINCT n.id LIMIT 100",
+    ))
+}
+
+fn corpus_aggregate_count(
+    rng: &mut dyn Rng,
+    dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    let ids = dataset.ids("aggregate_count", 1)?;
+    Ok(one_id_corpus(
+        rng,
+        ids,
+        "MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN count(n) AS c",
+    ))
+}
+
+fn corpus_aggregate_group(
+    rng: &mut dyn Rng,
+    dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    let ids = dataset.ids("aggregate_group", 1)?;
+    Ok(one_id_corpus(
+        rng,
+        ids,
+        "MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.age AS age, count(*) AS c ORDER BY c DESC LIMIT 10",
+    ))
+}
+
+fn corpus_shortest_path(
+    rng: &mut dyn Rng,
+    dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    let ids = dataset.ids("shortest_path", 2)?;
+    // FalkorDB's shortestPath form is `WITH shortestPath(...) AS p` and requires a *directed*
+    // pattern; bound the search to 6 hops and `coalesce` a missing path to -1 so an unreachable
+    // pair returns a row instead of erroring.
+    let text = "MATCH (s:User {id: $from}), (t:User {id: $to}) \
+                WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1) AS len";
+    Ok((0..CORPUS_SIZE)
+        .map(|_| {
+            // Pick two *distinct* indices (ids are unique) so `from != to`: choose `to` from the
+            // n-1 other slots and skip past `from`.
+            let n = ids.len();
+            let from_idx = rng.random_range(0..n);
+            let mut to_idx = rng.random_range(0..n - 1);
+            if to_idx >= from_idx {
+                to_idx += 1;
+            }
+            QueryBuilder::new()
+                .text(text)
+                .param("from", ids[from_idx])
+                .param("to", ids[to_idx])
+                .build()
+        })
+        .collect())
+}
+
+fn corpus_property_projection(
+    rng: &mut dyn Rng,
+    dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    let ids = dataset.ids("property_projection", 1)?;
+    Ok(one_id_corpus(
+        rng,
+        ids,
+        "MATCH (n:User {id: $id}) RETURN n.id, n.age",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[test]
+    fn catalog_covers_every_op_with_matching_spec() {
+        let all = catalog();
+        assert_eq!(all.len(), OpName::all().len());
+        for (entry, op) in all.iter().zip(OpName::all()) {
+            assert_eq!(entry.name, *op);
+            assert_eq!(entry.kind, QueryType::Read, "Part 2 ops are all reads");
+            assert!(!entry.description.is_empty());
+        }
+    }
+
+    #[test]
+    fn dataset_requirement_min_ids() {
+        assert_eq!(DatasetRequirement::None.min_ids(), 0);
+        assert_eq!(DatasetRequirement::OneId.min_ids(), 1);
+        assert_eq!(DatasetRequirement::TwoIds.min_ids(), 2);
+    }
+
+    #[test]
+    fn shortest_path_corpus_uses_two_distinct_params() {
+        // The tightest case: exactly two ids. Every entry must use both params with from != to.
+        let ds = DatasetHandle {
+            node_ids: vec![1, 2],
+        };
+        let mut rng = StdRng::seed_from_u64(9);
+        let corpus = spec(OpName::ShortestPath)
+            .build_corpus(&mut rng, &ds, 0, 1)
+            .expect("shortest_path corpus");
+        assert_eq!(corpus.len(), CORPUS_SIZE);
+        for q in &corpus {
+            assert!(q.text.contains("shortestPath"));
+            let from = q.params.get("from").expect("from param");
+            let to = q.params.get("to").expect("to param");
+            assert_ne!(
+                format!("{from:?}"),
+                format!("{to:?}"),
+                "shortest_path endpoints must be distinct"
+            );
+        }
+    }
+}

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -235,7 +235,7 @@ fn corpus_match_by_index(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = dataset.ids("match_by_index", 1)?;
+    let ids = &dataset.node_ids;
     Ok(one_id_corpus(
         rng,
         ids,
@@ -267,7 +267,7 @@ fn corpus_expand_1_hop(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = dataset.ids("expand_1_hop", 1)?;
+    let ids = &dataset.node_ids;
     Ok(one_id_corpus(
         rng,
         ids,
@@ -281,7 +281,7 @@ fn corpus_expand_hops_5(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = dataset.ids("expand_hops_5", 1)?;
+    let ids = &dataset.node_ids;
     // Exactly five typed hops; `DISTINCT` + `LIMIT` bound the fan-out payload.
     Ok(one_id_corpus(
         rng,
@@ -296,7 +296,7 @@ fn corpus_aggregate_count(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = dataset.ids("aggregate_count", 1)?;
+    let ids = &dataset.node_ids;
     Ok(one_id_corpus(
         rng,
         ids,
@@ -310,7 +310,7 @@ fn corpus_aggregate_group(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = dataset.ids("aggregate_group", 1)?;
+    let ids = &dataset.node_ids;
     Ok(one_id_corpus(
         rng,
         ids,
@@ -324,7 +324,7 @@ fn corpus_shortest_path(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = dataset.ids("shortest_path", 2)?;
+    let ids = &dataset.node_ids;
     // FalkorDB's shortestPath form is `WITH shortestPath(...) AS p` and requires a *directed*
     // pattern; bound the search to 6 hops and `coalesce` a missing path to -1 so an unreachable
     // pair returns a row instead of erroring.
@@ -355,7 +355,7 @@ fn corpus_property_projection(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = dataset.ids("property_projection", 1)?;
+    let ids = &dataset.node_ids;
     Ok(one_id_corpus(
         rng,
         ids,

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -368,10 +368,12 @@ fn dedup_ops(ops: &[OpName]) -> Vec<OpName> {
 }
 
 /// Ensure the target graph key exists: a read (`RO_QUERY`) against a never-written graph fails with
-/// "Invalid graph operation on empty key". Probe with a read first and only write to instantiate
-/// the graph when the error is exactly that empty-key condition — so a read-only replica whose
-/// graph already exists still works, and any other error (auth/network) is surfaced rather than
-/// masked. Both are bounded by the client deadline.
+/// "Invalid graph operation on empty key". Probe with a read first; only when the error is exactly
+/// that empty-key condition, re-run the same trivial `RETURN 1` over the writable `GRAPH.QUERY`
+/// command (not `RO_QUERY`) — which instantiates the empty graph key even though the query itself
+/// mutates nothing. So a read-only replica whose graph already exists still works via the read
+/// path, and any other error (auth/network) is surfaced rather than masked. Both are bounded by the
+/// client deadline.
 async fn ensure_graph_exists(
     graph: &mut falkordb::AsyncGraph,
     config: &Config,

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -166,19 +166,19 @@ pub enum CacheMode {
 /// FalkorDB keys its plan cache on the query **body** (the text after the `CYPHER <params>` prefix
 /// that [`Query::to_cypher`] emits). [`CacheMode::Cached`] uses the body verbatim, so a corpus of
 /// varying parameter values still reuses one cached plan → *execution only*. [`CacheMode::Uncached`]
-/// appends a unique trailing comment `/* co<nonce>-<i> */`, making every invocation a distinct
-/// cache key that FalkorDB must recompile → *execution + compilation*. The per-run `nonce` keeps a
+/// appends a unique trailing comment `/* co<run_token>-<i> */`, making every invocation a distinct
+/// cache key that FalkorDB must recompile → *execution + compilation*. The per-run `run_token` keeps a
 /// previous run's uncached comments from being served from cache.
 fn render_cypher(
     query: &Query,
     mode: CacheMode,
-    nonce: u64,
+    run_token: u64,
     i: usize,
 ) -> String {
     let base = query.to_cypher();
     match mode {
         CacheMode::Cached => base,
-        CacheMode::Uncached => format!("{} /* co{:x}-{} */", base, nonce, i),
+        CacheMode::Uncached => format!("{} /* co{:x}-{} */", base, run_token, i),
     }
 }
 
@@ -326,9 +326,9 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         DatasetHandle::default()
     };
 
-    // A fresh OS-random nonce per run keeps uncached-mode comments globally unique, so a small
+    // A fresh OS-random run_token per run keeps uncached-mode comments globally unique, so a small
     // run's uncached queries can never be served from a previous run's plan cache.
-    let nonce = rand::random_range(0..=u64::MAX);
+    let run_token = rand::random_range(0..=u64::MAX);
 
     let mut operations = BTreeMap::new();
     for op in ops {
@@ -337,7 +337,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         let mut rng = StdRng::seed_from_u64(config.seed ^ op.salt());
         let corpus = op_spec.build_corpus(&mut rng, &dataset, 0, 1)?;
         let op_report =
-            measure_op(&mut graph, config, &op_spec, &corpus, nonce, client_deadline).await?;
+            measure_op(&mut graph, config, &op_spec, &corpus, run_token, client_deadline).await?;
         operations.insert(op.as_str().to_string(), op_report);
     }
 
@@ -471,13 +471,13 @@ async fn measure_op(
     config: &Config,
     op_spec: &OperationSpec,
     corpus: &[Query],
-    nonce: u64,
+    run_token: u64,
     client_deadline: Duration,
 ) -> BenchmarkResult<OperationReport> {
     let mut cached_set: Option<crate::synthetic::report::MetricSet> = None;
     let mut uncached_set: Option<crate::synthetic::report::MetricSet> = None;
     for &mode in config.cache.modes() {
-        let set = measure_mode(graph, config, op_spec, corpus, mode, nonce, client_deadline).await?;
+        let set = measure_mode(graph, config, op_spec, corpus, mode, run_token, client_deadline).await?;
         match mode {
             CacheMode::Cached => cached_set = Some(set),
             CacheMode::Uncached => uncached_set = Some(set),
@@ -507,7 +507,7 @@ async fn measure_mode(
     op_spec: &OperationSpec,
     corpus: &[Query],
     mode: CacheMode,
-    nonce: u64,
+    run_token: u64,
     client_deadline: Duration,
 ) -> BenchmarkResult<crate::synthetic::report::MetricSet> {
     let kind = op_spec.kind;
@@ -516,14 +516,14 @@ async fn measure_mode(
     // first-touch compilation on its first sample. (No help for uncached, whose every query is
     // unique by design.)
     if config.warmup == 0 && mode == CacheMode::Cached {
-        let cypher = render_cypher(&corpus[0], mode, nonce, 0);
+        let cypher = render_cypher(&corpus[0], mode, run_token, 0);
         let _ = run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline)
             .await?;
     }
 
     // Warm-up (discarded) primes the plan cache (cached mode) and the connection.
     for i in 0..config.warmup {
-        let cypher = render_cypher(&corpus[i % corpus.len()], mode, nonce, i);
+        let cypher = render_cypher(&corpus[i % corpus.len()], mode, run_token, i);
         let _ = run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline)
             .await?;
     }
@@ -532,7 +532,7 @@ async fn measure_mode(
     for i in 0..config.samples {
         // Continue the uncached comment counter past warm-up so every key stays unique.
         let idx = config.warmup + i;
-        let cypher = render_cypher(&corpus[idx % corpus.len()], mode, nonce, idx);
+        let cypher = render_cypher(&corpus[idx % corpus.len()], mode, run_token, idx);
         let sample =
             run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline).await?;
         samples.push(sample);
@@ -771,7 +771,7 @@ mod tests {
         assert_eq!(c0, c1);
         assert!(!c0.contains("/* co"));
         assert!(c0.contains("RETURN n.id"));
-        // Uncached: a unique per-invocation comment ⇒ distinct cache key; the nonce keeps it apart
+        // Uncached: a unique per-invocation comment ⇒ distinct cache key; the run_token keeps it apart
         // from other runs.
         let u0 = render_cypher(&q, CacheMode::Uncached, 0xABCD, 0);
         let u1 = render_cypher(&q, CacheMode::Uncached, 0xABCD, 1);

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1,10 +1,18 @@
-//! Synthetic per-operation benchmark — Part 1: a single-operation latency probe.
+//! Synthetic per-operation benchmark — Part 2: a selectable catalog of read operations.
 //!
-//! Measures one Cypher operation in isolation against a FalkorDB endpoint, capturing on every
-//! invocation the paired *server time* (FalkorDB's reported internal execution time) and *total
-//! time* (end-to-end client round-trip), then summarizes them with severe-outlier removal and
-//! writes a JSON report + console summary. This is the foundation the rest of the epic builds on.
+//! Measures one or more Cypher read operations in isolation against a FalkorDB endpoint. For each
+//! selected operation it pre-generates a seeded corpus of parameterized queries (see
+//! [`catalog`]), then, under each plan-cache condition, captures on every invocation the paired
+//! *server time* (FalkorDB's reported internal execution time) and *total time* (end-to-end client
+//! round-trip), summarizes them with severe-outlier removal, and derives the expression
+//! *compilation cost* (uncached − cached). One JSON block is written per operation.
+//!
+//! Note that per-operation latency distributions can be right-skewed (e.g. high-degree seed nodes
+//! for expansions), so the summary trims only *severe* outliers (beyond 3×IQR) and both cache
+//! modes cycle the same corpus in the same order, keeping the cached-vs-uncached medians comparable
+//! on a matched workload.
 
+pub mod catalog;
 pub mod op_runner;
 pub mod provenance;
 pub mod report;
@@ -13,86 +21,111 @@ pub mod stats;
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::falkor::falkor_endpoint_to_redis_url;
-use crate::query::{Query, QueryBuilder};
 use crate::queries_repository::QueryType;
+use crate::query::Query;
+use crate::synthetic::catalog::{spec, DatasetHandle, DatasetRequirement, OperationSpec, CORPUS_SIZE};
 use crate::synthetic::op_runner::{run_and_drain, OpSample};
 use crate::synthetic::report::{Meta, OperationReport, Report};
 use clap::ValueEnum;
 use falkordb::{ConnectionStrategy, FalkorClientBuilder};
+use futures::StreamExt;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{info, warn};
 
-/// The set of operations the probe can run. Part 1 ships a single dataset-free baseline; later
-/// parts extend this enum and the catalog together (it stays the single source of truth so
-/// `--help`, shell completion and the catalog never drift).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+/// The default graph key the probe targets when `--graph` isn't given.
+pub const DEFAULT_GRAPH: &str = "falkor";
+
+/// How many `:User` ids to sample from the live graph to seed operation corpora.
+const DATASET_SAMPLE_SIZE: usize = 512;
+
+/// The set of operations the probe can measure. `OpName` is the single source of truth: it's a
+/// clap `ValueEnum` (so `--op`, `--help` and shell completion list exactly these), and every
+/// variant maps to one [`catalog::OperationSpec`] via [`catalog::spec`] (an exhaustive match, so a
+/// new variant won't compile until it has a corpus). Read primitives target the benchmark's
+/// `:User {id, age}` / `(:User)-[:Friend]->(:User)` schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum)]
 #[value(rename_all = "snake_case")]
 pub enum OpName {
     /// `RETURN $i` — a pure round-trip / server parse+exec baseline that needs no dataset.
     ReturnConst,
+    /// Point lookup on the `:User(id)` index.
+    MatchByIndex,
+    /// Full `:User` label scan with a non-indexable predicate.
+    MatchByLabelScan,
+    /// 1-hop `:Friend` expansion from a seed node.
+    #[value(name = "expand_1_hop")]
+    Expand1Hop,
+    /// Fixed 5-hop `:Friend` expansion from a seed node.
+    #[value(name = "expand_hops_5")]
+    ExpandHops5,
+    /// Count a seed node's 1-hop `:Friend` neighbours.
+    AggregateCount,
+    /// Group a seed node's neighbours by age with counts.
+    AggregateGroup,
+    /// Bounded shortest `:Friend` path between two seed nodes.
+    ShortestPath,
+    /// Project scalar properties of an indexed node.
+    PropertyProjection,
 }
 
 impl OpName {
+    /// Every operation, in declaration order (the catalog's canonical order).
+    pub fn all() -> &'static [OpName] {
+        OpName::value_variants()
+    }
+
+    /// Every read operation (all of them, for now — writes arrive in Part 5). Used by
+    /// `--all-reads`.
+    pub fn all_reads() -> Vec<OpName> {
+        OpName::all()
+            .iter()
+            .copied()
+            .filter(|op| spec(*op).kind == QueryType::Read)
+            .collect()
+    }
+
     /// The stable string id used in reports and on the CLI.
     pub fn as_str(self) -> &'static str {
         match self {
             OpName::ReturnConst => "return_const",
+            OpName::MatchByIndex => "match_by_index",
+            OpName::MatchByLabelScan => "match_by_label_scan",
+            OpName::Expand1Hop => "expand_1_hop",
+            OpName::ExpandHops5 => "expand_hops_5",
+            OpName::AggregateCount => "aggregate_count",
+            OpName::AggregateGroup => "aggregate_group",
+            OpName::ShortestPath => "shortest_path",
+            OpName::PropertyProjection => "property_projection",
         }
     }
 
     /// Whether this operation reads or writes (selects `RO_QUERY` vs `QUERY`).
     pub fn kind(self) -> QueryType {
-        match self {
-            OpName::ReturnConst => QueryType::Read,
-        }
+        spec(self).kind
     }
 
-    /// A one-line description for `list-ops`.
+    /// A one-line description for `list-ops` and the report.
     pub fn description(self) -> &'static str {
-        match self {
-            OpName::ReturnConst => "RETURN $i — pure round-trip baseline (no dataset required)",
-        }
+        spec(self).description
     }
 
-    /// Build the query for invocation `i`: a parameterized query whose body is constant but whose
-    /// parameter *value* varies with `i`, so we exercise real parameter binding rather than a
-    /// single frozen literal (while the constant body still lets the plan cache work — see
-    /// [`Self::render_cypher`]).
-    pub fn build_query(
-        self,
-        i: usize,
-    ) -> Query {
-        // Keep the parameter value in the non-negative i32 range (the only integer QueryParam
-        // width) so a very large invocation index can't truncate to a negative value.
-        let param = (i % (i32::MAX as usize)) as i32;
+    /// A stable per-operation salt mixed into the RNG seed so two ops with the same corpus shape
+    /// don't draw identical parameter sequences from one `--seed`. Fixed constants (not the
+    /// declaration index) so reordering the enum can't shift an op's corpus.
+    pub fn salt(self) -> u64 {
         match self {
-            OpName::ReturnConst => QueryBuilder::new()
-                .text("RETURN $i AS x")
-                .param("i", param)
-                .build(),
-        }
-    }
-
-    /// Render the Cypher string for invocation `i` in the given cache mode.
-    ///
-    /// FalkorDB keys its plan cache on the query **body** — the text after the `CYPHER <params>`
-    /// prefix that [`Query::to_cypher`] emits — so varying only a parameter *value* still hits the
-    /// cache. In [`CacheMode::Cached`] the body (`RETURN $i AS x`) is therefore identical every
-    /// invocation (only the stripped `CYPHER i = <n>` prefix changes), so after warm-up the plan is
-    /// reused and only execution is measured. In [`CacheMode::Uncached`] a unique trailing comment
-    /// (`/* co<i> */`) is appended to the body, making every invocation a distinct cache key and
-    /// forcing FalkorDB to recompile each time (verified via the response's `cached_execution`
-    /// flag), which exposes expression-compilation cost.
-    pub fn render_cypher(
-        self,
-        i: usize,
-        mode: CacheMode,
-    ) -> String {
-        let base = self.build_query(i).to_cypher();
-        match mode {
-            CacheMode::Cached => base,
-            CacheMode::Uncached => format!("{} /* co{} */", base, i),
+            OpName::ReturnConst => 0x5259_5f43_4f4e_5354,
+            OpName::MatchByIndex => 0x4d54_4348_5f49_4458,
+            OpName::MatchByLabelScan => 0x4c41_4245_4c5f_5343,
+            OpName::Expand1Hop => 0x4558_5031_484f_5000,
+            OpName::ExpandHops5 => 0x4558_5035_484f_5053,
+            OpName::AggregateCount => 0x4147_475f_434e_5400,
+            OpName::AggregateGroup => 0x4147_475f_4752_5000,
+            OpName::ShortestPath => 0x5348_5254_5f50_5448,
+            OpName::PropertyProjection => 0x5052_4f50_5f50_524a,
         }
     }
 }
@@ -128,13 +161,39 @@ pub enum CacheMode {
     Uncached,
 }
 
-/// Configuration for a single-operation probe run.
+/// Render one corpus query to a Cypher string for the given cache mode.
+///
+/// FalkorDB keys its plan cache on the query **body** (the text after the `CYPHER <params>` prefix
+/// that [`Query::to_cypher`] emits). [`CacheMode::Cached`] uses the body verbatim, so a corpus of
+/// varying parameter values still reuses one cached plan → *execution only*. [`CacheMode::Uncached`]
+/// appends a unique trailing comment `/* co<nonce>-<i> */`, making every invocation a distinct
+/// cache key that FalkorDB must recompile → *execution + compilation*. The per-run `nonce` keeps a
+/// previous run's uncached comments from being served from cache.
+fn render_cypher(
+    query: &Query,
+    mode: CacheMode,
+    nonce: u64,
+    i: usize,
+) -> String {
+    let base = query.to_cypher();
+    match mode {
+        CacheMode::Cached => base,
+        CacheMode::Uncached => format!("{} /* co{:x}-{} */", base, nonce, i),
+    }
+}
+
+/// Configuration for a synthetic probe run over one or more operations.
 #[derive(Debug, Clone)]
 pub struct Config {
     pub endpoint: String,
-    pub op: OpName,
+    /// Graph key to measure against (default [`DEFAULT_GRAPH`]).
+    pub graph: String,
+    /// Operations to measure, in order. Deduplicated (first occurrence wins) before running.
+    pub ops: Vec<OpName>,
     pub samples: usize,
     pub warmup: usize,
+    /// Seed for the per-operation parameter corpora (same seed ⇒ identical corpora).
+    pub seed: u64,
     pub server_timeout_ms: i64,
     pub client_deadline_ms: u64,
     pub cache: CacheSelection,
@@ -146,9 +205,11 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             endpoint: "falkor://127.0.0.1:6379".to_string(),
-            op: OpName::ReturnConst,
+            graph: DEFAULT_GRAPH.to_string(),
+            ops: vec![OpName::ReturnConst],
             samples: 1000,
             warmup: 200,
+            seed: 0,
             server_timeout_ms: 5_000,
             client_deadline_ms: 6_000,
             cache: CacheSelection::Both,
@@ -161,8 +222,8 @@ impl Default for Config {
 /// Print the available operations (for `synthetic list-ops`).
 pub fn list_ops() -> String {
     let mut out = String::from("Available operations:\n");
-    for op in OpName::value_variants() {
-        out.push_str(&format!("  {:<16} {}\n", op.as_str(), op.description()));
+    for op in OpName::all() {
+        out.push_str(&format!("  {:<20} {}\n", op.as_str(), op.description()));
     }
     out
 }
@@ -209,12 +270,19 @@ pub async fn open_graph(
     Ok(client.select_graph(graph_name))
 }
 
-/// Run the probe: connect (single connection), collect server provenance, warm up, measure, then
-/// build the [`Report`]. Writing the report to disk is the caller's responsibility (see
-/// [`run_and_report`]).
+/// Run the probe: connect (single connection), collect server provenance, sample the graph to seed
+/// corpora, then measure each selected operation under each cache mode and build the [`Report`].
+/// Writing the report to disk is the caller's responsibility (see [`run_and_report`]).
 pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     if config.samples == 0 {
         return Err(OtherError("samples must be greater than 0".to_string()));
+    }
+    let ops = dedup_ops(&config.ops);
+    if ops.is_empty() {
+        return Err(OtherError(
+            "no operations selected — pass --op <name> (repeatable/comma-separated) or --all-reads"
+                .to_string(),
+        ));
     }
 
     let started_at_epoch_secs = SystemTime::now()
@@ -223,7 +291,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         .unwrap_or(0);
 
     // A single dedicated connection: honest single-flight latency.
-    let mut graph = open_graph(&config.endpoint, "falkor").await?;
+    let mut graph = open_graph(&config.endpoint, &config.graph).await?;
 
     // Server provenance (best-effort: log and continue on failure).
     let redis_url = falkor_endpoint_to_redis_url(Some(&config.endpoint));
@@ -245,12 +313,71 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     }
 
     let client_deadline = Duration::from_millis(config.client_deadline_ms);
+    ensure_graph_exists(&mut graph, config, client_deadline).await?;
 
-    // Ensure the graph key exists: a read (`RO_QUERY`) against a never-written graph fails with
-    // "Invalid graph operation on empty key". Probe with a read first and only write to
-    // instantiate the graph when the error is exactly that empty-key condition — so a read-only
-    // replica whose graph already exists still works, and any other error (auth/network) is
-    // surfaced rather than masked. Both are bounded by the client deadline.
+    // Only sample the graph if some selected op needs seed ids (return_const / label scan don't),
+    // so a return_const-only run doesn't fail on a graph that has no :User data.
+    let needs_dataset = ops
+        .iter()
+        .any(|op| spec(*op).requirement != DatasetRequirement::None);
+    let dataset = if needs_dataset {
+        probe_dataset(&mut graph, config, client_deadline).await?
+    } else {
+        DatasetHandle::default()
+    };
+
+    // A fresh OS-random nonce per run keeps uncached-mode comments globally unique, so a small
+    // run's uncached queries can never be served from a previous run's plan cache.
+    let nonce = rand::random_range(0..=u64::MAX);
+
+    let mut operations = BTreeMap::new();
+    for op in ops {
+        let op_spec = spec(op);
+        // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
+        let mut rng = StdRng::seed_from_u64(config.seed ^ op.salt());
+        let corpus = op_spec.build_corpus(&mut rng, &dataset, 0, 1)?;
+        let op_report =
+            measure_op(&mut graph, config, &op_spec, &corpus, nonce, client_deadline).await?;
+        operations.insert(op.as_str().to_string(), op_report);
+    }
+
+    Ok(Report {
+        meta: Meta {
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            endpoint: redact_endpoint(&config.endpoint),
+            graph: config.graph.clone(),
+            samples: config.samples,
+            warmup: config.warmup,
+            seed: config.seed,
+            corpus_size: CORPUS_SIZE,
+            server_timeout_ms: config.server_timeout_ms,
+            client_deadline_ms: config.client_deadline_ms,
+            connection: "pool(size=1)".to_string(),
+            started_at_epoch_secs,
+            server,
+        },
+        operations,
+    })
+}
+
+/// Deduplicate the selected ops, preserving first-occurrence order (so a repeated `--op` or an
+/// overlap between `--op` and `--all-reads` doesn't silently overwrite a report entry).
+fn dedup_ops(ops: &[OpName]) -> Vec<OpName> {
+    let mut seen = std::collections::HashSet::new();
+    ops.iter().copied().filter(|op| seen.insert(*op)).collect()
+}
+
+/// Ensure the target graph key exists: a read (`RO_QUERY`) against a never-written graph fails with
+/// "Invalid graph operation on empty key". Probe with a read first and only write to instantiate
+/// the graph when the error is exactly that empty-key condition — so a read-only replica whose
+/// graph already exists still works, and any other error (auth/network) is surfaced rather than
+/// masked. Both are bounded by the client deadline.
+async fn ensure_graph_exists(
+    graph: &mut falkordb::AsyncGraph,
+    config: &Config,
+    client_deadline: Duration,
+) -> BenchmarkResult<()> {
+    let name = &config.graph;
     let probe = tokio::time::timeout(
         client_deadline,
         graph
@@ -259,9 +386,9 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             .execute(),
     )
     .await
-    .map_err(|e| OtherError(format!("graph 'falkor' readiness probe timed out: {}", e)))?;
+    .map_err(|e| OtherError(format!("graph '{}' readiness probe timed out: {}", name, e)))?;
     match probe {
-        Ok(_) => {}
+        Ok(_) => Ok(()),
         Err(e) => {
             let msg = format!("{:?}", e);
             if is_empty_graph_key(&msg) {
@@ -273,59 +400,63 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
                         .execute(),
                 )
                 .await
-                .map_err(|e| OtherError(format!("graph 'falkor' instantiation timed out: {}", e)))?
                 .map_err(|e| {
-                    OtherError(format!("failed to instantiate graph 'falkor': {:?}", e))
+                    OtherError(format!("graph '{}' instantiation timed out: {}", name, e))
+                })?
+                .map_err(|e| {
+                    OtherError(format!("failed to instantiate graph '{}': {:?}", name, e))
                 })?;
+                Ok(())
             } else {
-                return Err(OtherError(format!(
-                    "graph 'falkor' readiness probe failed: {}",
-                    msg
-                )));
+                Err(OtherError(format!(
+                    "graph '{}' readiness probe failed: {}",
+                    name, msg
+                )))
             }
         }
     }
+}
 
-    // Measure the operation under each requested plan-cache condition.
-    let mut cached_set: Option<crate::synthetic::report::MetricSet> = None;
-    let mut uncached_set: Option<crate::synthetic::report::MetricSet> = None;
-    for &mode in config.cache.modes() {
-        let set = measure_mode(&mut graph, config, mode, client_deadline).await?;
-        match mode {
-            CacheMode::Cached => cached_set = Some(set),
-            CacheMode::Uncached => uncached_set = Some(set),
+/// Sample up to [`DATASET_SAMPLE_SIZE`] existing `:User` ids (ascending, for a stable reproducible
+/// sample) to seed operation corpora. A graph with no `:User` nodes yields an empty handle; ops
+/// that need seed ids then fail with a clear message (ops that don't, like `return_const` or the
+/// label scan, still run).
+async fn probe_dataset(
+    graph: &mut falkordb::AsyncGraph,
+    config: &Config,
+    client_deadline: Duration,
+) -> BenchmarkResult<DatasetHandle> {
+    let cypher = format!(
+        "MATCH (n:User) WHERE n.id >= {} AND n.id <= {} RETURN n.id AS id ORDER BY id LIMIT {}",
+        i32::MIN,
+        i32::MAX,
+        DATASET_SAMPLE_SIZE
+    );
+    let collect = async {
+        let mut result = graph
+            .ro_query(&cypher)
+            .with_timeout(config.server_timeout_ms)
+            .execute()
+            .await
+            .map_err(|e| OtherError(format!("dataset probe failed: {:?}", e)))?;
+        let mut node_ids = Vec::new();
+        while let Some(row) = result.data.next().await {
+            let row = row.map_err(|e| OtherError(format!("dataset probe row error: {:?}", e)))?;
+            // ids are read as i64 then narrowed; out-of-`i32`-range ids are skipped (QueryParam is
+            // i32) rather than clamped, so we never target a wrong/nonexistent node.
+            let id: i64 = row
+                .try_get_at(0)
+                .map_err(|e| OtherError(format!("dataset probe decode error: {:?}", e)))?;
+            if let Ok(id) = i32::try_from(id) {
+                node_ids.push(id);
+            }
         }
-    }
-
-    // Derived expression-compilation cost: how much slower an uncached (recompiled) run's server
-    // time is than a cached (plan-reused) one.
-    let compilation_ms_median = match (&cached_set, &uncached_set) {
-        (Some(c), Some(u)) => Some(u.server_ms.median - c.server_ms.median),
-        _ => None,
+        Ok::<Vec<i32>, crate::error::BenchmarkError>(node_ids)
     };
-
-    let op_report = OperationReport {
-        cached: cached_set,
-        uncached: uncached_set,
-        compilation_ms_median,
-    };
-    let mut operations = BTreeMap::new();
-    operations.insert(config.op.as_str().to_string(), op_report);
-
-    Ok(Report {
-        meta: Meta {
-            tool_version: env!("CARGO_PKG_VERSION").to_string(),
-            endpoint: redact_endpoint(&config.endpoint),
-            samples: config.samples,
-            warmup: config.warmup,
-            server_timeout_ms: config.server_timeout_ms,
-            client_deadline_ms: config.client_deadline_ms,
-            connection: "pool(size=1)".to_string(),
-            started_at_epoch_secs,
-            server,
-        },
-        operations,
-    })
+    let node_ids = tokio::time::timeout(client_deadline, collect)
+        .await
+        .map_err(|e| OtherError(format!("dataset probe timed out: {}", e)))??;
+    Ok(DatasetHandle { node_ids })
 }
 
 /// Whether a query error string is FalkorDB's "graph key does not exist yet" condition.
@@ -334,37 +465,76 @@ fn is_empty_graph_key(msg: &str) -> bool {
     m.contains("empty key") || m.contains("invalid graph operation")
 }
 
-/// Warm up then measure `config.samples` invocations of `config.op` in one cache mode.
+/// Measure one operation under every requested cache mode and derive its compilation cost.
+async fn measure_op(
+    graph: &mut falkordb::AsyncGraph,
+    config: &Config,
+    op_spec: &OperationSpec,
+    corpus: &[Query],
+    nonce: u64,
+    client_deadline: Duration,
+) -> BenchmarkResult<OperationReport> {
+    let mut cached_set: Option<crate::synthetic::report::MetricSet> = None;
+    let mut uncached_set: Option<crate::synthetic::report::MetricSet> = None;
+    for &mode in config.cache.modes() {
+        let set = measure_mode(graph, config, op_spec, corpus, mode, nonce, client_deadline).await?;
+        match mode {
+            CacheMode::Cached => cached_set = Some(set),
+            CacheMode::Uncached => uncached_set = Some(set),
+        }
+    }
+
+    // Derived expression-compilation cost: how much slower an uncached (recompiled) run's server
+    // time is than a cached (plan-reused) one. Both modes cycle the same corpus in the same order,
+    // so the medians compare a matched workload.
+    let compilation_ms_median = match (&cached_set, &uncached_set) {
+        (Some(c), Some(u)) => Some(u.server_ms.median - c.server_ms.median),
+        _ => None,
+    };
+
+    Ok(OperationReport {
+        cached: cached_set,
+        uncached: uncached_set,
+        compilation_ms_median,
+    })
+}
+
+/// Warm up then measure `config.samples` invocations of one operation in one cache mode, cycling
+/// through the pre-generated `corpus` (so parameter values vary while the body stays constant).
 async fn measure_mode(
     graph: &mut falkordb::AsyncGraph,
     config: &Config,
+    op_spec: &OperationSpec,
+    corpus: &[Query],
     mode: CacheMode,
+    nonce: u64,
     client_deadline: Duration,
 ) -> BenchmarkResult<crate::synthetic::report::MetricSet> {
+    let kind = op_spec.kind;
+
+    // Prime the plan cache once even when warmup==0, so a cached-mode measurement never pays
+    // first-touch compilation on its first sample. (No help for uncached, whose every query is
+    // unique by design.)
+    if config.warmup == 0 && mode == CacheMode::Cached {
+        let cypher = render_cypher(&corpus[0], mode, nonce, 0);
+        let _ = run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline)
+            .await?;
+    }
+
     // Warm-up (discarded) primes the plan cache (cached mode) and the connection.
     for i in 0..config.warmup {
-        let cypher = config.op.render_cypher(i, mode);
-        let _ = run_and_drain(
-            graph,
-            config.op.kind(),
-            &cypher,
-            config.server_timeout_ms,
-            client_deadline,
-        )
-        .await?;
+        let cypher = render_cypher(&corpus[i % corpus.len()], mode, nonce, i);
+        let _ = run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline)
+            .await?;
     }
 
     let mut samples: Vec<OpSample> = Vec::with_capacity(config.samples);
     for i in 0..config.samples {
-        let cypher = config.op.render_cypher(config.warmup + i, mode);
-        let sample = run_and_drain(
-            graph,
-            config.op.kind(),
-            &cypher,
-            config.server_timeout_ms,
-            client_deadline,
-        )
-        .await?;
+        // Continue the uncached comment counter past warm-up so every key stays unique.
+        let idx = config.warmup + i;
+        let cypher = render_cypher(&corpus[idx % corpus.len()], mode, nonce, idx);
+        let sample =
+            run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline).await?;
         samples.push(sample);
     }
 
@@ -445,20 +615,33 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
     match command {
         crate::cli::SyntheticCommands::Run {
             endpoint,
-            op,
+            graph,
+            ops,
+            all_reads,
             samples,
             warmup,
+            seed,
             cache,
             server_timeout_ms,
             client_deadline_ms,
             out,
             server_image,
         } => {
+            // --all-reads expands to every read op; otherwise use the (deduplicated) --op list.
+            let ops = if all_reads { OpName::all_reads() } else { ops };
+            if ops.is_empty() {
+                return Err(OtherError(
+                    "no operations selected — pass --op <name> (repeatable/comma-separated) or --all-reads"
+                        .to_string(),
+                ));
+            }
             let config = Config {
                 endpoint,
-                op,
+                graph,
+                ops,
                 samples,
                 warmup,
+                seed,
                 server_timeout_ms,
                 client_deadline_ms,
                 cache,
@@ -477,6 +660,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::query::QueryBuilder;
 
     #[test]
     fn op_name_maps_are_consistent() {
@@ -486,33 +670,114 @@ mod tests {
     }
 
     #[test]
-    fn build_query_is_parameterized_and_varies() {
-        let q0 = OpName::ReturnConst.build_query(0);
-        let q1 = OpName::ReturnConst.build_query(1);
-        assert!(q0.text.contains("$i"));
-        assert_eq!(q0.params.len(), 1);
-        // Different invocation index ⇒ different parameter value.
-        assert_ne!(q0.params.get("i"), q1.params.get("i"));
+    fn clap_value_names_match_as_str() {
+        // The CLI value (used by --op, --help and shell completion) must equal `as_str()` so the
+        // catalog, reports and CLI never disagree (e.g. `expand_1_hop`, not `expand1_hop`).
+        for op in OpName::all() {
+            let cli = op
+                .to_possible_value()
+                .expect("every op is selectable")
+                .get_name()
+                .to_string();
+            assert_eq!(cli, op.as_str(), "clap name vs as_str mismatch");
+        }
     }
 
     #[test]
-    fn uncached_render_is_unique_per_invocation_cached_is_stable() {
-        // Cached mode: no per-invocation uniqueness token, so FalkorDB caches by the parameterized
-        // query body (it strips the leading `CYPHER <params>` prefix from the cache key), and the
-        // plan is reused across invocations.
-        let c0 = OpName::ReturnConst.render_cypher(0, CacheMode::Cached);
-        let c1 = OpName::ReturnConst.render_cypher(1, CacheMode::Cached);
-        assert!(!c0.contains("/* co"));
-        assert!(!c1.contains("/* co"));
-        assert!(c0.contains("RETURN $i AS x"));
-        assert!(c1.contains("RETURN $i AS x"));
+    fn every_op_builds_valid_parameterized_cypher() {
+        use crate::synthetic::catalog::{spec, DatasetHandle, CORPUS_SIZE};
+        // A dataset with enough ids for every op (incl. shortest_path's TwoIds).
+        let dataset = DatasetHandle {
+            node_ids: (1..=50).collect(),
+        };
+        for op in OpName::all() {
+            let s = spec(*op);
+            let mut rng = StdRng::seed_from_u64(7 ^ op.salt());
+            let corpus = s
+                .build_corpus(&mut rng, &dataset, 0, 1)
+                .unwrap_or_else(|e| panic!("corpus for {} should build: {}", op.as_str(), e));
+            assert_eq!(corpus.len(), CORPUS_SIZE, "op {}", op.as_str());
+            // Every corpus entry shares one identical body (required for cache correctness), is
+            // parameterized (no inlined literals beyond the body), and the rendered Cypher never
+            // returns a whole node/edge (scalar projections only).
+            let body0 = &corpus[0].text;
+            for q in &corpus {
+                assert_eq!(&q.text, body0, "op {} bodies must match", op.as_str());
+                assert!(q.text.contains("RETURN"), "op {} must RETURN", op.as_str());
+            }
+        }
+    }
 
-        // Uncached mode: a unique trailing token per `i` ⇒ distinct plan-cache key each run.
-        let u0 = OpName::ReturnConst.render_cypher(0, CacheMode::Uncached);
-        let u1 = OpName::ReturnConst.render_cypher(1, CacheMode::Uncached);
+    #[test]
+    fn corpus_is_deterministic_in_seed() {
+        use crate::synthetic::catalog::{spec, DatasetHandle};
+        let dataset = DatasetHandle {
+            node_ids: (1..=100).collect(),
+        };
+        let build = |seed: u64| {
+            let s = spec(OpName::MatchByIndex);
+            let mut rng = StdRng::seed_from_u64(seed);
+            s.build_corpus(&mut rng, &dataset, 0, 1).unwrap()
+        };
+        let params = |c: &[Query]| -> Vec<String> { c.iter().map(|q| q.to_cypher()).collect() };
+        // Same seed ⇒ byte-identical corpus; different seed ⇒ different corpus.
+        assert_eq!(params(&build(42)), params(&build(42)));
+        assert_ne!(params(&build(42)), params(&build(43)));
+    }
+
+    #[test]
+    fn ops_needing_seeds_error_on_empty_dataset() {
+        use crate::synthetic::catalog::{spec, DatasetHandle};
+        let empty = DatasetHandle::default();
+        // return_const and the label scan need no ids; the rest do.
+        assert!(spec(OpName::ReturnConst)
+            .build_corpus(&mut StdRng::seed_from_u64(1), &empty, 0, 1)
+            .is_ok());
+        assert!(spec(OpName::MatchByLabelScan)
+            .build_corpus(&mut StdRng::seed_from_u64(1), &empty, 0, 1)
+            .is_ok());
+        assert!(spec(OpName::MatchByIndex)
+            .build_corpus(&mut StdRng::seed_from_u64(1), &empty, 0, 1)
+            .is_err());
+        // shortest_path needs two ids: one is not enough.
+        let one = DatasetHandle { node_ids: vec![1] };
+        assert!(spec(OpName::ShortestPath)
+            .build_corpus(&mut StdRng::seed_from_u64(1), &one, 0, 1)
+            .is_err());
+    }
+
+    #[test]
+    fn all_reads_covers_the_catalog_and_dedups() {
+        let reads = OpName::all_reads();
+        assert_eq!(reads.len(), OpName::all().len(), "all ops are reads in Part 2");
+        // dedup_ops keeps first occurrence and drops duplicates / overlaps.
+        let deduped = dedup_ops(&[
+            OpName::MatchByIndex,
+            OpName::Expand1Hop,
+            OpName::MatchByIndex,
+        ]);
+        assert_eq!(deduped, vec![OpName::MatchByIndex, OpName::Expand1Hop]);
+    }
+
+    #[test]
+    fn render_cypher_cached_stable_uncached_unique() {
+        let q = QueryBuilder::new()
+            .text("MATCH (n:User {id: $id}) RETURN n.id")
+            .param("id", 7)
+            .build();
+        // Cached: body verbatim (plan reused), no uniqueness token.
+        let c0 = render_cypher(&q, CacheMode::Cached, 0xABCD, 0);
+        let c1 = render_cypher(&q, CacheMode::Cached, 0xABCD, 1);
+        assert_eq!(c0, c1);
+        assert!(!c0.contains("/* co"));
+        assert!(c0.contains("RETURN n.id"));
+        // Uncached: a unique per-invocation comment ⇒ distinct cache key; the nonce keeps it apart
+        // from other runs.
+        let u0 = render_cypher(&q, CacheMode::Uncached, 0xABCD, 0);
+        let u1 = render_cypher(&q, CacheMode::Uncached, 0xABCD, 1);
         assert_ne!(u0, u1);
-        assert!(u0.contains("/* co0 */"));
-        assert!(u1.contains("/* co1 */"));
+        assert!(u0.contains("/* coabcd-0 */"));
+        assert!(u1.contains("/* coabcd-1 */"));
     }
 
     #[test]
@@ -571,9 +836,32 @@ mod tests {
         // Exercises the CLI→Config mapping without a server: samples==0 is rejected up front.
         let command = crate::cli::SyntheticCommands::Run {
             endpoint: "falkor://127.0.0.1:6379".to_string(),
-            op: OpName::ReturnConst,
+            graph: "falkor".to_string(),
+            ops: vec![OpName::ReturnConst],
+            all_reads: false,
             samples: 0,
             warmup: 0,
+            seed: 0,
+            cache: CacheSelection::Both,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: "unused.json".to_string(),
+            server_image: None,
+        };
+        assert!(run_command(command).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_command_run_requires_an_op() {
+        // Neither --op nor --all-reads ⇒ a clear error before any network use.
+        let command = crate::cli::SyntheticCommands::Run {
+            endpoint: "falkor://127.0.0.1:6379".to_string(),
+            graph: "falkor".to_string(),
+            ops: vec![],
+            all_reads: false,
+            samples: 100,
+            warmup: 0,
+            seed: 0,
             cache: CacheSelection::Both,
             server_timeout_ms: 5_000,
             client_deadline_ms: 6_000,

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -5,6 +5,11 @@ use crate::synthetic::stats::Summary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// Serde default for [`Meta::graph`]: the graph a pre-Part-2 report was measured against.
+fn default_graph() -> String {
+    crate::synthetic::DEFAULT_GRAPH.to_string()
+}
+
 /// Server build/provenance captured from `INFO server` + `MODULE LIST`, plus the operator-supplied
 /// image reference. FalkorDB does not expose a graph-module git SHA to clients, so the reproducible
 /// identity is `module_graph_ver` (real for tagged releases, a `999999` placeholder on `:edge`)
@@ -44,9 +49,10 @@ impl ServerInfo {
 pub struct Meta {
     pub tool_version: String,
     pub endpoint: String,
-    /// Graph key the probe measured against. `#[serde(default)]` so reports written before Part 2
-    /// (which lacked this field) still deserialize.
-    #[serde(default)]
+    /// Graph key the probe measured against. Defaults to [`crate::synthetic::DEFAULT_GRAPH`] when
+    /// deserializing a pre-Part-2 report (which lacked this field but always measured the default
+    /// graph), so an old report round-trips to its true graph rather than an empty string.
+    #[serde(default = "default_graph")]
     pub graph: String,
     pub samples: usize,
     pub warmup: usize,
@@ -275,7 +281,8 @@ mod tests {
             "operations": {}
         }"#;
         let report: Report = serde_json::from_str(old).expect("old report should deserialize");
-        assert_eq!(report.meta.graph, "");
+        // A pre-Part-2 report always measured the default graph, so `graph` reconstructs to it.
+        assert_eq!(report.meta.graph, "falkor");
         assert_eq!(report.meta.seed, 0);
         assert_eq!(report.meta.corpus_size, 0);
         assert_eq!(report.meta.samples, 1000);

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -44,13 +44,19 @@ impl ServerInfo {
 pub struct Meta {
     pub tool_version: String,
     pub endpoint: String,
-    /// Graph key the probe measured against.
+    /// Graph key the probe measured against. `#[serde(default)]` so reports written before Part 2
+    /// (which lacked this field) still deserialize.
+    #[serde(default)]
     pub graph: String,
     pub samples: usize,
     pub warmup: usize,
     /// Seed used to generate the per-operation parameter corpora (for reproducibility).
+    /// `#[serde(default)]` for backward compatibility with pre-Part-2 reports.
+    #[serde(default)]
     pub seed: u64,
-    /// Number of distinct parameterizations pre-generated per operation.
+    /// Number of distinct parameterizations pre-generated per operation. `#[serde(default)]` for
+    /// backward compatibility with pre-Part-2 reports.
+    #[serde(default)]
     pub corpus_size: usize,
     pub server_timeout_ms: i64,
     pub client_deadline_ms: u64,
@@ -251,6 +257,28 @@ mod tests {
         assert_eq!(op.compilation_ms_median, Some(0.05));
         assert_eq!(back.meta.server.module_graph_ver, Some(42001));
         assert_eq!(back.meta.server.cache_size, Some(25));
+    }
+
+    #[test]
+    fn pre_part2_report_deserializes_with_defaults() {
+        // A report written before Part 2 has no graph/seed/corpus_size fields; `#[serde(default)]`
+        // must let it deserialize (falling back to empty/0) rather than erroring.
+        let old = r#"{
+            "meta": {
+                "tool_version": "0.1.0",
+                "endpoint": "falkor://127.0.0.1:6379",
+                "samples": 1000, "warmup": 200,
+                "server_timeout_ms": 5000, "client_deadline_ms": 6000,
+                "connection": "pool(size=1)", "started_at_epoch_secs": 42,
+                "server": {}
+            },
+            "operations": {}
+        }"#;
+        let report: Report = serde_json::from_str(old).expect("old report should deserialize");
+        assert_eq!(report.meta.graph, "");
+        assert_eq!(report.meta.seed, 0);
+        assert_eq!(report.meta.corpus_size, 0);
+        assert_eq!(report.meta.samples, 1000);
     }
 
     #[test]

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -44,8 +44,14 @@ impl ServerInfo {
 pub struct Meta {
     pub tool_version: String,
     pub endpoint: String,
+    /// Graph key the probe measured against.
+    pub graph: String,
     pub samples: usize,
     pub warmup: usize,
+    /// Seed used to generate the per-operation parameter corpora (for reproducibility).
+    pub seed: u64,
+    /// Number of distinct parameterizations pre-generated per operation.
+    pub corpus_size: usize,
     pub server_timeout_ms: i64,
     pub client_deadline_ms: u64,
     /// Connection strategy, e.g. `"pool(size=1)"`.
@@ -102,8 +108,13 @@ impl Report {
     pub fn to_console(&self) -> String {
         let mut out = String::new();
         out.push_str(&format!(
-            "synthetic benchmark — endpoint {}  samples {}  warmup {}  connection {}\n",
-            self.meta.endpoint, self.meta.samples, self.meta.warmup, self.meta.connection
+            "synthetic benchmark — endpoint {}  graph {}  samples {}  warmup {}  seed {}  connection {}\n",
+            self.meta.endpoint,
+            self.meta.graph,
+            self.meta.samples,
+            self.meta.warmup,
+            self.meta.seed,
+            self.meta.connection
         ));
         let v = self
             .meta
@@ -207,8 +218,11 @@ mod tests {
             meta: Meta {
                 tool_version: "0.1.0".to_string(),
                 endpoint: "falkor://127.0.0.1:6379".to_string(),
+                graph: "falkor".to_string(),
                 samples: 1000,
                 warmup: 200,
+                seed: 0,
+                corpus_size: 256,
                 server_timeout_ms: 5000,
                 client_deadline_ms: 6000,
                 connection: "pool(size=1)".to_string(),

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1,13 +1,16 @@
-//! Integration tests for the synthetic single-operation probe.
+//! Integration tests for the synthetic per-operation probe.
 //!
 //! These require a reachable FalkorDB (set `FALKORDB_HOST`/`FALKORDB_PORT` or default to
 //! `127.0.0.1:6379`). They are `#[ignore]`d so a plain `cargo test` stays hermetic; run them with
 //! a live server via `just synthetic-it`, and the coverage job runs them with `--include-ignored`
-//! against a FalkorDB service.
+//! against a FalkorDB service. Each test uses its own graph key so the ignored tests can run
+//! concurrently without clobbering each other.
 
 use benchmark::queries_repository::QueryType;
 use benchmark::synthetic::op_runner::run_and_drain;
-use benchmark::synthetic::{list_ops, open_graph, run, run_and_report, CacheSelection, Config, OpName};
+use benchmark::synthetic::{
+    list_ops, open_graph, run, run_and_report, CacheSelection, Config, OpName,
+};
 use std::time::Duration;
 
 fn endpoint() -> String {
@@ -16,12 +19,14 @@ fn endpoint() -> String {
     format!("falkor://{host}:{port}")
 }
 
-fn base_config() -> Config {
+fn base_config(graph: &str) -> Config {
     Config {
         endpoint: endpoint(),
-        op: OpName::ReturnConst,
+        graph: graph.to_string(),
+        ops: vec![OpName::ReturnConst],
         samples: 300,
         warmup: 50,
+        seed: 1,
         server_timeout_ms: 5_000,
         client_deadline_ms: 6_000,
         cache: CacheSelection::Both,
@@ -30,11 +35,53 @@ fn base_config() -> Config {
     }
 }
 
+/// Drop `graph` if it exists (ignore "missing key" errors).
+async fn drop_graph(graph: &str) {
+    if let Ok(mut g) = open_graph(&endpoint(), graph).await {
+        let _ = g.delete().await;
+    }
+}
+
+/// Seed a tiny `:User {id, age}` graph wired with `:Friend` edges (a ring plus +7 skip edges) so
+/// the read primitives (index lookup, expansion, aggregation, shortest path) have data to touch.
+async fn seed_user_graph(graph: &str, users: i64) {
+    drop_graph(graph).await;
+    let mut g = open_graph(&endpoint(), graph).await.expect("open seed graph");
+    // Any query instantiates the (freshly dropped) graph key; index first so lookups use it.
+    g.query("CREATE INDEX FOR (u:User) ON (u.id)")
+        .execute()
+        .await
+        .expect("create id index");
+    g.query(&format!(
+        "UNWIND range(1, {users}) AS i CREATE (:User {{id: i, age: 18 + i % 50}})"
+    ))
+    .execute()
+    .await
+    .expect("create users");
+    if users > 1 {
+        // Ring edges i -> (i mod N) + 1, plus skip edges i -> ((i+6) mod N) + 1.
+        g.query(&format!(
+            "MATCH (u:User) WITH u MATCH (v:User {{id: (u.id % {users}) + 1}}) CREATE (u)-[:Friend]->(v)"
+        ))
+        .execute()
+        .await
+        .expect("ring edges");
+        g.query(&format!(
+            "MATCH (u:User) WITH u MATCH (v:User {{id: ((u.id + 6) % {users}) + 1}}) CREATE (u)-[:Friend]->(v)"
+        ))
+        .execute()
+        .await
+        .expect("skip edges");
+    }
+}
+
 #[tokio::test]
 #[ignore = "requires a running FalkorDB server"]
 async fn probe_produces_valid_report() {
-    let config = base_config();
+    // `return_const` needs no dataset, so a fresh empty graph is fine.
+    let config = base_config("syn_it_return_const");
     let samples = config.samples;
+    drop_graph(&config.graph).await;
 
     let report = run(&config).await.expect("probe run should succeed");
 
@@ -42,8 +89,6 @@ async fn probe_produces_valid_report() {
         .operations
         .get("return_const")
         .expect("report should contain the measured op");
-
-    // Both cache modes were measured.
     let cached = op.cached.as_ref().expect("cached metrics present");
     let uncached = op.uncached.as_ref().expect("uncached metrics present");
 
@@ -62,19 +107,92 @@ async fn probe_produces_valid_report() {
         "uncached mode should mostly miss the plan cache (got {})",
         uncached.cached_false_rate
     );
-
-    // A compilation cost was derived from both modes.
     assert!(op.compilation_ms_median.is_some());
 
-    // Provenance was captured from the live server.
-    assert!(
-        report.meta.server.redis_version.is_some(),
-        "redis_version should be read from INFO server"
+    // Provenance + Part 2 metadata were captured.
+    assert!(report.meta.server.redis_version.is_some());
+    assert!(report.meta.server.cache_size.is_some());
+    assert_eq!(report.meta.graph, "syn_it_return_const");
+    assert_eq!(
+        report.meta.corpus_size,
+        benchmark::synthetic::catalog::CORPUS_SIZE
     );
-    assert!(
-        report.meta.server.cache_size.is_some(),
-        "CACHE_SIZE should be read via GRAPH.CONFIG"
+    drop_graph(&config.graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn read_catalog_runs_against_seeded_graph() {
+    let graph = "syn_it_reads";
+    seed_user_graph(graph, 200).await;
+
+    let report = run(&Config {
+        graph: graph.to_string(),
+        ops: OpName::all_reads(),
+        samples: 60,
+        warmup: 10,
+        cache: CacheSelection::Both,
+        ..base_config(graph)
+    })
+    .await
+    .expect("read catalog run should succeed");
+
+    // Every read op was measured and produced samples with a sane (finite, non-negative) server
+    // time and total >= server. Smoke-testing the whole catalog catches invalid Cypher/plans.
+    for op in OpName::all_reads() {
+        let r = report
+            .operations
+            .get(op.as_str())
+            .unwrap_or_else(|| panic!("report missing op {}", op.as_str()));
+        let cached = r
+            .cached
+            .as_ref()
+            .unwrap_or_else(|| panic!("op {} missing cached metrics", op.as_str()));
+        assert!(cached.server_ms.n > 0, "op {} has no samples", op.as_str());
+        assert!(
+            cached.server_ms.median >= 0.0 && cached.server_ms.median.is_finite(),
+            "op {} server median not sane: {}",
+            op.as_str(),
+            cached.server_ms.median
+        );
+        assert!(
+            cached.total_ms.median >= cached.server_ms.median,
+            "op {} total < server",
+            op.as_str()
+        );
+        assert!(
+            r.compilation_ms_median.is_some(),
+            "op {} lacks compilation",
+            op.as_str()
+        );
+    }
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn same_seed_yields_identical_report_shape() {
+    // Determinism end-to-end: two runs with the same seed measure identical corpora, so the report
+    // structure (ops + cache modes) matches. (Latencies differ; we assert on the corpus metadata.)
+    let graph = "syn_it_seeded";
+    seed_user_graph(graph, 120).await;
+    let cfg = Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::MatchByIndex, OpName::Expand1Hop],
+        samples: 40,
+        warmup: 10,
+        seed: 4242,
+        cache: CacheSelection::Cached,
+        ..base_config(graph)
+    };
+    let a = run(&cfg).await.expect("run a");
+    let b = run(&cfg).await.expect("run b");
+    assert_eq!(a.meta.seed, b.meta.seed);
+    assert_eq!(
+        a.operations.keys().collect::<Vec<_>>(),
+        b.operations.keys().collect::<Vec<_>>()
     );
+    drop_graph(graph).await;
 }
 
 #[tokio::test]
@@ -85,11 +203,14 @@ async fn run_and_report_writes_json_file() {
         .join(format!("synthetic-report-it-{}.json", std::process::id()))
         .to_string_lossy()
         .into_owned();
+    let graph = "syn_it_json";
+    drop_graph(graph).await;
     let config = Config {
+        graph: graph.to_string(),
         samples: 120,
         warmup: 20,
         out: out.clone(),
-        ..base_config()
+        ..base_config(graph)
     };
 
     run_and_report(&config)
@@ -100,18 +221,23 @@ async fn run_and_report_writes_json_file() {
     assert!(written.contains("return_const"));
     assert!(written.contains("\"cached\""));
     assert!(written.contains("\"uncached\""));
+    assert!(written.contains("\"corpus_size\""));
     let _ = std::fs::remove_file(&out);
+    drop_graph(graph).await;
 }
 
 #[tokio::test]
 #[ignore = "requires a running FalkorDB server"]
 async fn cached_only_and_uncached_only_modes() {
+    let graph = "syn_it_modes";
+    drop_graph(graph).await;
     // Cached-only: no uncached block.
     let cached_report = run(&Config {
+        graph: graph.to_string(),
         samples: 100,
         warmup: 20,
         cache: CacheSelection::Cached,
-        ..base_config()
+        ..base_config(graph)
     })
     .await
     .expect("cached-only run should succeed");
@@ -122,10 +248,11 @@ async fn cached_only_and_uncached_only_modes() {
 
     // Uncached-only: no cached block, and it misses the plan cache.
     let uncached_report = run(&Config {
+        graph: graph.to_string(),
         samples: 100,
         warmup: 20,
         cache: CacheSelection::Uncached,
-        ..base_config()
+        ..base_config(graph)
     })
     .await
     .expect("uncached-only run should succeed");
@@ -133,6 +260,51 @@ async fn cached_only_and_uncached_only_modes() {
     assert!(uop.cached.is_none());
     let uncached = uop.uncached.as_ref().unwrap();
     assert!(uncached.cached_false_rate > 0.5);
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn missing_seed_data_errors_clearly() {
+    // A graph with no :User nodes: an op that needs seed ids fails with a clear message.
+    let graph = "syn_it_empty";
+    seed_user_graph(graph, 0).await; // creates the index but no users
+    let err = run(&Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::MatchByIndex],
+        samples: 20,
+        warmup: 2,
+        ..base_config(graph)
+    })
+    .await
+    .expect_err("match_by_index should fail without seed ids");
+    assert!(
+        format!("{err:?}").contains("seed"),
+        "error should mention missing seed data: {err:?}"
+    );
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn warmup_zero_still_primes_cached_plan() {
+    // With warmup=0 the cached mode primes the plan once before measuring, so it never pays
+    // first-touch compilation and still reports all-cache-hit executions.
+    let graph = "syn_it_warm0";
+    drop_graph(graph).await;
+    let report = run(&Config {
+        graph: graph.to_string(),
+        samples: 40,
+        warmup: 0,
+        cache: CacheSelection::Cached,
+        ..base_config(graph)
+    })
+    .await
+    .expect("warmup=0 cached run should succeed");
+    let op = report.operations.get("return_const").unwrap();
+    let cached = op.cached.as_ref().unwrap();
+    assert_eq!(cached.server_ms.n + cached.server_ms.removed, 40);
+    drop_graph(graph).await;
 }
 
 #[tokio::test]
@@ -144,7 +316,7 @@ async fn bad_endpoint_errors_out() {
         samples: 10,
         warmup: 2,
         client_deadline_ms: 1_000,
-        ..base_config()
+        ..base_config("syn_it_bad")
     };
     assert!(run(&config).await.is_err());
 }
@@ -152,7 +324,10 @@ async fn bad_endpoint_errors_out() {
 #[test]
 fn list_ops_is_non_empty() {
     // Pure helper — no server needed; keeps the smoke path covered even without `--ignored`.
-    assert!(list_ops().contains("return_const"));
+    let listing = list_ops();
+    assert!(listing.contains("return_const"));
+    assert!(listing.contains("match_by_index"));
+    assert!(listing.contains("shortest_path"));
 }
 
 #[tokio::test]
@@ -176,26 +351,40 @@ async fn op_runner_reads_writes_and_reports_errors() {
     assert_eq!(write.rows, 1);
 
     // A read that returns a row: drains it and reports a finite, non-negative server time.
-    let read = run_and_drain(&mut graph, QueryType::Read, "RETURN 1 AS x", 5_000, Duration::from_secs(5))
-        .await
-        .expect("read op should succeed");
+    let read = run_and_drain(
+        &mut graph,
+        QueryType::Read,
+        "RETURN 1 AS x",
+        5_000,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("read op should succeed");
     assert_eq!(read.rows, 1);
     assert!(read.server_ms.is_finite() && read.server_ms >= 0.0);
     assert!(read.total_ms >= read.server_ms);
 
     // A syntactically invalid query surfaces as an error rather than a panic.
-    assert!(
-        run_and_drain(&mut graph, QueryType::Read, "THIS IS NOT CYPHER", 5_000, Duration::from_secs(5))
-            .await
-            .is_err()
-    );
+    assert!(run_and_drain(
+        &mut graph,
+        QueryType::Read,
+        "THIS IS NOT CYPHER",
+        5_000,
+        Duration::from_secs(5)
+    )
+    .await
+    .is_err());
 
     // An impossibly small client deadline trips the whole-operation timeout guard.
-    assert!(
-        run_and_drain(&mut graph, QueryType::Read, "RETURN 1", 5_000, Duration::from_nanos(1))
-            .await
-            .is_err()
-    );
+    assert!(run_and_drain(
+        &mut graph,
+        QueryType::Read,
+        "RETURN 1",
+        5_000,
+        Duration::from_nanos(1)
+    )
+    .await
+    .is_err());
 
     // Tidy up the scratch graph.
     let _ = graph.delete().await;
@@ -204,17 +393,19 @@ async fn op_runner_reads_writes_and_reports_errors() {
 #[tokio::test]
 #[ignore = "requires a running FalkorDB server"]
 async fn probe_instantiates_a_missing_graph() {
-    // Delete the probe's graph first so `run()` exercises the empty-key instantiation path.
-    if let Ok(mut g) = open_graph(&endpoint(), "falkor").await {
-        let _ = g.delete().await;
-    }
+    // Use a dedicated graph and delete it first so `run()` exercises the empty-key instantiation
+    // path deterministically without racing other tests on a shared key.
+    let graph = "syn_it_instantiate";
+    drop_graph(graph).await;
     let report = run(&Config {
+        graph: graph.to_string(),
         samples: 60,
         warmup: 10,
         cache: CacheSelection::Cached,
-        ..base_config()
+        ..base_config(graph)
     })
     .await
     .expect("probe should instantiate the missing graph and succeed");
     assert!(report.operations.contains_key("return_const"));
+    drop_graph(graph).await;
 }

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -42,8 +42,9 @@ async fn drop_graph(graph: &str) {
     }
 }
 
-/// Seed a tiny `:User {id, age}` graph wired with `:Friend` edges (a ring plus +7 skip edges) so
-/// the read primitives (index lookup, expansion, aggregation, shortest path) have data to touch.
+/// Seed a tiny `:User {id, age}` graph wired with `:Friend` edges (a `+1` ring plus longer skip
+/// edges) so the read primitives (index lookup, expansion, aggregation, shortest path) have data to
+/// touch.
 async fn seed_user_graph(graph: &str, users: i64) {
     drop_graph(graph).await;
     let mut g = open_graph(&endpoint(), graph).await.expect("open seed graph");
@@ -59,7 +60,8 @@ async fn seed_user_graph(graph: &str, users: i64) {
     .await
     .expect("create users");
     if users > 1 {
-        // Ring edges i -> (i mod N) + 1, plus skip edges i -> ((i+6) mod N) + 1.
+        // Ring edges i -> (i mod N) + 1 (a +1 step), plus skip edges i -> ((i + 6) mod N) + 1
+        // (a +7 step for these 1-based ids) to give expansions and shortest paths more structure.
         g.query(&format!(
             "MATCH (u:User) WITH u MATCH (v:User {{id: (u.id % {users}) + 1}}) CREATE (u)-[:Friend]->(v)"
         ))

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -375,13 +375,15 @@ async fn op_runner_reads_writes_and_reports_errors() {
     .await
     .is_err());
 
-    // An impossibly small client deadline trips the whole-operation timeout guard.
+    // A tiny client deadline against a query that does real server-side work reliably trips the
+    // whole-operation timeout guard. (A trivial query like `RETURN 1` can finish within tokio's
+    // ~1ms timer resolution on a fast localhost server, so use a query that takes many ms.)
     assert!(run_and_drain(
         &mut graph,
         QueryType::Read,
-        "RETURN 1",
+        "UNWIND range(1, 5000000) AS x RETURN count(x)",
         5_000,
-        Duration::from_nanos(1)
+        Duration::from_millis(1)
     )
     .await
     .is_err());


### PR DESCRIPTION
Part 2 of #200 — closes #202. Depends on Part 1 (#207, merged).

## What
Extends the synthetic per-operation probe from a single baseline op to a **selectable catalog of read operations**, each measured in isolation under **cached & uncached** plan-cache modes at concurrency 1, with the derived per-op `compilation_ms`.

### Operation catalog (`src/synthetic/catalog.rs`)
- `OperationSpec` + object-safe `CorpusFn = fn(&mut dyn rand::Rng, &DatasetHandle, worker, workers) -> BenchmarkResult<Vec<Query>>` + `DatasetHandle`, wired through `spec(op)` (an **exhaustive match** — a new `OpName` won't compile without a corpus). `OpName` stays the single source of truth.
- 8 read primitives over the `:User {id, age}` / `(:User)-[:Friend]->(:User)` schema:

| Operation | Measures | Plan (EXPLAIN-verified) |
|---|---|---|
| `match_by_index` | `:User(id)` point lookup | Node By Index Scan |
| `match_by_label_scan` | full label scan (non-indexable predicate) | Node By Label Scan |
| `expand_1_hop` / `expand_hops_5` | 1- / fixed-5-hop `:Friend` expansion | Conditional Traverse |
| `aggregate_count` / `aggregate_group` | neighbour count / group-by-age | Aggregate |
| `shortest_path` | bounded directed shortest `:Friend` path | shortestPath |
| `property_projection` | scalar property projection | Index Scan + Project |

- Every query projects **scalars** (never whole nodes — avoids the single-connection `SingleThreadedRuntime` decode issue); each op pre-generates a **seeded** corpus (`--seed` yields a byte-identical corpus, unit-tested).

### Runner (`src/synthetic/mod.rs`)
- `Config` gains `ops: Vec<OpName>`, `graph`, `seed`. `run()` samples the live graph once (i32-bounded, ordered), then measures each selected op, cycling its corpus over warmup+samples and deriving `compilation_ms` per op.
- Uncached uniqueness uses a **fresh OS-random per-run nonce** so a small run can't be served a previous run's cached plan. The dataset probe is **skipped** when no selected op needs seed ids; ops that need seeds error clearly when the graph has none.

### CLI (`src/cli.rs`)
`--op` (repeatable **and** comma-separated `ValueEnum`, so `--op <TAB>` completes), `--all-reads` (conflicts with `--op`), `--graph`, `--seed`. Report `meta` records `graph`/`seed`/`corpus_size`.

## Example
```bash
just synthetic-bench --graph main --op match_by_index,expand_1_hop,aggregate_count --samples 500
just synthetic-bench --graph main --all-reads --samples 500
```
Each op prints a `server_ms`/`total_ms` block per cache mode plus `compilation_ms`.

## Tests / validation
- **64 unit tests**: corpus determinism (same/different seed), every op builds valid parameterized Cypher (identical body per op), `--op`/`--all-reads`/dedup, unknown-op clap error, CLI-name vs `as_str` consistency, seed-requirement errors, render/cache modes.
- **10 integration tests** (docker, run under coverage): seed a tiny `:User`/`:Friend` graph and smoke-test the **whole** read catalog end-to-end (samples > 0, `total >= server`), plus determinism, cache-mode, warmup=0, missing-seed, and graph-isolation cases.
- Ran the full `just` gate set (build, clippy, test, doc); **patch coverage ~97%** (catalog.rs ~99%, mod.rs ~96%).
- Rubber-duck reviewed the design **and** implementation; addressed cross-run nonce collision, guaranteed-distinct `shortest_path` endpoints, dataset-probe skipping, i32-bounded sampling, and non-empty-corpus enforcement.

Not merging — awaiting review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-operation synthetic benchmarking for a selectable catalog of read operations (lookups, traversals, aggregations, shortest paths, property projections).
  * Enhanced CLI to support multiple operations via repeatable/comma-separated `--op`, plus an `--all-reads` option.
  * Added deterministic runs with `--seed`, and expanded benchmark reporting/JSON with graph, seed, and corpus size; console output now includes these details.

* **Documentation**
  * Rewrote the synthetic benchmark section with the operation catalog, updated run examples, and reproducible setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->