### PR TITLE
feat(synthetic): closed-loop concurrency sweep engine (part 4 of #200)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@ Key recipes:
 | `just coverage-local` | Spin up a Docker FalkorDB, run `just coverage`, then tear it down. |
 | `just coverage-html` | Open a browsable HTML coverage report locally (also needs a FalkorDB). |
 | `just synthetic-bench` | Run the synthetic per-operation latency probe (needs a live FalkorDB). |
+| `just synthetic-bench-one <op>` | Sweep one operation over the concurrency curve (needs a live FalkorDB). |
 | `just synthetic-ops` | List the synthetic operations. |
 | `just synthetic-it` | Run the synthetic integration test against a live FalkorDB. |
 | `just fmt` / `just fmt-check` | Format Rust in place / check formatting. |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ path = "src/main.rs"
 
 
 [dev-dependencies]
+# `test-util` (not in tokio's `full`) enables `#[tokio::test(start_paused = true)]` so the
+# concurrency-engine throughput test drives a virtual clock deterministically.
+tokio = { version = "1.52.3", features = ["test-util"] }
 
 [profile.release]
 opt-level = 3  # This is the default

--- a/Justfile
+++ b/Justfile
@@ -140,6 +140,11 @@ synthetic-bench *args:
     if [ "${1:-}" = "--" ]; then shift; fi
     cargo run --release --bin benchmark -- synthetic run "$@"
 
+# Sweep a single operation over the concurrency curve (default 1,2,4,8,16,32); extra flags forward
+# to `synthetic run`, e.g. `just synthetic-bench-one match_by_index --concurrency 1,8,32`.
+synthetic-bench-one op *args:
+    cargo run --release --bin benchmark -- synthetic run --op {{op}} {{args}}
+
 # List the available synthetic operations.
 synthetic-ops:
     cargo run --quiet --bin benchmark -- synthetic list-ops

--- a/Justfile
+++ b/Justfile
@@ -143,7 +143,16 @@ synthetic-bench *args:
 # Sweep a single operation over the concurrency curve (default 1,2,4,8,16,32); extra flags forward
 # to `synthetic run`, e.g. `just synthetic-bench-one match_by_index --concurrency 1,8,32`.
 synthetic-bench-one op *args:
-    cargo run --release --bin benchmark -- synthetic run --op {{op}} {{args}}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # `op` is forwarded explicitly via `--op {{op}}`, so drop it from the positional args (just
+    # passes every recipe argument, the named `op` included, as `$@`). Then drop an optional leading
+    # `--` so both `just synthetic-bench-one <op> --concurrency 1,8` and
+    # `just synthetic-bench-one <op> -- --concurrency 1,8` forward the flags to the probe; otherwise
+    # a literal `--` reaches Clap and later flags become positional.
+    shift || true
+    if [ "${1:-}" = "--" ]; then shift; fi
+    cargo run --release --bin benchmark -- synthetic run --op {{op}} "$@"
 
 # List the available synthetic operations.
 synthetic-ops:

--- a/readme.md
+++ b/readme.md
@@ -161,10 +161,12 @@ workflow. Please cover new code with tests and keep coverage high — **patch co
 Measures a curated suite of **read operations in isolation** — one at a time, selectable — capturing
 on every invocation both the **server time** (FalkorDB's reported internal execution time) and the
 **total time** (end-to-end client round-trip), then summarizing them with severe-outlier removal
-(Tukey fences, like Criterion.rs) and writing a JSON report with one block per operation. It uses a
-single dedicated connection for honest single-flight latency. This is Part 3 of a larger tool (see
-the design epic [#200](https://github.com/FalkorDB/benchmark/issues/200)); it can now **generate its
-own reproducible dataset**, with a concurrency sweep and write operations still to come.
+(Tukey fences, like Criterion.rs) and writing a JSON report with one block per operation. For each
+operation it sweeps a list of **concurrency levels**, so the report traces how latency (including the
+p99 tail) changes as achieved throughput rises — the latency-vs-throughput curve and its saturation
+"knee". This is Part 4 of a larger tool (see the design epic
+[#200](https://github.com/FalkorDB/benchmark/issues/200)); it can **generate its own reproducible
+dataset** and sweep concurrency, with write operations still to come.
 
 Each operation is measured under two plan-cache conditions so you can see the cost of expression
 **compilation** separately from execution:
@@ -177,6 +179,24 @@ Each operation is measured under two plan-cache conditions so you can see the co
 is load-time only, so the uncached condition is produced client-side and verified via the response's
 `cached_execution` flag; the server's actual `CACHE_SIZE` is recorded in the report.) Use `--cache
 cached|uncached|both` (default `both`).
+
+#### Concurrency sweep (latency vs throughput)
+
+Every operation is measured at each level of a configurable **concurrency sweep** (`--concurrency`,
+default `1,2,4,8,16,32`). Each level `C` runs a **closed-loop** engine: `C` worker tasks, each with
+its own dedicated connection, fire one query, await it to completion (row draining included), then
+immediately fire the next — so there are always exactly `C` requests in flight. After a discarded
+warm-up window, every worker measures in a shared window; the level reports the pooled latency
+percentiles (p50/p90/p95/p99) and the **achieved throughput** (`completed ÷ window`, ops/sec).
+
+Because a new request is issued only after the previous one *completes*, the reported throughput is
+**achieved, not offered** — it can never exceed the server's own service rate, so it is immune to
+[coordinated omission](https://www.scylladb.com/2021/04/22/on-coordinated-omission/) but also can't
+model a fixed external arrival rate (open-loop / arrival-rate load is future work). Read the curve by
+following latency as `C` (and throughput) rise: throughput climbs until the server saturates, after
+which extra concurrency mostly inflates the tail — the highest-throughput level is flagged as the
+`<- knee`. A single-level sweep (`--concurrency 1`) reproduces the classic single-connection latency
+measurement plus its achieved throughput.
 
 #### Operation catalog
 
@@ -222,30 +242,35 @@ just synthetic-ops
 IMAGE=$(docker inspect --format '{{index .RepoDigests 0}}' falkordb/falkordb:latest)
 just synthetic-bench --endpoint falkor://127.0.0.1:6379 --graph main \
     --op match_by_index,expand_1_hop,aggregate_count --samples 500 --warmup 100 \
-    --cache both --seed 42 --server-image "$IMAGE" --out synthetic-report.json
+    --concurrency 1,4,16,32 --cache both --seed 42 --server-image "$IMAGE" \
+    --out synthetic-report.json
 # ...or measure the whole read catalog at once:
 just synthetic-bench --graph main --all-reads --samples 500
+# ...or sweep a single operation (uses the default 1,2,4,8,16,32 concurrency sweep):
+just synthetic-bench-one match_by_index
 ```
 
-Sample output (one block per selected op):
+Sample output (one block per selected op; one table row per concurrency level, per cache mode):
 
 ```text
-synthetic benchmark — endpoint falkor://127.0.0.1:6379  graph main  samples 500  warmup 100  seed 42  connection pool(size=1)
+synthetic benchmark — endpoint falkor://127.0.0.1:6379  graph main  samples 500  warmup 100  concurrency [1,4,16,32]  seed 42  connection pool(size=1) per worker
 server — falkordb module ver 4.20.1  redis 8.6.3  CACHE_SIZE 25
 server image: falkordb/falkordb@sha256:9042fdc4...
 
 match_by_index
   [cached — plan reused, execution only]
-    server_ms  median 0.033  mean 0.034  p99 0.059  (n=487, removed 13)
-    total_ms   median 0.427  mean 0.440  p99 0.596  (n=487, removed 13)
-    non_internal_ms (paired total-server)  median 0.394
-    cached_execution=false: 0.0%  (unknown 0)
+    C    throughput(ops/s)   server p50/p90/p99        total p50/p90/p99         miss%
+    1              2950     0.081 / 0.150 / 0.200     0.330 / 0.500 / 0.900     0.0
+    4             11800     0.090 / 0.170 / 0.260     0.340 / 0.520 / 1.100     0.0
+   16             30400     0.180 / 0.900 / 1.900     0.600 / 2.100 / 4.200     0.0
+   32             41200     0.350 / 1.700 / 3.400     0.780 / 3.900 / 7.900     0.0  <- knee
   [uncached — plan-cache miss each run, execution + compilation]
-    server_ms  median 0.058  mean 0.063  p99 0.093  (n=497, removed 3)
-    total_ms   median 0.452  mean 0.461  p99 0.604  (n=497, removed 3)
-    non_internal_ms (paired total-server)  median 0.391
-    cached_execution=false: 100.0%  (unknown 0)
-  compilation_ms (median uncached-cached server time)  0.025
+    C    throughput(ops/s)   server p50/p90/p99        total p50/p90/p99         miss%
+    1              2100     0.106 / 0.180 / 0.240     0.360 / 0.540 / 0.960   100.0
+   ...
+  compilation_ms (median uncached-cached server time) by level:
+    C=1    0.025
+    C=32   0.040
 
 expand_1_hop
   ...
@@ -294,6 +319,7 @@ nodes = 100000
 edges = 1000000
 operations = ["match_by_index", "expand_hops_5", "aggregate_count"]
 samples = 500
+concurrency = [1, 4, 16, 32]   # closed-loop worker counts to sweep (default 1,2,4,8,16,32)
 cache = "both"           # cached | uncached | both
 # endpoint / graph / warmup / server_timeout_ms / client_deadline_ms / out are all optional
 ```

--- a/readme.md
+++ b/readme.md
@@ -190,13 +190,15 @@ warm-up window, every worker measures in a shared window; the level reports the 
 percentiles (p50/p90/p95/p99) and the **achieved throughput** (`completed ÷ window`, ops/sec).
 
 Because a new request is issued only after the previous one *completes*, the reported throughput is
-**achieved, not offered** — it can never exceed the server's own service rate, so it is immune to
-[coordinated omission](https://www.scylladb.com/2021/04/22/on-coordinated-omission/) but also can't
-model a fixed external arrival rate (open-loop / arrival-rate load is future work). Read the curve by
-following latency as `C` (and throughput) rise: throughput climbs until the server saturates, after
-which extra concurrency mostly inflates the tail — the highest-throughput level is flagged as the
-`<- knee`. A single-level sweep (`--concurrency 1`) reproduces the classic single-connection latency
-measurement plus its achieved throughput.
+**achieved, not offered** — it can never exceed the server's own service rate. The measured
+latencies therefore describe behaviour *at that achieved rate*: a closed loop does not model a fixed
+external arrival rate, so it neither reproduces nor corrects for
+[coordinated omission](https://www.scylladb.com/2021/04/22/on-coordinated-omission/) — quantifying
+the tail under a target offered load needs open-loop / arrival-rate testing (future work). Read the
+curve by following latency as `C` (and throughput) rise: throughput climbs until the server
+saturates, after which extra concurrency mostly inflates the tail — the highest-throughput level is
+flagged as the `<- knee`. A single-level sweep (`--concurrency 1`) reproduces the classic
+single-connection latency measurement plus its achieved throughput.
 
 #### Operation catalog
 

--- a/readme.md
+++ b/readme.md
@@ -259,14 +259,14 @@ server image: falkordb/falkordb@sha256:9042fdc4...
 
 match_by_index
   [cached — plan reused, execution only]
-    C    throughput(ops/s)   server p50/p90/p99        total p50/p90/p99         miss%
-    1              2950     0.081 / 0.150 / 0.200     0.330 / 0.500 / 0.900     0.0
-    4             11800     0.090 / 0.170 / 0.260     0.340 / 0.520 / 1.100     0.0
-   16             30400     0.180 / 0.900 / 1.900     0.600 / 2.100 / 4.200     0.0
-   32             41200     0.350 / 1.700 / 3.400     0.780 / 3.900 / 7.900     0.0  <- knee
+    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
+    1              2950     0.081 / 0.130 / 0.150 / 0.200     0.330 / 0.470 / 0.500 / 0.900     0.0
+    4             11800     0.090 / 0.160 / 0.170 / 0.260     0.340 / 0.500 / 0.520 / 1.100     0.0
+   16             30400     0.180 / 0.700 / 0.900 / 1.900     0.600 / 1.800 / 2.100 / 4.200     0.0
+   32             41200     0.350 / 1.400 / 1.700 / 3.400     0.780 / 3.400 / 3.900 / 7.900     0.0  <- knee
   [uncached — plan-cache miss each run, execution + compilation]
-    C    throughput(ops/s)   server p50/p90/p99        total p50/p90/p99         miss%
-    1              2100     0.106 / 0.180 / 0.240     0.360 / 0.540 / 0.960   100.0
+    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
+    1              2100     0.106 / 0.160 / 0.180 / 0.240     0.360 / 0.500 / 0.540 / 0.960   100.0
    ...
   compilation_ms (median uncached-cached server time) by level:
     C=1    0.025

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,9 @@ saturates, after which extra concurrency mostly inflates the tail — the highes
 flagged as the `<- knee`. A single-level sweep (`--concurrency 1`) reproduces the classic
 single-connection latency measurement plus its achieved throughput.
 
+See [`synthetic-benchmark.md`](synthetic-benchmark.md) for the concurrency model, the report schema
+(`operations[].levels[]`), and how to read the curve in depth.
+
 #### Operation catalog
 
 Select operations with `--op <name>` (repeatable and comma-separated) or `--all-reads`. All read

--- a/readme.md
+++ b/readme.md
@@ -185,7 +185,8 @@ cached|uncached|both` (default `both`).
 Every operation is measured at each level of a configurable **concurrency sweep** (`--concurrency`,
 default `1,2,4,8,16,32`). Each level `C` runs a **closed-loop** engine: `C` worker tasks, each with
 its own dedicated connection, fire one query, await it to completion (row draining included), then
-immediately fire the next — so there are always exactly `C` requests in flight. After a discarded
+immediately fire the next — so there are at most `C` requests in flight (one outstanding per active
+worker). After a discarded
 warm-up window, every worker measures in a shared window; the level reports the pooled latency
 percentiles (p50/p90/p95/p99) and the **achieved throughput** (`completed ÷ window`, ops/sec).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -260,10 +260,7 @@ pub enum SyntheticCommands {
             help = "path to a synthetic-bench.toml config (auto-detected in the CWD if present); CLI flags override it"
         )]
         config: Option<String>,
-        #[arg(
-            long,
-            help = "FalkorDB endpoint (default falkor://127.0.0.1:6379)"
-        )]
+        #[arg(long, help = "FalkorDB endpoint (default falkor://127.0.0.1:6379)")]
         endpoint: Option<String>,
         #[arg(long, help = "graph key to measure against (default falkor)")]
         graph: Option<String>,
@@ -286,6 +283,13 @@ pub enum SyntheticCommands {
         #[arg(long, help = "number of warm-up invocations, discarded (default 200)")]
         warmup: Option<usize>,
         #[arg(
+            long = "concurrency",
+            value_delimiter = ',',
+            num_args = 1..,
+            help = "concurrency levels to sweep (closed-loop workers C), repeatable/comma-separated (e.g. --concurrency 1,4,16,32). Default 1,2,4,8,16,32."
+        )]
+        concurrency: Vec<usize>,
+        #[arg(
             long,
             help = "seed for the dataset and the per-operation corpora (same seed ⇒ identical workload; default 0)"
         )]
@@ -296,11 +300,17 @@ pub enum SyntheticCommands {
             help = "plan-cache condition: cached, uncached, or both (default both)"
         )]
         cache: Option<CacheSelection>,
-        #[arg(long, help = "FalkorDB server-side per-query timeout in ms (default 5000)")]
+        #[arg(
+            long,
+            help = "FalkorDB server-side per-query timeout in ms (default 5000)"
+        )]
         server_timeout_ms: Option<i64>,
         #[arg(long, help = "client-side deadline per query in ms (default 6000)")]
         client_deadline_ms: Option<u64>,
-        #[arg(long, help = "path to write the JSON report (default synthetic-report.json)")]
+        #[arg(
+            long,
+            help = "path to write the JSON report (default synthetic-report.json)"
+        )]
         out: Option<String>,
         #[arg(
             long,

--- a/src/synthetic/config.rs
+++ b/src/synthetic/config.rs
@@ -25,6 +25,8 @@ pub struct FileConfig {
     pub operations: Option<Vec<OpName>>,
     pub samples: Option<usize>,
     pub warmup: Option<usize>,
+    /// Concurrency sweep (closed-loop worker counts). Defaults to the built-in sweep when omitted.
+    pub concurrency: Option<Vec<usize>>,
     pub seed: Option<u64>,
     pub cache: Option<CacheSelection>,
     pub server_timeout_ms: Option<i64>,
@@ -75,6 +77,8 @@ pub struct CliOverrides {
     pub all_reads: bool,
     pub samples: Option<usize>,
     pub warmup: Option<usize>,
+    /// Explicit `--concurrency` sweep (empty = not passed).
+    pub concurrency: Vec<usize>,
     pub seed: Option<u64>,
     pub cache: Option<CacheSelection>,
     pub server_timeout_ms: Option<i64>,
@@ -116,6 +120,16 @@ pub fn resolve(
 
     let seed = cli.seed.or(file.seed).unwrap_or(defaults.seed);
 
+    // Concurrency sweep: explicit `--concurrency` wins, else the file's, else the built-in sweep.
+    // Validation (non-empty, ≥1, dedup/sort) happens in `run()` via `normalize_concurrency`.
+    let concurrency = if !cli.concurrency.is_empty() {
+        cli.concurrency.clone()
+    } else {
+        file.concurrency
+            .clone()
+            .unwrap_or_else(|| defaults.concurrency.clone())
+    };
+
     let dataset = if cli.generate {
         let nodes = cli.nodes.or(file.nodes).ok_or_else(|| {
             OtherError("--generate needs --nodes (or `nodes` in the config)".to_string())
@@ -152,6 +166,7 @@ pub fn resolve(
         ops,
         samples: cli.samples.or(file.samples).unwrap_or(default_samples),
         warmup: cli.warmup.or(file.warmup).unwrap_or(default_warmup),
+        concurrency,
         seed,
         server_timeout_ms: cli
             .server_timeout_ms
@@ -201,10 +216,12 @@ mod tests {
             graph: Some("from_file".to_string()),
             operations: Some(vec![OpName::MatchByIndex]),
             cache: Some(CacheSelection::Cached),
+            concurrency: Some(vec![2, 8]),
             ..Default::default()
         };
         let cli = CliOverrides {
-            samples: Some(999), // overrides file's 50
+            samples: Some(999),          // overrides file's 50
+            concurrency: vec![1, 4, 16], // overrides file's [2, 8]
             ..Default::default()
         };
         let cfg = resolve(cli, Some(file)).unwrap();
@@ -213,6 +230,27 @@ mod tests {
         assert_eq!(cfg.warmup, Config::default().warmup); // default (unset anywhere)
         assert_eq!(cfg.ops, vec![OpName::MatchByIndex]); // from file
         assert_eq!(cfg.cache, CacheSelection::Cached);
+        assert_eq!(cfg.concurrency, vec![1, 4, 16]); // CLI wins over file
+    }
+
+    #[test]
+    fn concurrency_falls_back_to_file_then_default() {
+        // No CLI concurrency ⇒ the file's sweep is used.
+        let file = FileConfig {
+            operations: Some(vec![OpName::ReturnConst]),
+            concurrency: Some(vec![4, 32]),
+            ..Default::default()
+        };
+        let cfg = resolve(CliOverrides::default(), Some(file)).unwrap();
+        assert_eq!(cfg.concurrency, vec![4, 32]);
+
+        // Neither CLI nor file ⇒ the built-in default sweep.
+        let file2 = FileConfig {
+            operations: Some(vec![OpName::ReturnConst]),
+            ..Default::default()
+        };
+        let cfg2 = resolve(CliOverrides::default(), Some(file2)).unwrap();
+        assert_eq!(cfg2.concurrency, Config::default().concurrency);
     }
 
     #[test]
@@ -254,7 +292,10 @@ mod tests {
             ..Default::default()
         };
         let cfg = resolve(CliOverrides::default(), Some(file.clone())).unwrap();
-        assert!(cfg.dataset.is_none(), "file alone must not authorize generation");
+        assert!(
+            cfg.dataset.is_none(),
+            "file alone must not authorize generation"
+        );
 
         // --generate + file dimensions ⇒ a validated DatasetSpec.
         let cli = CliOverrides {

--- a/src/synthetic/engine.rs
+++ b/src/synthetic/engine.rs
@@ -5,8 +5,11 @@
 //! fires the next from its pre-generated sequence — a **closed loop**: there is always exactly one
 //! outstanding request per worker, so at most `C` are in flight. Because a new request is issued
 //! only after the previous one *completes*, the throughput it reports is **achieved** (what the
-//! server actually served), not **offered** (a target arrival rate) — so it cannot suffer
-//! coordinated omission, but it also can't push past the server's own service rate.
+//! server actually served), not **offered** (a target arrival rate), and it can't push past the
+//! server's own service rate. The measured latencies therefore describe behaviour *at that achieved
+//! rate*: a closed loop does not model a fixed offered load, so it neither reproduces nor corrects
+//! for coordinated omission — quantifying the tail under a target arrival rate needs open-loop
+//! testing (out of scope for this engine).
 //!
 //! ## Windowing
 //! Every worker runs `warmup` discarded invocations, then all workers cross a [`Barrier`] together
@@ -168,7 +171,9 @@ where
         _ => Duration::ZERO,
     };
 
-    let mut samples_all: Vec<OpSample> = Vec::new();
+    // Every worker produces exactly `samples` measured invocations on the success path, so the
+    // pooled length is known up front — preallocate to keep aggregation allocation-free.
+    let mut samples_all: Vec<OpSample> = Vec::with_capacity(concurrency * samples);
     for output in outputs {
         samples_all.extend(output.samples);
     }

--- a/src/synthetic/engine.rs
+++ b/src/synthetic/engine.rs
@@ -1,0 +1,410 @@
+//! The closed-loop concurrency engine that turns a set of workers into one measurement *level*.
+//!
+//! A *level* runs `C` worker tasks against a connection pool of size `C` (one connection per
+//! worker). Each worker fires an operation, awaits it to completion (row draining included), then
+//! fires the next from its pre-generated sequence — a **closed loop**: there is always exactly one
+//! outstanding request per worker, so at most `C` are in flight. Because a new request is issued
+//! only after the previous one *completes*, the throughput it reports is **achieved** (what the
+//! server actually served), not **offered** (a target arrival rate) — so it cannot suffer
+//! coordinated omission, but it also can't push past the server's own service rate.
+//!
+//! ## Windowing
+//! Every worker runs `warmup` discarded invocations, then all workers cross a [`Barrier`] together
+//! so the measurement window starts with all `C` active. Each worker records when its first
+//! measured invocation *started* and its last one *completed*; the level's window is
+//! `max(last_completed) − min(first_started)` and achieved throughput is `completed / window`.
+//! Using the observed span (rather than a single leader clock) keeps the throughput honest even
+//! though workers are released a few microseconds apart.
+//!
+//! The engine is generic over an [`OpInvoker`] so the real graph worker and a deterministic fake
+//! (used by the unit tests to assert exact in-flight concurrency and throughput math) share one
+//! code path.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::synthetic::op_runner::OpSample;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Barrier;
+use tokio::task::JoinSet;
+// `tokio::time::Instant` (not `std::time::Instant`) so the measurement window advances with the
+// runtime clock — real time in production, and the virtual clock under a `start_paused` test, which
+// makes the throughput math deterministic.
+use tokio::time::Instant;
+
+/// One unit of work the engine can drive: invocation `seq` of an operation on a worker's own
+/// connection. `seq` is the worker-local monotonic counter (warm-up invocations are `0..warmup`,
+/// measured ones continue from `warmup`), letting the implementor vary parameters and force a
+/// plan-cache miss deterministically.
+///
+/// The returned future must be `Send` (the engine drives each worker on its own `tokio` task) and
+/// borrows `&mut self`, so a worker owns its connection exclusively for the whole level.
+pub trait OpInvoker: Send + 'static {
+    fn invoke(
+        &mut self,
+        seq: u64,
+    ) -> impl Future<Output = BenchmarkResult<OpSample>> + Send;
+}
+
+/// The raw result of one measurement level: every retained-or-not paired sample pooled across
+/// workers, the number of completed measured invocations, and the wall-clock measurement window.
+pub struct LevelRun {
+    /// Paired `(server_ms, total_ms)` samples pooled across all workers (warm-up excluded).
+    pub samples: Vec<OpSample>,
+    /// Count of completed measured invocations (`= samples.len()`), the numerator of throughput.
+    pub completed: usize,
+    /// Observed measurement window: `max(last_completed) − min(first_started)` across workers.
+    pub window: Duration,
+}
+
+impl LevelRun {
+    /// Achieved throughput in operations per second (`completed / window`), or `0.0` for a
+    /// degenerate (zero-length) window.
+    pub fn throughput_ops_per_sec(&self) -> f64 {
+        let secs = self.window.as_secs_f64();
+        if secs > 0.0 {
+            self.completed as f64 / secs
+        } else {
+            0.0
+        }
+    }
+}
+
+/// Per-worker output collected before pooling: its measured samples and the span it was active.
+struct WorkerOutput {
+    samples: Vec<OpSample>,
+    first_started: Instant,
+    last_completed: Instant,
+}
+
+/// Drive one closed-loop measurement level to completion.
+///
+/// Spawns one task per worker; each runs `warmup` discarded invocations, waits on a shared
+/// [`Barrier`] so all `C` enter the measurement window together, then runs `samples` measured
+/// invocations recording paired latencies. The window is the observed `max(last_completed) −
+/// min(first_started)` span. On the first worker error (or a task panic) every other worker is
+/// aborted and the error is returned — a partial, misleading throughput is never reported.
+///
+/// Fails fast if `workers` is empty or `samples == 0`.
+pub async fn run_closed_loop<W>(
+    workers: Vec<W>,
+    warmup: usize,
+    samples: usize,
+) -> BenchmarkResult<LevelRun>
+where
+    W: OpInvoker,
+{
+    let concurrency = workers.len();
+    if concurrency == 0 {
+        return Err(OtherError("concurrency must be >= 1".to_string()));
+    }
+    if samples == 0 {
+        return Err(OtherError("samples must be >= 1".to_string()));
+    }
+
+    // All workers cross this barrier after warm-up, so the measurement window opens with every
+    // worker active (no ramp where only some workers have started measuring).
+    let barrier = Arc::new(Barrier::new(concurrency));
+    let mut set: JoinSet<BenchmarkResult<WorkerOutput>> = JoinSet::new();
+
+    for mut worker in workers {
+        let barrier = Arc::clone(&barrier);
+        set.spawn(async move {
+            // Warm-up (discarded): primes the plan cache (cached mode) and the connection.
+            for seq in 0..warmup as u64 {
+                let _ = worker.invoke(seq).await?;
+            }
+
+            barrier.wait().await;
+
+            let mut out: Vec<OpSample> = Vec::with_capacity(samples);
+            let mut first_started: Option<Instant> = None;
+            let mut last_completed = Instant::now();
+            for k in 0..samples as u64 {
+                // Continue the sequence past warm-up so every worker key stays unique.
+                let seq = warmup as u64 + k;
+                let started = Instant::now();
+                if first_started.is_none() {
+                    first_started = Some(started);
+                }
+                let sample = worker.invoke(seq).await?;
+                last_completed = Instant::now();
+                out.push(sample);
+            }
+
+            Ok(WorkerOutput {
+                // `samples >= 1` is enforced above, so `first_started` is always set.
+                first_started: first_started.unwrap_or(last_completed),
+                last_completed,
+                samples: out,
+            })
+        });
+    }
+
+    // Collect fail-fast: on the first error or panic, abort the rest and surface the error rather
+    // than aggregating a misleading throughput from a half-run level.
+    let mut outputs: Vec<WorkerOutput> = Vec::with_capacity(concurrency);
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok(Ok(output)) => outputs.push(output),
+            Ok(Err(e)) => {
+                set.abort_all();
+                while set.join_next().await.is_some() {}
+                return Err(e);
+            }
+            Err(join_err) => {
+                set.abort_all();
+                while set.join_next().await.is_some() {}
+                return Err(OtherError(format!("worker task failed: {}", join_err)));
+            }
+        }
+    }
+
+    let first = outputs.iter().map(|o| o.first_started).min();
+    let last = outputs.iter().map(|o| o.last_completed).max();
+    let window = match (first, last) {
+        (Some(f), Some(l)) => l.saturating_duration_since(f),
+        _ => Duration::ZERO,
+    };
+
+    let mut samples_all: Vec<OpSample> = Vec::new();
+    for output in outputs {
+        samples_all.extend(output.samples);
+    }
+    let completed = samples_all.len();
+
+    Ok(LevelRun {
+        samples: samples_all,
+        completed,
+        window,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A fake worker that guarantees the engine really holds `C` requests in flight at once: on its
+    /// first measured invocation it bumps a shared in-flight counter, records the running maximum,
+    /// then blocks on a shared `Barrier(C)`. Only when *all* `C` workers have incremented (so the
+    /// observed max is exactly `C`) does the barrier release. This makes `max == C` deterministic
+    /// regardless of scheduler timing, without any instrumentation in the production engine.
+    struct InFlightProbe {
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+        gate: Arc<Barrier>,
+        gated: bool,
+    }
+
+    impl OpInvoker for InFlightProbe {
+        async fn invoke(
+            &mut self,
+            _seq: u64,
+        ) -> BenchmarkResult<OpSample> {
+            let gate_now = !self.gated;
+            self.gated = true;
+            let cur = self.in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+            self.max_in_flight.fetch_max(cur, Ordering::Relaxed);
+            if gate_now {
+                // Hold every worker's first request in flight until all C have arrived.
+                self.gate.wait().await;
+            }
+            self.in_flight.fetch_sub(1, Ordering::Relaxed);
+            Ok(OpSample {
+                server_ms: 1.0,
+                total_ms: 1.0,
+                rows: 0,
+                cached: Some(false),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn engine_holds_exactly_c_in_flight() {
+        const C: usize = 6;
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let gate = Arc::new(Barrier::new(C));
+        let workers: Vec<InFlightProbe> = (0..C)
+            .map(|_| InFlightProbe {
+                in_flight: Arc::clone(&in_flight),
+                max_in_flight: Arc::clone(&max_in_flight),
+                gate: Arc::clone(&gate),
+                gated: false,
+            })
+            .collect();
+
+        let run = run_closed_loop(workers, 0, 4).await.unwrap();
+        assert_eq!(run.completed, C * 4);
+        assert_eq!(
+            max_in_flight.load(Ordering::Relaxed),
+            C,
+            "closed loop must hold exactly C requests in flight"
+        );
+        assert_eq!(
+            in_flight.load(Ordering::Relaxed),
+            0,
+            "every request must complete"
+        );
+    }
+
+    /// A fake fixed-latency worker: each invocation sleeps exactly `latency` then returns a sample
+    /// reporting that latency. Under paused `tokio` time the sleeps advance a virtual clock, so the
+    /// throughput math is exact and instant.
+    struct FixedLatency {
+        latency: Duration,
+    }
+
+    impl OpInvoker for FixedLatency {
+        async fn invoke(
+            &mut self,
+            _seq: u64,
+        ) -> BenchmarkResult<OpSample> {
+            let latency = self.latency;
+            tokio::time::sleep(latency).await;
+            Ok(OpSample {
+                server_ms: latency.as_secs_f64() * 1_000.0,
+                total_ms: latency.as_secs_f64() * 1_000.0,
+                rows: 0,
+                cached: Some(false),
+            })
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn throughput_is_c_over_latency() {
+        const C: usize = 4;
+        let latency = Duration::from_millis(10);
+        let workers: Vec<FixedLatency> = (0..C).map(|_| FixedLatency { latency }).collect();
+
+        let run = run_closed_loop(workers, 0, 5).await.unwrap();
+        assert_eq!(run.completed, C * 5);
+        // window ≈ 5 × 10ms = 50ms; throughput ≈ 20 / 0.05 = 400 = C / latency.
+        let expected = C as f64 / latency.as_secs_f64();
+        let throughput = run.throughput_ops_per_sec();
+        assert!(
+            (throughput - expected).abs() / expected < 0.05,
+            "throughput {throughput} should be ~C/latency {expected}"
+        );
+    }
+
+    /// A fake whose reported `server_ms` equals its invocation `seq`, so leaked warm-up samples are
+    /// detectable (they'd carry `seq < warmup`).
+    struct SeqEcho;
+
+    impl OpInvoker for SeqEcho {
+        async fn invoke(
+            &mut self,
+            seq: u64,
+        ) -> BenchmarkResult<OpSample> {
+            Ok(OpSample {
+                server_ms: seq as f64,
+                total_ms: seq as f64,
+                rows: 0,
+                cached: Some(false),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn warmup_samples_are_excluded_and_pooled() {
+        const C: usize = 3;
+        let warmup = 5;
+        let samples = 4;
+        let workers: Vec<SeqEcho> = (0..C).map(|_| SeqEcho).collect();
+
+        let run = run_closed_loop(workers, warmup, samples).await.unwrap();
+        // Pooled across all workers, warm-up excluded.
+        assert_eq!(run.samples.len(), C * samples);
+        assert_eq!(run.completed, C * samples);
+        // Every retained sample is a measured one (seq >= warmup); no warm-up leaked in.
+        assert!(
+            run.samples.iter().all(|s| s.server_ms >= warmup as f64),
+            "warm-up invocations must not appear in the measured samples"
+        );
+    }
+
+    /// A fake that errors on a chosen invocation, to prove fail-fast doesn't deadlock on the
+    /// warm-up barrier when a worker returns early.
+    struct FailAt {
+        fail_seq: u64,
+    }
+
+    impl OpInvoker for FailAt {
+        async fn invoke(
+            &mut self,
+            seq: u64,
+        ) -> BenchmarkResult<OpSample> {
+            if seq == self.fail_seq {
+                return Err(OtherError("boom".to_string()));
+            }
+            Ok(OpSample {
+                server_ms: 1.0,
+                total_ms: 1.0,
+                rows: 0,
+                cached: Some(false),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn error_during_warmup_fails_fast_without_deadlock() {
+        // Worker 0 errors in warm-up before reaching the barrier; the others are parked on it.
+        // Fail-fast must abort them and return the error rather than hang forever.
+        let mut workers: Vec<FailAt> = (0..4).map(|_| FailAt { fail_seq: u64::MAX }).collect();
+        workers[0].fail_seq = 0; // fail on the first warm-up invocation
+        let result = run_closed_loop(workers, 2, 3).await;
+        assert!(result.is_err(), "a worker error must fail the level");
+    }
+
+    #[tokio::test]
+    async fn empty_workers_is_an_error() {
+        let workers: Vec<SeqEcho> = Vec::new();
+        assert!(run_closed_loop(workers, 0, 4).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn zero_samples_is_an_error() {
+        let workers: Vec<SeqEcho> = (0..2).map(|_| SeqEcho).collect();
+        assert!(run_closed_loop(workers, 1, 0).await.is_err());
+    }
+
+    #[test]
+    fn throughput_handles_degenerate_window() {
+        // A normal window divides completed by seconds…
+        let run = LevelRun {
+            samples: Vec::new(),
+            completed: 100,
+            window: Duration::from_secs(2),
+        };
+        assert_eq!(run.throughput_ops_per_sec(), 50.0);
+        // …and a zero-length window yields 0.0 rather than an infinity/NaN.
+        let degenerate = LevelRun {
+            samples: Vec::new(),
+            completed: 100,
+            window: Duration::ZERO,
+        };
+        assert_eq!(degenerate.throughput_ops_per_sec(), 0.0);
+    }
+
+    /// A fake whose invocation panics, to exercise the engine's task-panic (`JoinError`) path.
+    struct PanicWorker;
+
+    impl OpInvoker for PanicWorker {
+        async fn invoke(
+            &mut self,
+            _seq: u64,
+        ) -> BenchmarkResult<OpSample> {
+            panic!("worker panic");
+        }
+    }
+
+    #[tokio::test]
+    async fn worker_panic_is_surfaced_as_an_error() {
+        let workers: Vec<PanicWorker> = (0..2).map(|_| PanicWorker).collect();
+        let result = run_closed_loop(workers, 0, 2).await;
+        assert!(result.is_err(), "a panicking worker must fail the level");
+    }
+}

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -18,6 +18,7 @@
 pub mod catalog;
 pub mod config;
 pub mod dataset;
+pub mod engine;
 pub mod op_runner;
 pub mod provenance;
 pub mod report;
@@ -28,20 +29,32 @@ use crate::error::BenchmarkResult;
 use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
 use crate::query::Query;
-use crate::synthetic::catalog::{spec, DatasetHandle, DatasetRequirement, OperationSpec, CORPUS_SIZE};
+use crate::synthetic::catalog::{
+    spec, DatasetHandle, DatasetRequirement, OperationSpec, CORPUS_SIZE,
+};
 use crate::synthetic::dataset::DatasetSpec;
+use crate::synthetic::engine::{run_closed_loop, OpInvoker};
 use crate::synthetic::op_runner::{run_and_drain, OpSample};
-use crate::synthetic::report::{DatasetInfo, Meta, OperationReport, Report};
+use crate::synthetic::report::{
+    DatasetInfo, LevelMetrics, LevelReport, Meta, OperationReport, Report,
+};
 use clap::ValueEnum;
-use falkordb::{ConnectionStrategy, FalkorClientBuilder};
+use falkordb::{AsyncGraph, ConnectionStrategy, FalkorClientBuilder};
 use futures::StreamExt;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde::de::{self, Deserializer};
 use serde::Deserialize;
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::{info, warn};
+
+/// The default concurrency sweep (closed-loop worker counts `C`) when none is configured: the
+/// canonical latency-vs-throughput curve from `1` to `32` workers.
+pub const DEFAULT_CONCURRENCY: &[usize] = &[1, 2, 4, 8, 16, 32];
 
 /// The default graph key the probe targets when `--graph` isn't given.
 pub const DEFAULT_GRAPH: &str = "falkor";
@@ -203,19 +216,21 @@ pub enum CacheMode {
 /// FalkorDB keys its plan cache on the query **body** (the text after the `CYPHER <params>` prefix
 /// that [`Query::to_cypher`] emits). [`CacheMode::Cached`] uses the body verbatim, so a corpus of
 /// varying parameter values still reuses one cached plan → *execution only*. [`CacheMode::Uncached`]
-/// appends a unique trailing comment `/* co<run_token>-<i> */`, making every invocation a distinct
-/// cache key that FalkorDB must recompile → *execution + compilation*. The per-run `run_token` keeps a
-/// previous run's uncached comments from being served from cache.
+/// appends a unique trailing comment `/* co<run_token>-<uid> */`, making every invocation a distinct
+/// cache key that FalkorDB must recompile → *execution + compilation*. The per-run `run_token` keeps
+/// a previous run's uncached comments from being served from cache; `uid` is a **run-global** unique
+/// invocation id (disjoint per worker and per concurrency level), so no two invocations anywhere in
+/// the sweep ever collide.
 fn render_cypher(
     query: &Query,
     mode: CacheMode,
     run_token: u64,
-    i: usize,
+    uid: u64,
 ) -> String {
     let base = query.to_cypher();
     match mode {
         CacheMode::Cached => base,
-        CacheMode::Uncached => format!("{} /* co{:x}-{} */", base, run_token, i),
+        CacheMode::Uncached => format!("{} /* co{:x}-{} */", base, run_token, uid),
     }
 }
 
@@ -229,6 +244,9 @@ pub struct Config {
     pub ops: Vec<OpName>,
     pub samples: usize,
     pub warmup: usize,
+    /// Concurrency levels to sweep (closed-loop worker counts `C`); each op is measured once per
+    /// level, tracing its latency-vs-throughput curve. Non-empty, each ≥ 1, deduped + sorted.
+    pub concurrency: Vec<usize>,
     /// Seed for the per-operation parameter corpora (same seed ⇒ identical corpora).
     pub seed: u64,
     pub server_timeout_ms: i64,
@@ -249,6 +267,7 @@ impl Default for Config {
             ops: vec![OpName::ReturnConst],
             samples: 1000,
             warmup: 200,
+            concurrency: DEFAULT_CONCURRENCY.to_vec(),
             seed: 0,
             server_timeout_ms: 5_000,
             client_deadline_ms: 6_000,
@@ -318,6 +337,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     if config.samples == 0 {
         return Err(OtherError("samples must be greater than 0".to_string()));
     }
+    let concurrency = normalize_concurrency(&config.concurrency)?;
     let ops = dedup_ops(&config.ops);
     if ops.is_empty() {
         return Err(OtherError(
@@ -395,6 +415,14 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     // run's uncached queries can never be served from a previous run's plan cache.
     let run_token = rand::random_range(0..=u64::MAX);
 
+    // The setup connection's work (provenance, dataset generation/probe) is done; drop it so it
+    // doesn't sit idle as a `C + 1`-th connection while the workers open their own pools.
+    drop(graph);
+
+    // Run-global allocator of disjoint invocation-id ranges: every worker claims a block so its
+    // uncached query text can never collide with another worker's or another level's.
+    let uid_alloc = AtomicU64::new(0);
+
     let mut operations = BTreeMap::new();
     // Capture each op's corpus fingerprint (in execution order) so the corpus_hash reflects the
     // exact rendered workload — parameter values included — not just the op names.
@@ -403,10 +431,18 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         let op_spec = spec(op);
         // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
         let mut rng = StdRng::seed_from_u64(config.seed ^ op.salt());
-        let corpus = op_spec.build_corpus(&mut rng, &dataset, 0, 1)?;
+        let corpus = Arc::new(op_spec.build_corpus(&mut rng, &dataset, 0, 1)?);
         op_fingerprints.push((op, dataset::corpus_fingerprint(&corpus)));
-        let op_report =
-            measure_op(&mut graph, config, &op_spec, &corpus, run_token, client_deadline).await?;
+        let op_report = measure_op(
+            config,
+            &concurrency,
+            &op_spec,
+            Arc::clone(&corpus),
+            run_token,
+            &uid_alloc,
+            client_deadline,
+        )
+        .await?;
         operations.insert(op.as_str().to_string(), op_report);
     }
 
@@ -416,27 +452,54 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         seed: spec.seed,
         nodes: spec.nodes,
         edges: spec.edges,
-        corpus_hash: dataset::corpus_hash(spec, config.seed, CORPUS_SIZE, &op_fingerprints, &dataset),
+        corpus_hash: dataset::corpus_hash(
+            spec,
+            config.seed,
+            CORPUS_SIZE,
+            &op_fingerprints,
+            &dataset,
+        ),
     });
 
     Ok(Report {
+        schema_version: crate::synthetic::report::SCHEMA_VERSION,
         meta: Meta {
             tool_version: env!("CARGO_PKG_VERSION").to_string(),
             endpoint: redact_endpoint(&config.endpoint),
             graph: config.graph.clone(),
             samples: config.samples,
             warmup: config.warmup,
+            concurrency: concurrency.clone(),
             seed: config.seed,
             corpus_size: CORPUS_SIZE,
             server_timeout_ms: config.server_timeout_ms,
             client_deadline_ms: config.client_deadline_ms,
-            connection: "pool(size=1)".to_string(),
+            connection: "pool(size=1) per worker".to_string(),
             started_at_epoch_secs,
             server,
             dataset: dataset_info,
         },
         operations,
     })
+}
+
+/// Validate and canonicalize the configured concurrency sweep: non-empty, every level ≥ 1,
+/// deduplicated and sorted ascending (so the curve reads low → high and each `C` runs once).
+fn normalize_concurrency(concurrency: &[usize]) -> BenchmarkResult<Vec<usize>> {
+    if concurrency.is_empty() {
+        return Err(OtherError(
+            "concurrency must list at least one level (e.g. --concurrency 1,4,16)".to_string(),
+        ));
+    }
+    if concurrency.contains(&0) {
+        return Err(OtherError(
+            "concurrency levels must be >= 1 (0 workers can't measure anything)".to_string(),
+        ));
+    }
+    let mut levels: Vec<usize> = concurrency.to_vec();
+    levels.sort_unstable();
+    levels.dedup();
+    Ok(levels)
 }
 
 /// Deduplicate the selected ops, preserving first-occurrence order (so a repeated `--op` or an
@@ -549,80 +612,142 @@ pub(crate) fn is_empty_graph_key(msg: &str) -> bool {
     m.contains("empty key") || m.contains("invalid graph operation")
 }
 
-/// Measure one operation under every requested cache mode and derive its compilation cost.
-async fn measure_op(
-    graph: &mut falkordb::AsyncGraph,
-    config: &Config,
-    op_spec: &OperationSpec,
-    corpus: &[Query],
-    run_token: u64,
-    client_deadline: Duration,
-) -> BenchmarkResult<OperationReport> {
-    let mut cached_set: Option<crate::synthetic::report::MetricSet> = None;
-    let mut uncached_set: Option<crate::synthetic::report::MetricSet> = None;
-    for &mode in config.cache.modes() {
-        let set = measure_mode(graph, config, op_spec, corpus, mode, run_token, client_deadline).await?;
-        match mode {
-            CacheMode::Cached => cached_set = Some(set),
-            CacheMode::Uncached => uncached_set = Some(set),
-        }
-    }
-
-    // Derived expression-compilation cost: how much slower an uncached (recompiled) run's server
-    // time is than a cached (plan-reused) one. Both modes cycle the same corpus in the same order,
-    // so the medians compare a matched workload.
-    let compilation_ms_median = match (&cached_set, &uncached_set) {
-        (Some(c), Some(u)) => Some(u.server_ms.median - c.server_ms.median),
-        _ => None,
-    };
-
-    Ok(OperationReport {
-        cached: cached_set,
-        uncached: uncached_set,
-        compilation_ms_median,
-    })
-}
-
-/// Warm up then measure `config.samples` invocations of one operation in one cache mode, cycling
-/// through the pre-generated `corpus` (so parameter values vary while the body stays constant).
-async fn measure_mode(
-    graph: &mut falkordb::AsyncGraph,
-    config: &Config,
-    op_spec: &OperationSpec,
-    corpus: &[Query],
+/// A closed-loop worker for one operation, cache mode and connection: owns a single-socket
+/// `AsyncGraph` and drives one query at a time via [`run_and_drain`]. The worker cycles its corpus
+/// from a decorrelating `corpus_offset` (so concurrent workers don't march in lock-step) and claims
+/// a disjoint `uid_base` so its uncached query text is globally unique across the whole sweep.
+struct GraphWorker {
+    graph: AsyncGraph,
+    kind: QueryType,
+    corpus: Arc<Vec<Query>>,
     mode: CacheMode,
     run_token: u64,
+    corpus_offset: usize,
+    uid_base: u64,
+    server_timeout_ms: i64,
     client_deadline: Duration,
-) -> BenchmarkResult<crate::synthetic::report::MetricSet> {
-    let kind = op_spec.kind;
+}
 
+impl OpInvoker for GraphWorker {
+    fn invoke(
+        &mut self,
+        seq: u64,
+    ) -> impl Future<Output = BenchmarkResult<OpSample>> + Send {
+        let idx = (self.corpus_offset + seq as usize) % self.corpus.len();
+        let cypher = render_cypher(
+            &self.corpus[idx],
+            self.mode,
+            self.run_token,
+            self.uid_base + seq,
+        );
+        let kind = self.kind;
+        let server_timeout_ms = self.server_timeout_ms;
+        let client_deadline = self.client_deadline;
+        let graph = &mut self.graph;
+        async move { run_and_drain(graph, kind, &cypher, server_timeout_ms, client_deadline).await }
+    }
+}
+
+/// Measure one operation across the concurrency sweep, under every requested cache mode, and derive
+/// its per-level compilation cost.
+#[allow(clippy::too_many_arguments)]
+async fn measure_op(
+    config: &Config,
+    concurrency: &[usize],
+    op_spec: &OperationSpec,
+    corpus: Arc<Vec<Query>>,
+    run_token: u64,
+    uid_alloc: &AtomicU64,
+    client_deadline: Duration,
+) -> BenchmarkResult<OperationReport> {
+    let mut levels = Vec::with_capacity(concurrency.len());
+    for &c in concurrency {
+        let mut cached: Option<LevelMetrics> = None;
+        let mut uncached: Option<LevelMetrics> = None;
+        for &mode in config.cache.modes() {
+            let metrics = measure_level(
+                config,
+                c,
+                op_spec,
+                &corpus,
+                mode,
+                run_token,
+                uid_alloc,
+                client_deadline,
+            )
+            .await?;
+            match mode {
+                CacheMode::Cached => cached = Some(metrics),
+                CacheMode::Uncached => uncached = Some(metrics),
+            }
+        }
+
+        // Derived expression-compilation cost: how much slower an uncached (recompiled) run's
+        // server time is than a cached (plan-reused) one, at this concurrency level.
+        let compilation_ms_median = match (&cached, &uncached) {
+            (Some(cm), Some(um)) => Some(um.metrics.server_ms.median - cm.metrics.server_ms.median),
+            _ => None,
+        };
+
+        levels.push(LevelReport {
+            concurrency: c,
+            cached,
+            uncached,
+            compilation_ms_median,
+        });
+    }
+
+    Ok(OperationReport { levels })
+}
+
+/// Measure one operation at one concurrency level `C` in one cache mode via the closed-loop engine:
+/// open `C` single-socket connections (one per worker), drive them to completion, and summarize the
+/// pooled samples plus the achieved throughput.
+#[allow(clippy::too_many_arguments)]
+async fn measure_level(
+    config: &Config,
+    concurrency: usize,
+    op_spec: &OperationSpec,
+    corpus: &Arc<Vec<Query>>,
+    mode: CacheMode,
+    run_token: u64,
+    uid_alloc: &AtomicU64,
+    client_deadline: Duration,
+) -> BenchmarkResult<LevelMetrics> {
     // Prime the plan cache once even when warmup==0, so a cached-mode measurement never pays
     // first-touch compilation on its first sample. (No help for uncached, whose every query is
-    // unique by design.)
-    if config.warmup == 0 && mode == CacheMode::Cached {
-        let cypher = render_cypher(&corpus[0], mode, run_token, 0);
-        let _ = run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline)
-            .await?;
+    // unique by design.) An untimed warm-up invocation does exactly that.
+    let effective_warmup = if config.warmup == 0 && mode == CacheMode::Cached {
+        1
+    } else {
+        config.warmup
+    };
+
+    // Each worker claims a disjoint id block wide enough for its warm-up + measured invocations, so
+    // no two workers (here or at any other level) ever render the same uncached query text.
+    let block = (effective_warmup + config.samples) as u64;
+    let mut workers = Vec::with_capacity(concurrency);
+    for w in 0..concurrency {
+        let graph = open_graph(&config.endpoint, &config.graph).await?;
+        workers.push(GraphWorker {
+            graph,
+            kind: op_spec.kind,
+            corpus: Arc::clone(corpus),
+            mode,
+            run_token,
+            corpus_offset: w % corpus.len(),
+            uid_base: uid_alloc.fetch_add(block, Ordering::Relaxed),
+            server_timeout_ms: config.server_timeout_ms,
+            client_deadline,
+        });
     }
 
-    // Warm-up (discarded) primes the plan cache (cached mode) and the connection.
-    for i in 0..config.warmup {
-        let cypher = render_cypher(&corpus[i % corpus.len()], mode, run_token, i);
-        let _ = run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline)
-            .await?;
-    }
-
-    let mut samples: Vec<OpSample> = Vec::with_capacity(config.samples);
-    for i in 0..config.samples {
-        // Continue the uncached comment counter past warm-up so every key stays unique.
-        let idx = config.warmup + i;
-        let cypher = render_cypher(&corpus[idx % corpus.len()], mode, run_token, idx);
-        let sample =
-            run_and_drain(graph, kind, &cypher, config.server_timeout_ms, client_deadline).await?;
-        samples.push(sample);
-    }
-
-    summarize_samples(&samples)
+    let run = run_closed_loop(workers, effective_warmup, config.samples).await?;
+    let metrics = summarize_samples(&run.samples)?;
+    Ok(LevelMetrics {
+        throughput_ops_per_sec: run.throughput_ops_per_sec(),
+        metrics,
+    })
 }
 
 /// Summarize a set of paired samples into a [`MetricSet`].
@@ -705,6 +830,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             all_reads,
             samples,
             warmup,
+            concurrency,
             seed,
             cache,
             server_timeout_ms,
@@ -722,6 +848,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 all_reads,
                 samples,
                 warmup,
+                concurrency,
                 seed,
                 cache,
                 server_timeout_ms,
@@ -840,7 +967,11 @@ mod tests {
     #[test]
     fn all_reads_covers_the_catalog_and_dedups() {
         let reads = OpName::all_reads();
-        assert_eq!(reads.len(), OpName::all().len(), "all catalog ops are reads");
+        assert_eq!(
+            reads.len(),
+            OpName::all().len(),
+            "all catalog ops are reads"
+        );
         // dedup_ops keeps first occurrence and drops duplicates / overlaps.
         let deduped = dedup_ops(&[
             OpName::MatchByIndex,
@@ -879,6 +1010,22 @@ mod tests {
             CacheSelection::Both.modes(),
             &[CacheMode::Cached, CacheMode::Uncached]
         );
+    }
+
+    #[test]
+    fn normalize_concurrency_sorts_dedups_and_validates() {
+        // Deduped + sorted ascending so the curve reads low → high.
+        assert_eq!(
+            normalize_concurrency(&[8, 1, 4, 1, 8]).unwrap(),
+            vec![1, 4, 8]
+        );
+        assert_eq!(
+            normalize_concurrency(DEFAULT_CONCURRENCY).unwrap(),
+            vec![1, 2, 4, 8, 16, 32]
+        );
+        // Empty and zero-containing sweeps are rejected.
+        assert!(normalize_concurrency(&[]).is_err());
+        assert!(normalize_concurrency(&[1, 0, 4]).is_err());
     }
 
     #[test]
@@ -943,6 +1090,7 @@ mod tests {
             all_reads: false,
             samples: Some(0),
             warmup: Some(0),
+            concurrency: vec![],
             seed: Some(0),
             cache: Some(CacheSelection::Both),
             server_timeout_ms: Some(5_000),
@@ -980,6 +1128,7 @@ mod tests {
             all_reads: false,
             samples: Some(100),
             warmup: Some(0),
+            concurrency: vec![],
             seed: Some(0),
             cache: Some(CacheSelection::Both),
             server_timeout_ms: Some(5_000),
@@ -1009,10 +1158,30 @@ mod tests {
     #[test]
     fn summarize_samples_computes_paired_residual_and_cache() {
         let samples = vec![
-            OpSample { server_ms: 0.10, total_ms: 0.40, rows: 1, cached: Some(true) },
-            OpSample { server_ms: 0.12, total_ms: 0.45, rows: 1, cached: Some(false) },
-            OpSample { server_ms: 0.11, total_ms: 0.42, rows: 1, cached: None },
-            OpSample { server_ms: 0.13, total_ms: 0.44, rows: 1, cached: Some(true) },
+            OpSample {
+                server_ms: 0.10,
+                total_ms: 0.40,
+                rows: 1,
+                cached: Some(true),
+            },
+            OpSample {
+                server_ms: 0.12,
+                total_ms: 0.45,
+                rows: 1,
+                cached: Some(false),
+            },
+            OpSample {
+                server_ms: 0.11,
+                total_ms: 0.42,
+                rows: 1,
+                cached: None,
+            },
+            OpSample {
+                server_ms: 0.13,
+                total_ms: 0.44,
+                rows: 1,
+                cached: Some(true),
+            },
         ];
         let r = summarize_samples(&samples).unwrap();
         assert_eq!(r.server_ms.n, 4);
@@ -1031,10 +1200,20 @@ mod tests {
         let mut samples: Vec<OpSample> = (0..20)
             .map(|i| {
                 let s = 0.10 + i as f64 * 0.001;
-                OpSample { server_ms: s, total_ms: s + 0.3, rows: 1, cached: Some(true) }
+                OpSample {
+                    server_ms: s,
+                    total_ms: s + 0.3,
+                    rows: 1,
+                    cached: Some(true),
+                }
             })
             .collect();
-        samples.push(OpSample { server_ms: 0.11, total_ms: 500.0, rows: 1, cached: Some(true) });
+        samples.push(OpSample {
+            server_ms: 0.11,
+            total_ms: 500.0,
+            rows: 1,
+            cached: Some(true),
+        });
         let r = summarize_samples(&samples).unwrap();
         assert_eq!(r.server_ms.n, r.total_ms.n);
         assert_eq!(r.total_ms.n, r.non_internal_ms.n);
@@ -1047,9 +1226,24 @@ mod tests {
         // A tiny sample set: `severe_fence` returns None (nothing removed → the `within` no-fence
         // path), and with every `cached` unknown the false-rate collapses to 0.0.
         let samples = vec![
-            OpSample { server_ms: 0.10, total_ms: 0.40, rows: 1, cached: None },
-            OpSample { server_ms: 0.12, total_ms: 0.45, rows: 1, cached: None },
-            OpSample { server_ms: 0.11, total_ms: 0.42, rows: 1, cached: None },
+            OpSample {
+                server_ms: 0.10,
+                total_ms: 0.40,
+                rows: 1,
+                cached: None,
+            },
+            OpSample {
+                server_ms: 0.12,
+                total_ms: 0.45,
+                rows: 1,
+                cached: None,
+            },
+            OpSample {
+                server_ms: 0.11,
+                total_ms: 0.42,
+                rows: 1,
+                cached: None,
+            },
         ];
         let r = summarize_samples(&samples).unwrap();
         assert_eq!(r.server_ms.n, 3);

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -185,8 +185,13 @@ fn default_schema_version() -> u32 {
 /// The full report written to `synthetic-report.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Report {
-    /// On-disk schema version (see [`SCHEMA_VERSION`]); lets later tooling (baseline comparison)
-    /// detect an incompatible older report instead of silently misreading it.
+    /// On-disk schema version (see [`SCHEMA_VERSION`]). Because the `operations[].levels[]` shape
+    /// changed in v2, a v1 report that actually contains operation data will **not** deserialize
+    /// into this struct — so tooling cannot rely on parsing a full [`Report`] to detect an old
+    /// version. Instead, read `schema_version` from the raw JSON first (a tiny
+    /// `{ "schema_version": u32 }` probe) and branch/migrate on it; the `serde` default of `1` only
+    /// covers reports that predate the field on otherwise-compatible reads (e.g. metadata-only or
+    /// an empty `operations` map).
     #[serde(default = "default_schema_version")]
     pub schema_version: u32,
     pub meta: Meta,

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -285,7 +285,7 @@ fn render_op_levels(
         }
         out.push_str(&format!("  [{}]\n", mode_label));
         out.push_str(
-            "    C    throughput(ops/s)   server p50/p90/p99        total p50/p90/p99         miss%\n",
+            "    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%\n",
         );
         for level in &op.levels {
             let Some(m) = pick(level) else { continue };
@@ -295,14 +295,16 @@ fn render_op_levels(
                 ""
             };
             out.push_str(&format!(
-                "  {:>3}   {:>15.0}   {:>7.3} /{:>6.3} /{:>6.3}   {:>7.3} /{:>6.3} /{:>6.3}   {:>5.1}{}\n",
+                "  {:>3}   {:>15.0}   {:>7.3} /{:>6.3} /{:>6.3} /{:>6.3}   {:>7.3} /{:>6.3} /{:>6.3} /{:>6.3}   {:>5.1}{}\n",
                 level.concurrency,
                 m.throughput_ops_per_sec,
                 m.metrics.server_ms.median,
                 m.metrics.server_ms.p90,
+                m.metrics.server_ms.p95,
                 m.metrics.server_ms.p99,
                 m.metrics.total_ms.median,
                 m.metrics.total_ms.p90,
+                m.metrics.total_ms.p95,
                 m.metrics.total_ms.p99,
                 m.metrics.cached_false_rate * 100.0,
                 knee_mark,
@@ -450,8 +452,8 @@ mod tests {
         assert!(out.contains("return_const"));
         // The latency-vs-throughput table headers and both cache-mode sections.
         assert!(out.contains("throughput(ops/s)"));
-        assert!(out.contains("server p50/p90/p99"));
-        assert!(out.contains("total p50/p90/p99"));
+        assert!(out.contains("server p50/p90/p95/p99"));
+        assert!(out.contains("total p50/p90/p95/p99"));
         assert!(out.contains("cached — plan reused"));
         assert!(out.contains("uncached — plan-cache miss"));
         assert!(out.contains("compilation_ms"));

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -56,6 +56,10 @@ pub struct Meta {
     pub graph: String,
     pub samples: usize,
     pub warmup: usize,
+    /// Concurrency levels swept (the closed-loop worker counts `C`). `#[serde(default)]` for
+    /// backward compatibility with pre-Part-4 reports (which always measured single-connection).
+    #[serde(default)]
+    pub concurrency: Vec<usize>,
     /// Seed used to generate the per-operation parameter corpora (for reproducibility).
     /// `#[serde(default)]` for backward compatibility with pre-Part-2 reports.
     #[serde(default)]
@@ -102,26 +106,89 @@ pub struct MetricSet {
     pub cached_unknown: usize,
 }
 
-/// Stats for one operation across cache modes.
+/// One (operation, cache-mode) measurement at a single concurrency level: the latency stats plus
+/// the **achieved** throughput the closed-loop engine sustained at that level.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LevelMetrics {
+    /// Achieved throughput (completed measured invocations ÷ wall-clock window), operations/sec.
+    pub throughput_ops_per_sec: f64,
+    /// Latency + cache-health stats over the pooled (outlier-filtered) samples for this level.
+    pub metrics: MetricSet,
+}
+
+/// Stats for one operation at one concurrency level `C`, across cache modes.
 ///
 /// `cached` measures with the plan cache warm (execution only); `uncached` forces a plan-cache
 /// miss on every invocation (unique query text), so it also pays expression **compilation** each
 /// time. `compilation_ms_median` is the derived per-op compilation cost when both were measured.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OperationReport {
+pub struct LevelReport {
+    /// Number of concurrent closed-loop workers (`C`) this level ran with.
+    pub concurrency: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cached: Option<MetricSet>,
+    pub cached: Option<LevelMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uncached: Option<MetricSet>,
+    pub uncached: Option<LevelMetrics>,
     /// `uncached.server_ms.median − cached.server_ms.median` (exposes compilation slowness without
     /// hiding execution). Present only when both modes were measured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compilation_ms_median: Option<f64>,
 }
 
+/// Stats for one operation across the whole concurrency sweep.
+///
+/// Each entry of `levels` is the same operation measured at one concurrency `C`; together they
+/// trace the latency-vs-throughput curve. A single-element sweep (`concurrency = [1]`) reproduces
+/// the pre-Part-4 single-connection measurement (plus its achieved throughput).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationReport {
+    pub levels: Vec<LevelReport>,
+}
+
+impl OperationReport {
+    /// The level with the highest achieved throughput (across either cache mode), i.e. the sweep's
+    /// saturation "knee". `None` when no level recorded a throughput.
+    fn knee_concurrency(&self) -> Option<usize> {
+        self.levels
+            .iter()
+            .filter_map(|lvl| {
+                let t = level_peak_throughput(lvl)?;
+                Some((lvl.concurrency, t))
+            })
+            .max_by(|a, b| a.1.total_cmp(&b.1))
+            .map(|(c, _)| c)
+    }
+}
+
+/// The higher of a level's cached/uncached achieved throughput, if any mode was measured.
+fn level_peak_throughput(level: &LevelReport) -> Option<f64> {
+    let cached = level.cached.as_ref().map(|m| m.throughput_ops_per_sec);
+    let uncached = level.uncached.as_ref().map(|m| m.throughput_ops_per_sec);
+    match (cached, uncached) {
+        (Some(a), Some(b)) => Some(a.max(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+/// The current synthetic-report schema version. Bumped when the on-disk shape changes
+/// incompatibly (Part 4 introduced `operations[].levels[]` and per-metric `p95`).
+pub const SCHEMA_VERSION: u32 = 2;
+
+/// Serde default for [`Report::schema_version`]: a report written before the field existed is a
+/// pre-Part-4 (v1) report.
+fn default_schema_version() -> u32 {
+    1
+}
+
 /// The full report written to `synthetic-report.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Report {
+    /// On-disk schema version (see [`SCHEMA_VERSION`]); lets later tooling (baseline comparison)
+    /// detect an incompatible older report instead of silently misreading it.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
     pub meta: Meta,
     pub operations: BTreeMap<String, OperationReport>,
 }
@@ -135,12 +202,23 @@ impl Report {
     /// Render a compact human-readable summary (one block per operation).
     pub fn to_console(&self) -> String {
         let mut out = String::new();
+        let concurrency = if self.meta.concurrency.is_empty() {
+            "1".to_string()
+        } else {
+            self.meta
+                .concurrency
+                .iter()
+                .map(|c| c.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        };
         out.push_str(&format!(
-            "synthetic benchmark — endpoint {}  graph {}  samples {}  warmup {}  seed {}  connection {}\n",
+            "synthetic benchmark — endpoint {}  graph {}  samples {}  warmup {}  concurrency [{}]  seed {}  connection {}\n",
             self.meta.endpoint,
             self.meta.graph,
             self.meta.samples,
             self.meta.warmup,
+            concurrency,
             self.meta.seed,
             self.meta.connection
         ));
@@ -178,46 +256,67 @@ impl Report {
         }
         for (name, op) in &self.operations {
             out.push_str(&format!("\n{}\n", name));
-            if let Some(m) = &op.cached {
-                out.push_str("  [cached — plan reused, execution only]\n");
-                render_metric_set(&mut out, m);
-            }
-            if let Some(m) = &op.uncached {
-                out.push_str("  [uncached — plan-cache miss each run, execution + compilation]\n");
-                render_metric_set(&mut out, m);
-            }
-            if let Some(comp) = op.compilation_ms_median {
-                out.push_str(&format!(
-                    "  compilation_ms (median uncached-cached server time)  {:.3}\n",
-                    comp
-                ));
-            }
+            render_op_levels(&mut out, op);
         }
         out
     }
 }
 
-/// Render one metric set (server/total/residual + cache health) as indented console lines.
-fn render_metric_set(
+/// Render one operation's concurrency sweep as a latency-vs-throughput table per cache mode,
+/// followed by the derived per-level compilation cost. The highest-throughput level (the
+/// saturation "knee") is flagged.
+fn render_op_levels(
     out: &mut String,
-    m: &MetricSet,
+    op: &OperationReport,
 ) {
-    out.push_str(&format!(
-        "    server_ms  median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
-        m.server_ms.median, m.server_ms.mean, m.server_ms.p99, m.server_ms.n, m.server_ms.removed
-    ));
-    out.push_str(&format!(
-        "    total_ms   median {:.3}  mean {:.3}  p99 {:.3}  (n={}, removed {})\n",
-        m.total_ms.median, m.total_ms.mean, m.total_ms.p99, m.total_ms.n, m.total_ms.removed
-    ));
-    out.push_str(&format!(
-        "    non_internal_ms (paired total-server)  median {:.3}\n",
-        m.non_internal_ms.median
-    ));
-    out.push_str(&format!(
-        "    cached_execution=false: {:.1}%  (unknown {})\n",
-        m.cached_false_rate * 100.0, m.cached_unknown
-    ));
+    let knee = op.knee_concurrency();
+    for (mode_label, pick) in [
+        (
+            "cached — plan reused, execution only",
+            (|l: &LevelReport| l.cached.as_ref()) as fn(&LevelReport) -> Option<&LevelMetrics>,
+        ),
+        (
+            "uncached — plan-cache miss each run, execution + compilation",
+            (|l: &LevelReport| l.uncached.as_ref()) as fn(&LevelReport) -> Option<&LevelMetrics>,
+        ),
+    ] {
+        if !op.levels.iter().any(|l| pick(l).is_some()) {
+            continue;
+        }
+        out.push_str(&format!("  [{}]\n", mode_label));
+        out.push_str(
+            "    C    throughput(ops/s)   server p50/p90/p99        total p50/p90/p99         miss%\n",
+        );
+        for level in &op.levels {
+            let Some(m) = pick(level) else { continue };
+            let knee_mark = if knee == Some(level.concurrency) {
+                "  <- knee"
+            } else {
+                ""
+            };
+            out.push_str(&format!(
+                "  {:>3}   {:>15.0}   {:>7.3} /{:>6.3} /{:>6.3}   {:>7.3} /{:>6.3} /{:>6.3}   {:>5.1}{}\n",
+                level.concurrency,
+                m.throughput_ops_per_sec,
+                m.metrics.server_ms.median,
+                m.metrics.server_ms.p90,
+                m.metrics.server_ms.p99,
+                m.metrics.total_ms.median,
+                m.metrics.total_ms.p90,
+                m.metrics.total_ms.p99,
+                m.metrics.cached_false_rate * 100.0,
+                knee_mark,
+            ));
+        }
+    }
+    if op.levels.iter().any(|l| l.compilation_ms_median.is_some()) {
+        out.push_str("  compilation_ms (median uncached-cached server time) by level:\n");
+        for level in &op.levels {
+            if let Some(comp) = level.compilation_ms_median {
+                out.push_str(&format!("    C={:<4} {:.3}\n", level.concurrency, comp));
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -238,28 +337,48 @@ mod tests {
         }
     }
 
+    fn sample_level_metrics(throughput: f64) -> LevelMetrics {
+        LevelMetrics {
+            throughput_ops_per_sec: throughput,
+            metrics: sample_metric_set(),
+        }
+    }
+
     fn sample_report() -> Report {
         let mut operations = BTreeMap::new();
         operations.insert(
             "return_const".to_string(),
             OperationReport {
-                cached: Some(sample_metric_set()),
-                uncached: Some(sample_metric_set()),
-                compilation_ms_median: Some(0.05),
+                levels: vec![
+                    LevelReport {
+                        concurrency: 1,
+                        cached: Some(sample_level_metrics(2_950.0)),
+                        uncached: Some(sample_level_metrics(2_800.0)),
+                        compilation_ms_median: Some(0.05),
+                    },
+                    LevelReport {
+                        concurrency: 8,
+                        cached: Some(sample_level_metrics(30_400.0)),
+                        uncached: Some(sample_level_metrics(28_000.0)),
+                        compilation_ms_median: Some(0.06),
+                    },
+                ],
             },
         );
         Report {
+            schema_version: SCHEMA_VERSION,
             meta: Meta {
                 tool_version: "0.1.0".to_string(),
                 endpoint: "falkor://127.0.0.1:6379".to_string(),
                 graph: "falkor".to_string(),
                 samples: 1000,
                 warmup: 200,
+                concurrency: vec![1, 8],
                 seed: 0,
                 corpus_size: 256,
                 server_timeout_ms: 5000,
                 client_deadline_ms: 6000,
-                connection: "pool(size=1)".to_string(),
+                connection: "pool(size=1) per worker".to_string(),
                 started_at_epoch_secs: 42,
                 server: ServerInfo {
                     module_graph_ver: Some(42001),
@@ -278,20 +397,29 @@ mod tests {
         let report = sample_report();
         let json = report.to_json().unwrap();
         let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.schema_version, SCHEMA_VERSION);
         assert_eq!(back.meta.samples, 1000);
+        assert_eq!(back.meta.concurrency, vec![1, 8]);
         assert_eq!(back.operations.len(), 1);
         let op = back.operations.get("return_const").unwrap();
-        assert!(op.cached.is_some());
-        assert!(op.uncached.is_some());
-        assert_eq!(op.compilation_ms_median, Some(0.05));
+        assert_eq!(op.levels.len(), 2);
+        let l0 = &op.levels[0];
+        assert_eq!(l0.concurrency, 1);
+        assert!(l0.cached.is_some());
+        assert!(l0.uncached.is_some());
+        assert_eq!(l0.compilation_ms_median, Some(0.05));
+        assert_eq!(l0.cached.as_ref().unwrap().throughput_ops_per_sec, 2_950.0);
+        // p95 is present on every summary (Part 4 addition).
+        let _ = l0.cached.as_ref().unwrap().metrics.server_ms.p95;
         assert_eq!(back.meta.server.module_graph_ver, Some(42001));
         assert_eq!(back.meta.server.cache_size, Some(25));
     }
 
     #[test]
-    fn pre_part2_report_deserializes_with_defaults() {
-        // A report written before Part 2 has no graph/seed/corpus_size fields; `#[serde(default)]`
-        // must let it deserialize (falling back to empty/0) rather than erroring.
+    fn pre_part4_report_deserializes_with_defaults() {
+        // A report written before Part 4 has no schema_version/concurrency fields; `#[serde(
+        // default)]` must let its metadata deserialize rather than erroring. (The operation shape
+        // changed to `levels[]`, so only the metadata is exercised here.)
         let old = r#"{
             "meta": {
                 "tool_version": "0.1.0",
@@ -304,28 +432,107 @@ mod tests {
             "operations": {}
         }"#;
         let report: Report = serde_json::from_str(old).expect("old report should deserialize");
+        // Missing schema_version reconstructs to the pre-Part-4 version 1.
+        assert_eq!(report.schema_version, 1);
         // A pre-Part-2 report always measured the default graph, so `graph` reconstructs to it.
         assert_eq!(report.meta.graph, "falkor");
         assert_eq!(report.meta.seed, 0);
         assert_eq!(report.meta.corpus_size, 0);
+        assert!(report.meta.concurrency.is_empty());
         assert_eq!(report.meta.samples, 1000);
     }
 
     #[test]
     fn console_contains_key_fields() {
         let mut r = sample_report();
-        r.meta.server.server_image =
-            Some("falkordb/falkordb:v4.2.1@sha256:deadbeef".to_string());
+        r.meta.server.server_image = Some("falkordb/falkordb:v4.2.1@sha256:deadbeef".to_string());
         let out = r.to_console();
         assert!(out.contains("return_const"));
-        assert!(out.contains("server_ms"));
-        assert!(out.contains("total_ms"));
-        assert!(out.contains("4.20.1"));
-        assert!(out.contains("cached"));
+        // The latency-vs-throughput table headers and both cache-mode sections.
+        assert!(out.contains("throughput(ops/s)"));
+        assert!(out.contains("server p50/p90/p99"));
+        assert!(out.contains("total p50/p90/p99"));
+        assert!(out.contains("cached — plan reused"));
+        assert!(out.contains("uncached — plan-cache miss"));
         assert!(out.contains("compilation_ms"));
+        // Concurrency sweep is echoed in the header, and the knee is flagged.
+        assert!(out.contains("concurrency [1,8]"));
+        assert!(out.contains("<- knee"));
+        assert!(out.contains("4.20.1"));
         assert!(out.contains("CACHE_SIZE 25"));
         // The operator-supplied image identity is echoed when present.
         assert!(out.contains("server image: falkordb/falkordb:v4.2.1@sha256:deadbeef"));
+    }
+
+    #[test]
+    fn console_renders_single_cache_modes_and_defaults() {
+        // Empty meta.concurrency (a pre-Part-4-style report) renders the implicit single level, and
+        // single-cache-mode ops render only their measured table (exercising the mode-skip and the
+        // knee/peak-throughput paths for one-sided levels).
+        let mut r = sample_report();
+        r.meta.concurrency = vec![];
+        let mut ops = BTreeMap::new();
+        ops.insert(
+            "cached_only".to_string(),
+            OperationReport {
+                levels: vec![
+                    LevelReport {
+                        concurrency: 1,
+                        cached: Some(sample_level_metrics(100.0)),
+                        uncached: None,
+                        compilation_ms_median: None,
+                    },
+                    LevelReport {
+                        concurrency: 4,
+                        cached: Some(sample_level_metrics(400.0)),
+                        uncached: None,
+                        compilation_ms_median: None,
+                    },
+                ],
+            },
+        );
+        ops.insert(
+            "uncached_only".to_string(),
+            OperationReport {
+                levels: vec![LevelReport {
+                    concurrency: 1,
+                    cached: None,
+                    uncached: Some(sample_level_metrics(50.0)),
+                    compilation_ms_median: None,
+                }],
+            },
+        );
+        ops.insert(
+            "mixed".to_string(),
+            OperationReport {
+                levels: vec![
+                    LevelReport {
+                        concurrency: 1,
+                        cached: Some(sample_level_metrics(100.0)),
+                        uncached: Some(sample_level_metrics(90.0)),
+                        compilation_ms_median: Some(0.02),
+                    },
+                    // A level measured in cached mode only: no uncached row, no compilation.
+                    LevelReport {
+                        concurrency: 4,
+                        cached: Some(sample_level_metrics(300.0)),
+                        uncached: None,
+                        compilation_ms_median: None,
+                    },
+                ],
+            },
+        );
+        r.operations = ops;
+        let out = r.to_console();
+
+        // An empty concurrency sweep prints the implicit single level.
+        assert!(out.contains("concurrency [1]"));
+        assert!(out.contains("cached_only"));
+        assert!(out.contains("uncached_only"));
+        // The knee is flagged on the highest-throughput level across the report.
+        assert!(out.contains("<- knee"));
+        // The mixed op's compilation block is present (from the level that has both modes).
+        assert!(out.contains("compilation_ms"));
     }
 
     #[test]
@@ -338,7 +545,9 @@ mod tests {
             corpus_hash: "sha256:abc123".to_string(),
         });
         let out = r.to_console();
-        assert!(out.contains("dataset — seed 42  nodes 1000  edges 5000  corpus_hash sha256:abc123"));
+        assert!(
+            out.contains("dataset — seed 42  nodes 1000  edges 5000  corpus_hash sha256:abc123")
+        );
         // Absent by default (externally-supplied graph).
         assert!(!sample_report().to_console().contains("dataset —"));
     }

--- a/src/synthetic/stats.rs
+++ b/src/synthetic/stats.rs
@@ -1,6 +1,6 @@
 //! Robust latency statistics for the synthetic benchmark.
 //!
-//! Computes the summary each measured metric reports (min/mean/median/p90/p99/std-dev) after
+//! Computes the summary each measured metric reports (min/mean/median/p90/p95/p99/std-dev) after
 //! removing *severe* outliers with Tukey fences (values outside `[Q1 - 3·IQR, Q3 + 3·IQR]`), the
 //! same idea Criterion.rs uses to keep a few pathological samples from dominating an estimate.
 
@@ -18,6 +18,7 @@ pub struct Summary {
     pub mean: f64,
     pub median: f64,
     pub p90: f64,
+    pub p95: f64,
     pub p99: f64,
     pub max: f64,
     /// Population standard deviation of the retained samples.
@@ -96,6 +97,7 @@ pub fn summarize_kept(
         mean,
         median: percentile_sorted(&vals, 50.0),
         p90: percentile_sorted(&vals, 90.0),
+        p95: percentile_sorted(&vals, 95.0),
         p99: percentile_sorted(&vals, 99.0),
         max: vals[n - 1],
         stddev: variance.sqrt(),
@@ -109,7 +111,11 @@ pub fn summarize(samples: &[f64]) -> Option<Summary> {
     let finite: Vec<f64> = samples.iter().copied().filter(|v| v.is_finite()).collect();
     match severe_fence(&finite) {
         Some((lo, hi)) => {
-            let kept: Vec<f64> = finite.iter().copied().filter(|&v| v >= lo && v <= hi).collect();
+            let kept: Vec<f64> = finite
+                .iter()
+                .copied()
+                .filter(|&v| v >= lo && v <= hi)
+                .collect();
             let removed = finite.len() - kept.len();
             summarize_kept(&kept, removed)
         }
@@ -137,6 +143,8 @@ mod tests {
         assert!(approx(percentile_sorted(&v, 50.0), 5.5));
         // p90 interpolates between the 9th and 10th values: 9 + 0.1*(10-9) = 9.1.
         assert!(approx(percentile_sorted(&v, 90.0), 9.1));
+        // p95 interpolates 9 + 0.55*(10-9) = 9.55.
+        assert!(approx(percentile_sorted(&v, 95.0), 9.55));
     }
 
     #[test]

--- a/synthetic-bench.example.toml
+++ b/synthetic-bench.example.toml
@@ -23,6 +23,10 @@ samples = 1000
 warmup = 200
 cache = "both"              # cached | uncached | both
 
+# Concurrency sweep: the closed-loop worker counts to measure each op at, tracing the
+# latency-vs-throughput curve. Each level opens that many dedicated connections.
+concurrency = [1, 2, 4, 8, 16, 32]
+
 # Connection / output (all optional).
 # endpoint = "falkor://127.0.0.1:6379"
 # graph = "falkor"

--- a/synthetic-benchmark.md
+++ b/synthetic-benchmark.md
@@ -19,8 +19,9 @@ default `1,2,4,8,16,32`). A level `C` runs a **closed-loop** engine:
 - `C` worker tasks, each owning its **own dedicated connection** (an independent single-socket
   client — not a clone of one handle, which would share a schema cache).
 - Each worker fires one query, **awaits it to completion** (row draining included), then immediately
-  fires the next from its pre-generated sequence — so there are always **exactly `C` requests in
-  flight**.
+  fires the next from its pre-generated sequence — so there are at most **`C` requests in flight**
+  (one outstanding request per active worker; the exactly-`C` test asserts the *maximum* observed
+  concurrency equals `C`).
 - After a discarded **warm-up** window, all workers cross a barrier together so the measurement
   window opens with every worker active; each records when its first measured invocation *started*
   and its last one *completed*.
@@ -103,26 +104,47 @@ match_by_index
 
 ## Report schema
 
-The JSON report groups each operation's measurements by concurrency level:
+The JSON report groups each operation's measurements by concurrency level. Abridged example (one
+level shown; `levels[]` has one entry per swept concurrency, and each `metrics.*_ms` summary carries
+the full `min`/`mean`/`median`/`p90`/`p95`/`p99`/`max`/`stddev` set):
 
-```text
-operations["match_by_index"] = {
-  "levels": [
-    {
-      "concurrency": 1,
-      "cached":   { "throughput_ops_per_sec": 2950.0, "metrics": { server_ms, total_ms, non_internal_ms, cached_false_rate, cached_unknown } },
-      "uncached": { "throughput_ops_per_sec": 2100.0, "metrics": { … } },
-      "compilation_ms_median": 0.025
-    },
-    { "concurrency": 4,  … },
-    …
-  ]
+```json
+{
+  "schema_version": 2,
+  "meta": { "concurrency": [1, 4, 16, 32] },
+  "operations": {
+    "match_by_index": {
+      "levels": [
+        {
+          "concurrency": 1,
+          "cached": {
+            "throughput_ops_per_sec": 2950.0,
+            "metrics": {
+              "server_ms": { "n": 487, "removed": 13, "median": 0.081, "p90": 0.130, "p95": 0.150, "p99": 0.200 },
+              "total_ms": { "median": 0.330, "p95": 0.500, "p99": 0.900 },
+              "non_internal_ms": { "median": 0.249 },
+              "cached_false_rate": 0.0,
+              "cached_unknown": 0
+            }
+          },
+          "uncached": {
+            "throughput_ops_per_sec": 2100.0,
+            "metrics": {
+              "server_ms": { "median": 0.106, "p95": 0.180, "p99": 0.240 },
+              "cached_false_rate": 1.0,
+              "cached_unknown": 0
+            }
+          },
+          "compilation_ms_median": 0.025
+        }
+      ]
+    }
+  }
 }
 ```
 
-Each `metrics.*_ms` summary carries `min/mean/median/p90/p95/p99/max/stddev` (plus `n` retained and
-`removed` severe outliers). The top-level report also records `schema_version` (`2` since Part 4)
-and `meta.concurrency` (the sweep that was run).
+The top-level report also records `schema_version` (`2` since Part 4) and `meta.concurrency` (the
+sweep that was run).
 
 > [!NOTE]
 > The Part 4 report shape is a **breaking change** from earlier versions: an operation's stats moved

--- a/synthetic-benchmark.md
+++ b/synthetic-benchmark.md
@@ -1,0 +1,144 @@
+# Synthetic benchmark — concurrency sweep (latency vs throughput)
+
+Companion documentation for the synthetic per-operation benchmark's **concurrency sweep engine**
+(Part 4 of the design epic [#200](https://github.com/FalkorDB/benchmark/issues/200)). For the
+operation catalog, the reproducible dataset generator, and the plan-cache (cached-vs-uncached)
+comparison, see the [Synthetic per-operation benchmark section of the README](readme.md#synthetic-per-operation-benchmark-experimental).
+
+## What & why
+
+The headline capability is showing, **per operation, how latency (including the p99 tail) changes as
+achieved throughput rises** — the latency-vs-throughput curve and its saturation "knee" — by
+sweeping a configurable concurrency level `C`.
+
+## How it works
+
+Each operation is measured at every level of a configurable **concurrency sweep** (`--concurrency`,
+default `1,2,4,8,16,32`). A level `C` runs a **closed-loop** engine:
+
+- `C` worker tasks, each owning its **own dedicated connection** (an independent single-socket
+  client — not a clone of one handle, which would share a schema cache).
+- Each worker fires one query, **awaits it to completion** (row draining included), then immediately
+  fires the next from its pre-generated sequence — so there are always **exactly `C` requests in
+  flight**.
+- After a discarded **warm-up** window, all workers cross a barrier together so the measurement
+  window opens with every worker active; each records when its first measured invocation *started*
+  and its last one *completed*.
+- The level's window is `max(last_completed) − min(first_started)`, and the **achieved throughput**
+  is `completed ÷ window` (ops/sec). Latency percentiles (p50/p90/p95/p99) are pooled across all
+  workers, after severe-outlier removal.
+
+### Achieved vs offered throughput (coordinated-omission caveat)
+
+Because a new request is issued only after the previous one *completes*, the reported throughput is
+**achieved, not offered** — it can never exceed the server's own service rate. The measured
+latencies therefore describe behaviour **at that achieved rate**: a closed loop does **not** model a
+fixed external arrival rate, so it neither reproduces nor corrects for
+[coordinated omission](https://www.scylladb.com/2021/04/22/on-coordinated-omission/). Quantifying the
+tail under a target offered load needs open-loop / arrival-rate testing, which is **out of scope**
+(future work), along with writes.
+
+### How to read the curve
+
+Follow latency as `C` (and throughput) rise: throughput climbs until the server saturates, after
+which extra concurrency mostly inflates the tail. The highest-throughput level is flagged with
+`<- knee` in the console table. A single-level sweep (`--concurrency 1`) reproduces the classic
+single-connection latency measurement plus its achieved throughput.
+
+### Cache modes per level
+
+Every level is still measured under **both** plan-cache conditions, with the derived compilation
+cost — the epic's standing mandate:
+
+- **cached** — the plan is reused (warm cache) → execution only;
+- **uncached** — a unique per-invocation query-text token forces a plan-cache miss every run →
+  execution + compilation.
+
+`compilation_ms ≈ uncached − cached` server time, computed **per level** (so you can see how
+compilation cost itself behaves under concurrency). Uncached query text stays globally unique across
+the whole sweep (every worker at every level claims a disjoint block of invocation ids), so no two
+invocations are ever served from a previous one's cached plan.
+
+## Usage
+
+Sweep one operation over the default curve, or pass explicit levels:
+
+```bash
+# one operation over the default 1,2,4,8,16,32 sweep
+just synthetic-bench-one match_by_index
+
+# explicit levels + more flags forwarded to the probe
+just synthetic-bench-one match_by_index -- --concurrency 1,4,16,32 --samples 500
+
+# the general recipe also takes --concurrency
+just synthetic-bench --graph main --op match_by_index --concurrency 1,4,16,32 --samples 500
+```
+
+Or set it in the config file (`synthetic-bench.toml`; any CLI flag overrides it):
+
+```toml
+concurrency = [1, 4, 16, 32]   # closed-loop worker counts to sweep (default 1,2,4,8,16,32)
+```
+
+## Console output
+
+One block per operation; one table row per concurrency level, per cache mode; the knee is flagged:
+
+```text
+match_by_index
+  [cached — plan reused, execution only]
+    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
+    1              2950     0.081 / 0.130 / 0.150 / 0.200     0.330 / 0.470 / 0.500 / 0.900     0.0
+    4             11800     0.090 / 0.160 / 0.170 / 0.260     0.340 / 0.500 / 0.520 / 1.100     0.0
+   16             30400     0.180 / 0.700 / 0.900 / 1.900     0.600 / 1.800 / 2.100 / 4.200     0.0
+   32             41200     0.350 / 1.400 / 1.700 / 3.400     0.780 / 3.400 / 3.900 / 7.900     0.0  <- knee
+  [uncached — plan-cache miss each run, execution + compilation]
+    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
+    1              2100     0.106 / 0.160 / 0.180 / 0.240     0.360 / 0.500 / 0.540 / 0.960   100.0
+   ...
+  compilation_ms (median uncached-cached server time) by level:
+    C=1    0.025
+    C=32   0.040
+```
+
+## Report schema
+
+The JSON report groups each operation's measurements by concurrency level:
+
+```text
+operations["match_by_index"] = {
+  "levels": [
+    {
+      "concurrency": 1,
+      "cached":   { "throughput_ops_per_sec": 2950.0, "metrics": { server_ms, total_ms, non_internal_ms, cached_false_rate, cached_unknown } },
+      "uncached": { "throughput_ops_per_sec": 2100.0, "metrics": { … } },
+      "compilation_ms_median": 0.025
+    },
+    { "concurrency": 4,  … },
+    …
+  ]
+}
+```
+
+Each `metrics.*_ms` summary carries `min/mean/median/p90/p95/p99/max/stddev` (plus `n` retained and
+`removed` severe outliers). The top-level report also records `schema_version` (`2` since Part 4)
+and `meta.concurrency` (the sweep that was run).
+
+> [!NOTE]
+> The Part 4 report shape is a **breaking change** from earlier versions: an operation's stats moved
+> from top-level `cached`/`uncached` fields to `levels[]`. A pre-Part-4 (v1) report that contains
+> operation data will not deserialize into the new shape, so tooling should read `schema_version`
+> from the raw JSON first and migrate on it.
+
+## What the tests guarantee
+
+- **Exactly `C` in flight** — an instrumented fake worker asserts the observed maximum concurrency
+  equals `C` (a barrier makes it deterministic, not scheduler-dependent).
+- **Throughput math** — with a fake fixed-latency op under a paused clock, `throughput ≈ C / latency`.
+- **Warm-up excluded & pooled** — measured samples pool across workers with warm-up invocations
+  omitted.
+- **Fail-fast** — a worker error *or* panic aborts the level and surfaces the error rather than
+  reporting a partial, misleading throughput (no deadlock on the warm-up barrier).
+- **Integration (docker)** — a real sweep over `[1, 4, 8]` asserts every level reports positive
+  throughput with an ordered p50 ≤ p90 ≤ p95 ≤ p99, and that throughput rises above the `C=1`
+  baseline.

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -9,6 +9,7 @@
 use benchmark::queries_repository::QueryType;
 use benchmark::synthetic::dataset::DatasetSpec;
 use benchmark::synthetic::op_runner::run_and_drain;
+use benchmark::synthetic::report::{LevelReport, OperationReport};
 use benchmark::synthetic::{
     list_ops, open_graph, run, run_and_report, CacheSelection, Config, OpName,
 };
@@ -27,6 +28,7 @@ fn base_config(graph: &str) -> Config {
         ops: vec![OpName::ReturnConst],
         samples: 300,
         warmup: 50,
+        concurrency: vec![1],
         seed: 1,
         server_timeout_ms: 5_000,
         client_deadline_ms: 6_000,
@@ -35,6 +37,18 @@ fn base_config(graph: &str) -> Config {
         server_image: None,
         dataset: None,
     }
+}
+
+/// Assert an operation was measured at exactly one concurrency level (the single-level default the
+/// non-sweep integration tests use) and return that [`LevelReport`].
+fn only_level(op: &OperationReport) -> &LevelReport {
+    assert_eq!(
+        op.levels.len(),
+        1,
+        "expected exactly one concurrency level, got {}",
+        op.levels.len()
+    );
+    &op.levels[0]
 }
 
 /// Drop `graph` if it exists (ignore "missing key" errors).
@@ -47,9 +61,14 @@ async fn drop_graph(graph: &str) {
 /// Seed a tiny `:User {id, age}` graph wired with `:Friend` edges (a `+1` ring plus longer skip
 /// edges) so the read primitives (index lookup, expansion, aggregation, shortest path) have data to
 /// touch.
-async fn seed_user_graph(graph: &str, users: i64) {
+async fn seed_user_graph(
+    graph: &str,
+    users: i64,
+) {
     drop_graph(graph).await;
-    let mut g = open_graph(&endpoint(), graph).await.expect("open seed graph");
+    let mut g = open_graph(&endpoint(), graph)
+        .await
+        .expect("open seed graph");
     // Any query instantiates the (freshly dropped) graph key; index first so lookups use it.
     g.query("CREATE INDEX FOR (u:User) ON (u.id)")
         .execute()
@@ -93,12 +112,22 @@ async fn probe_produces_valid_report() {
         .operations
         .get("return_const")
         .expect("report should contain the measured op");
-    let cached = op.cached.as_ref().expect("cached metrics present");
-    let uncached = op.uncached.as_ref().expect("uncached metrics present");
+    let lvl = only_level(op);
+    let cached_lm = lvl.cached.as_ref().expect("cached metrics present");
+    let uncached_lm = lvl.uncached.as_ref().expect("uncached metrics present");
+    let cached = &cached_lm.metrics;
+    let uncached = &uncached_lm.metrics;
 
     // Every sample is accounted for (retained + severe-outliers removed) in each mode.
     assert_eq!(cached.server_ms.n + cached.server_ms.removed, samples);
     assert_eq!(uncached.server_ms.n + uncached.server_ms.removed, samples);
+
+    // The single-connection level still records an achieved throughput.
+    assert!(
+        cached_lm.throughput_ops_per_sec > 0.0,
+        "throughput should be positive, got {}",
+        cached_lm.throughput_ops_per_sec
+    );
 
     // Positive server + total time, and total >= server within each mode.
     assert!(cached.server_ms.median > 0.0);
@@ -111,7 +140,7 @@ async fn probe_produces_valid_report() {
         "uncached mode should mostly miss the plan cache (got {})",
         uncached.cached_false_rate
     );
-    assert!(op.compilation_ms_median.is_some());
+    assert!(lvl.compilation_ms_median.is_some());
 
     // Provenance + run metadata were captured.
     assert!(report.meta.server.redis_version.is_some());
@@ -148,10 +177,12 @@ async fn read_catalog_runs_against_seeded_graph() {
             .operations
             .get(op.as_str())
             .unwrap_or_else(|| panic!("report missing op {}", op.as_str()));
-        let cached = r
+        let lvl = only_level(r);
+        let cached = &lvl
             .cached
             .as_ref()
-            .unwrap_or_else(|| panic!("op {} missing cached metrics", op.as_str()));
+            .unwrap_or_else(|| panic!("op {} missing cached metrics", op.as_str()))
+            .metrics;
         assert!(cached.server_ms.n > 0, "op {} has no samples", op.as_str());
         assert!(
             cached.server_ms.median >= 0.0 && cached.server_ms.median.is_finite(),
@@ -165,7 +196,7 @@ async fn read_catalog_runs_against_seeded_graph() {
             op.as_str()
         );
         assert!(
-            r.compilation_ms_median.is_some(),
+            lvl.compilation_ms_median.is_some(),
             "op {} lacks compilation",
             op.as_str()
         );
@@ -223,6 +254,8 @@ async fn run_and_report_writes_json_file() {
 
     let written = std::fs::read_to_string(&out).expect("report file should exist");
     assert!(written.contains("return_const"));
+    assert!(written.contains("\"levels\""));
+    assert!(written.contains("\"throughput_ops_per_sec\""));
     assert!(written.contains("\"cached\""));
     assert!(written.contains("\"uncached\""));
     assert!(written.contains("\"corpus_size\""));
@@ -246,9 +279,10 @@ async fn cached_only_and_uncached_only_modes() {
     .await
     .expect("cached-only run should succeed");
     let cop = cached_report.operations.get("return_const").unwrap();
-    assert!(cop.cached.is_some());
-    assert!(cop.uncached.is_none());
-    assert!(cop.compilation_ms_median.is_none());
+    let clvl = only_level(cop);
+    assert!(clvl.cached.is_some());
+    assert!(clvl.uncached.is_none());
+    assert!(clvl.compilation_ms_median.is_none());
 
     // Uncached-only: no cached block, and it misses the plan cache.
     let uncached_report = run(&Config {
@@ -261,8 +295,9 @@ async fn cached_only_and_uncached_only_modes() {
     .await
     .expect("uncached-only run should succeed");
     let uop = uncached_report.operations.get("return_const").unwrap();
-    assert!(uop.cached.is_none());
-    let uncached = uop.uncached.as_ref().unwrap();
+    let ulvl = only_level(uop);
+    assert!(ulvl.cached.is_none());
+    let uncached = &ulvl.uncached.as_ref().unwrap().metrics;
     assert!(uncached.cached_false_rate > 0.5);
     drop_graph(graph).await;
 }
@@ -306,7 +341,7 @@ async fn warmup_zero_still_primes_cached_plan() {
     .await
     .expect("warmup=0 cached run should succeed");
     let op = report.operations.get("return_const").unwrap();
-    let cached = op.cached.as_ref().unwrap();
+    let cached = &only_level(op).cached.as_ref().unwrap().metrics;
     assert_eq!(cached.server_ms.n + cached.server_ms.removed, 40);
     // The pre-measurement prime means every measured sample is a cache hit.
     assert_eq!(
@@ -474,7 +509,7 @@ async fn generated_dataset_has_exact_counts_index_and_hash() {
 
     // shortest_path produced measured samples (the connected-pair pool guarantees a bounded path).
     let op = report.operations.get("shortest_path").unwrap();
-    assert!(op.cached.as_ref().unwrap().server_ms.n > 0);
+    assert!(only_level(op).cached.as_ref().unwrap().metrics.server_ms.n > 0);
     drop_graph(graph).await;
 }
 
@@ -506,13 +541,79 @@ async fn generation_is_reproducible_across_runs() {
     drop_graph(graph).await;
 }
 
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn concurrency_sweep_produces_per_level_throughput_and_percentiles() {
+    // Sweep one op over [1, 4, 8]; every level must report achieved throughput and a full set of
+    // percentiles, and throughput must rise with concurrency somewhere (monotonic-ish up) — the
+    // whole point of the latency-vs-throughput curve.
+    let graph = "syn_it_sweep";
+    seed_user_graph(graph, 200).await;
+
+    let report = run(&Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::MatchByIndex],
+        samples: 120,
+        warmup: 20,
+        concurrency: vec![1, 4, 8],
+        cache: CacheSelection::Cached,
+        ..base_config(graph)
+    })
+    .await
+    .expect("concurrency sweep should succeed");
+
+    let op = report.operations.get("match_by_index").expect("op present");
+    assert_eq!(
+        op.levels.iter().map(|l| l.concurrency).collect::<Vec<_>>(),
+        vec![1, 4, 8],
+        "levels are the swept concurrencies, sorted ascending"
+    );
+    assert_eq!(report.meta.concurrency, vec![1, 4, 8]);
+
+    let mut throughputs = Vec::new();
+    for lvl in &op.levels {
+        let m = lvl
+            .cached
+            .as_ref()
+            .unwrap_or_else(|| panic!("level C={} missing cached metrics", lvl.concurrency));
+        assert!(
+            m.throughput_ops_per_sec > 0.0,
+            "level C={} has non-positive throughput {}",
+            lvl.concurrency,
+            m.throughput_ops_per_sec
+        );
+        // Every level carries a full percentile set, correctly ordered.
+        let s = &m.metrics.server_ms;
+        assert!(s.n > 0, "level C={} has no samples", lvl.concurrency);
+        assert!(
+            s.median <= s.p90 && s.p90 <= s.p95 && s.p95 <= s.p99 && s.p99.is_finite(),
+            "level C={} percentiles must be ordered p50<=p90<=p95<=p99 (got {:?})",
+            lvl.concurrency,
+            (s.median, s.p90, s.p95, s.p99)
+        );
+        throughputs.push(m.throughput_ops_per_sec);
+    }
+
+    // Closed-loop achieved throughput should climb with concurrency at least somewhere before it
+    // saturates (a loose, non-flaky check for "monotonic-ish up").
+    assert!(
+        throughputs[1..].iter().any(|&t| t > throughputs[0]),
+        "throughput should rise above the C=1 baseline as concurrency grows: {throughputs:?}"
+    );
+    drop_graph(graph).await;
+}
+
 /// Read a single-row `RETURN count(...)`/scalar i64.
 async fn scalar_i64(
     graph: &mut falkordb::AsyncGraph,
     cypher: &str,
 ) -> i64 {
     use futures::StreamExt;
-    let mut result = graph.ro_query(cypher).execute().await.expect("scalar query");
+    let mut result = graph
+        .ro_query(cypher)
+        .execute()
+        .await
+        .expect("scalar query");
     match result.data.next().await {
         Some(Ok(row)) => row.try_get_at::<i64>(0).expect("i64 scalar"),
         other => panic!("unexpected scalar response: {other:?}"),


### PR DESCRIPTION
Closes #204 (Part 4 of the synthetic per-operation benchmark epic #200).

## What & why
Adds the headline feature: a **closed-loop concurrency engine** that measures every operation across a configurable sweep of worker counts `C`, so the report shows **how latency (incl. the p99 tail) changes as achieved throughput rises** — the latency-vs-throughput curve and its saturation "knee".

## How it works
- **`src/synthetic/engine.rs` (new)** — `run_closed_loop<W: OpInvoker>(workers, warmup, samples)` spawns `C` worker tasks (one dedicated connection each). Each runs a discarded warm-up, waits on a `Barrier(C)` so the measurement window opens with all `C` active, then fires→awaits(drain)→fires the next. Records paired `(server_ms, total_ms)`; window = `max(last_completed) − min(first_started)` (`tokio::time::Instant`), throughput = `completed / window`. Fail-fast via a `JoinSet` (`abort_all()` on the first worker error **or** task panic — no barrier deadlock, no leaked tasks).
- **`mod.rs`** — `GraphWorker` (impl `OpInvoker`) owns its own `open_graph` client (independent single-socket pools, **not** clones that share a schema cache) and cycles the shared corpus from a per-worker offset. Uncached query text stays **globally unique** across the whole sweep via a run-global `AtomicU64` uid allocator (each worker claims a disjoint block once at construction — no hot-path atomics). `measure_op` sweeps concurrency × cache modes; `run()` drops the setup connection before measuring and validates the sweep (`normalize_concurrency`: non-empty, ≥1, dedup+sort).
- **`report.rs`** — `OperationReport` is now `{ levels: [LevelReport] }`; each `LevelReport { concurrency, cached, uncached, compilation_ms_median }` carries `LevelMetrics { throughput_ops_per_sec, metrics }`. New latency-vs-throughput **console table** (knee flagged), plus `schema_version` (2, serde-defaults to 1 for old reports). **`stats.rs`** — add `p95` to `Summary` (issue asks p50/p90/p95/p99).
- **`config.rs` / `cli.rs`** — `--concurrency 1,4,16,32` (default `1,2,4,8,16,32`), with file + CLI merge. **`Justfile`** — `synthetic-bench-one <op>`.

Every operation is still measured under **both** cache modes per level with the derived `compilation_ms` (the epic's standing mandate).

### Sample output
```text
match_by_index
  [cached — plan reused, execution only]
    C    throughput(ops/s)   server p50/p90/p99        total p50/p90/p99         miss%
    1              2929     0.058 / 0.072 / 0.082     0.325 / 0.373 / 0.422     0.0
    4              9227     0.062 / 0.097 / 0.127     0.424 / 0.494 / 0.573     0.0
    8             13325     0.069 / 0.143 / 0.217     0.585 / 0.739 / 0.882     0.0
   16             17413     0.067 / 0.145 / 0.227     0.893 / 1.164 / 1.447     0.0  <- knee
```

## Scope
**In:** closed-loop achieved throughput, per-level percentiles, the sweep, console table + JSON `levels[]`, cache-mode comparison per level. **Out (future):** open-loop/arrival-rate + coordinated-omission correction; writes (Part 5).

## Tests
- Unit (engine): **exactly-C-in-flight** (deterministic via a barrier in the fake invoker; asserts observed max == C), **throughput ≈ C/latency** (paused Tokio clock), warm-up exclusion + pooling, fail-fast on worker error **and** panic, degenerate-window + guard cases.
- Integration (docker): sweep one op over `[1,4,8]` — asserts per-level throughput > 0, ordered p50≤p90≤p95≤p99, and throughput rises above the C=1 baseline.
- Docs: concurrency model + **closed-loop / coordinated-omission caveat** + how to read the curve.

## Local validation (all green)
`just build`, `just clippy` (-D warnings), `just test`, `just fmt-check`, `just doc`, `just doc-check`, `just synthetic-it` (13/13 vs live FalkorDB), `just coverage` — new files 96–100% line coverage (engine 96.3%, report 99.1%, config 96.6%, stats 100%).

> [!NOTE]
> Breaking report-schema change (`operations[].cached/uncached` → `operations[].levels[]`), expected per the issue; `schema_version` distinguishes old reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added closed-loop concurrency sweep benchmarking with per-level throughput/latency metrics and knee detection.
  * Updated synthetic-bench CLI/config to accept concurrency lists and produce per-level cached/uncached results.
* **Documentation**
  * Expanded synthetic benchmark docs and README examples/output for concurrency sweep and the updated report schema.
* **Bug Fixes**
  * Improved uncached query uniqueness during concurrent execution; added deterministic timing support for tests.
* **Tests**
  * Strengthened synthetic probe assertions and added an (ignored) integration check for per-level sweep correctness.
* **Chores**
  * Added a new synthetic benchmark recipe in the Justfile and updated Copilot instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->