### PR TITLE
docs(synthetic): align "exactly C" wording with the "at most C" invariant

### DIFF
--- a/src/synthetic/engine.rs
+++ b/src/synthetic/engine.rs
@@ -2,8 +2,8 @@
 //!
 //! A *level* runs `C` worker tasks against a connection pool of size `C` (one connection per
 //! worker). Each worker fires an operation, awaits it to completion (row draining included), then
-//! fires the next from its pre-generated sequence — a **closed loop**: there is always exactly one
-//! outstanding request per worker, so at most `C` are in flight. Because a new request is issued
+//! fires the next from its pre-generated sequence — a **closed loop**: each worker keeps at most one
+//! outstanding request, so at most `C` are in flight. Because a new request is issued
 //! only after the previous one *completes*, the throughput it reports is **achieved** (what the
 //! server actually served), not **offered** (a target arrival rate), and it can't push past the
 //! server's own service rate. The measured latencies therefore describe behaviour *at that achieved
@@ -246,7 +246,7 @@ mod tests {
         assert_eq!(
             max_in_flight.load(Ordering::Relaxed),
             C,
-            "closed loop must hold exactly C requests in flight"
+            "closed loop must reach C concurrent requests in flight (observed peak)"
         );
         assert_eq!(
             in_flight.load(Ordering::Relaxed),

--- a/synthetic-benchmark.md
+++ b/synthetic-benchmark.md
@@ -154,8 +154,10 @@ sweep that was run).
 
 ## What the tests guarantee
 
-- **Exactly `C` in flight** — an instrumented fake worker asserts the observed maximum concurrency
-  equals `C` (a barrier makes it deterministic, not scheduler-dependent).
+- **Peak concurrency reaches `C`** — an instrumented fake worker asserts the observed *maximum*
+  in-flight count equals `C` (a barrier makes it deterministic, not scheduler-dependent), confirming
+  the closed loop actually saturates all `C` workers even though the steady-state invariant is *at
+  most* `C`.
 - **Throughput math** — with a fake fixed-latency op under a paused clock, `throughput ≈ C / latency`.
 - **Warm-up excluded & pooled** — measured samples pool across workers with warm-up invocations
   omitted.


### PR DESCRIPTION
Follow-up to #211 (spotted in review of the merged docs).

A few spots still described the closed loop as holding **"exactly `C`" in flight**. The steady-state invariant is **at most `C`** — a worker briefly has zero requests outstanding between completing one and firing the next — while the exactly-`C` unit test asserts the observed **maximum** equals `C` (i.e. the loop *reaches* `C`, confirming full saturation).

Reworded for consistency:
- `synthetic-benchmark.md` → the "What the tests guarantee" bullet ("**Peak concurrency reaches `C`**").
- `engine.rs` module doc ("each worker keeps at most one outstanding request, so at most `C` are in flight").
- The `engine_holds_exactly_c_in_flight` assertion message.

Docs/comment/assertion-message only — no behaviour change. Validated: `just test` (engine tests), `just fmt-check`, `just doc-check`.