### PR TITLE
feat(synthetic): seeded reproducible dataset generator + config file (part 3 of #200)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "strum 0.26.3",
  "strum_macros 0.28.0",
  "sysinfo",
@@ -215,6 +216,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -225,6 +227,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -272,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -440,6 +451,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -461,6 +481,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "deadpool"
@@ -497,6 +527,16 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dispatch2"
@@ -726,6 +766,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -2267,10 +2317,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -2677,6 +2747,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2950,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3278,6 +3394,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ lazy_static = "1.5"
 hyper = { version = "0.14.31", features = ["server", "runtime", "http1", "tcp"] }
 nonzero = "0.2.0"
 sysinfo = "0.39.5"
+toml = { version = "0.8", default-features = false, features = ["parse"] }
+sha2 = "0.10"
 [patch."https://github.com/FalkorDB/falkordb-rs.git"]
 falkordb = { path = "vendor/falkordb-rs" }
 

--- a/Justfile
+++ b/Justfile
@@ -102,9 +102,12 @@ run *args:
 
 # === Synthetic per-operation benchmark =======================================
 
-# Needs a reachable FalkorDB, e.g. `docker run -d -p 6379:6379 falkordb/falkordb:latest`. Example:
-# `just synthetic-bench --graph demo --op match_by_index,expand_1_hop --samples 500` (or --all-reads).
-# Read primitives need a `:User {id}` / `:Friend` dataset in --graph; see the README catalog.
+# Needs a reachable FalkorDB, e.g. `docker run -d -p 6379:6379 falkordb/falkordb:latest`. Examples:
+# `just synthetic-bench --graph demo --op match_by_index,expand_1_hop --samples 500` (or --all-reads),
+# or generate a reproducible dataset first:
+# `just synthetic-bench --graph bench --generate --nodes 100000 --edges 1000000 --all-reads`.
+# Read primitives need a `:User {id}` / `:Friend` dataset in --graph (use --generate or a config
+# file, `synthetic-bench.toml`; see the README catalog + `synthetic-bench.example.toml`).
 # Run the synthetic per-operation latency probe (forwards args to `synthetic run`).
 synthetic-bench *args:
     #!/usr/bin/env bash

--- a/readme.md
+++ b/readme.md
@@ -143,9 +143,9 @@ Measures a curated suite of **read operations in isolation** — one at a time, 
 on every invocation both the **server time** (FalkorDB's reported internal execution time) and the
 **total time** (end-to-end client round-trip), then summarizing them with severe-outlier removal
 (Tukey fences, like Criterion.rs) and writing a JSON report with one block per operation. It uses a
-single dedicated connection for honest single-flight latency. This is Part 2 of a larger tool (see
-[`synthetic-benchmark.md`](synthetic-benchmark.md)); later parts add a generated synthetic dataset,
-a concurrency sweep, and write operations.
+single dedicated connection for honest single-flight latency. This is Part 3 of a larger tool (see
+the design epic [#200](https://github.com/FalkorDB/benchmark/issues/200)); it can now **generate its
+own reproducible dataset**, with a concurrency sweep and write operations still to come.
 
 Each operation is measured under two plan-cache conditions so you can see the cost of expression
 **compilation** separately from execution:
@@ -166,9 +166,10 @@ ops except `return_const` target the benchmark's `:User {id, age}` / `(:User)-[:
 schema (with an index on `:User(id)`). Most draw their parameters from `:User` ids sampled out of
 `--graph` (`shortest_path` needs two, `match_by_index`/`expand_*`/`aggregate_*`/`property_projection`
 one); `return_const` and `match_by_label_scan` need no seed ids (they vary a constant / a scan
-modulus). A reproducible generated dataset arrives in Part 3, so for now point `--graph` at a graph
-that already holds that schema. Every query projects **scalars** (never whole nodes) and is
-parameterized; the corpus is seeded (`--seed`) so the same seed yields an identical corpus.
+modulus). Either point `--graph` at a graph that already holds that schema, or let the tool
+**generate a reproducible one** (see [Generating a dataset](#generating-a-reproducible-dataset)
+below). Every query projects **scalars** (never whole nodes) and is parameterized; the corpus is
+seeded (`--seed`) so the same seed yields an identical corpus.
 
 | Operation | What it measures | Cypher (body) |
 |---|---|---|
@@ -236,6 +237,54 @@ The report's `meta.server` block records the FalkorDB module version, `redis_ver
 `CACHE_SIZE`, and the operator-supplied `--server-image` (FalkorDB does not expose a graph-module
 git SHA to clients, so the image digest is the reproducible build identity). A `:edge` image reports
 a `999999` placeholder version and the tool warns you to use a tagged image for comparisons.
+
+#### Generating a reproducible dataset
+
+Instead of measuring whatever graph the endpoint already holds, the tool can **generate its own**
+seeded `:User {id, age}` / `(:User)-[:Friend]->(:User)` graph so results are controlled and
+comparable across runs, machines and FalkorDB versions. Pass `--generate` with `--nodes`/`--edges`:
+
+```bash
+just synthetic-bench --graph bench --generate --nodes 100000 --edges 1000000 \
+    --op match_by_index,expand_hops_5,aggregate_count --samples 500 --seed 42
+```
+
+- `--generate` is **destructive**: it drops and rewrites `--graph` (so it's opt-in on the CLI and is
+  never authorized by a config file alone). It creates the `:User(id)` index, then bulk-loads the
+  nodes and edges via `UNWIND` batches.
+- The graph is generated deterministically from `--seed`: `edges` must be `≥ nodes` (a ring backbone
+  guarantees connectivity for expansions/shortest paths); `edges` counts relationships. The same
+  seed + knobs reproduce the exact same graph and the same operation corpora everywhere.
+- When a dataset is generated, the report's `meta.dataset` records `{seed, nodes, edges,
+  corpus_hash}`. **`corpus_hash`** (`sha256:…`) is a stable fingerprint of the whole workload — the
+  dataset knobs, the selected operations (in order) and their query bodies, and the sampled input
+  pools. **Only compare runs whose `corpus_hash` matches**; a different hash means a different
+  workload. (For an externally-supplied graph the tool can't fingerprint the data, so no
+  `corpus_hash` is emitted.)
+
+#### Config file (`synthetic-bench.toml`)
+
+For a growing knob set you can put the configuration in a `synthetic-bench.toml` file (auto-detected
+in the working directory, or pass `--config <path>`). Any CLI flag **overrides** the file, which in
+turn overrides the built-in defaults; generation still requires the explicit `--generate` flag.
+
+```toml
+# synthetic-bench.toml
+seed = 42
+nodes = 100000
+edges = 1000000
+operations = ["match_by_index", "expand_hops_5", "aggregate_count"]
+samples = 500
+cache = "both"           # cached | uncached | both
+# endpoint / graph / warmup / server_timeout_ms / client_deadline_ms / out are all optional
+```
+
+```bash
+just synthetic-bench --generate     # reads synthetic-bench.toml, builds the dataset, runs the ops
+```
+
+Unknown keys and misspelled operation names are rejected with a clear error, and operation names use
+the same spelling as `--op` (e.g. `expand_1_hop`).
 
 To run the integration test against a live server:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::queries_repository::QueryCoverageProfile;
 use crate::scenario::Vendor;
-use crate::synthetic::{CacheSelection, OpName, DEFAULT_GRAPH};
+use crate::synthetic::{CacheSelection, OpName};
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 
@@ -248,29 +248,31 @@ pub enum Commands {
 }
 
 /// Subcommands of `benchmark synthetic`.
+// The `Run` variant carries many optional CLI knobs; this subcommand enum is parsed once at
+// startup, so the size gap versus the unit `ListOps` variant doesn't matter.
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
 pub enum SyntheticCommands {
     #[command(about = "run the per-operation latency probe over one or more read operations")]
     Run {
         #[arg(
-            long,
-            default_value = "falkor://127.0.0.1:6379",
-            help = "FalkorDB endpoint (e.g., falkor://127.0.0.1:6379)"
+            long = "config",
+            help = "path to a synthetic-bench.toml config (auto-detected in the CWD if present); CLI flags override it"
         )]
-        endpoint: String,
+        config: Option<String>,
         #[arg(
             long,
-            default_value_t = DEFAULT_GRAPH.to_string(),
-            help = "graph key to measure against"
+            help = "FalkorDB endpoint (default falkor://127.0.0.1:6379)"
         )]
-        graph: String,
+        endpoint: Option<String>,
+        #[arg(long, help = "graph key to measure against (default falkor)")]
+        graph: Option<String>,
         #[arg(
             long = "op",
             value_enum,
             value_delimiter = ',',
             num_args = 1..,
-            required_unless_present = "all_reads",
-            help = "operation(s) to measure; repeatable and comma-separated (e.g. --op match_by_index --op expand_1_hop or --op match_by_index,expand_1_hop)"
+            help = "operation(s) to measure; repeatable and comma-separated (e.g. --op match_by_index --op expand_1_hop or --op match_by_index,expand_1_hop). Overrides the config's operations."
         )]
         ops: Vec<OpName>,
         #[arg(
@@ -279,55 +281,42 @@ pub enum SyntheticCommands {
             help = "measure every read operation (mutually exclusive with --op)"
         )]
         all_reads: bool,
+        #[arg(long, help = "number of measured invocations (default 1000)")]
+        samples: Option<usize>,
+        #[arg(long, help = "number of warm-up invocations, discarded (default 200)")]
+        warmup: Option<usize>,
         #[arg(
             long,
-            default_value_t = 1000,
-            help = "number of measured invocations"
+            help = "seed for the dataset and the per-operation corpora (same seed ⇒ identical workload; default 0)"
         )]
-        samples: usize,
-        #[arg(
-            long,
-            default_value_t = 200,
-            help = "number of warm-up invocations (discarded)"
-        )]
-        warmup: usize,
-        #[arg(
-            long,
-            default_value_t = 0,
-            help = "seed for the per-operation parameter corpora (same seed ⇒ identical corpora)"
-        )]
-        seed: u64,
+        seed: Option<u64>,
         #[arg(
             long,
             value_enum,
-            default_value = "both",
-            help = "plan-cache condition: cached (plan reused), uncached (recompiled each run), or both (compare + expose compilation cost)"
+            help = "plan-cache condition: cached, uncached, or both (default both)"
         )]
-        cache: CacheSelection,
-        #[arg(
-            long,
-            default_value_t = 5000,
-            help = "FalkorDB server-side per-query timeout (ms)"
-        )]
-        server_timeout_ms: i64,
-        #[arg(
-            long,
-            default_value_t = 6000,
-            help = "client-side deadline per query (ms)"
-        )]
-        client_deadline_ms: u64,
-        #[arg(
-            long,
-            default_value = "synthetic-report.json",
-            help = "path to write the JSON report"
-        )]
-        out: String,
+        cache: Option<CacheSelection>,
+        #[arg(long, help = "FalkorDB server-side per-query timeout in ms (default 5000)")]
+        server_timeout_ms: Option<i64>,
+        #[arg(long, help = "client-side deadline per query in ms (default 6000)")]
+        client_deadline_ms: Option<u64>,
+        #[arg(long, help = "path to write the JSON report (default synthetic-report.json)")]
+        out: Option<String>,
         #[arg(
             long,
             env = "FALKOR_SERVER_IMAGE",
             help = "operator-supplied server image identity (e.g. falkordb/falkordb:v4.2.1@sha256:...), recorded verbatim"
         )]
         server_image: Option<String>,
+        #[arg(
+            long,
+            help = "GENERATE a reproducible dataset into --graph before measuring. DESTRUCTIVE: drops and rewrites the graph. Requires --nodes/--edges (or config)."
+        )]
+        generate: bool,
+        #[arg(long, help = "dataset node count (with --generate)")]
+        nodes: Option<usize>,
+        #[arg(long, help = "dataset edge count, must be >= nodes (with --generate)")]
+        edges: Option<usize>,
     },
     #[command(about = "list the available operations")]
     ListOps,

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -22,12 +22,20 @@ pub const CORPUS_SIZE: usize = 256;
 
 /// A minimal, seed-independent snapshot of the live graph that operation corpora draw from.
 ///
-/// Part 2 reads this from whatever graph the endpoint already has (Part 3 will generate a
-/// reproducible dataset). `node_ids` is sorted ascending for a stable, reproducible sample.
+/// In Part 2 this is sampled from whatever graph the endpoint already has; Part 3's generator
+/// ([`crate::synthetic::dataset`]) builds it directly from a seeded [`DatasetSpec`]. `node_ids` is
+/// sorted ascending for a stable sample; `connected_pairs` holds `(from, to)` pairs known to be
+/// reachable within the bounded `shortest_path` hop limit (empty when sampled from an external
+/// graph whose connectivity we can't assume).
+///
+/// [`DatasetSpec`]: crate::synthetic::dataset::DatasetSpec
 #[derive(Debug, Clone, Default)]
 pub struct DatasetHandle {
     /// A sample of existing `:User` ids, ascending. Empty if the graph has no `:User` nodes.
     pub node_ids: Vec<i32>,
+    /// Seeded `(from, to)` pairs guaranteed connected within the shortest-path hop bound. Empty for
+    /// externally-probed graphs (Part 2), populated by the Part 3 generator.
+    pub connected_pairs: Vec<(i32, i32)>,
 }
 
 impl DatasetHandle {
@@ -324,12 +332,30 @@ fn corpus_shortest_path(
     _worker: usize,
     _workers: usize,
 ) -> BenchmarkResult<Vec<Query>> {
-    let ids = &dataset.node_ids;
     // FalkorDB's shortestPath form is `WITH shortestPath(...) AS p` and requires a *directed*
     // pattern; bound the search to 6 hops and `coalesce` a missing path to -1 so an unreachable
     // pair returns a row instead of erroring.
     let text = "MATCH (s:User {id: $from}), (t:User {id: $to}) \
                 WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1) AS len";
+
+    // Prefer the generator's connected pairs (guaranteed to have a bounded path, so we measure real
+    // path-finding rather than mostly-unreachable misses). Fall back to two distinct sampled ids
+    // for an externally-probed graph whose connectivity we can't assume.
+    if !dataset.connected_pairs.is_empty() {
+        let pairs = &dataset.connected_pairs;
+        return Ok((0..CORPUS_SIZE)
+            .map(|_| {
+                let (from, to) = pairs[rng.random_range(0..pairs.len())];
+                QueryBuilder::new()
+                    .text(text)
+                    .param("from", from)
+                    .param("to", to)
+                    .build()
+            })
+            .collect());
+    }
+
+    let ids = &dataset.node_ids;
     Ok((0..CORPUS_SIZE)
         .map(|_| {
             // Pick two *distinct* indices (ids are unique) so `from != to`: choose `to` from the
@@ -389,9 +415,10 @@ mod tests {
 
     #[test]
     fn shortest_path_corpus_uses_two_distinct_params() {
-        // The tightest case: exactly two ids. Every entry must use both params with from != to.
+        // The tightest case: exactly two ids and no connected-pair pool (external-graph path).
         let ds = DatasetHandle {
             node_ids: vec![1, 2],
+            ..Default::default()
         };
         let mut rng = StdRng::seed_from_u64(9);
         let corpus = spec(OpName::ShortestPath)
@@ -406,6 +433,36 @@ mod tests {
                 format!("{from:?}"),
                 format!("{to:?}"),
                 "shortest_path endpoints must be distinct"
+            );
+        }
+    }
+
+    #[test]
+    fn shortest_path_prefers_connected_pairs_when_present() {
+        use crate::query::QueryParam;
+        // With a connected-pair pool, every query must draw its (from, to) from that pool.
+        let ds = DatasetHandle {
+            node_ids: (1..=1000).collect(),
+            connected_pairs: vec![(10, 11), (20, 25), (30, 33)],
+        };
+        let allowed: std::collections::HashSet<(i32, i32)> =
+            ds.connected_pairs.iter().copied().collect();
+        let mut rng = StdRng::seed_from_u64(5);
+        let corpus = spec(OpName::ShortestPath)
+            .build_corpus(&mut rng, &ds, 0, 1)
+            .expect("shortest_path corpus");
+        for q in &corpus {
+            let from = match q.params.get("from") {
+                Some(QueryParam::Integer(i)) => *i,
+                other => panic!("from not an integer: {other:?}"),
+            };
+            let to = match q.params.get("to") {
+                Some(QueryParam::Integer(i)) => *i,
+                other => panic!("to not an integer: {other:?}"),
+            };
+            assert!(
+                allowed.contains(&(from, to)),
+                "pair ({from},{to}) not from the connected-pair pool"
             );
         }
     }

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -401,7 +401,7 @@ mod tests {
         assert_eq!(all.len(), OpName::all().len());
         for (entry, op) in all.iter().zip(OpName::all()) {
             assert_eq!(entry.name, *op);
-            assert_eq!(entry.kind, QueryType::Read, "Part 2 ops are all reads");
+            assert_eq!(entry.kind, QueryType::Read, "all catalog ops are reads");
             assert!(!entry.description.is_empty());
         }
     }

--- a/src/synthetic/config.rs
+++ b/src/synthetic/config.rs
@@ -1,0 +1,316 @@
+//! `synthetic-bench.toml` config file and the merge that turns it + CLI flags into a [`Config`].
+//!
+//! The growing knob set lives in an optional TOML file; any value can be overridden by an explicit
+//! CLI flag (precedence: **CLI flag > file value > built-in default**). Dataset *generation* is
+//! never authorized by the file alone — it drops and rewrites the target graph, so it requires the
+//! explicit `--generate` CLI flag (the file only supplies the dimensions).
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::synthetic::dataset::DatasetSpec;
+use crate::synthetic::{CacheSelection, Config, OpName, DEFAULT_GRAPH};
+use serde::Deserialize;
+use std::path::Path;
+
+/// The default config file auto-detected in the working directory when `--config` isn't given.
+pub const DEFAULT_CONFIG_FILE: &str = "synthetic-bench.toml";
+
+/// Parsed `synthetic-bench.toml`. Every field is optional; unknown keys are rejected so a typo
+/// (e.g. `node = 1000`) fails loudly instead of being silently ignored.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileConfig {
+    pub endpoint: Option<String>,
+    pub graph: Option<String>,
+    pub operations: Option<Vec<OpName>>,
+    pub samples: Option<usize>,
+    pub warmup: Option<usize>,
+    pub seed: Option<u64>,
+    pub cache: Option<CacheSelection>,
+    pub server_timeout_ms: Option<i64>,
+    pub client_deadline_ms: Option<u64>,
+    pub out: Option<String>,
+    /// Dataset dimensions (used only when generation is requested via `--generate`).
+    pub nodes: Option<usize>,
+    pub edges: Option<usize>,
+}
+
+impl FileConfig {
+    /// Parse a `FileConfig` from TOML text.
+    pub fn from_toml(text: &str) -> BenchmarkResult<FileConfig> {
+        toml::from_str(text).map_err(|e| OtherError(format!("invalid synthetic config: {}", e)))
+    }
+
+    /// Load the config from `path`, or return `None` if `path` is `None` and no default file exists.
+    /// An explicitly-requested path that is missing/invalid is an error.
+    pub fn load(path: Option<&str>) -> BenchmarkResult<Option<FileConfig>> {
+        match path {
+            Some(p) => {
+                let text = std::fs::read_to_string(p)
+                    .map_err(|e| OtherError(format!("could not read config '{}': {}", p, e)))?;
+                Ok(Some(FileConfig::from_toml(&text)?))
+            }
+            None => {
+                if Path::new(DEFAULT_CONFIG_FILE).exists() {
+                    let text = std::fs::read_to_string(DEFAULT_CONFIG_FILE).map_err(|e| {
+                        OtherError(format!("could not read {}: {}", DEFAULT_CONFIG_FILE, e))
+                    })?;
+                    Ok(Some(FileConfig::from_toml(&text)?))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
+/// The subset of CLI flags that can override the file/defaults. `None` means "flag not passed".
+#[derive(Debug, Clone, Default)]
+pub struct CliOverrides {
+    pub endpoint: Option<String>,
+    pub graph: Option<String>,
+    /// Explicit `--op` list (empty = not passed).
+    pub ops: Vec<OpName>,
+    /// `--all-reads` selects every read op (mutually exclusive with `--op`).
+    pub all_reads: bool,
+    pub samples: Option<usize>,
+    pub warmup: Option<usize>,
+    pub seed: Option<u64>,
+    pub cache: Option<CacheSelection>,
+    pub server_timeout_ms: Option<i64>,
+    pub client_deadline_ms: Option<u64>,
+    pub out: Option<String>,
+    pub server_image: Option<String>,
+    /// Explicit destructive consent to generate + load a dataset into `graph`.
+    pub generate: bool,
+    pub nodes: Option<usize>,
+    pub edges: Option<usize>,
+}
+
+/// Merge CLI overrides over an optional file config to produce the final [`Config`].
+///
+/// Operation selection precedence: explicit `--op` replaces everything; else `--all-reads`; else
+/// the file's `operations`; else it's an error (nothing to measure). Generation is enabled only by
+/// `--generate`, and then `nodes`/`edges` must resolve from a flag or the file.
+pub fn resolve(
+    cli: CliOverrides,
+    file: Option<FileConfig>,
+) -> BenchmarkResult<Config> {
+    let file = file.unwrap_or_default();
+    let defaults = Config::default();
+
+    let ops = if !cli.ops.is_empty() {
+        cli.ops.clone()
+    } else if cli.all_reads {
+        OpName::all_reads()
+    } else {
+        file.operations.clone().unwrap_or_default()
+    };
+    if ops.is_empty() {
+        return Err(OtherError(
+            "no operations selected — pass --op <name> (repeatable/comma-separated), --all-reads, \
+             or set `operations = [...]` in the config file"
+                .to_string(),
+        ));
+    }
+
+    let seed = cli.seed.or(file.seed).unwrap_or(defaults.seed);
+
+    let dataset = if cli.generate {
+        let nodes = cli.nodes.or(file.nodes).ok_or_else(|| {
+            OtherError("--generate needs --nodes (or `nodes` in the config)".to_string())
+        })?;
+        let edges = cli.edges.or(file.edges).ok_or_else(|| {
+            OtherError("--generate needs --edges (or `edges` in the config)".to_string())
+        })?;
+        let spec = DatasetSpec { seed, nodes, edges };
+        spec.validate()?;
+        Some(spec)
+    } else {
+        None
+    };
+
+    Ok(Config {
+        endpoint: cli
+            .endpoint
+            .or(file.endpoint)
+            .unwrap_or(defaults.endpoint),
+        graph: cli
+            .graph
+            .or(file.graph)
+            .unwrap_or_else(|| DEFAULT_GRAPH.to_string()),
+        ops,
+        samples: cli.samples.or(file.samples).unwrap_or(defaults.samples),
+        warmup: cli.warmup.or(file.warmup).unwrap_or(defaults.warmup),
+        seed,
+        server_timeout_ms: cli
+            .server_timeout_ms
+            .or(file.server_timeout_ms)
+            .unwrap_or(defaults.server_timeout_ms),
+        client_deadline_ms: cli
+            .client_deadline_ms
+            .or(file.client_deadline_ms)
+            .unwrap_or(defaults.client_deadline_ms),
+        cache: cli.cache.or(file.cache).unwrap_or(defaults.cache),
+        out: cli.out.or(file.out).unwrap_or(defaults.out),
+        server_image: cli.server_image,
+        dataset,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_operations_by_cli_name() {
+        let cfg = FileConfig::from_toml(
+            "seed = 42\nnodes = 100\nedges = 500\noperations = [\"match_by_index\", \"expand_1_hop\"]\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.seed, Some(42));
+        assert_eq!(cfg.nodes, Some(100));
+        assert_eq!(
+            cfg.operations.unwrap(),
+            vec![OpName::MatchByIndex, OpName::Expand1Hop]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_keys_and_bad_op() {
+        assert!(FileConfig::from_toml("node = 100\n").is_err()); // typo: `node`
+        assert!(FileConfig::from_toml("operations = [\"nope\"]\n").is_err());
+        // digit-name ops use the CLI spelling, not serde's default snake_case.
+        assert!(FileConfig::from_toml("operations = [\"expand1_hop\"]\n").is_err());
+    }
+
+    #[test]
+    fn cli_overrides_file_which_overrides_defaults() {
+        let file = FileConfig {
+            samples: Some(50),
+            graph: Some("from_file".to_string()),
+            operations: Some(vec![OpName::MatchByIndex]),
+            cache: Some(CacheSelection::Cached),
+            ..Default::default()
+        };
+        let cli = CliOverrides {
+            samples: Some(999), // overrides file's 50
+            ..Default::default()
+        };
+        let cfg = resolve(cli, Some(file)).unwrap();
+        assert_eq!(cfg.samples, 999); // CLI wins
+        assert_eq!(cfg.graph, "from_file"); // file wins over default
+        assert_eq!(cfg.warmup, Config::default().warmup); // default (unset anywhere)
+        assert_eq!(cfg.ops, vec![OpName::MatchByIndex]); // from file
+        assert_eq!(cfg.cache, CacheSelection::Cached);
+    }
+
+    #[test]
+    fn cli_ops_replace_file_ops() {
+        let file = FileConfig {
+            operations: Some(vec![OpName::MatchByIndex, OpName::Expand1Hop]),
+            ..Default::default()
+        };
+        let cli = CliOverrides {
+            ops: vec![OpName::AggregateCount],
+            ..Default::default()
+        };
+        let cfg = resolve(cli, Some(file)).unwrap();
+        assert_eq!(cfg.ops, vec![OpName::AggregateCount]);
+    }
+
+    #[test]
+    fn all_reads_selects_everything() {
+        let cli = CliOverrides {
+            all_reads: true,
+            ..Default::default()
+        };
+        let cfg = resolve(cli, None).unwrap();
+        assert_eq!(cfg.ops, OpName::all_reads());
+    }
+
+    #[test]
+    fn no_ops_is_an_error() {
+        assert!(resolve(CliOverrides::default(), None).is_err());
+    }
+
+    #[test]
+    fn generate_requires_dimensions_and_is_cli_gated() {
+        // File supplies nodes/edges/operations, but without --generate no dataset is built.
+        let file = FileConfig {
+            nodes: Some(100),
+            edges: Some(500),
+            operations: Some(vec![OpName::MatchByIndex]),
+            ..Default::default()
+        };
+        let cfg = resolve(CliOverrides::default(), Some(file.clone())).unwrap();
+        assert!(cfg.dataset.is_none(), "file alone must not authorize generation");
+
+        // --generate + file dimensions ⇒ a validated DatasetSpec.
+        let cli = CliOverrides {
+            generate: true,
+            ..Default::default()
+        };
+        let spec = resolve(cli, Some(file)).unwrap().dataset.unwrap();
+        assert_eq!((spec.seed, spec.nodes, spec.edges), (0, 100, 500));
+
+        // --generate without dimensions anywhere ⇒ error (missing nodes).
+        let cli = CliOverrides {
+            generate: true,
+            all_reads: true,
+            ..Default::default()
+        };
+        assert!(resolve(cli, None).is_err());
+
+        // --generate with nodes but no edges ⇒ error (missing edges branch).
+        let cli = CliOverrides {
+            generate: true,
+            nodes: Some(100),
+            all_reads: true,
+            ..Default::default()
+        };
+        assert!(resolve(cli, None).is_err());
+
+        // --generate with invalid dimensions (edges < nodes) ⇒ error.
+        let cli = CliOverrides {
+            generate: true,
+            nodes: Some(100),
+            edges: Some(10),
+            all_reads: true,
+            ..Default::default()
+        };
+        assert!(resolve(cli, None).is_err());
+    }
+
+    #[test]
+    fn cli_seed_flows_into_dataset_and_corpus() {
+        let cli = CliOverrides {
+            generate: true,
+            nodes: Some(50),
+            edges: Some(200),
+            seed: Some(7),
+            all_reads: true,
+            ..Default::default()
+        };
+        let cfg = resolve(cli, None).unwrap();
+        assert_eq!(cfg.seed, 7);
+        assert_eq!(cfg.dataset.unwrap().seed, 7);
+    }
+
+    #[test]
+    fn load_reads_explicit_path_and_errors_on_missing() {
+        // An explicitly-requested but missing path is an error.
+        assert!(FileConfig::load(Some("/nonexistent/synthetic-bench.toml")).is_err());
+
+        // A real file loads.
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("syn-load-{}.toml", std::process::id()));
+        std::fs::write(&path, "seed = 9\nnodes = 20\nedges = 100\n").unwrap();
+        let cfg = FileConfig::load(Some(path.to_str().unwrap()))
+            .unwrap()
+            .expect("config present");
+        assert_eq!(cfg.seed, Some(9));
+        assert_eq!(cfg.nodes, Some(20));
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/synthetic/config.rs
+++ b/src/synthetic/config.rs
@@ -299,12 +299,20 @@ mod tests {
 
     #[test]
     fn load_reads_explicit_path_and_errors_on_missing() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+
         // An explicitly-requested but missing path is an error.
         assert!(FileConfig::load(Some("/nonexistent/synthetic-bench.toml")).is_err());
 
-        // A real file loads.
+        // A real file loads. The name mixes pid + a process-unique counter so parallel tests can't
+        // collide on the same path.
         let dir = std::env::temp_dir();
-        let path = dir.join(format!("syn-load-{}.toml", std::process::id()));
+        let path = dir.join(format!(
+            "syn-load-{}-{}.toml",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
         std::fs::write(&path, "seed = 9\nnodes = 20\nedges = 100\n").unwrap();
         let cfg = FileConfig::load(Some(path.to_str().unwrap()))
             .unwrap()

--- a/src/synthetic/config.rs
+++ b/src/synthetic/config.rs
@@ -130,29 +130,39 @@ pub fn resolve(
         None
     };
 
+    // Destructure the defaults once so each field is a plain local (no partial moves out of a
+    // struct that's still in use below).
+    let Config {
+        endpoint: default_endpoint,
+        samples: default_samples,
+        warmup: default_warmup,
+        server_timeout_ms: default_server_timeout_ms,
+        client_deadline_ms: default_client_deadline_ms,
+        cache: default_cache,
+        out: default_out,
+        ..
+    } = defaults;
+
     Ok(Config {
-        endpoint: cli
-            .endpoint
-            .or(file.endpoint)
-            .unwrap_or(defaults.endpoint),
+        endpoint: cli.endpoint.or(file.endpoint).unwrap_or(default_endpoint),
         graph: cli
             .graph
             .or(file.graph)
             .unwrap_or_else(|| DEFAULT_GRAPH.to_string()),
         ops,
-        samples: cli.samples.or(file.samples).unwrap_or(defaults.samples),
-        warmup: cli.warmup.or(file.warmup).unwrap_or(defaults.warmup),
+        samples: cli.samples.or(file.samples).unwrap_or(default_samples),
+        warmup: cli.warmup.or(file.warmup).unwrap_or(default_warmup),
         seed,
         server_timeout_ms: cli
             .server_timeout_ms
             .or(file.server_timeout_ms)
-            .unwrap_or(defaults.server_timeout_ms),
+            .unwrap_or(default_server_timeout_ms),
         client_deadline_ms: cli
             .client_deadline_ms
             .or(file.client_deadline_ms)
-            .unwrap_or(defaults.client_deadline_ms),
-        cache: cli.cache.or(file.cache).unwrap_or(defaults.cache),
-        out: cli.out.or(file.out).unwrap_or(defaults.out),
+            .unwrap_or(default_client_deadline_ms),
+        cache: cli.cache.or(file.cache).unwrap_or(default_cache),
+        out: cli.out.or(file.out).unwrap_or(default_out),
         server_image: cli.server_image,
         dataset,
     })

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -10,6 +10,7 @@
 
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
+use crate::query::Query;
 use crate::synthetic::catalog::DatasetHandle;
 use crate::synthetic::OpName;
 use falkordb::AsyncGraph;
@@ -20,7 +21,7 @@ use std::time::Duration;
 
 /// Bumped whenever the generator algorithm or the operation catalog's query bodies change, so a
 /// [`corpus_hash`] from an older build never compares equal to a newer, differently-generated one.
-pub const GENERATOR_VERSION: &str = "synthbench/v1";
+pub const GENERATOR_VERSION: &str = "synthbench/v2";
 
 /// Max distinct `:User` ids sampled into the [`DatasetHandle`] id pool.
 const POOL_IDS: usize = 4096;
@@ -48,12 +49,16 @@ pub fn splitmix64(mut x: u64) -> u64 {
 }
 
 /// One reproducible draw keyed by `(seed, domain, index)`.
+///
+/// Non-commutative in `(domain, index)`: the domain keys an independent stream and the index
+/// offsets it, so two different domains can't alias by swapping roles with an index.
 fn mix(
     seed: u64,
     domain: u64,
     index: u64,
 ) -> u64 {
-    splitmix64(seed ^ splitmix64(domain) ^ splitmix64(index))
+    let keyed = splitmix64(seed ^ domain);
+    splitmix64(keyed.wrapping_add(index.wrapping_mul(0x9E37_79B9_7F4A_7C15)))
 }
 
 /// The knobs that fully determine a synthetic dataset.
@@ -124,25 +129,32 @@ impl DatasetSpec {
     }
 
     /// A deterministic, sorted sample of up to [`POOL_IDS`] distinct `:User` ids.
+    ///
+    /// Uses Floyd's algorithm so it always returns exactly `min(nodes, POOL_IDS)` *distinct* ids
+    /// (no rejection-sampling under-fill), deterministically from the seed.
     fn node_id_pool(&self) -> Vec<i32> {
-        if self.nodes <= POOL_IDS {
-            return (1..=self.nodes as i32).collect();
+        let n = self.nodes;
+        let k = POOL_IDS.min(n);
+        if n <= POOL_IDS {
+            return (1..=n as i32).collect();
         }
-        let n = self.nodes as u64;
-        let mut ids = BTreeSet::new();
-        let mut i: u64 = 0;
-        // Bounded attempts; distinct fills quickly since nodes > POOL_IDS.
-        let cap = (POOL_IDS as u64) * 8;
-        while ids.len() < POOL_IDS && i < cap {
-            ids.insert(1 + (mix(self.seed, DOMAIN_POOL_ID, i) % n) as i32);
-            i += 1;
+        // Floyd's algorithm: pick k distinct values from [0, n) in O(k), then map to 1-based ids.
+        let mut chosen = BTreeSet::<u64>::new();
+        for (step, j) in ((n - k) as u64..n as u64).enumerate() {
+            let t = mix(self.seed, DOMAIN_POOL_ID, step as u64) % (j + 1);
+            let pick = if chosen.contains(&t) { j } else { t };
+            chosen.insert(pick);
         }
-        ids.into_iter().collect()
+        chosen.into_iter().map(|v| (v + 1) as i32).collect()
     }
 
     /// A deterministic sample of up to [`POOL_PAIRS`] `(from, to)` pairs that are guaranteed
     /// reachable within `MAX_PAIR_HOPS` directed ring hops (so bounded shortest-path finds a path).
+    /// Returns empty for a degenerate (`nodes < 2`) spec so [`Self::handle`] never panics.
     fn connected_pair_pool(&self) -> Vec<(i32, i32)> {
+        if self.nodes < 2 {
+            return Vec::new();
+        }
         let n = self.nodes as u64;
         let max_k = MAX_PAIR_HOPS.min(self.nodes - 1) as u64; // >= 1 since nodes >= 2
         let count = POOL_PAIRS.min(self.nodes);
@@ -156,7 +168,8 @@ impl DatasetSpec {
             .collect()
     }
 
-    /// Build the seeded [`DatasetHandle`] pools this spec implies (no server access).
+    /// Build the seeded [`DatasetHandle`] pools this spec implies (no server access). Safe for any
+    /// spec: a degenerate (`nodes < 2`) spec yields empty pools rather than panicking.
     pub fn handle(&self) -> DatasetHandle {
         DatasetHandle {
             node_ids: self.node_id_pool(),
@@ -165,15 +178,28 @@ impl DatasetSpec {
     }
 }
 
+/// A canonical fingerprint of an operation's fully-rendered parameter corpus: a SHA-256 over every
+/// query's `CYPHER <params> <body>` string, in order. Because it captures the actual parameter
+/// *values* (not just the query body), a change in how the corpus is sampled — e.g. a different RNG
+/// — changes the fingerprint, so [`corpus_hash`] can never equate two genuinely different workloads.
+pub fn corpus_fingerprint(corpus: &[Query]) -> String {
+    let mut h = Sha256::new();
+    for q in corpus {
+        h.update(q.to_cypher().as_bytes());
+        h.update(b"\n");
+    }
+    format!("{:x}", h.finalize())
+}
+
 /// Compute the workload's `corpus_hash`: an algorithm-tagged SHA-256 over everything that defines
 /// the measured workload — generator version, dataset knobs, the corpus seed & size, each selected
-/// operation (in execution order) with its cached query body, and a digest of the sampled pools.
-/// Two runs are only comparable when their `corpus_hash` matches.
+/// operation (in execution order) paired with a [`corpus_fingerprint`] of its rendered queries, and
+/// a digest of the sampled pools. Two runs are only comparable when their `corpus_hash` matches.
 pub fn corpus_hash(
     spec: &DatasetSpec,
     corpus_seed: u64,
     corpus_size: usize,
-    op_bodies: &[(OpName, String)],
+    op_fingerprints: &[(OpName, String)],
     handle: &DatasetHandle,
 ) -> String {
     let mut h = Sha256::new();
@@ -182,8 +208,8 @@ pub fn corpus_hash(
         "\ndataset:seed={},nodes={},edges={}\ncorpus:seed={},size={}\n",
         spec.seed, spec.nodes, spec.edges, corpus_seed, corpus_size
     ));
-    for (op, body) in op_bodies {
-        h.update(format!("op={}\nbody={}\n", op.as_str(), body));
+    for (op, fp) in op_fingerprints {
+        h.update(format!("op={}\ncorpus={}\n", op.as_str(), fp));
     }
     // Pool digest guards against a generator change that alters sampled inputs without a version
     // bump.
@@ -213,9 +239,30 @@ pub async fn generate_and_load(
         return Err(OtherError("dataset batch_size must be greater than 0".to_string()));
     }
 
-    // Clean slate: drop the graph key (ignore "doesn't exist yet"), then (re)create the id index
-    // before any data so every insert maintains it and it's operational throughout.
-    let _ = graph.delete().await;
+    // Clean slate: drop the graph key so we don't load on top of stale data. A "graph doesn't
+    // exist yet" error is expected and ignored; anything else (auth/network/wrong type) must abort
+    // rather than silently loading into a graph we couldn't clear. Bounded by the load deadline.
+    match tokio::time::timeout(load_deadline, graph.delete()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            let msg = format!("{:?}", e);
+            if !crate::synthetic::is_empty_graph_key(&msg) {
+                return Err(OtherError(format!(
+                    "failed to drop graph before generating dataset: {}",
+                    msg
+                )));
+            }
+        }
+        Err(e) => {
+            return Err(OtherError(format!(
+                "dropping graph before generating dataset timed out: {}",
+                e
+            )))
+        }
+    }
+
+    // (Re)create the id index before any data so every insert maintains it and it's operational
+    // throughout.
     exec_drain(
         graph,
         "CREATE INDEX FOR (u:User) ON (u.id)",
@@ -469,6 +516,51 @@ mod tests {
     }
 
     #[test]
+    fn handle_is_panic_free_for_degenerate_specs() {
+        // handle() must not panic even for invalid specs (validate() gates the real path, but
+        // direct callers shouldn't hit a modulo-by-zero / underflow).
+        for nodes in [0usize, 1] {
+            let h = DatasetSpec {
+                seed: 1,
+                nodes,
+                edges: 0,
+            }
+            .handle();
+            assert!(h.connected_pairs.is_empty());
+        }
+    }
+
+    #[test]
+    fn corpus_fingerprint_is_deterministic_and_param_sensitive() {
+        use crate::query::QueryBuilder;
+        let q = |id: i32| {
+            QueryBuilder::new()
+                .text("MATCH (n:User {id: $id}) RETURN n.id")
+                .param("id", id)
+                .build()
+        };
+        let a = vec![q(1), q(2), q(3)];
+        let b = vec![q(1), q(2), q(3)];
+        let c = vec![q(1), q(2), q(4)]; // one different parameter value
+        assert_eq!(corpus_fingerprint(&a), corpus_fingerprint(&b));
+        assert_ne!(corpus_fingerprint(&a), corpus_fingerprint(&c));
+    }
+
+    #[test]
+    fn node_pool_fills_exactly_when_nodes_just_exceed_cap() {
+        // The Floyd sampler returns exactly POOL_IDS distinct ids even when nodes barely exceeds it
+        // (the old rejection sampler could under-fill here).
+        let h = DatasetSpec {
+            seed: 3,
+            nodes: POOL_IDS + 1,
+            edges: POOL_IDS + 1,
+        }
+        .handle();
+        assert_eq!(h.node_ids.len(), POOL_IDS);
+        assert!(h.node_ids.windows(2).all(|w| w[0] < w[1])); // distinct + sorted
+    }
+
+    #[test]
     fn corpus_hash_golden_value_is_pinned() {
         // A fixed config must always hash to the same value, on any machine/toolchain — this is the
         // cross-process/version stability the comparability gate depends on. If this ever changes,
@@ -484,7 +576,7 @@ mod tests {
         )];
         assert_eq!(
             corpus_hash(&s, 0, 256, &bodies, &s.handle()),
-            "sha256:89279c54669ecb881391168b6b67e4b51af13c1a4eb0331fbccd0938527e43ee"
+            "sha256:daa1d6d9810babea1faf1871e1884b8803e8b83259430ddecfc0a926bddbbb28"
         );
     }
 }

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -466,7 +466,9 @@ mod tests {
         // node_ids are distinct, sorted and in range.
         assert!(h1.node_ids.windows(2).all(|w| w[0] < w[1]));
         assert!(h1.node_ids.iter().all(|&id| (1..=10_000).contains(&id)));
-        // Every connected pair is distinct and within MAX_PAIR_HOPS ring steps.
+        // Each connected pair has distinct endpoints (from != to) and is within MAX_PAIR_HOPS ring
+        // steps. (Pairs are sampled independently, so the pool may contain repeats — that's fine;
+        // corpus_hash fingerprints the actual sampled pairs, so it stays reproducible regardless.)
         for (a, b) in &h1.connected_pairs {
             assert_ne!(a, b);
             let n = 10_000i64;

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -17,6 +17,7 @@ use falkordb::AsyncGraph;
 use futures::StreamExt;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
+use std::fmt::Write as _;
 use std::time::Duration;
 
 /// Bumped whenever the generator algorithm or the operation catalog's query bodies change, so a
@@ -279,7 +280,8 @@ pub async fn generate_and_load(
         if in_batch > 0 {
             batch.push(',');
         }
-        batch.push_str(&format!("{{id:{},age:{}}}", id, spec.node_age(id)));
+        // write! appends directly into the batch buffer (no per-row temporary String).
+        let _ = write!(batch, "{{id:{},age:{}}}", id, spec.node_age(id));
         in_batch += 1;
         if in_batch == batch_size {
             flush_nodes(graph, &batch, server_timeout_ms, load_deadline).await?;
@@ -299,7 +301,7 @@ pub async fn generate_and_load(
         if in_batch > 0 {
             batch.push(',');
         }
-        batch.push_str(&format!("{{src:{},dst:{}}}", src, dst));
+        let _ = write!(batch, "{{src:{},dst:{}}}", src, dst);
         in_batch += 1;
         if in_batch == batch_size {
             flush_edges(graph, &batch, server_timeout_ms, load_deadline).await?;

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -228,7 +228,7 @@ pub fn corpus_hash(
 /// was there (the graph key is dropped first). Creates the `:User(id)` index, loads nodes then
 /// edges in `batch_size` `UNWIND` batches, verifies the final counts, and returns the seeded
 /// [`DatasetHandle`] the operation corpora draw from. `load_deadline` bounds each batch.
-pub async fn generate_and_load(
+pub(crate) async fn generate_and_load(
     graph: &mut AsyncGraph,
     spec: &DatasetSpec,
     batch_size: usize,
@@ -271,7 +271,7 @@ pub async fn generate_and_load(
         load_deadline,
     )
     .await
-    .map_err(|e| OtherError(format!("failed to create :User(id) index: {:?}", e)))?;
+    .map_err(|e| OtherError(format!("failed to create :User(id) index: {}", e)))?;
 
     // Nodes: UNWIND [{id,age},...] AS row CREATE (u:User) SET u = row
     let mut batch = String::new();

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -1,0 +1,491 @@
+//! Seeded, reproducible synthetic dataset generator (Part 3).
+//!
+//! Generates a deterministic `:User {id, age}` / `(:User)-[:Friend]->(:User)` graph from a
+//! [`DatasetSpec`] and bulk-loads it via `UNWIND` batches, so operation numbers are controlled and
+//! comparable across runs, machines and FalkorDB versions. All randomness is derived from a
+//! portable [`splitmix64`] stream keyed by `(seed, domain, index)` — **not** `rand`'s `StdRng`,
+//! whose output isn't guaranteed stable across versions — so "same seed ⇒ same dataset" holds
+//! everywhere. A [`corpus_hash`] over the spec + selected operations + query bodies + sampled pools
+//! is recorded in the report so runs are only compared when the workload truly matches.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::synthetic::catalog::DatasetHandle;
+use crate::synthetic::OpName;
+use falkordb::AsyncGraph;
+use futures::StreamExt;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+/// Bumped whenever the generator algorithm or the operation catalog's query bodies change, so a
+/// [`corpus_hash`] from an older build never compares equal to a newer, differently-generated one.
+pub const GENERATOR_VERSION: &str = "synthbench/v1";
+
+/// Max distinct `:User` ids sampled into the [`DatasetHandle`] id pool.
+const POOL_IDS: usize = 4096;
+/// Max connected `(from, to)` pairs sampled into the [`DatasetHandle`] pair pool.
+const POOL_PAIRS: usize = 1024;
+/// Longest ring distance used when building guaranteed-connected pairs (kept ≤ 5 so the bounded
+/// `shortest_path` query — `[:Friend*1..6]` — always finds a path).
+const MAX_PAIR_HOPS: usize = 5;
+
+// Domain separators so independent derived streams (ages, edge endpoints, pools) never correlate.
+const DOMAIN_AGE: u64 = 0x4147_45f0;
+const DOMAIN_EDGE_SRC: u64 = 0x5352_43f0;
+const DOMAIN_EDGE_OFF: u64 = 0x4f46_46f0;
+const DOMAIN_POOL_ID: u64 = 0x4944_f000;
+const DOMAIN_PAIR_I: u64 = 0x5041_49f0;
+const DOMAIN_PAIR_K: u64 = 0x5041_4bf0;
+
+/// A portable, deterministic 64-bit mixer (SplitMix64). Stable across platforms and toolchains.
+pub fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = x;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// One reproducible draw keyed by `(seed, domain, index)`.
+fn mix(
+    seed: u64,
+    domain: u64,
+    index: u64,
+) -> u64 {
+    splitmix64(seed ^ splitmix64(domain) ^ splitmix64(index))
+}
+
+/// The knobs that fully determine a synthetic dataset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DatasetSpec {
+    pub seed: u64,
+    pub nodes: usize,
+    pub edges: usize,
+}
+
+impl DatasetSpec {
+    /// Validate the knobs: at least two nodes (so shortest-path endpoints can differ and `id`s fit
+    /// `i32`), at most `i32::MAX` nodes (the only integer `QueryParam` width), and at least `nodes`
+    /// edges (so the ring backbone that guarantees connectivity fits within the edge budget).
+    pub fn validate(&self) -> BenchmarkResult<()> {
+        if self.nodes < 2 {
+            return Err(OtherError(format!(
+                "dataset needs at least 2 nodes (got {})",
+                self.nodes
+            )));
+        }
+        if self.nodes > i32::MAX as usize {
+            return Err(OtherError(format!(
+                "dataset nodes ({}) exceeds the i32 id range",
+                self.nodes
+            )));
+        }
+        if self.edges < self.nodes {
+            return Err(OtherError(format!(
+                "dataset edges ({}) must be >= nodes ({}) so the connected ring backbone fits",
+                self.edges, self.nodes
+            )));
+        }
+        if self.edges > i64::MAX as usize {
+            return Err(OtherError(format!("dataset edges ({}) too large", self.edges)));
+        }
+        Ok(())
+    }
+
+    /// Deterministic age for node `id` (an un-indexed property the label-scan op filters on).
+    fn node_age(
+        &self,
+        id: i32,
+    ) -> i32 {
+        18 + (mix(self.seed, DOMAIN_AGE, id as u64) % 60) as i32
+    }
+
+    /// The `e`-th directed `:Friend` edge as `(src_id, dst_id)`.
+    ///
+    /// The first `nodes` edges form a ring `i -> (i mod nodes) + 1` (a connected backbone that
+    /// guarantees every node is reachable and gives shortest-path/expansions structure). Any edges
+    /// beyond that are seeded-random with a non-zero offset, so `src != dst` without retry loops.
+    fn edge_at(
+        &self,
+        e: usize,
+    ) -> (i32, i32) {
+        let n = self.nodes as u64;
+        if (e as u64) < n {
+            let src = e as u64 + 1;
+            let dst = (src % n) + 1;
+            (src as i32, dst as i32)
+        } else {
+            let src0 = mix(self.seed, DOMAIN_EDGE_SRC, e as u64) % n;
+            let offset = 1 + (mix(self.seed, DOMAIN_EDGE_OFF, e as u64) % (n - 1));
+            let dst0 = (src0 + offset) % n;
+            ((src0 + 1) as i32, (dst0 + 1) as i32)
+        }
+    }
+
+    /// A deterministic, sorted sample of up to [`POOL_IDS`] distinct `:User` ids.
+    fn node_id_pool(&self) -> Vec<i32> {
+        if self.nodes <= POOL_IDS {
+            return (1..=self.nodes as i32).collect();
+        }
+        let n = self.nodes as u64;
+        let mut ids = BTreeSet::new();
+        let mut i: u64 = 0;
+        // Bounded attempts; distinct fills quickly since nodes > POOL_IDS.
+        let cap = (POOL_IDS as u64) * 8;
+        while ids.len() < POOL_IDS && i < cap {
+            ids.insert(1 + (mix(self.seed, DOMAIN_POOL_ID, i) % n) as i32);
+            i += 1;
+        }
+        ids.into_iter().collect()
+    }
+
+    /// A deterministic sample of up to [`POOL_PAIRS`] `(from, to)` pairs that are guaranteed
+    /// reachable within `MAX_PAIR_HOPS` directed ring hops (so bounded shortest-path finds a path).
+    fn connected_pair_pool(&self) -> Vec<(i32, i32)> {
+        let n = self.nodes as u64;
+        let max_k = MAX_PAIR_HOPS.min(self.nodes - 1) as u64; // >= 1 since nodes >= 2
+        let count = POOL_PAIRS.min(self.nodes);
+        (0..count)
+            .map(|j| {
+                let from = mix(self.seed, DOMAIN_PAIR_I, j as u64) % n; // 0-based
+                let k = 1 + (mix(self.seed, DOMAIN_PAIR_K, j as u64) % max_k);
+                let to = (from + k) % n;
+                ((from + 1) as i32, (to + 1) as i32)
+            })
+            .collect()
+    }
+
+    /// Build the seeded [`DatasetHandle`] pools this spec implies (no server access).
+    pub fn handle(&self) -> DatasetHandle {
+        DatasetHandle {
+            node_ids: self.node_id_pool(),
+            connected_pairs: self.connected_pair_pool(),
+        }
+    }
+}
+
+/// Compute the workload's `corpus_hash`: an algorithm-tagged SHA-256 over everything that defines
+/// the measured workload — generator version, dataset knobs, the corpus seed & size, each selected
+/// operation (in execution order) with its cached query body, and a digest of the sampled pools.
+/// Two runs are only comparable when their `corpus_hash` matches.
+pub fn corpus_hash(
+    spec: &DatasetSpec,
+    corpus_seed: u64,
+    corpus_size: usize,
+    op_bodies: &[(OpName, String)],
+    handle: &DatasetHandle,
+) -> String {
+    let mut h = Sha256::new();
+    h.update(GENERATOR_VERSION.as_bytes());
+    h.update(format!(
+        "\ndataset:seed={},nodes={},edges={}\ncorpus:seed={},size={}\n",
+        spec.seed, spec.nodes, spec.edges, corpus_seed, corpus_size
+    ));
+    for (op, body) in op_bodies {
+        h.update(format!("op={}\nbody={}\n", op.as_str(), body));
+    }
+    // Pool digest guards against a generator change that alters sampled inputs without a version
+    // bump.
+    for id in &handle.node_ids {
+        h.update(id.to_le_bytes());
+    }
+    for (a, b) in &handle.connected_pairs {
+        h.update(a.to_le_bytes());
+        h.update(b.to_le_bytes());
+    }
+    format!("sha256:{:x}", h.finalize())
+}
+
+/// Generate the dataset described by `spec` and bulk-load it into `graph`, **replacing** whatever
+/// was there (the graph key is dropped first). Creates the `:User(id)` index, loads nodes then
+/// edges in `batch_size` `UNWIND` batches, verifies the final counts, and returns the seeded
+/// [`DatasetHandle`] the operation corpora draw from. `load_deadline` bounds each batch.
+pub async fn generate_and_load(
+    graph: &mut AsyncGraph,
+    spec: &DatasetSpec,
+    batch_size: usize,
+    load_deadline: Duration,
+    server_timeout_ms: i64,
+) -> BenchmarkResult<DatasetHandle> {
+    spec.validate()?;
+    if batch_size == 0 {
+        return Err(OtherError("dataset batch_size must be greater than 0".to_string()));
+    }
+
+    // Clean slate: drop the graph key (ignore "doesn't exist yet"), then (re)create the id index
+    // before any data so every insert maintains it and it's operational throughout.
+    let _ = graph.delete().await;
+    exec_drain(
+        graph,
+        "CREATE INDEX FOR (u:User) ON (u.id)",
+        server_timeout_ms,
+        load_deadline,
+    )
+    .await
+    .map_err(|e| OtherError(format!("failed to create :User(id) index: {:?}", e)))?;
+
+    // Nodes: UNWIND [{id,age},...] AS row CREATE (u:User) SET u = row
+    let mut batch = String::new();
+    let mut in_batch = 0usize;
+    for id in 1..=spec.nodes as i32 {
+        if in_batch > 0 {
+            batch.push(',');
+        }
+        batch.push_str(&format!("{{id:{},age:{}}}", id, spec.node_age(id)));
+        in_batch += 1;
+        if in_batch == batch_size {
+            flush_nodes(graph, &batch, server_timeout_ms, load_deadline).await?;
+            batch.clear();
+            in_batch = 0;
+        }
+    }
+    if in_batch > 0 {
+        flush_nodes(graph, &batch, server_timeout_ms, load_deadline).await?;
+        batch.clear();
+    }
+
+    // Edges: UNWIND [{src,dst},...] AS row MATCH (n:User{id:row.src}),(m:User{id:row.dst}) CREATE ...
+    in_batch = 0;
+    for e in 0..spec.edges {
+        let (src, dst) = spec.edge_at(e);
+        if in_batch > 0 {
+            batch.push(',');
+        }
+        batch.push_str(&format!("{{src:{},dst:{}}}", src, dst));
+        in_batch += 1;
+        if in_batch == batch_size {
+            flush_edges(graph, &batch, server_timeout_ms, load_deadline).await?;
+            batch.clear();
+            in_batch = 0;
+        }
+    }
+    if in_batch > 0 {
+        flush_edges(graph, &batch, server_timeout_ms, load_deadline).await?;
+    }
+
+    // Verify the load produced exactly the requested counts before anyone measures against it.
+    let node_count = count(graph, "MATCH (n:User) RETURN count(n)", server_timeout_ms, load_deadline).await?;
+    if node_count != spec.nodes as i64 {
+        return Err(OtherError(format!(
+            "dataset load produced {} nodes, expected {}",
+            node_count, spec.nodes
+        )));
+    }
+    let edge_count = count(
+        graph,
+        "MATCH (:User)-[e:Friend]->(:User) RETURN count(e)",
+        server_timeout_ms,
+        load_deadline,
+    )
+    .await?;
+    if edge_count != spec.edges as i64 {
+        return Err(OtherError(format!(
+            "dataset load produced {} edges, expected {}",
+            edge_count, spec.edges
+        )));
+    }
+
+    Ok(spec.handle())
+}
+
+async fn flush_nodes(
+    graph: &mut AsyncGraph,
+    maps: &str,
+    server_timeout_ms: i64,
+    deadline: Duration,
+) -> BenchmarkResult<()> {
+    let q = format!("UNWIND [{}] AS row CREATE (u:User) SET u = row", maps);
+    exec_drain(graph, &q, server_timeout_ms, deadline).await
+}
+
+async fn flush_edges(
+    graph: &mut AsyncGraph,
+    maps: &str,
+    server_timeout_ms: i64,
+    deadline: Duration,
+) -> BenchmarkResult<()> {
+    let q = format!(
+        "UNWIND [{}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend]->(m)",
+        maps
+    );
+    exec_drain(graph, &q, server_timeout_ms, deadline).await
+}
+
+/// Execute a write query and drain its (empty) result set, bounded by `deadline`.
+async fn exec_drain(
+    graph: &mut AsyncGraph,
+    cypher: &str,
+    server_timeout_ms: i64,
+    deadline: Duration,
+) -> BenchmarkResult<()> {
+    let fut = async {
+        let mut result = graph
+            .query(cypher)
+            .with_timeout(server_timeout_ms)
+            .execute()
+            .await
+            .map_err(|e| OtherError(format!("load query failed: {:?}", e)))?;
+        while let Some(row) = result.data.next().await {
+            row.map_err(|e| OtherError(format!("load row error: {:?}", e)))?;
+        }
+        Ok::<(), crate::error::BenchmarkError>(())
+    };
+    tokio::time::timeout(deadline, fut)
+        .await
+        .map_err(|e| OtherError(format!("load query timed out after {:?}: {}", deadline, e)))?
+}
+
+/// Run a `RETURN count(...)` scalar query and read the single i64 result.
+async fn count(
+    graph: &mut AsyncGraph,
+    cypher: &str,
+    server_timeout_ms: i64,
+    deadline: Duration,
+) -> BenchmarkResult<i64> {
+    let fut = async {
+        let mut result = graph
+            .ro_query(cypher)
+            .with_timeout(server_timeout_ms)
+            .execute()
+            .await
+            .map_err(|e| OtherError(format!("count query failed: {:?}", e)))?;
+        match result.data.next().await {
+            Some(Ok(row)) => row
+                .try_get_at::<i64>(0)
+                .map_err(|e| OtherError(format!("count decode error: {:?}", e))),
+            Some(Err(e)) => Err(OtherError(format!("count row error: {:?}", e))),
+            None => Err(OtherError("count query returned no rows".to_string())),
+        }
+    };
+    tokio::time::timeout(deadline, fut)
+        .await
+        .map_err(|e| OtherError(format!("count query timed out: {}", e)))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(seed: u64, nodes: usize, edges: usize) -> DatasetSpec {
+        DatasetSpec { seed, nodes, edges }
+    }
+
+    #[test]
+    fn validate_rejects_bad_knobs() {
+        assert!(spec(1, 0, 0).validate().is_err());
+        assert!(spec(1, 1, 5).validate().is_err()); // < 2 nodes
+        assert!(spec(1, 10, 9).validate().is_err()); // edges < nodes
+        assert!(spec(1, 10, 10).validate().is_ok());
+        assert!(spec(1, 10, 100).validate().is_ok());
+        // nodes beyond the i32 id range are rejected.
+        assert!(spec(1, i32::MAX as usize + 1, i32::MAX as usize + 1)
+            .validate()
+            .is_err());
+    }
+
+    #[test]
+    fn edges_are_deterministic_and_never_self_loops() {
+        let s = spec(42, 50, 400);
+        for e in 0..s.edges {
+            let (a, b) = s.edge_at(e);
+            assert_ne!(a, b, "edge {e} is a self-loop");
+            assert!((1..=50).contains(&a) && (1..=50).contains(&b));
+            // Deterministic: same spec, same edge.
+            assert_eq!(s.edge_at(e), spec(42, 50, 400).edge_at(e));
+        }
+        // The first `nodes` edges are the ring backbone.
+        assert_eq!(s.edge_at(0), (1, 2));
+        assert_eq!(s.edge_at(49), (50, 1));
+    }
+
+    #[test]
+    fn different_seed_changes_edges() {
+        let a: Vec<_> = (0..400).map(|e| spec(1, 50, 400).edge_at(e)).collect();
+        let b: Vec<_> = (0..400).map(|e| spec(2, 50, 400).edge_at(e)).collect();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn handle_pools_are_deterministic_and_valid() {
+        let s = spec(7, 10_000, 50_000);
+        let h1 = s.handle();
+        let h2 = s.handle();
+        assert_eq!(h1.node_ids, h2.node_ids);
+        assert_eq!(h1.connected_pairs, h2.connected_pairs);
+        assert_eq!(h1.node_ids.len(), POOL_IDS);
+        // node_ids are distinct, sorted and in range.
+        assert!(h1.node_ids.windows(2).all(|w| w[0] < w[1]));
+        assert!(h1.node_ids.iter().all(|&id| (1..=10_000).contains(&id)));
+        // Every connected pair is distinct and within MAX_PAIR_HOPS ring steps.
+        for (a, b) in &h1.connected_pairs {
+            assert_ne!(a, b);
+            let n = 10_000i64;
+            let fwd = (((*b as i64 - *a as i64) % n) + n) % n;
+            assert!((1..=MAX_PAIR_HOPS as i64).contains(&fwd), "pair {a}->{b} not within {MAX_PAIR_HOPS} hops");
+        }
+    }
+
+    #[test]
+    fn small_graph_pools_are_all_ids() {
+        let s = spec(3, 8, 20);
+        let h = s.handle();
+        assert_eq!(h.node_ids, (1..=8).collect::<Vec<i32>>());
+        assert!(!h.connected_pairs.is_empty());
+    }
+
+    #[test]
+    fn corpus_hash_is_stable_and_knob_sensitive() {
+        let s = spec(42, 1000, 5000);
+        let h = s.handle();
+        let bodies = vec![
+            (OpName::MatchByIndex, "MATCH (n:User {id: $id}) RETURN n.id".to_string()),
+            (OpName::ShortestPath, "…".to_string()),
+        ];
+        let base = corpus_hash(&s, 0, 256, &bodies, &h);
+        // Stable: identical inputs ⇒ identical hash, and it's tagged.
+        assert!(base.starts_with("sha256:"));
+        assert_eq!(base, corpus_hash(&s, 0, 256, &bodies, &h));
+        // Sensitive to every knob.
+        assert_ne!(base, corpus_hash(&spec(43, 1000, 5000), 0, 256, &bodies, &spec(43, 1000, 5000).handle()));
+        assert_ne!(base, corpus_hash(&spec(42, 1001, 5000), 0, 256, &bodies, &spec(42, 1001, 5000).handle()));
+        assert_ne!(base, corpus_hash(&spec(42, 1000, 6000), 0, 256, &bodies, &h));
+        assert_ne!(base, corpus_hash(&s, 1, 256, &bodies, &h)); // corpus seed
+        assert_ne!(base, corpus_hash(&s, 0, 512, &bodies, &h)); // corpus size
+        // Sensitive to op set / order and to a changed query body.
+        let reordered = vec![bodies[1].clone(), bodies[0].clone()];
+        assert_ne!(base, corpus_hash(&s, 0, 256, &reordered, &h));
+        let edited = vec![
+            (OpName::MatchByIndex, "MATCH (n:User {id: $id}) RETURN n.id, n.age".to_string()),
+            bodies[1].clone(),
+        ];
+        assert_ne!(base, corpus_hash(&s, 0, 256, &edited, &h));
+    }
+
+    #[test]
+    fn splitmix64_matches_known_vector() {
+        // Golden value pins the portable stream so a refactor can't silently shift determinism.
+        assert_eq!(splitmix64(0), 0xE220A8397B1DCDAF);
+    }
+
+    #[test]
+    fn corpus_hash_golden_value_is_pinned() {
+        // A fixed config must always hash to the same value, on any machine/toolchain — this is the
+        // cross-process/version stability the comparability gate depends on. If this ever changes,
+        // bump GENERATOR_VERSION deliberately (it invalidates prior comparisons).
+        let s = DatasetSpec {
+            seed: 42,
+            nodes: 1000,
+            edges: 5000,
+        };
+        let bodies = vec![(
+            OpName::MatchByIndex,
+            "MATCH (n:User {id: $id}) RETURN n.id".to_string(),
+        )];
+        assert_eq!(
+            corpus_hash(&s, 0, 256, &bodies, &s.handle()),
+            "sha256:89279c54669ecb881391168b6b67e4b51af13c1a4eb0331fbccd0938527e43ee"
+        );
+    }
+}
+

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -840,7 +840,7 @@ mod tests {
     #[test]
     fn all_reads_covers_the_catalog_and_dedups() {
         let reads = OpName::all_reads();
-        assert_eq!(reads.len(), OpName::all().len(), "all ops are reads in Part 2");
+        assert_eq!(reads.len(), OpName::all().len(), "all catalog ops are reads");
         // dedup_ops keeps first occurrence and drops duplicates / overlaps.
         let deduped = dedup_ops(&[
             OpName::MatchByIndex,
@@ -925,8 +925,18 @@ mod tests {
     #[tokio::test]
     async fn run_command_run_maps_args_and_validates() {
         // Exercises the CLI→Config mapping without a server: samples==0 is rejected up front.
+        // Use an empty temp config (not `config: None`) so the test never auto-detects an ambient
+        // `synthetic-bench.toml` from the working directory.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let cfg_path = std::env::temp_dir().join(format!(
+            "syn-maps-{}-{}.toml",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::write(&cfg_path, "# empty\n").unwrap();
         let command = crate::cli::SyntheticCommands::Run {
-            config: None,
+            config: Some(cfg_path.to_string_lossy().into_owned()),
             endpoint: Some("falkor://127.0.0.1:6379".to_string()),
             graph: Some("falkor".to_string()),
             ops: vec![OpName::ReturnConst],
@@ -944,6 +954,7 @@ mod tests {
             edges: None,
         };
         assert!(run_command(command).await.is_err());
+        let _ = std::fs::remove_file(&cfg_path);
     }
 
     #[tokio::test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -941,9 +941,16 @@ mod tests {
     async fn run_command_run_requires_an_op() {
         // Neither --op nor --all-reads nor any config `operations` ⇒ a clear error before any
         // network use. Point --config at a real but empty config file so the file *loads* fine and
-        // the failure comes from the no-operations validation (not a missing-file read error).
+        // the failure comes from the no-operations validation (not a missing-file read error). The
+        // filename mixes pid + a process-unique counter so parallel tests can't collide.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
         let dir = std::env::temp_dir();
-        let cfg_path = dir.join(format!("syn-noops-{}.toml", std::process::id()));
+        let cfg_path = dir.join(format!(
+            "syn-noops-{}-{}.toml",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
         std::fs::write(&cfg_path, "# empty config, no operations\n").unwrap();
         let command = crate::cli::SyntheticCommands::Run {
             config: Some(cfg_path.to_string_lossy().into_owned()),

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -939,10 +939,14 @@ mod tests {
 
     #[tokio::test]
     async fn run_command_run_requires_an_op() {
-        // Neither --op nor --all-reads nor a config ⇒ a clear error before any network use.
-        // (Uses a config path that doesn't exist so no ambient synthetic-bench.toml is picked up.)
+        // Neither --op nor --all-reads nor any config `operations` ⇒ a clear error before any
+        // network use. Point --config at a real but empty config file so the file *loads* fine and
+        // the failure comes from the no-operations validation (not a missing-file read error).
+        let dir = std::env::temp_dir();
+        let cfg_path = dir.join(format!("syn-noops-{}.toml", std::process::id()));
+        std::fs::write(&cfg_path, "# empty config, no operations\n").unwrap();
         let command = crate::cli::SyntheticCommands::Run {
-            config: Some("/nonexistent/synthetic-bench.toml".to_string()),
+            config: Some(cfg_path.to_string_lossy().into_owned()),
             endpoint: Some("falkor://127.0.0.1:6379".to_string()),
             graph: Some("falkor".to_string()),
             ops: vec![],
@@ -959,7 +963,12 @@ mod tests {
             nodes: None,
             edges: None,
         };
-        assert!(run_command(command).await.is_err());
+        let err = run_command(command).await.expect_err("no ops ⇒ error");
+        assert!(
+            format!("{err:?}").contains("no operations selected"),
+            "expected a no-operations error, got: {err:?}"
+        );
+        let _ = std::fs::remove_file(&cfg_path);
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -14,11 +14,6 @@
 //! for expansions), so the summary trims only *severe* outliers (beyond 3×IQR) and both cache
 //! modes cycle the same corpus in the same order, keeping the cached-vs-uncached medians comparable
 //! on a matched workload.
-//!
-//! Note that per-operation latency distributions can be right-skewed (e.g. high-degree seed nodes
-//! for expansions), so the summary trims only *severe* outliers (beyond 3×IQR) and both cache
-//! modes cycle the same corpus in the same order, keeping the cached-vs-uncached medians comparable
-//! on a matched workload.
 
 pub mod catalog;
 pub mod config;
@@ -369,7 +364,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         let load_deadline = Duration::from_millis(config.client_deadline_ms.max(60_000));
         let load_server_timeout_ms = config
             .server_timeout_ms
-            .max(load_deadline.as_millis() as i64);
+            .max(i64::try_from(load_deadline.as_millis()).unwrap_or(i64::MAX));
         info!(
             "generating synthetic dataset (seed {}, nodes {}, edges {}) into graph '{}'",
             spec.seed, spec.nodes, spec.edges, config.graph

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -387,15 +387,15 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     let run_token = rand::random_range(0..=u64::MAX);
 
     let mut operations = BTreeMap::new();
-    // Capture each op's cached query body (in execution order) so the corpus_hash reflects the
-    // exact workload, not just the op names.
-    let mut op_bodies: Vec<(OpName, String)> = Vec::with_capacity(ops.len());
+    // Capture each op's corpus fingerprint (in execution order) so the corpus_hash reflects the
+    // exact rendered workload — parameter values included — not just the op names.
+    let mut op_fingerprints: Vec<(OpName, String)> = Vec::with_capacity(ops.len());
     for op in ops {
         let op_spec = spec(op);
         // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
         let mut rng = StdRng::seed_from_u64(config.seed ^ op.salt());
         let corpus = op_spec.build_corpus(&mut rng, &dataset, 0, 1)?;
-        op_bodies.push((op, corpus[0].text.clone()));
+        op_fingerprints.push((op, dataset::corpus_fingerprint(&corpus)));
         let op_report =
             measure_op(&mut graph, config, &op_spec, &corpus, run_token, client_deadline).await?;
         operations.insert(op.as_str().to_string(), op_report);
@@ -407,7 +407,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         seed: spec.seed,
         nodes: spec.nodes,
         edges: spec.edges,
-        corpus_hash: dataset::corpus_hash(spec, config.seed, CORPUS_SIZE, &op_bodies, &dataset),
+        corpus_hash: dataset::corpus_hash(spec, config.seed, CORPUS_SIZE, &op_fingerprints, &dataset),
     });
 
     Ok(Report {
@@ -535,7 +535,7 @@ async fn probe_dataset(
 }
 
 /// Whether a query error string is FalkorDB's "graph key does not exist yet" condition.
-fn is_empty_graph_key(msg: &str) -> bool {
+pub(crate) fn is_empty_graph_key(msg: &str) -> bool {
     let m = msg.to_ascii_lowercase();
     m.contains("empty key") || m.contains("invalid graph operation")
 }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1,11 +1,19 @@
-//! Synthetic per-operation benchmark — Part 2: a selectable catalog of read operations.
+//! Synthetic per-operation benchmark — a selectable catalog of read operations over a controlled
+//! dataset.
 //!
-//! Measures one or more Cypher read operations in isolation against a FalkorDB endpoint. For each
-//! selected operation it pre-generates a seeded corpus of parameterized queries (see
-//! [`catalog`]), then, under each plan-cache condition, captures on every invocation the paired
-//! *server time* (FalkorDB's reported internal execution time) and *total time* (end-to-end client
-//! round-trip), summarizes them with severe-outlier removal, and derives the expression
-//! *compilation cost* (uncached − cached). One JSON block is written per operation.
+//! Measures one or more Cypher read operations in isolation against a FalkorDB endpoint. The graph
+//! is either sampled from the live endpoint or **generated reproducibly** from a seed (see
+//! [`dataset`]). For each selected operation it pre-generates a seeded corpus of parameterized
+//! queries (see [`catalog`]), then, under each plan-cache condition, captures on every invocation
+//! the paired *server time* (FalkorDB's reported internal execution time) and *total time*
+//! (end-to-end client round-trip), summarizes them with severe-outlier removal, and derives the
+//! expression *compilation cost* (uncached − cached). One JSON block is written per operation; when
+//! the dataset was generated, a `corpus_hash` fingerprints the whole workload for comparability.
+//!
+//! Note that per-operation latency distributions can be right-skewed (e.g. high-degree seed nodes
+//! for expansions), so the summary trims only *severe* outliers (beyond 3×IQR) and both cache
+//! modes cycle the same corpus in the same order, keeping the cached-vs-uncached medians comparable
+//! on a matched workload.
 //!
 //! Note that per-operation latency distributions can be right-skewed (e.g. high-degree seed nodes
 //! for expansions), so the summary trims only *severe* outliers (beyond 3×IQR) and both cache
@@ -355,7 +363,13 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     // Dataset: either generate a reproducible one (Part 3) or sample the live graph (Part 2).
     let dataset = if let Some(spec) = &config.dataset {
         // Generation replaces the target graph, so it's gated behind explicit CLI consent upstream.
+        // Bulk-load batches do real server-side work, so give them a generous deadline *and* a
+        // matching server-side per-query timeout (the default measurement timeout — often 5s — is
+        // too small for a large UNWIND batch and would trip before the client deadline).
         let load_deadline = Duration::from_millis(config.client_deadline_ms.max(60_000));
+        let load_server_timeout_ms = config
+            .server_timeout_ms
+            .max(load_deadline.as_millis() as i64);
         info!(
             "generating synthetic dataset (seed {}, nodes {}, edges {}) into graph '{}'",
             spec.seed, spec.nodes, spec.edges, config.graph
@@ -365,7 +379,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             spec,
             DATASET_LOAD_BATCH,
             load_deadline,
-            config.server_timeout_ms,
+            load_server_timeout_ms,
         )
         .await?
     } else {

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -13,6 +13,8 @@
 //! on a matched workload.
 
 pub mod catalog;
+pub mod config;
+pub mod dataset;
 pub mod op_runner;
 pub mod provenance;
 pub mod report;
@@ -24,13 +26,16 @@ use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
 use crate::query::Query;
 use crate::synthetic::catalog::{spec, DatasetHandle, DatasetRequirement, OperationSpec, CORPUS_SIZE};
+use crate::synthetic::dataset::DatasetSpec;
 use crate::synthetic::op_runner::{run_and_drain, OpSample};
-use crate::synthetic::report::{Meta, OperationReport, Report};
+use crate::synthetic::report::{DatasetInfo, Meta, OperationReport, Report};
 use clap::ValueEnum;
 use falkordb::{ConnectionStrategy, FalkorClientBuilder};
 use futures::StreamExt;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
+use serde::de::{self, Deserializer};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{info, warn};
@@ -38,8 +43,11 @@ use tracing::{info, warn};
 /// The default graph key the probe targets when `--graph` isn't given.
 pub const DEFAULT_GRAPH: &str = "falkor";
 
-/// How many `:User` ids to sample from the live graph to seed operation corpora.
+/// How many `:User` ids to sample from the live graph to seed operation corpora (Part 2 path).
 const DATASET_SAMPLE_SIZE: usize = 512;
+
+/// `UNWIND` batch size used when the generator bulk-loads a synthetic dataset.
+const DATASET_LOAD_BATCH: usize = 1000;
 
 /// The set of operations the probe can measure. `OpName` is the single source of truth: it's a
 /// clap `ValueEnum` (so `--op`, `--help` and shell completion list exactly these), and every
@@ -128,11 +136,37 @@ impl OpName {
             OpName::PropertyProjection => 0x5052_4f50_5f50_524a,
         }
     }
+
+    /// Parse an op from its canonical [`Self::as_str`] name (the CLI/config spelling).
+    pub fn from_cli_str(s: &str) -> Option<OpName> {
+        OpName::all().iter().copied().find(|op| op.as_str() == s)
+    }
+}
+
+/// Deserialize an `OpName` from its canonical [`OpName::as_str`] name, so a `synthetic-bench.toml`
+/// `operations = ["expand_1_hop", ...]` list uses the exact same spelling as the CLI (a plain
+/// `rename_all = "snake_case"` derive would produce `expand1_hop`).
+impl<'de> Deserialize<'de> for OpName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        OpName::from_cli_str(&s).ok_or_else(|| {
+            let names: Vec<&str> = OpName::all().iter().map(|op| op.as_str()).collect();
+            de::Error::custom(format!(
+                "unknown operation '{}' (expected one of: {})",
+                s,
+                names.join(", ")
+            ))
+        })
+    }
 }
 
 /// Which plan-cache condition to measure an operation under.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
 #[value(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum CacheSelection {
     /// Warm plan cache: identical query **body** every run (only the stripped `CYPHER <params>`
     /// prefix varies), so the plan is reused → execution only.
@@ -199,6 +233,9 @@ pub struct Config {
     pub cache: CacheSelection,
     pub out: String,
     pub server_image: Option<String>,
+    /// When `Some`, generate a reproducible synthetic dataset (Part 3) into `graph`, **replacing**
+    /// its contents, before measuring. Gated behind explicit CLI consent (`--generate`).
+    pub dataset: Option<DatasetSpec>,
 }
 
 impl Default for Config {
@@ -215,6 +252,7 @@ impl Default for Config {
             cache: CacheSelection::Both,
             out: "synthetic-report.json".to_string(),
             server_image: None,
+            dataset: None,
         }
     }
 }
@@ -313,17 +351,35 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     }
 
     let client_deadline = Duration::from_millis(config.client_deadline_ms);
-    ensure_graph_exists(&mut graph, config, client_deadline).await?;
 
-    // Only sample the graph if some selected op needs seed ids (return_const / label scan don't),
-    // so a return_const-only run doesn't fail on a graph that has no :User data.
-    let needs_dataset = ops
-        .iter()
-        .any(|op| spec(*op).requirement != DatasetRequirement::None);
-    let dataset = if needs_dataset {
-        probe_dataset(&mut graph, config, client_deadline).await?
+    // Dataset: either generate a reproducible one (Part 3) or sample the live graph (Part 2).
+    let dataset = if let Some(spec) = &config.dataset {
+        // Generation replaces the target graph, so it's gated behind explicit CLI consent upstream.
+        let load_deadline = Duration::from_millis(config.client_deadline_ms.max(60_000));
+        info!(
+            "generating synthetic dataset (seed {}, nodes {}, edges {}) into graph '{}'",
+            spec.seed, spec.nodes, spec.edges, config.graph
+        );
+        dataset::generate_and_load(
+            &mut graph,
+            spec,
+            DATASET_LOAD_BATCH,
+            load_deadline,
+            config.server_timeout_ms,
+        )
+        .await?
     } else {
-        DatasetHandle::default()
+        ensure_graph_exists(&mut graph, config, client_deadline).await?;
+        // Only sample the graph if some selected op needs seed ids (return_const / label scan
+        // don't), so a return_const-only run doesn't fail on a graph that has no :User data.
+        let needs_dataset = ops
+            .iter()
+            .any(|op| spec(*op).requirement != DatasetRequirement::None);
+        if needs_dataset {
+            probe_dataset(&mut graph, config, client_deadline).await?
+        } else {
+            DatasetHandle::default()
+        }
     };
 
     // A fresh OS-random run_token per run keeps uncached-mode comments globally unique, so a small
@@ -331,15 +387,28 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     let run_token = rand::random_range(0..=u64::MAX);
 
     let mut operations = BTreeMap::new();
+    // Capture each op's cached query body (in execution order) so the corpus_hash reflects the
+    // exact workload, not just the op names.
+    let mut op_bodies: Vec<(OpName, String)> = Vec::with_capacity(ops.len());
     for op in ops {
         let op_spec = spec(op);
         // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
         let mut rng = StdRng::seed_from_u64(config.seed ^ op.salt());
         let corpus = op_spec.build_corpus(&mut rng, &dataset, 0, 1)?;
+        op_bodies.push((op, corpus[0].text.clone()));
         let op_report =
             measure_op(&mut graph, config, &op_spec, &corpus, run_token, client_deadline).await?;
         operations.insert(op.as_str().to_string(), op_report);
     }
+
+    // Record dataset provenance + the workload's corpus_hash only when we generated the data (we
+    // can't fingerprint an externally-supplied graph, so comparing hashes would be misleading).
+    let dataset_info = config.dataset.as_ref().map(|spec| DatasetInfo {
+        seed: spec.seed,
+        nodes: spec.nodes,
+        edges: spec.edges,
+        corpus_hash: dataset::corpus_hash(spec, config.seed, CORPUS_SIZE, &op_bodies, &dataset),
+    });
 
     Ok(Report {
         meta: Meta {
@@ -355,6 +424,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             connection: "pool(size=1)".to_string(),
             started_at_epoch_secs,
             server,
+            dataset: dataset_info,
         },
         operations,
     })
@@ -458,7 +528,10 @@ async fn probe_dataset(
     let node_ids = tokio::time::timeout(client_deadline, collect)
         .await
         .map_err(|e| OtherError(format!("dataset probe timed out: {}", e)))??;
-    Ok(DatasetHandle { node_ids })
+    Ok(DatasetHandle {
+        node_ids,
+        ..Default::default()
+    })
 }
 
 /// Whether a query error string is FalkorDB's "graph key does not exist yet" condition.
@@ -610,12 +683,13 @@ pub async fn run_and_report(config: &Config) -> BenchmarkResult<()> {
     Ok(())
 }
 
-/// Execute a parsed `synthetic` subcommand. This keeps `main.rs` a thin shell: it maps the CLI
-/// [`crate::cli::SyntheticCommands`] onto a [`Config`] and runs the probe, or prints the operation
-/// catalog.
+/// Execute a parsed `synthetic` subcommand. This keeps `main.rs` a thin shell: it loads the
+/// optional `synthetic-bench.toml`, merges it with the CLI overrides into a [`Config`] and runs the
+/// probe, or prints the operation catalog.
 pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkResult<()> {
     match command {
         crate::cli::SyntheticCommands::Run {
+            config: config_path,
             endpoint,
             graph,
             ops,
@@ -628,28 +702,29 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             client_deadline_ms,
             out,
             server_image,
+            generate,
+            nodes,
+            edges,
         } => {
-            // --all-reads expands to every read op; otherwise use the (deduplicated) --op list.
-            let ops = if all_reads { OpName::all_reads() } else { ops };
-            if ops.is_empty() {
-                return Err(OtherError(
-                    "no operations selected — pass --op <name> (repeatable/comma-separated) or --all-reads"
-                        .to_string(),
-                ));
-            }
-            let config = Config {
+            let overrides = config::CliOverrides {
                 endpoint,
                 graph,
                 ops,
+                all_reads,
                 samples,
                 warmup,
                 seed,
+                cache,
                 server_timeout_ms,
                 client_deadline_ms,
-                cache,
                 out,
                 server_image,
+                generate,
+                nodes,
+                edges,
             };
+            let file = config::FileConfig::load(config_path.as_deref())?;
+            let config = config::resolve(overrides, file)?;
             run_and_report(&config).await
         }
         crate::cli::SyntheticCommands::ListOps => {
@@ -691,6 +766,7 @@ mod tests {
         // A dataset with enough ids for every op (incl. shortest_path's TwoIds).
         let dataset = DatasetHandle {
             node_ids: (1..=50).collect(),
+            ..Default::default()
         };
         for op in OpName::all() {
             let s = spec(*op);
@@ -715,6 +791,7 @@ mod tests {
         use crate::synthetic::catalog::{spec, DatasetHandle};
         let dataset = DatasetHandle {
             node_ids: (1..=100).collect(),
+            ..Default::default()
         };
         let build = |seed: u64| {
             let s = spec(OpName::MatchByIndex);
@@ -742,7 +819,10 @@ mod tests {
             .build_corpus(&mut StdRng::seed_from_u64(1), &empty, 0, 1)
             .is_err());
         // shortest_path needs two ids: one is not enough.
-        let one = DatasetHandle { node_ids: vec![1] };
+        let one = DatasetHandle {
+            node_ids: vec![1],
+            ..Default::default()
+        };
         assert!(spec(OpName::ShortestPath)
             .build_corpus(&mut StdRng::seed_from_u64(1), &one, 0, 1)
             .is_err());
@@ -837,38 +917,47 @@ mod tests {
     async fn run_command_run_maps_args_and_validates() {
         // Exercises the CLI→Config mapping without a server: samples==0 is rejected up front.
         let command = crate::cli::SyntheticCommands::Run {
-            endpoint: "falkor://127.0.0.1:6379".to_string(),
-            graph: "falkor".to_string(),
+            config: None,
+            endpoint: Some("falkor://127.0.0.1:6379".to_string()),
+            graph: Some("falkor".to_string()),
             ops: vec![OpName::ReturnConst],
             all_reads: false,
-            samples: 0,
-            warmup: 0,
-            seed: 0,
-            cache: CacheSelection::Both,
-            server_timeout_ms: 5_000,
-            client_deadline_ms: 6_000,
-            out: "unused.json".to_string(),
+            samples: Some(0),
+            warmup: Some(0),
+            seed: Some(0),
+            cache: Some(CacheSelection::Both),
+            server_timeout_ms: Some(5_000),
+            client_deadline_ms: Some(6_000),
+            out: Some("unused.json".to_string()),
             server_image: None,
+            generate: false,
+            nodes: None,
+            edges: None,
         };
         assert!(run_command(command).await.is_err());
     }
 
     #[tokio::test]
     async fn run_command_run_requires_an_op() {
-        // Neither --op nor --all-reads ⇒ a clear error before any network use.
+        // Neither --op nor --all-reads nor a config ⇒ a clear error before any network use.
+        // (Uses a config path that doesn't exist so no ambient synthetic-bench.toml is picked up.)
         let command = crate::cli::SyntheticCommands::Run {
-            endpoint: "falkor://127.0.0.1:6379".to_string(),
-            graph: "falkor".to_string(),
+            config: Some("/nonexistent/synthetic-bench.toml".to_string()),
+            endpoint: Some("falkor://127.0.0.1:6379".to_string()),
+            graph: Some("falkor".to_string()),
             ops: vec![],
             all_reads: false,
-            samples: 100,
-            warmup: 0,
-            seed: 0,
-            cache: CacheSelection::Both,
-            server_timeout_ms: 5_000,
-            client_deadline_ms: 6_000,
-            out: "unused.json".to_string(),
+            samples: Some(100),
+            warmup: Some(0),
+            seed: Some(0),
+            cache: Some(CacheSelection::Both),
+            server_timeout_ms: Some(5_000),
+            client_deadline_ms: Some(6_000),
+            out: Some("unused.json".to_string()),
             server_image: None,
+            generate: false,
+            nodes: None,
+            edges: None,
         };
         assert!(run_command(command).await.is_err());
     }

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -70,6 +70,22 @@ pub struct Meta {
     pub connection: String,
     pub started_at_epoch_secs: u64,
     pub server: ServerInfo,
+    /// Present only when the probe generated its own reproducible dataset (Part 3). Absent for an
+    /// externally-provided graph, whose contents we can't fingerprint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dataset: Option<DatasetInfo>,
+}
+
+/// Provenance for a generated synthetic dataset: its knobs and the `corpus_hash` that identifies
+/// the whole workload (dataset + selected operations + query bodies), so runs are only compared
+/// when they match.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatasetInfo {
+    pub seed: u64,
+    pub nodes: usize,
+    pub edges: usize,
+    /// Algorithm-tagged hash (`sha256:…`) of the full workload; equal iff comparable.
+    pub corpus_hash: String,
 }
 
 /// Latency and cache-health stats for one (operation, cache-mode) measurement.
@@ -153,6 +169,12 @@ impl Report {
         ));
         if let Some(img) = &self.meta.server.server_image {
             out.push_str(&format!("server image: {}\n", img));
+        }
+        if let Some(d) = &self.meta.dataset {
+            out.push_str(&format!(
+                "dataset — seed {}  nodes {}  edges {}  corpus_hash {}\n",
+                d.seed, d.nodes, d.edges, d.corpus_hash
+            ));
         }
         for (name, op) in &self.operations {
             out.push_str(&format!("\n{}\n", name));
@@ -245,6 +267,7 @@ mod tests {
                     redis_version: Some("8.6.3".to_string()),
                     ..Default::default()
                 },
+                dataset: None,
             },
             operations,
         }
@@ -303,6 +326,21 @@ mod tests {
         assert!(out.contains("CACHE_SIZE 25"));
         // The operator-supplied image identity is echoed when present.
         assert!(out.contains("server image: falkordb/falkordb:v4.2.1@sha256:deadbeef"));
+    }
+
+    #[test]
+    fn console_shows_dataset_block_when_generated() {
+        let mut r = sample_report();
+        r.meta.dataset = Some(DatasetInfo {
+            seed: 42,
+            nodes: 1000,
+            edges: 5000,
+            corpus_hash: "sha256:abc123".to_string(),
+        });
+        let out = r.to_console();
+        assert!(out.contains("dataset — seed 42  nodes 1000  edges 5000  corpus_hash sha256:abc123"));
+        // Absent by default (externally-supplied graph).
+        assert!(!sample_report().to_console().contains("dataset —"));
     }
 
     #[test]

--- a/synthetic-bench.example.toml
+++ b/synthetic-bench.example.toml
@@ -1,0 +1,31 @@
+# Example configuration for the synthetic per-operation benchmark.
+#
+# Copy this to `synthetic-bench.toml` (auto-detected in the working directory) or pass it with
+# `--config <path>`. Every key is optional; any CLI flag overrides the value here, which in turn
+# overrides the built-in defaults. Unknown keys and misspelled operation names are rejected.
+#
+# NOTE: generating the dataset drops and rewrites the target graph, so it is only performed when you
+# pass the explicit `--generate` flag on the command line — this file only supplies the dimensions.
+
+# Seed for the dataset AND the per-operation corpora: the same seed reproduces the exact same
+# workload (graph + parameters) on any machine.
+seed = 42
+
+# Dataset dimensions (used with `--generate`). `edges` must be >= `nodes` and counts relationships.
+nodes = 100000
+edges = 1000000
+
+# Operations to measure, using the same names as `--op` (see `benchmark synthetic list-ops`).
+operations = ["match_by_index", "expand_hops_5", "aggregate_count"]
+
+# Measurement knobs (all optional; shown with their defaults).
+samples = 1000
+warmup = 200
+cache = "both"              # cached | uncached | both
+
+# Connection / output (all optional).
+# endpoint = "falkor://127.0.0.1:6379"
+# graph = "falkor"
+# server_timeout_ms = 5000
+# client_deadline_ms = 6000
+# out = "synthetic-report.json"

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -113,7 +113,7 @@ async fn probe_produces_valid_report() {
     );
     assert!(op.compilation_ms_median.is_some());
 
-    // Provenance + Part 2 metadata were captured.
+    // Provenance + run metadata were captured.
     assert!(report.meta.server.redis_version.is_some());
     assert!(report.meta.server.cache_size.is_some());
     assert_eq!(report.meta.graph, "syn_it_return_const");
@@ -308,6 +308,11 @@ async fn warmup_zero_still_primes_cached_plan() {
     let op = report.operations.get("return_const").unwrap();
     let cached = op.cached.as_ref().unwrap();
     assert_eq!(cached.server_ms.n + cached.server_ms.removed, 40);
+    // The pre-measurement prime means every measured sample is a cache hit.
+    assert_eq!(
+        cached.cached_false_rate, 0.0,
+        "cached-mode run with a prime should report all cache hits"
+    );
     drop_graph(graph).await;
 }
 
@@ -467,7 +472,7 @@ async fn generated_dataset_has_exact_counts_index_and_hash() {
         plan.join("\n")
     );
 
-    // shortest_path measured real (non-negative) path lengths, not all misses.
+    // shortest_path produced measured samples (the connected-pair pool guarantees a bounded path).
     let op = report.operations.get("shortest_path").unwrap();
     assert!(op.cached.as_ref().unwrap().server_ms.n > 0);
     drop_graph(graph).await;

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -452,12 +452,12 @@ async fn generated_dataset_has_exact_counts_index_and_hash() {
     assert_eq!(edge_count, 2000);
 
     // The :User(id) index exists and is OPERATIONAL...
-    let idx = scalar_i64(
+    let operational = scalar_i64(
         &mut g,
-        "CALL db.indexes() YIELD label WHERE label = 'User' RETURN count(*)",
+        "CALL db.indexes() YIELD label, status WHERE label = 'User' AND status = 'OPERATIONAL' RETURN count(*)",
     )
     .await;
-    assert!(idx >= 1, "expected a :User index");
+    assert!(operational >= 1, "expected an OPERATIONAL :User index");
 
     // ...and the point-lookup op uses it (Node By Index Scan in the plan).
     let plan = explain(&mut g, "MATCH (n:User {id: 7}) RETURN n.id").await;

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -7,6 +7,7 @@
 //! concurrently without clobbering each other.
 
 use benchmark::queries_repository::QueryType;
+use benchmark::synthetic::dataset::DatasetSpec;
 use benchmark::synthetic::op_runner::run_and_drain;
 use benchmark::synthetic::{
     list_ops, open_graph, run, run_and_report, CacheSelection, Config, OpName,
@@ -32,6 +33,7 @@ fn base_config(graph: &str) -> Config {
         cache: CacheSelection::Both,
         out: "synthetic-report.json".to_string(),
         server_image: None,
+        dataset: None,
     }
 }
 
@@ -412,4 +414,111 @@ async fn probe_instantiates_a_missing_graph() {
     .expect("probe should instantiate the missing graph and succeed");
     assert!(report.operations.contains_key("return_const"));
     drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn generated_dataset_has_exact_counts_index_and_hash() {
+    // Generate a small reproducible dataset, then assert node/edge counts, that the :User(id) index
+    // exists and is used, and that the report carries a dataset block with a corpus_hash.
+    let graph = "syn_it_gen";
+    let report = run(&Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::MatchByIndex, OpName::ShortestPath],
+        samples: 40,
+        warmup: 10,
+        seed: 123,
+        cache: CacheSelection::Cached,
+        dataset: Some(DatasetSpec {
+            seed: 123,
+            nodes: 400,
+            edges: 2000,
+        }),
+        ..base_config(graph)
+    })
+    .await
+    .expect("generation run should succeed");
+
+    // The report records the generated dataset + a corpus_hash.
+    let ds = report.meta.dataset.as_ref().expect("dataset info present");
+    assert_eq!((ds.seed, ds.nodes, ds.edges), (123, 400, 2000));
+    assert!(ds.corpus_hash.starts_with("sha256:"));
+
+    // Exact counts in the graph.
+    let mut g = open_graph(&endpoint(), graph).await.expect("open graph");
+    let node_count = scalar_i64(&mut g, "MATCH (n:User) RETURN count(n)").await;
+    let edge_count = scalar_i64(&mut g, "MATCH (:User)-[e:Friend]->(:User) RETURN count(e)").await;
+    assert_eq!(node_count, 400);
+    assert_eq!(edge_count, 2000);
+
+    // The :User(id) index exists and is OPERATIONAL...
+    let idx = scalar_i64(
+        &mut g,
+        "CALL db.indexes() YIELD label WHERE label = 'User' RETURN count(*)",
+    )
+    .await;
+    assert!(idx >= 1, "expected a :User index");
+
+    // ...and the point-lookup op uses it (Node By Index Scan in the plan).
+    let plan = explain(&mut g, "MATCH (n:User {id: 7}) RETURN n.id").await;
+    assert!(
+        plan.iter().any(|line| line.contains("Index Scan")),
+        "match_by_index should use the index, got plan:\n{}",
+        plan.join("\n")
+    );
+
+    // shortest_path measured real (non-negative) path lengths, not all misses.
+    let op = report.operations.get("shortest_path").unwrap();
+    assert!(op.cached.as_ref().unwrap().server_ms.n > 0);
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn generation_is_reproducible_across_runs() {
+    // Same seed + knobs ⇒ identical corpus_hash, even though the graph is regenerated from scratch.
+    let graph = "syn_it_gen_repro";
+    let cfg = Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::MatchByIndex, OpName::AggregateCount],
+        samples: 30,
+        warmup: 5,
+        seed: 77,
+        cache: CacheSelection::Cached,
+        dataset: Some(DatasetSpec {
+            seed: 77,
+            nodes: 300,
+            edges: 1500,
+        }),
+        ..base_config(graph)
+    };
+    let a = run(&cfg).await.expect("run a");
+    let b = run(&cfg).await.expect("run b");
+    assert_eq!(
+        a.meta.dataset.unwrap().corpus_hash,
+        b.meta.dataset.unwrap().corpus_hash
+    );
+    drop_graph(graph).await;
+}
+
+/// Read a single-row `RETURN count(...)`/scalar i64.
+async fn scalar_i64(
+    graph: &mut falkordb::AsyncGraph,
+    cypher: &str,
+) -> i64 {
+    use futures::StreamExt;
+    let mut result = graph.ro_query(cypher).execute().await.expect("scalar query");
+    match result.data.next().await {
+        Some(Ok(row)) => row.try_get_at::<i64>(0).expect("i64 scalar"),
+        other => panic!("unexpected scalar response: {other:?}"),
+    }
+}
+
+/// Return the `GRAPH.EXPLAIN` plan lines for `cypher`.
+async fn explain(
+    graph: &mut falkordb::AsyncGraph,
+    cypher: &str,
+) -> Vec<String> {
+    let plan = graph.explain(cypher).execute().await.expect("explain");
+    plan.plan().to_vec()
 }


### PR DESCRIPTION
Part 3 of #200 — closes #203. Builds on Parts 1 (#207) & 2 (#208), both merged.

## What
Adds a **dedicated, seeded, reproducible dataset generator** so operation numbers are controlled and comparable across runs, machines and FalkorDB versions — the basis for trustworthy version comparison later. It also introduces a `synthetic-bench.toml` config file for the growing knob set.

### Generator (`src/synthetic/dataset.rs`)
- `DatasetSpec { seed, nodes, edges }` → a `:User {id, age}` / `(:User)-[:Friend]->(:User)` graph, generated **deterministically** from a portable hand-rolled **SplitMix64** stream (not `rand`'s `StdRng`, whose output isn't guaranteed stable across versions). Deterministic ages; a **ring backbone** `i -> (i%n)+1` guarantees connectivity for expansions/shortest-paths, plus seeded random edges (`dst = (src+offset)%n`, so no self-loops, no retry loops). Validation: `2 ≤ nodes ≤ i32::MAX`, `edges ≥ nodes`.
- `generate_and_load()` drops+rewrites the target graph, creates the `:User(id)` index, bulk-loads nodes then edges via `UNWIND` batches, and **verifies exact counts**. A graph-drop failure that isn't "graph doesn't exist yet" (auth/network/wrong-type) aborts rather than loading onto un-cleared data.
- **`corpus_hash`** = algorithm-tagged SHA-256 over the generator version, dataset knobs, corpus seed/size, each selected op (in execution order) paired with a **fingerprint of its fully-rendered corpus** (parameter values included), and a digest of the sampled pools. Stable across processes/versions (golden-value test); it can't equate two genuinely different workloads even if the RNG changes.
- Seeded pools: `node_ids` via **Floyd's algorithm** (always exactly `min(nodes, POOL_IDS)` distinct ids) and `connected_pairs` (reachable within the bounded `shortest_path` hop limit, so it measures real paths). `handle()` is panic-free for any spec.

### Runner / report
- `Config.dataset: Option<DatasetSpec>`; `run()` generates the dataset (when requested) instead of probing an existing graph, and records `meta.dataset {seed, nodes, edges, corpus_hash}` — **only when it generated the data** (an external graph can't be fingerprinted, so comparing hashes would mislead).

### Config file (`src/synthetic/config.rs`)
- `synthetic-bench.toml` (auto-detected in the CWD, or `--config <path>`) supplies the knob set; **CLI flags override the file, which overrides defaults**. Unknown keys and bad op names are rejected (`deny_unknown_fields`); op names use the `--op` spelling (custom `OpName` deserialize).
- **Generation is destructive** (drops the graph) and is gated behind the explicit `--generate` CLI flag — a config file alone never authorizes it.

### CLI
`synthetic run` args are now optional (merged with the file); adds `--config`, `--generate`, `--nodes`, `--edges`.

## Example
```bash
just synthetic-bench --graph bench --generate --nodes 100000 --edges 1000000 \
    --op match_by_index,expand_hops_5,aggregate_count --samples 500 --seed 42
```
The report header carries `dataset {seed, nodes, edges, corpus_hash}`; see `synthetic-bench.example.toml`.

## Tests / validation
- **87 unit tests**: deterministic generation (same seed ⇒ same counts + pools + hash; a knob change ⇒ a different hash), a pinned **golden** `corpus_hash` + SplitMix64 vector (cross-process/version stability), Floyd exact-fill, panic-free `handle()`, config-file parse/merge precedence, generation gating.
- **2 new integration tests** (docker): generate a graph and assert **exact node/edge counts**, the `:User(id)` index exists and is used (`GRAPH.EXPLAIN` → Node By Index Scan), and that regeneration with the same seed yields an identical `corpus_hash`.
- Ran the full `just` gate (build, clippy `-D warnings`, test incl. the new doc-example doctests, `doc`, and the new `just doc-check` links/shell checks from #209). **Patch coverage ~95%**.
- **Design and implementation both rubber-duck reviewed**; fixes applied for swallowed graph-drop errors, corpus_hash workload-identity, Floyd sampling, panic-free pools, and non-commutative key mixing.

## Notes
- Merged latest master, so this includes and passes the doc-link/code-example validation added in #209.
- The `synthetic-benchmark.md` link fix (repoint to epic #200) matches what #209 did.

Not merging — awaiting review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reproducible synthetic dataset generation with configurable nodes, edges, and seed.
  * Added TOML configuration support through `synthetic-bench.toml` or an explicit configuration path.
  * Added dataset provenance and workload hashes to benchmark reports.
  * Improved shortest-path sampling using generated connected pairs.

* **Documentation**
  * Updated README and example configuration with dataset generation, configuration precedence, validation, and usage guidance.
  * Expanded command examples for synthetic benchmarks.

* **Bug Fixes**
  * Improved validation and error messages for unknown configuration keys and operation names.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->