### PR TITLE
feat(synthetic): wire write ops into the engine — create_node + merge_miss (part 5b of #200)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,11 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
+  # A transient CodeRabbit review error (most often "Review rate limited") must not turn the
+  # "CodeRabbit" commit-status check red and fail the whole PR — CodeRabbit still reviews and
+  # comments, we just don't gate the PR on a rate-limit hiccup. (Overrides the org default, which
+  # currently fails the status on such errors.)
+  fail_commit_status: false
   auto_review:
     enabled: true
     drafts: false

--- a/readme.md
+++ b/readme.md
@@ -158,15 +158,16 @@ workflow. Please cover new code with tests and keep coverage high — **patch co
 
 ### Synthetic per-operation benchmark (experimental)
 
-Measures a curated suite of **read operations in isolation** — one at a time, selectable — capturing
-on every invocation both the **server time** (FalkorDB's reported internal execution time) and the
-**total time** (end-to-end client round-trip), then summarizing them with severe-outlier removal
-(Tukey fences, like Criterion.rs) and writing a JSON report with one block per operation. For each
-operation it sweeps a list of **concurrency levels**, so the report traces how latency (including the
-p99 tail) changes as achieved throughput rises — the latency-vs-throughput curve and its saturation
-"knee". This is Part 4 of a larger tool (see the design epic
+Measures a curated suite of **read and write operations in isolation** — one at a time, selectable —
+capturing on every invocation both the **server time** (FalkorDB's reported internal execution time)
+and the **total time** (end-to-end client round-trip), then summarizing them with severe-outlier
+removal (Tukey fences, like Criterion.rs) and writing a JSON report with one block per operation. For
+each operation it sweeps a list of **concurrency levels**, so the report traces how latency
+(including the p99 tail) changes as achieved throughput rises — the latency-vs-throughput curve and
+its saturation "knee". This is Part 5 of a larger tool (see the design epic
 [#200](https://github.com/FalkorDB/benchmark/issues/200)); it can **generate its own reproducible
-dataset** and sweep concurrency, with write operations still to come.
+dataset**, sweep concurrency, and measure **write operations** with steady-state isolation (see
+[Write operations](#write-operations-steady-state-isolation) below).
 
 Each operation is measured under two plan-cache conditions so you can see the cost of expression
 **compilation** separately from execution:
@@ -206,15 +207,19 @@ See [`synthetic-benchmark.md`](synthetic-benchmark.md) for the concurrency model
 
 #### Operation catalog
 
-Select operations with `--op <name>` (repeatable and comma-separated) or `--all-reads`. All read
-ops except `return_const` target the benchmark's `:User {id, age}` / `(:User)-[:Friend]->(:User)`
-schema (with an index on `:User(id)`). Most draw their parameters from `:User` ids sampled out of
+Select operations with `--op <name>` (repeatable and comma-separated) or `--all-reads`. `--all-reads`
+selects every **read** op; **write** ops (`create_node`, `merge_miss`) are opt-in via `--op` so a
+sweep never mutates a graph unless you ask. All read ops except `return_const` target the benchmark's
+`:User {id, age}` / `(:User)-[:Friend]->(:User)` schema (with an index on `:User(id)`). Most draw
+their parameters from `:User` ids sampled out of
 `--graph` (`shortest_path` needs two, `match_by_index`/`expand_*`/`aggregate_*`/`property_projection`
 one); `return_const` and `match_by_label_scan` need no seed ids (they vary a constant / a scan
-modulus). Either point `--graph` at a graph that already holds that schema, or let the tool
-**generate a reproducible one** (see [Generating a dataset](#generating-a-reproducible-dataset)
-below). Every query projects **scalars** (never whole nodes) and is parameterized; the corpus is
-seeded (`--seed`) so the same seed yields an identical corpus.
+modulus). Write ops need no seed ids either — they target their own scratch namespace (see
+[Write operations](#write-operations-steady-state-isolation)). Either point `--graph` at a graph that
+already holds that schema, or let the tool **generate a reproducible one** (see
+[Generating a dataset](#generating-a-reproducible-dataset) below). Every query projects **scalars**
+(never whole nodes) and is parameterized; the corpus is seeded (`--seed`) so the same seed yields an
+identical corpus.
 
 | Operation | What it measures | Cypher (body) |
 |---|---|---|
@@ -227,6 +232,8 @@ seeded (`--seed`) so the same seed yields an identical corpus.
 | `aggregate_group` | group neighbours by age with counts | `MATCH (s:User {id: $id})-[:Friend]->(n:User) RETURN n.age AS age, count(*) AS c ORDER BY c DESC LIMIT 10` |
 | `shortest_path` | bounded shortest `:Friend` path between two nodes | `MATCH (s:User {id: $from}), (t:User {id: $to}) WITH shortestPath((s)-[:Friend*1..6]->(t)) AS p RETURN coalesce(length(p), -1) AS len` |
 | `property_projection` | project scalar properties of an indexed node | `MATCH (n:User {id: $id}) RETURN n.id, n.age` |
+| `create_node` *(write)* | create a fresh scratch node each invocation | `CREATE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
+| `merge_miss` *(write)* | `MERGE` a fresh scratch node (always misses → creates) | `MERGE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
 
 Because `OpName` is a clap `ValueEnum`, `--op <TAB>` completes the operation names once you've
 installed completion (`benchmark generate-auto-complete <shell>`), and `just synthetic-ops` (or
@@ -288,6 +295,44 @@ The report's `meta.server` block records the FalkorDB module version, `redis_ver
 git SHA to clients, so the image digest is the reproducible build identity). A `:edge` image reports
 a `999999` placeholder version and the tool warns you to use a tagged image for comparisons.
 
+#### Write operations (steady-state isolation)
+
+Write ops (`create_node`, `merge_miss`, with more to come) measure mutation latency/throughput
+without the graph drifting between samples, so write numbers stay comparable across a long sweep.
+Only the operation itself is inside the timer; setup/reset/cleanup run in **untimed** hooks that
+abort the sample on failure. The isolation model:
+
+- **Scratch namespace.** A run writes only to a **run-unique label** `BenchScratch_<run_token>` (a
+  random per-run hex nonce), so a sweep never touches your real data or another run's scratch. The
+  label is shared by all workers of a run (keeping the plan cache warm), and the run's scratch is
+  dropped on a fresh connection after each level — even if the level errored — so nothing leaks into
+  the next op/level.
+- **Disjoint per-worker keys.** At concurrency `C`, worker `w` owns the key band
+  `[w·reset_every, (w+1)·reset_every − 1]` and uses `window_key = w·reset_every + (seq mod
+  reset_every)` for invocation `seq`. Bands never overlap, so concurrent writers never collide, and
+  within a window every key is unique — so `merge_miss` always misses (creates) and identities never
+  repeat. Keys are **run-independent** (only the label carries the nonce), so the workload stays
+  comparable across runs; `(w+1)·reset_every` must fit `i32` (FalkorDB params), which bounds
+  `reset_every × C`.
+- **Run-level reset (sawtooth).** Every `reset_every` operations — counted over the **global**
+  warm-up + measured sequence — each worker runs an untimed reset that deletes its key band before
+  it is reused, bounding write drift to one sawtooth window. Tune the cadence with `--reset-every N`
+  (config `reset_every`, default 50000); a smaller `N` keeps the graph tighter but spends more time
+  resetting. `merge_miss` staying a miss across resets is the isolation guarantee: a shared key or a
+  missed reset would turn a `MERGE` into a hit, and the run would error.
+- **Per-sample verification.** Each write checks FalkorDB's mutation counters against the operation's
+  intent (`create_node`/`merge_miss` ⇒ exactly one node created), so a silent no-op fails loudly
+  rather than producing a fast, misleading sample.
+
+**Limitation:** this is closed-loop steady state, not a fixed arrival rate — the reset produces a
+sawtooth in graph size within each window; it bounds drift, it does not eliminate it.
+
+```bash
+# measure the write ops over a concurrency sweep, resetting each worker's scratch every 50k ops
+just synthetic-bench --graph bench --op create_node,merge_miss \
+    --concurrency 1,8,32 --reset-every 50000 --samples 500
+```
+
 #### Generating a reproducible dataset
 
 Instead of measuring whatever graph the endpoint already holds, the tool can **generate its own**
@@ -327,6 +372,7 @@ operations = ["match_by_index", "expand_hops_5", "aggregate_count"]
 samples = 500
 concurrency = [1, 4, 16, 32]   # closed-loop worker counts to sweep (default 1,2,4,8,16,32)
 cache = "both"           # cached | uncached | both
+reset_every = 50000      # write-op scratch reset cadence (ops per sawtooth window); read ops ignore it
 # endpoint / graph / warmup / server_timeout_ms / client_deadline_ms / out are all optional
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -253,7 +253,7 @@ pub enum Commands {
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
 pub enum SyntheticCommands {
-    #[command(about = "run the per-operation latency probe over one or more read operations")]
+    #[command(about = "run the per-operation latency/throughput probe over one or more read or write operations")]
     Run {
         #[arg(
             long = "config",
@@ -289,6 +289,11 @@ pub enum SyntheticCommands {
             help = "concurrency levels to sweep (closed-loop workers C), repeatable/comma-separated (e.g. --concurrency 1,4,16,32). Default 1,2,4,8,16,32."
         )]
         concurrency: Vec<usize>,
+        #[arg(
+            long = "reset-every",
+            help = "write-op reset cadence: every N ops each worker's scratch is reset (untimed) to bound write drift to one sawtooth window. Ignored by read ops. Default 50000."
+        )]
+        reset_every: Option<usize>,
         #[arg(
             long,
             help = "seed for the dataset and the per-operation corpora (same seed ⇒ identical workload; default 0)"

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -12,6 +12,7 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::query::{Query, QueryBuilder};
+use crate::synthetic::writes::{ExpectedMutation, WritePlan, WriteScratch};
 use crate::synthetic::OpName;
 use rand::{Rng, RngExt};
 
@@ -97,6 +98,9 @@ pub struct OperationSpec {
     pub description: &'static str,
     pub requirement: DatasetRequirement,
     pub corpus: CorpusFn,
+    /// Present for write operations (Part 5): the lifecycle hooks, mutation to verify, and timed
+    /// query builder. `None` for reads, which use `corpus` instead.
+    pub write: Option<WritePlan>,
 }
 
 impl OperationSpec {
@@ -137,6 +141,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "RETURN $i — pure round-trip baseline (no dataset required)",
             requirement: DatasetRequirement::None,
             corpus: corpus_return_const,
+            write: None,
         },
         OpName::MatchByIndex => OperationSpec {
             name: op,
@@ -144,6 +149,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "point lookup on the :User(id) index",
             requirement: DatasetRequirement::OneId,
             corpus: corpus_match_by_index,
+            write: None,
         },
         OpName::MatchByLabelScan => OperationSpec {
             name: op,
@@ -151,6 +157,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "full :User label scan with a non-indexable predicate",
             requirement: DatasetRequirement::None,
             corpus: corpus_match_by_label_scan,
+            write: None,
         },
         OpName::Expand1Hop => OperationSpec {
             name: op,
@@ -158,6 +165,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "1-hop :Friend expansion from a seed node",
             requirement: DatasetRequirement::OneId,
             corpus: corpus_expand_1_hop,
+            write: None,
         },
         OpName::ExpandHops5 => OperationSpec {
             name: op,
@@ -165,6 +173,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "fixed 5-hop :Friend expansion from a seed node",
             requirement: DatasetRequirement::OneId,
             corpus: corpus_expand_hops_5,
+            write: None,
         },
         OpName::AggregateCount => OperationSpec {
             name: op,
@@ -172,6 +181,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "count a seed node's 1-hop :Friend neighbours",
             requirement: DatasetRequirement::OneId,
             corpus: corpus_aggregate_count,
+            write: None,
         },
         OpName::AggregateGroup => OperationSpec {
             name: op,
@@ -179,6 +189,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "group a seed node's neighbours by age with counts",
             requirement: DatasetRequirement::OneId,
             corpus: corpus_aggregate_group,
+            write: None,
         },
         OpName::ShortestPath => OperationSpec {
             name: op,
@@ -186,6 +197,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "bounded shortest :Friend path between two seed nodes",
             requirement: DatasetRequirement::TwoIds,
             corpus: corpus_shortest_path,
+            write: None,
         },
         OpName::PropertyProjection => OperationSpec {
             name: op,
@@ -193,8 +205,105 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "project scalar properties of an indexed node",
             requirement: DatasetRequirement::OneId,
             corpus: corpus_property_projection,
+            write: None,
+        },
+        OpName::CreateNode => OperationSpec {
+            name: op,
+            kind: QueryType::Write,
+            description: "create a fresh scratch node each invocation",
+            requirement: DatasetRequirement::None,
+            corpus: write_corpus_stub,
+            write: Some(WritePlan {
+                expected: ExpectedMutation::NodeCreated,
+                plan_tag: "create_node.v1",
+                default_reset_every: DEFAULT_RESET_EVERY,
+                setup: write_clear_band,
+                reset: write_clear_band,
+                cleanup: write_cleanup_run,
+                render: write_create_node_render,
+            }),
+        },
+        OpName::MergeMiss => OperationSpec {
+            name: op,
+            kind: QueryType::Write,
+            description: "MERGE a fresh scratch node each invocation (always misses → creates)",
+            requirement: DatasetRequirement::None,
+            corpus: write_corpus_stub,
+            write: Some(WritePlan {
+                expected: ExpectedMutation::NodeCreated,
+                plan_tag: "merge_miss.v1",
+                default_reset_every: DEFAULT_RESET_EVERY,
+                setup: write_clear_band,
+                reset: write_clear_band,
+                cleanup: write_cleanup_run,
+                render: write_merge_miss_render,
+            }),
         },
     }
+}
+
+/// Default reset cadence (measured ops per sawtooth window) for write operations.
+pub const DEFAULT_RESET_EVERY: usize = 50_000;
+
+/// Delete only this worker's scratch rows (its key band) — used as both **setup** (a clean start,
+/// self-healing over any stale rows in this run's namespace) and **reset** (undo a window's
+/// accumulation). Scoped by the run-unique label *and* the worker's id band, so it can never touch
+/// another worker's or another run's data.
+fn write_clear_band(scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
+    let (lo, hi) = scratch.key_band();
+    let text = format!(
+        "MATCH (n:{}) WHERE n.id >= $lo AND n.id <= $hi DELETE n",
+        scratch.label()
+    );
+    Ok(vec![QueryBuilder::new()
+        .text(text)
+        .param("lo", lo)
+        .param("hi", hi)
+        .build()])
+}
+
+/// Drop the whole run's scratch (every worker's rows for the run-unique label) — the coordinator
+/// runs this once after a level, on a fresh connection.
+fn write_cleanup_run(scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
+    let text = format!("MATCH (n:{}) DELETE n", scratch.label());
+    Ok(vec![QueryBuilder::new().text(text).build()])
+}
+
+/// `create_node`: create a fresh scratch node with this invocation's within-window-unique id.
+fn write_create_node_render(
+    scratch: &WriteScratch,
+    seq: u64,
+) -> BenchmarkResult<Query> {
+    let text = format!("CREATE (n:{} {{id: $id}}) RETURN n.id", scratch.label());
+    Ok(QueryBuilder::new()
+        .text(text)
+        .param("id", scratch.window_key(seq))
+        .build())
+}
+
+/// `merge_miss`: `MERGE` a scratch node whose id is unique within the window, so it always misses
+/// and creates (never hits).
+fn write_merge_miss_render(
+    scratch: &WriteScratch,
+    seq: u64,
+) -> BenchmarkResult<Query> {
+    let text = format!("MERGE (n:{} {{id: $id}}) RETURN n.id", scratch.label());
+    Ok(QueryBuilder::new()
+        .text(text)
+        .param("id", scratch.window_key(seq))
+        .build())
+}
+
+/// Placeholder corpus for write ops: the runner builds their queries per-invocation via the
+/// [`WritePlan`] render, so this is never measured — it exists only to satisfy [`OperationSpec`]'s
+/// `corpus` field and the non-empty-corpus invariant.
+fn write_corpus_stub(
+    _rng: &mut dyn Rng,
+    _dataset: &DatasetHandle,
+    _worker: usize,
+    _workers: usize,
+) -> BenchmarkResult<Vec<Query>> {
+    Ok(vec![QueryBuilder::new().text("RETURN 1").build()])
 }
 
 /// Pick a uniformly-random id from the sample.
@@ -401,7 +510,13 @@ mod tests {
         assert_eq!(all.len(), OpName::all().len());
         for (entry, op) in all.iter().zip(OpName::all()) {
             assert_eq!(entry.name, *op);
-            assert_eq!(entry.kind, QueryType::Read, "all catalog ops are reads");
+            // A write op carries a WritePlan and QueryType::Write; a read carries neither.
+            assert_eq!(
+                entry.kind == QueryType::Write,
+                entry.write.is_some(),
+                "op {} kind must match presence of a write plan",
+                op.as_str()
+            );
             assert!(!entry.description.is_empty());
         }
     }
@@ -465,5 +580,83 @@ mod tests {
                 "pair ({from},{to}) not from the connected-pair pool"
             );
         }
+    }
+
+    // ---- Part 5 write operations ----------------------------------------------------------------
+
+    #[test]
+    fn write_ops_carry_a_write_plan_and_write_kind() {
+        for op in [OpName::CreateNode, OpName::MergeMiss] {
+            let s = spec(op);
+            assert_eq!(s.kind, QueryType::Write, "{} is a write op", op.as_str());
+            let plan = s.write.expect("write op carries a WritePlan");
+            assert_eq!(plan.expected, ExpectedMutation::NodeCreated);
+            assert_eq!(plan.default_reset_every, DEFAULT_RESET_EVERY);
+        }
+        // A read op carries no write plan and stays QueryType::Read.
+        let read = spec(OpName::MatchByIndex);
+        assert!(read.write.is_none());
+        assert_eq!(read.kind, QueryType::Read);
+    }
+
+    #[test]
+    fn create_node_render_targets_the_run_label_and_window_key() {
+        use crate::query::QueryParam;
+        // worker 2, reset_every 10 ⇒ window_key(3) = 2*10 + 3%10 = 23.
+        let scratch = WriteScratch::new(0xABCD, 2, 10).unwrap();
+        let q = write_create_node_render(&scratch, 3).unwrap();
+        assert_eq!(q.text, "CREATE (n:BenchScratch_abcd {id: $id}) RETURN n.id");
+        assert!(
+            matches!(q.params.get("id"), Some(QueryParam::Integer(23))),
+            "id must be the worker's window key, got {:?}",
+            q.params.get("id")
+        );
+    }
+
+    #[test]
+    fn merge_miss_render_uses_merge_with_the_window_key() {
+        use crate::query::QueryParam;
+        let scratch = WriteScratch::new(0x1, 0, 100).unwrap();
+        let q = write_merge_miss_render(&scratch, 7).unwrap();
+        assert_eq!(q.text, "MERGE (n:BenchScratch_1 {id: $id}) RETURN n.id");
+        assert!(matches!(q.params.get("id"), Some(QueryParam::Integer(7))));
+    }
+
+    #[test]
+    fn clear_band_deletes_only_this_workers_key_band() {
+        use crate::query::QueryParam;
+        // worker 3, reset_every 10 ⇒ band [30, 39].
+        let scratch = WriteScratch::new(0xF, 3, 10).unwrap();
+        let stmts = write_clear_band(&scratch).unwrap();
+        assert_eq!(stmts.len(), 1);
+        let q = &stmts[0];
+        assert_eq!(
+            q.text,
+            "MATCH (n:BenchScratch_f) WHERE n.id >= $lo AND n.id <= $hi DELETE n"
+        );
+        assert!(matches!(q.params.get("lo"), Some(QueryParam::Integer(30))));
+        assert!(matches!(q.params.get("hi"), Some(QueryParam::Integer(39))));
+    }
+
+    #[test]
+    fn cleanup_run_drops_the_whole_run_label_unparameterized() {
+        // Cleanup is scoped by the run-unique label (not a key band), so it wipes every worker's
+        // rows at once and carries no params.
+        let scratch = WriteScratch::new(0x2a, 5, 10).unwrap();
+        let stmts = write_cleanup_run(&scratch).unwrap();
+        assert_eq!(stmts.len(), 1);
+        assert_eq!(stmts[0].text, "MATCH (n:BenchScratch_2a) DELETE n");
+        assert!(stmts[0].params.is_empty());
+    }
+
+    #[test]
+    fn write_corpus_stub_is_a_single_placeholder_query() {
+        // Writes render their measured query per-invocation from the WritePlan, so the corpus is a
+        // never-measured stub that only satisfies the non-empty-corpus invariant.
+        let mut rng = StdRng::seed_from_u64(1);
+        let corpus = spec(OpName::CreateNode)
+            .build_corpus(&mut rng, &DatasetHandle::default(), 0, 4)
+            .expect("stub corpus builds without a dataset");
+        assert_eq!(corpus.len(), 1);
     }
 }

--- a/src/synthetic/config.rs
+++ b/src/synthetic/config.rs
@@ -27,6 +27,8 @@ pub struct FileConfig {
     pub warmup: Option<usize>,
     /// Concurrency sweep (closed-loop worker counts). Defaults to the built-in sweep when omitted.
     pub concurrency: Option<Vec<usize>>,
+    /// Reset cadence for write ops (untimed scratch reset every N ops). Ignored by read ops.
+    pub reset_every: Option<usize>,
     pub seed: Option<u64>,
     pub cache: Option<CacheSelection>,
     pub server_timeout_ms: Option<i64>,
@@ -79,6 +81,8 @@ pub struct CliOverrides {
     pub warmup: Option<usize>,
     /// Explicit `--concurrency` sweep (empty = not passed).
     pub concurrency: Vec<usize>,
+    /// `--reset-every` write reset cadence (`None` = not passed).
+    pub reset_every: Option<usize>,
     pub seed: Option<u64>,
     pub cache: Option<CacheSelection>,
     pub server_timeout_ms: Option<i64>,
@@ -150,6 +154,7 @@ pub fn resolve(
         endpoint: default_endpoint,
         samples: default_samples,
         warmup: default_warmup,
+        reset_every: default_reset_every,
         server_timeout_ms: default_server_timeout_ms,
         client_deadline_ms: default_client_deadline_ms,
         cache: default_cache,
@@ -167,6 +172,10 @@ pub fn resolve(
         samples: cli.samples.or(file.samples).unwrap_or(default_samples),
         warmup: cli.warmup.or(file.warmup).unwrap_or(default_warmup),
         concurrency,
+        reset_every: cli
+            .reset_every
+            .or(file.reset_every)
+            .unwrap_or(default_reset_every),
         seed,
         server_timeout_ms: cli
             .server_timeout_ms
@@ -251,6 +260,48 @@ mod tests {
         };
         let cfg2 = resolve(CliOverrides::default(), Some(file2)).unwrap();
         assert_eq!(cfg2.concurrency, Config::default().concurrency);
+    }
+
+    #[test]
+    fn reset_every_precedence_cli_over_file_over_default() {
+        // CLI wins over the file.
+        let file = FileConfig {
+            operations: Some(vec![OpName::CreateNode]),
+            reset_every: Some(3),
+            ..Default::default()
+        };
+        let cli = CliOverrides {
+            reset_every: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(resolve(cli, Some(file.clone())).unwrap().reset_every, 7);
+
+        // No CLI ⇒ the file's value.
+        assert_eq!(
+            resolve(CliOverrides::default(), Some(file))
+                .unwrap()
+                .reset_every,
+            3
+        );
+
+        // Neither CLI nor file ⇒ the built-in default.
+        let bare = FileConfig {
+            operations: Some(vec![OpName::CreateNode]),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve(CliOverrides::default(), Some(bare))
+                .unwrap()
+                .reset_every,
+            Config::default().reset_every
+        );
+    }
+
+    #[test]
+    fn reset_every_parses_from_toml() {
+        let cfg =
+            FileConfig::from_toml("operations = [\"create_node\"]\nreset_every = 12345\n").unwrap();
+        assert_eq!(cfg.reset_every, Some(12345));
     }
 
     #[test]

--- a/src/synthetic/engine.rs
+++ b/src/synthetic/engine.rs
@@ -222,6 +222,7 @@ mod tests {
                 total_ms: 1.0,
                 rows: 0,
                 cached: Some(false),
+                mutations: crate::synthetic::writes::MutationStats::default(),
             })
         }
     }
@@ -274,6 +275,7 @@ mod tests {
                 total_ms: latency.as_secs_f64() * 1_000.0,
                 rows: 0,
                 cached: Some(false),
+                mutations: crate::synthetic::writes::MutationStats::default(),
             })
         }
     }
@@ -309,6 +311,7 @@ mod tests {
                 total_ms: seq as f64,
                 rows: 0,
                 cached: Some(false),
+                mutations: crate::synthetic::writes::MutationStats::default(),
             })
         }
     }
@@ -350,6 +353,7 @@ mod tests {
                 total_ms: 1.0,
                 rows: 0,
                 cached: Some(false),
+                mutations: crate::synthetic::writes::MutationStats::default(),
             })
         }
     }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -39,6 +39,7 @@ use crate::synthetic::op_runner::{run_and_drain, OpSample};
 use crate::synthetic::report::{
     DatasetInfo, LevelMetrics, LevelReport, Meta, OperationReport, Report,
 };
+use crate::synthetic::writes::{verify_mutation, WritePlan, WriteScratch};
 use clap::ValueEnum;
 use falkordb::{AsyncGraph, ConnectionStrategy, FalkorClientBuilder};
 use futures::StreamExt;
@@ -47,7 +48,6 @@ use rand::SeedableRng;
 use serde::de::{self, Deserializer};
 use serde::Deserialize;
 use std::collections::BTreeMap;
-use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -94,6 +94,10 @@ pub enum OpName {
     ShortestPath,
     /// Project scalar properties of an indexed node.
     PropertyProjection,
+    /// (write) `CREATE` a fresh scratch node each invocation.
+    CreateNode,
+    /// (write) `MERGE` a fresh scratch node each invocation — always misses, so always creates.
+    MergeMiss,
 }
 
 impl OpName {
@@ -102,8 +106,7 @@ impl OpName {
         OpName::value_variants()
     }
 
-    /// Every read operation (all of them, for now — writes arrive in Part 5). Used by
-    /// `--all-reads`.
+    /// Every read operation. Used by `--all-reads` (write ops are opt-in via explicit `--op`).
     pub fn all_reads() -> Vec<OpName> {
         OpName::all()
             .iter()
@@ -124,6 +127,8 @@ impl OpName {
             OpName::AggregateGroup => "aggregate_group",
             OpName::ShortestPath => "shortest_path",
             OpName::PropertyProjection => "property_projection",
+            OpName::CreateNode => "create_node",
+            OpName::MergeMiss => "merge_miss",
         }
     }
 
@@ -151,6 +156,8 @@ impl OpName {
             OpName::AggregateGroup => 0x4147_475f_4752_5000,
             OpName::ShortestPath => 0x5348_5254_5f50_5448,
             OpName::PropertyProjection => 0x5052_4f50_5f50_524a,
+            OpName::CreateNode => 0x4352_4541_5445_4e44,
+            OpName::MergeMiss => 0x4d45_5247_455f_4d53,
         }
     }
 
@@ -248,6 +255,9 @@ pub struct Config {
     /// Concurrency levels to sweep (closed-loop worker counts `C`); each op is measured once per
     /// level, tracing its latency-vs-throughput curve. Non-empty, each ≥ 1, deduped + sorted.
     pub concurrency: Vec<usize>,
+    /// Reset cadence for write operations: every `reset_every` ops, each worker's scratch is reset
+    /// (untimed) to bound drift to one sawtooth window. Ignored by read ops.
+    pub reset_every: usize,
     /// Seed for the per-operation parameter corpora (same seed ⇒ identical corpora).
     pub seed: u64,
     pub server_timeout_ms: i64,
@@ -269,6 +279,7 @@ impl Default for Config {
             samples: 1000,
             warmup: 200,
             concurrency: DEFAULT_CONCURRENCY.to_vec(),
+            reset_every: crate::synthetic::catalog::DEFAULT_RESET_EVERY,
             seed: 0,
             server_timeout_ms: 5_000,
             client_deadline_ms: 6_000,
@@ -344,6 +355,12 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         return Err(OtherError(
             "no operations selected — pass --op <name> (repeatable/comma-separated) or --all-reads"
                 .to_string(),
+        ));
+    }
+    // Write ops need a positive reset cadence; fail fast before opening any connection.
+    if config.reset_every == 0 && ops.iter().any(|op| spec(*op).write.is_some()) {
+        return Err(OtherError(
+            "reset_every must be >= 1 for write operations".to_string(),
         ));
     }
 
@@ -433,7 +450,13 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
         let mut rng = StdRng::seed_from_u64(config.seed ^ op.salt());
         let corpus = Arc::new(op_spec.build_corpus(&mut rng, &dataset, 0, 1)?);
-        op_fingerprints.push((op, dataset::corpus_fingerprint(&corpus)));
+        // Fingerprint reads by their rendered corpus; writes by their stable plan tag + reset
+        // cadence (their queries are rendered per-invocation from scratch, not from the corpus).
+        let fingerprint = match &op_spec.write {
+            Some(plan) => format!("write:{}:reset_every={}", plan.plan_tag, config.reset_every),
+            None => dataset::corpus_fingerprint(&corpus),
+        };
+        op_fingerprints.push((op, fingerprint));
         let op_report = measure_op(
             config,
             &concurrency,
@@ -613,39 +636,97 @@ pub(crate) fn is_empty_graph_key(msg: &str) -> bool {
     m.contains("empty key") || m.contains("invalid graph operation")
 }
 
+/// Where a [`GraphWorker`] gets each invocation's query: a read cycles a shared corpus; a write
+/// renders a fresh query from its own [`WriteScratch`] and runs the untimed reset/verification.
+enum WorkerSource {
+    /// A read op: cycle the shared corpus from a decorrelating offset.
+    Read {
+        corpus: Arc<Vec<Query>>,
+        corpus_offset: usize,
+    },
+    /// A write op (Part 5): the plan's per-invocation render + the worker's isolated scratch.
+    Write {
+        plan: WritePlan,
+        scratch: WriteScratch,
+    },
+}
+
 /// A closed-loop worker for one operation, cache mode and connection: owns a single-socket
-/// `AsyncGraph` and drives one query at a time via [`run_and_drain`]. The worker cycles its corpus
-/// from a decorrelating `corpus_offset` (so concurrent workers don't march in lock-step) and claims
-/// a disjoint `uid_base` so its uncached query text is globally unique across the whole sweep.
+/// `AsyncGraph` and drives one query at a time via [`run_and_drain`]. Reads cycle a shared corpus
+/// from a decorrelating `corpus_offset`; writes render from a per-worker [`WriteScratch`], run an
+/// untimed reset at each window boundary, and verify each sample's mutation. It claims a disjoint
+/// `uid_base` so its uncached query text is globally unique across the whole sweep.
 struct GraphWorker {
     graph: AsyncGraph,
     kind: QueryType,
-    corpus: Arc<Vec<Query>>,
     mode: CacheMode,
     run_token: u64,
-    corpus_offset: usize,
     uid_base: u64,
     server_timeout_ms: i64,
     client_deadline: Duration,
+    /// Generous server-timeout/deadline for the untimed write hooks (a reset can delete a whole
+    /// window of nodes, which mustn't trip the tight measurement deadline).
+    hook_server_timeout_ms: i64,
+    hook_deadline: Duration,
+    source: WorkerSource,
 }
 
 impl OpInvoker for GraphWorker {
-    fn invoke(
+    async fn invoke(
         &mut self,
         seq: u64,
-    ) -> impl Future<Output = BenchmarkResult<OpSample>> + Send {
-        let idx = (self.corpus_offset + seq as usize) % self.corpus.len();
-        let cypher = render_cypher(
-            &self.corpus[idx],
-            self.mode,
-            self.run_token,
-            self.uid_base + seq,
-        );
+    ) -> BenchmarkResult<OpSample> {
+        let uid = self.uid_base + seq;
+        let mode = self.mode;
+        let run_token = self.run_token;
         let kind = self.kind;
         let server_timeout_ms = self.server_timeout_ms;
         let client_deadline = self.client_deadline;
-        let graph = &mut self.graph;
-        async move { run_and_drain(graph, kind, &cypher, server_timeout_ms, client_deadline).await }
+        // `&self.source` and `&mut self.graph` borrow disjoint fields, so both are live together.
+        match &self.source {
+            WorkerSource::Read {
+                corpus,
+                corpus_offset,
+            } => {
+                let idx = (corpus_offset + seq as usize) % corpus.len();
+                let cypher = render_cypher(&corpus[idx], mode, run_token, uid);
+                run_and_drain(&mut self.graph, kind, &cypher, server_timeout_ms, client_deadline)
+                    .await
+            }
+            WorkerSource::Write { plan, scratch } => {
+                let plan = *plan;
+                let scratch = scratch.clone();
+                // Undo the previous window's drift *before* reusing its key band — untimed, so it
+                // never lands in a sample. `seq` is the global (warm-up + measured) counter, so the
+                // cadence bounds warm-up accumulation too.
+                if scratch.schedule().should_reset(seq) {
+                    for q in (plan.reset)(&scratch)? {
+                        let c = q.to_cypher();
+                        run_and_drain(
+                            &mut self.graph,
+                            kind,
+                            &c,
+                            self.hook_server_timeout_ms,
+                            self.hook_deadline,
+                        )
+                        .await?;
+                    }
+                }
+                let base = (plan.render)(&scratch, seq)?;
+                let cypher = render_cypher(&base, mode, run_token, uid);
+                let sample = run_and_drain(
+                    &mut self.graph,
+                    kind,
+                    &cypher,
+                    server_timeout_ms,
+                    client_deadline,
+                )
+                .await?;
+                // The op must actually effect its intended mutation — a silent no-op is an error.
+                verify_mutation(plan.expected, &sample.mutations)?;
+                Ok(sample)
+            }
+        }
     }
 }
 
@@ -701,9 +782,27 @@ async fn measure_op(
     Ok(OperationReport { levels })
 }
 
+/// Run a list of untimed write statements (setup/reset/cleanup) to completion on `graph`.
+async fn run_write_stmts(
+    graph: &mut AsyncGraph,
+    stmts: Vec<Query>,
+    server_timeout_ms: i64,
+    deadline: Duration,
+) -> BenchmarkResult<()> {
+    for q in stmts {
+        let cypher = q.to_cypher();
+        run_and_drain(graph, QueryType::Write, &cypher, server_timeout_ms, deadline).await?;
+    }
+    Ok(())
+}
+
 /// Measure one operation at one concurrency level `C` in one cache mode via the closed-loop engine:
 /// open `C` single-socket connections (one per worker), drive them to completion, and summarize the
 /// pooled samples plus the achieved throughput.
+///
+/// For write ops each worker gets an isolated [`WriteScratch`], its untimed setup runs before the
+/// window, and the run's scratch is dropped afterward on a fresh connection (even if the level
+/// errored), so a failed write level never leaks scratch into the next one.
 #[allow(clippy::too_many_arguments)]
 async fn measure_level(
     config: &Config,
@@ -727,23 +826,72 @@ async fn measure_level(
     // Each worker claims a disjoint id block wide enough for its warm-up + measured invocations, so
     // no two workers (here or at any other level) ever render the same uncached query text.
     let block = (effective_warmup + config.samples) as u64;
+
+    // The untimed write hooks (setup/reset/cleanup) can touch a whole window of nodes, so give them
+    // a generous deadline independent of the tight per-op measurement deadline.
+    let hook_deadline = client_deadline.max(Duration::from_millis(60_000));
+    let hook_server_timeout_ms = config
+        .server_timeout_ms
+        .max(i64::try_from(hook_deadline.as_millis()).unwrap_or(i64::MAX));
+
     let mut workers = Vec::with_capacity(concurrency);
+    // One representative (plan, scratch) drives the post-level cleanup (the run label is shared, so
+    // any worker's scratch cleans the whole run).
+    let mut write_cleanup: Option<(WritePlan, WriteScratch)> = None;
     for w in 0..concurrency {
-        let graph = open_graph(&config.endpoint, &config.graph).await?;
+        let mut graph = open_graph(&config.endpoint, &config.graph).await?;
+        let uid_base = uid_alloc.fetch_add(block, Ordering::Relaxed);
+        let source = match &op_spec.write {
+            Some(plan) => {
+                let scratch = WriteScratch::new(run_token, w, config.reset_every)?;
+                // Untimed setup on this worker's own connection before the measurement window.
+                run_write_stmts(
+                    &mut graph,
+                    (plan.setup)(&scratch)?,
+                    hook_server_timeout_ms,
+                    hook_deadline,
+                )
+                .await?;
+                if write_cleanup.is_none() {
+                    write_cleanup = Some((*plan, scratch.clone()));
+                }
+                WorkerSource::Write {
+                    plan: *plan,
+                    scratch,
+                }
+            }
+            None => WorkerSource::Read {
+                corpus: Arc::clone(corpus),
+                corpus_offset: w % corpus.len(),
+            },
+        };
         workers.push(GraphWorker {
             graph,
             kind: op_spec.kind,
-            corpus: Arc::clone(corpus),
             mode,
             run_token,
-            corpus_offset: w % corpus.len(),
-            uid_base: uid_alloc.fetch_add(block, Ordering::Relaxed),
+            uid_base,
             server_timeout_ms: config.server_timeout_ms,
             client_deadline,
+            hook_server_timeout_ms,
+            hook_deadline,
+            source,
         });
     }
 
-    let run = run_closed_loop(workers, effective_warmup, config.samples).await?;
+    let run = run_closed_loop(workers, effective_warmup, config.samples).await;
+
+    // Drop the run's scratch on a fresh connection, whether or not the level succeeded, so a failed
+    // write level can't leave scratch behind for the next level/op.
+    if let Some((plan, scratch)) = write_cleanup {
+        if let Ok(mut g) = open_graph(&config.endpoint, &config.graph).await {
+            if let Ok(stmts) = (plan.cleanup)(&scratch) {
+                let _ = run_write_stmts(&mut g, stmts, hook_server_timeout_ms, hook_deadline).await;
+            }
+        }
+    }
+
+    let run = run?;
     let metrics = summarize_samples(&run.samples)?;
     Ok(LevelMetrics {
         throughput_ops_per_sec: run.throughput_ops_per_sec(),
@@ -832,6 +980,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             samples,
             warmup,
             concurrency,
+            reset_every,
             seed,
             cache,
             server_timeout_ms,
@@ -850,6 +999,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 samples,
                 warmup,
                 concurrency,
+                reset_every,
                 seed,
                 cache,
                 server_timeout_ms,
@@ -907,6 +1057,11 @@ mod tests {
         };
         for op in OpName::all() {
             let s = spec(*op);
+            // Write ops render their measured query per-invocation from a WriteScratch, not from a
+            // corpus (the corpus is a stub), so the read-corpus invariants below don't apply.
+            if s.write.is_some() {
+                continue;
+            }
             let mut rng = StdRng::seed_from_u64(7 ^ op.salt());
             let corpus = s
                 .build_corpus(&mut rng, &dataset, 0, 1)
@@ -968,10 +1123,22 @@ mod tests {
     #[test]
     fn all_reads_covers_the_catalog_and_dedups() {
         let reads = OpName::all_reads();
+        // `--all-reads` selects exactly the read-kind ops; write ops are opt-in via `--op`.
+        assert!(
+            reads.iter().all(|op| op.kind() == QueryType::Read),
+            "all_reads must contain only reads"
+        );
+        assert!(
+            !reads.contains(&OpName::CreateNode) && !reads.contains(&OpName::MergeMiss),
+            "write ops must be excluded from --all-reads"
+        );
         assert_eq!(
             reads.len(),
-            OpName::all().len(),
-            "all catalog ops are reads"
+            OpName::all()
+                .iter()
+                .filter(|op| op.kind() == QueryType::Read)
+                .count(),
+            "all_reads covers every read op"
         );
         // dedup_ops keeps first occurrence and drops duplicates / overlaps.
         let deduped = dedup_ops(&[
@@ -1092,6 +1259,7 @@ mod tests {
             samples: Some(0),
             warmup: Some(0),
             concurrency: vec![],
+            reset_every: None,
             seed: Some(0),
             cache: Some(CacheSelection::Both),
             server_timeout_ms: Some(5_000),
@@ -1130,6 +1298,7 @@ mod tests {
             samples: Some(100),
             warmup: Some(0),
             concurrency: vec![],
+            reset_every: None,
             seed: Some(0),
             cache: Some(CacheSelection::Both),
             server_timeout_ms: Some(5_000),
@@ -1156,6 +1325,22 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn run_rejects_zero_reset_every_for_write_ops_before_connecting() {
+        // A write op with reset_every == 0 fails the fast pre-connection validation, so no
+        // connection is opened — this stays hermetic (the endpoint is never touched).
+        let cfg = Config {
+            ops: vec![OpName::CreateNode],
+            reset_every: 0,
+            ..Config::default()
+        };
+        let err = run(&cfg).await.expect_err("zero cadence must be rejected");
+        assert!(
+            format!("{err:?}").contains("reset_every must be >= 1"),
+            "expected a reset_every validation error, got: {err:?}"
+        );
+    }
+
     #[test]
     fn summarize_samples_computes_paired_residual_and_cache() {
         let samples = vec![
@@ -1164,24 +1349,28 @@ mod tests {
                 total_ms: 0.40,
                 rows: 1,
                 cached: Some(true),
+                mutations: crate::synthetic::writes::MutationStats::default(),
             },
             OpSample {
                 server_ms: 0.12,
                 total_ms: 0.45,
                 rows: 1,
                 cached: Some(false),
+                mutations: crate::synthetic::writes::MutationStats::default(),
             },
             OpSample {
                 server_ms: 0.11,
                 total_ms: 0.42,
                 rows: 1,
                 cached: None,
+                mutations: crate::synthetic::writes::MutationStats::default(),
             },
             OpSample {
                 server_ms: 0.13,
                 total_ms: 0.44,
                 rows: 1,
                 cached: Some(true),
+                mutations: crate::synthetic::writes::MutationStats::default(),
             },
         ];
         let r = summarize_samples(&samples).unwrap();
@@ -1206,6 +1395,7 @@ mod tests {
                     total_ms: s + 0.3,
                     rows: 1,
                     cached: Some(true),
+                    mutations: crate::synthetic::writes::MutationStats::default(),
                 }
             })
             .collect();
@@ -1214,6 +1404,7 @@ mod tests {
             total_ms: 500.0,
             rows: 1,
             cached: Some(true),
+            mutations: crate::synthetic::writes::MutationStats::default(),
         });
         let r = summarize_samples(&samples).unwrap();
         assert_eq!(r.server_ms.n, r.total_ms.n);
@@ -1232,18 +1423,21 @@ mod tests {
                 total_ms: 0.40,
                 rows: 1,
                 cached: None,
+                mutations: crate::synthetic::writes::MutationStats::default(),
             },
             OpSample {
                 server_ms: 0.12,
                 total_ms: 0.45,
                 rows: 1,
                 cached: None,
+                mutations: crate::synthetic::writes::MutationStats::default(),
             },
             OpSample {
                 server_ms: 0.11,
                 total_ms: 0.42,
                 rows: 1,
                 cached: None,
+                mutations: crate::synthetic::writes::MutationStats::default(),
             },
         ];
         let r = summarize_samples(&samples).unwrap();

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -357,11 +357,21 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
                 .to_string(),
         ));
     }
-    // Write ops need a positive reset cadence; fail fast before opening any connection.
-    if config.reset_every == 0 && ops.iter().any(|op| spec(*op).write.is_some()) {
-        return Err(OtherError(
-            "reset_every must be >= 1 for write operations".to_string(),
-        ));
+    // Write ops need a positive reset cadence AND a per-worker key band that fits `i32` (FalkorDB
+    // params) at the widest concurrency level. Validate both up-front — before opening any
+    // connection or collecting provenance — so an invalid write config fails fast instead of after
+    // connection/provenance setup.
+    if ops.iter().any(|op| spec(*op).write.is_some()) {
+        if config.reset_every == 0 {
+            return Err(OtherError(
+                "reset_every must be >= 1 for write operations".to_string(),
+            ));
+        }
+        // The band bound grows with the worker id, so the largest level bounds every smaller one;
+        // reuse `WriteScratch::new`'s checked i32 arithmetic (its run_token doesn't affect the
+        // bound). `normalize_concurrency` guarantees a non-empty, ≥1 sweep, so `max_worker ≥ 0`.
+        let max_worker = concurrency.last().copied().unwrap_or(1).saturating_sub(1);
+        WriteScratch::new(0, max_worker, config.reset_every)?;
     }
 
     let started_at_epoch_secs = SystemTime::now()
@@ -1367,6 +1377,26 @@ mod tests {
         assert!(
             format!("{err:?}").contains("reset_every must be >= 1"),
             "expected a reset_every validation error, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_rejects_write_key_band_overflow_before_connecting() {
+        // A write op whose widest concurrency level × reset_every would overflow the i32 key range
+        // is rejected up-front, before any connection is opened (hermetic). Here worker 1's highest
+        // key is 2·(i32::MAX) − 1, well past i32::MAX.
+        let cfg = Config {
+            ops: vec![OpName::CreateNode],
+            reset_every: i32::MAX as usize,
+            concurrency: vec![2],
+            ..Config::default()
+        };
+        let err = run(&cfg)
+            .await
+            .expect_err("an overflowing key band must be rejected");
+        assert!(
+            format!("{err:?}").contains("overflows i32"),
+            "expected an i32 key-band overflow error, got: {err:?}"
         );
     }
 

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -796,13 +796,32 @@ async fn run_write_stmts(
     Ok(())
 }
 
+/// Open a fresh connection and drop a write run's scratch (its `cleanup` statements). Kept off the
+/// measurement connections so a level that errored still gets cleaned up, and so — unlike the
+/// per-op work — a cleanup failure is a **surfaced** error the caller can propagate on the success
+/// path rather than silent scratch pollution.
+async fn run_scratch_cleanup(
+    endpoint: &str,
+    graph: &str,
+    plan: WritePlan,
+    scratch: &WriteScratch,
+    server_timeout_ms: i64,
+    deadline: Duration,
+) -> BenchmarkResult<()> {
+    let mut g = open_graph(endpoint, graph).await?;
+    let stmts = (plan.cleanup)(scratch)?;
+    run_write_stmts(&mut g, stmts, server_timeout_ms, deadline).await
+}
+
 /// Measure one operation at one concurrency level `C` in one cache mode via the closed-loop engine:
 /// open `C` single-socket connections (one per worker), drive them to completion, and summarize the
 /// pooled samples plus the achieved throughput.
 ///
-/// For write ops each worker gets an isolated [`WriteScratch`], its untimed setup runs before the
-/// window, and the run's scratch is dropped afterward on a fresh connection (even if the level
-/// errored), so a failed write level never leaks scratch into the next one.
+/// For write ops each worker gets an isolated [`WriteScratch`] and its untimed setup runs before the
+/// window. The run's scratch is dropped afterward on a fresh connection whether or not the level
+/// errored, so a failed write level never leaks scratch into the next one. A cleanup failure on the
+/// **success** path is surfaced (leftover scratch must never silently pollute the graph); on the
+/// **failure** path cleanup stays best-effort so it can't mask the level's original error.
 #[allow(clippy::too_many_arguments)]
 async fn measure_level(
     config: &Config,
@@ -881,17 +900,27 @@ async fn measure_level(
 
     let run = run_closed_loop(workers, effective_warmup, config.samples).await;
 
-    // Drop the run's scratch on a fresh connection, whether or not the level succeeded, so a failed
-    // write level can't leave scratch behind for the next level/op.
-    if let Some((plan, scratch)) = write_cleanup {
-        if let Ok(mut g) = open_graph(&config.endpoint, &config.graph).await {
-            if let Ok(stmts) = (plan.cleanup)(&scratch) {
-                let _ = run_write_stmts(&mut g, stmts, hook_server_timeout_ms, hook_deadline).await;
-            }
+    // Drop the run's scratch on a fresh connection, whether or not the level succeeded, so a write
+    // level can't leave scratch behind for the next level/op. On the **success** path a cleanup
+    // failure is surfaced (leftover scratch must never silently pollute the graph); on the
+    // **failure** path cleanup stays best-effort so it can't mask the level's original error.
+    let cleanup = match write_cleanup {
+        Some((plan, scratch)) => {
+            run_scratch_cleanup(
+                &config.endpoint,
+                &config.graph,
+                plan,
+                &scratch,
+                hook_server_timeout_ms,
+                hook_deadline,
+            )
+            .await
         }
-    }
+        None => Ok(()),
+    };
 
-    let run = run?;
+    let run = run?; // a level error wins (cleanup already ran best-effort above)
+    cleanup?; // otherwise surface any cleanup failure so scratch can't leak silently
     let metrics = summarize_samples(&run.samples)?;
     Ok(LevelMetrics {
         throughput_ops_per_sec: run.throughput_ops_per_sec(),

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -8,6 +8,7 @@
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
+use crate::synthetic::writes::MutationStats;
 use falkordb::AsyncGraph;
 use futures::StreamExt;
 use std::hint::black_box;
@@ -25,6 +26,9 @@ pub struct OpSample {
     pub rows: usize,
     /// Whether the server reported a cached execution plan (`None` if the stat was absent).
     pub cached: Option<bool>,
+    /// The mutation counters FalkorDB reported (all zero for reads), so a write worker can verify
+    /// each sample actually effected its intended change (see [`crate::synthetic::writes`]).
+    pub mutations: MutationStats,
 }
 
 /// Execute one query against `graph`, timing the full round-trip and reading the server time.
@@ -63,6 +67,14 @@ pub async fn run_and_drain(
         .map_err(|e| OtherError(format!("query '{}' failed: {:?}", cypher, e)))?;
 
         let cached = query_result.get_cached_execution();
+        // Read the mutation counters (absent ⇒ 0, e.g. for reads) before draining the stream, so a
+        // write worker can verify the sample actually did what the operation intends.
+        let mutations = MutationStats {
+            nodes_created: query_result.get_nodes_created().unwrap_or(0),
+            nodes_deleted: query_result.get_nodes_deleted().unwrap_or(0),
+            relationships_created: query_result.get_relationship_created().unwrap_or(0),
+            properties_set: query_result.get_properties_set().unwrap_or(0),
+        };
         // A missing server-time stat is a hard error — never fold it into the numbers as NaN/0.
         let server_ms = validate_server_ms(query_result.get_internal_execution_time(), cypher)?;
 
@@ -76,10 +88,12 @@ pub async fn run_and_drain(
             let _ = black_box(row);
             rows += 1;
         }
-        Ok::<(f64, usize, Option<bool>), crate::error::BenchmarkError>((server_ms, rows, cached))
+        Ok::<(f64, usize, Option<bool>, MutationStats), crate::error::BenchmarkError>((
+            server_ms, rows, cached, mutations,
+        ))
     };
 
-    let (server_ms, rows, cached) = tokio::time::timeout(client_deadline, measured)
+    let (server_ms, rows, cached, mutations) = tokio::time::timeout(client_deadline, measured)
         .await
         .map_err(|e: Elapsed| {
             OtherError(format!(
@@ -96,6 +110,7 @@ pub async fn run_and_drain(
         total_ms,
         rows,
         cached,
+        mutations,
     })
 }
 

--- a/src/synthetic/writes.rs
+++ b/src/synthetic/writes.rs
@@ -21,6 +21,7 @@
 
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
+use crate::query::Query;
 
 /// Fires a reset every `reset_every` operations, counted over the **global** invocation sequence
 /// (warm-up + measured), so scratch that warm-up mutated is bounded too.
@@ -166,6 +167,15 @@ impl WriteScratch {
         self.schedule
     }
 
+    /// This worker's inclusive key band `[lo, hi]` (`lo = worker_id · reset_every`,
+    /// `hi = lo + reset_every - 1`) — the id range a reset scopes its delete to, so it only ever
+    /// clears this worker's rows. Both ends fit `i32` (validated in [`WriteScratch::new`]).
+    pub fn key_band(&self) -> (i32, i32) {
+        let lo = self.worker_id * self.schedule.reset_every();
+        let hi = lo + self.schedule.reset_every() - 1;
+        (lo as i32, hi as i32)
+    }
+
     /// This worker's index in the level (`0..concurrency`).
     pub fn worker_id(&self) -> usize {
         self.worker_id
@@ -175,6 +185,34 @@ impl WriteScratch {
     pub fn run_token(&self) -> u64 {
         self.run_token
     }
+}
+
+/// The lifecycle of a write operation: what it mutates (for per-sample verification), a stable tag
+/// for the workload hash, a default reset cadence, and the untimed setup/reset/cleanup hooks plus
+/// the timed per-invocation query builder. Fn pointers keep [`crate::synthetic::catalog::
+/// OperationSpec`] `Copy`; every hook returns already-built [`Query`]s scoped to a worker's
+/// [`WriteScratch`].
+#[derive(Clone, Copy)]
+pub struct WritePlan {
+    /// What each invocation must mutate, checked against the response counters via
+    /// [`verify_mutation`].
+    pub expected: ExpectedMutation,
+    /// A stable identifier for this operation's query shape, folded into the workload hash so a
+    /// change to the write bodies makes old and new runs incomparable. Bump the suffix when the
+    /// cypher changes (e.g. `"create_node.v1"`).
+    pub plan_tag: &'static str,
+    /// Reset cadence (ops per sawtooth window) when the config doesn't override `reset_every`.
+    pub default_reset_every: usize,
+    /// Untimed statements run once per worker before the measurement window (e.g. clear this
+    /// worker's key band, or pre-create a pool).
+    pub setup: fn(&WriteScratch) -> BenchmarkResult<Vec<Query>>,
+    /// Untimed statements run every `reset_every` ops to undo drift (scoped to this worker's band).
+    pub reset: fn(&WriteScratch) -> BenchmarkResult<Vec<Query>>,
+    /// Untimed statements run once after the level to drop the run's scratch (scoped to the run
+    /// label, so it clears every worker at once).
+    pub cleanup: fn(&WriteScratch) -> BenchmarkResult<Vec<Query>>,
+    /// The timed query for measured invocation `seq` (identity from `scratch.window_key(seq)`).
+    pub render: fn(&WriteScratch, u64) -> BenchmarkResult<Query>,
 }
 
 /// The mutation counters FalkorDB reports for a query, used to verify a write actually did what the

--- a/synthetic-bench.example.toml
+++ b/synthetic-bench.example.toml
@@ -16,6 +16,7 @@ nodes = 100000
 edges = 1000000
 
 # Operations to measure, using the same names as `--op` (see `benchmark synthetic list-ops`).
+# Read ops and write ops (e.g. `create_node`, `merge_miss`) can be mixed here.
 operations = ["match_by_index", "expand_hops_5", "aggregate_count"]
 
 # Measurement knobs (all optional; shown with their defaults).
@@ -26,6 +27,10 @@ cache = "both"              # cached | uncached | both
 # Concurrency sweep: the closed-loop worker counts to measure each op at, tracing the
 # latency-vs-throughput curve. Each level opens that many dedicated connections.
 concurrency = [1, 2, 4, 8, 16, 32]
+
+# Write-op reset cadence: every `reset_every` operations each worker's scratch is reset (untimed)
+# so write drift is bounded to one sawtooth window. Ignored by read ops.
+reset_every = 50000
 
 # Connection / output (all optional).
 # endpoint = "falkor://127.0.0.1:6379"

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -633,7 +633,7 @@ async fn write_ops_run_isolated_sweep_and_clean_up() {
         let op = report
             .operations
             .get(name)
-            .unwrap_or_else(|| panic!("{name} present in report"));
+            .unwrap_or_else(|| panic!("{name} missing from report"));
         let lvl = only_level(op);
         assert_eq!(lvl.concurrency, 8);
         let m = lvl

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -29,6 +29,7 @@ fn base_config(graph: &str) -> Config {
         samples: 300,
         warmup: 50,
         concurrency: vec![1],
+        reset_every: 1000,
         seed: 1,
         server_timeout_ms: 5_000,
         client_deadline_ms: 6_000,
@@ -600,6 +601,142 @@ async fn concurrency_sweep_produces_per_level_throughput_and_percentiles() {
         throughputs[1..].iter().any(|&t| t > throughputs[0]),
         "throughput should rise above the C=1 baseline as concurrency grows: {throughputs:?}"
     );
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn write_ops_run_isolated_sweep_and_clean_up() {
+    // create_node + merge_miss at C=8 over several sawtooth windows. A green run is itself the
+    // isolation proof: every sample verifies `nodes_created == 1`, so if two of the 8 workers ever
+    // shared a key, a key repeated within a window, or a reset failed to clear its band, a MERGE
+    // would hit instead of miss (nodes_created == 0) and the run would error. We also assert the
+    // seeded real data is untouched and the run's scratch is fully cleaned up afterward.
+    let graph = "syn_it_writes";
+    let seeded_users: i64 = 50;
+    seed_user_graph(graph, seeded_users).await;
+
+    let report = run(&Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::CreateNode, OpName::MergeMiss],
+        samples: 200, // > reset_every ⇒ multiple resets per worker
+        warmup: 20,
+        concurrency: vec![8],
+        reset_every: 50,
+        cache: CacheSelection::Cached,
+        ..base_config(graph)
+    })
+    .await
+    .expect("write sweep should succeed (isolation keeps every MERGE a miss)");
+
+    for name in ["create_node", "merge_miss"] {
+        let op = report
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} present in report"));
+        let lvl = only_level(op);
+        assert_eq!(lvl.concurrency, 8);
+        let m = lvl
+            .cached
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name} missing cached metrics"));
+        assert!(
+            m.throughput_ops_per_sec > 0.0,
+            "{name} must report positive throughput"
+        );
+        let s = &m.metrics.server_ms;
+        assert!(s.n > 0, "{name} must have samples");
+        assert!(
+            s.median <= s.p90 && s.p90 <= s.p95 && s.p95 <= s.p99 && s.p99.is_finite(),
+            "{name} percentiles must be ordered p50<=p90<=p95<=p99 (got {:?})",
+            (s.median, s.p90, s.p95, s.p99)
+        );
+    }
+
+    // Isolation from real data + cleanup: the seeded :User nodes are untouched, and no scratch node
+    // of any label leaks past the run's post-level cleanup (total node count == seeded users).
+    let mut g = open_graph(&endpoint(), graph).await.expect("reopen graph");
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH (u:User) RETURN count(u)").await,
+        seeded_users,
+        "seeded :User data must be untouched by the write sweep"
+    );
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await,
+        seeded_users,
+        "no scratch nodes may remain after the run's post-level cleanup"
+    );
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn write_scratch_reset_reuses_its_band_without_duplicates() {
+    // Pin the isolation model against the server directly: within a window every MERGE misses
+    // (unique keys), a band-scoped reset clears exactly this worker's rows, and the next window
+    // reuses the very same keys — still all misses, with no duplicate accumulation.
+    use benchmark::synthetic::writes::{verify_mutation, ExpectedMutation, WriteScratch};
+
+    let graph = "syn_it_write_reset";
+    drop_graph(graph).await;
+    let mut g = open_graph(&endpoint(), graph).await.expect("open graph");
+
+    let reset_every = 5usize;
+    let scratch = WriteScratch::new(0xBEEF, 0, reset_every).expect("scratch");
+    let label = scratch.label();
+    let count_cypher = format!("MATCH (n:{label}) RETURN count(n)");
+
+    // Window 1: `reset_every` distinct MERGEs, each a miss (creates exactly one node).
+    for seq in 0..reset_every as u64 {
+        let cypher = format!(
+            "MERGE (n:{label} {{id: {}}}) RETURN n.id",
+            scratch.window_key(seq)
+        );
+        let s = run_and_drain(&mut g, QueryType::Write, &cypher, 5_000, Duration::from_secs(5))
+            .await
+            .expect("window-1 merge");
+        verify_mutation(ExpectedMutation::NodeCreated, &s.mutations).expect("window-1 must miss");
+    }
+    assert_eq!(
+        scalar_i64(&mut g, &count_cypher).await,
+        reset_every as i64,
+        "one node per key after the first window"
+    );
+
+    // Reset: delete exactly this worker's key band (scoped by label + id range).
+    let (lo, hi) = scratch.key_band();
+    run_and_drain(
+        &mut g,
+        QueryType::Write,
+        &format!("MATCH (n:{label}) WHERE n.id >= {lo} AND n.id <= {hi} DELETE n"),
+        5_000,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("reset delete");
+    assert_eq!(
+        scalar_i64(&mut g, &count_cypher).await,
+        0,
+        "the reset clears the whole band"
+    );
+
+    // Window 2: `window_key` cycles back over the same keys, and every MERGE misses again.
+    for seq in reset_every as u64..2 * reset_every as u64 {
+        let cypher = format!(
+            "MERGE (n:{label} {{id: {}}}) RETURN n.id",
+            scratch.window_key(seq)
+        );
+        let s = run_and_drain(&mut g, QueryType::Write, &cypher, 5_000, Duration::from_secs(5))
+            .await
+            .expect("window-2 merge");
+        verify_mutation(ExpectedMutation::NodeCreated, &s.mutations).expect("window-2 must miss");
+    }
+    assert_eq!(
+        scalar_i64(&mut g, &count_cypher).await,
+        reset_every as i64,
+        "the reused band holds exactly one node per key — no duplicate accumulation"
+    );
+
     drop_graph(graph).await;
 }
 


### PR DESCRIPTION
Part 5 of the synthetic per-operation benchmark epic (#200) — **write operations with steady-state isolation** (#205) — is being landed as **3 stacked PRs** (approved with the user). This is **PR B**: it wires the Part 5a lifecycle/isolation primitives into the Part 4 closed-loop engine and ships the first vertical slice of write ops.

- **PR A** (#213, merged) — pure lifecycle/isolation primitives (`WriteScratch`, `ResetSchedule`, `MutationStats`, `verify_mutation`), fully unit-tested.
- **PR B (this one)** — wire the primitives into the engine + a `create_node`/`merge_miss` vertical slice.
- **PR C** — the remaining four write ops (`create_edge`, `set_property`, `delete_node`, `merge_hit`).

## What this PR does

- **`OperationSpec` gains an optional `WritePlan`** (fn-pointer `setup`/`reset`/`cleanup`/`render` hooks + `expected` mutation + a stable `plan_tag` + `default_reset_every`). Reads keep rendering from their seeded corpus; writes render per-invocation from a per-worker `WriteScratch`.
- **`GraphWorker` splits into a `Read`/`Write` `WorkerSource`.** A write worker:
  - runs an **untimed, band-scoped reset** at each `reset_every` window boundary (counted over the **global** warm-up+measured sequence, so warm-up drift is bounded too) *before* the band is reused;
  - renders the timed query from its `WriteScratch` (run-unique label + disjoint per-worker key band);
  - **verifies each sample's mutation counters** against the op intent — a silent no-op (a merge that hit, a create that mutated nothing) is a hard error, not a fast misleading sample.
- **`measure_level`** runs each worker untimed `setup` before the window and **drops the run scratch on a fresh connection after the level, even if the level errored**, so scratch never leaks into the next op/level.
- **`op_runner`** reads FalkorDB mutation counters into `OpSample.mutations`.
- **New `reset_every` knob** — CLI `--reset-every`, config `reset_every` (precedence CLI > file > default 50000), with a fail-fast `>= 1` validation for write ops (before any connection is opened).
- **Write ops are opt-in via `--op`** (excluded from `--all-reads`) so a sweep never mutates a graph unless you ask.

## Isolation model (why a green `merge_miss` run *is* the proof)

At concurrency `C`, worker `w` owns the disjoint key band `[w·reset_every, (w+1)·reset_every − 1]` and uses `window_key = w·reset_every + (seq mod reset_every)`. Bands never overlap and every key is unique within a window, so `merge_miss` always misses (creates). If two workers ever shared a key, a key repeated within a window, or a reset failed to clear its band, a `MERGE` would **hit** (`nodes_created == 0`) and the run would error. `(w+1)·reset_every` is validated to fit `i32` (FalkorDB params). Keys are run-independent (only the label carries the per-run nonce), so the workload stays comparable across runs.

## Tests

- **Unit** — the render/hook cypher for `create_node`/`merge_miss`/`clear_band`/`cleanup` (exact bodies + params), write-plan presence/kind, config `reset_every` precedence + TOML parse, and the fail-fast `reset_every == 0` rejection for write ops (hermetic — no connection opened).
- **Integration (`#[ignore]`, docker)** — an isolated `create_node`+`merge_miss` sweep at **C=8** over multiple reset windows that asserts non-empty per-level stats, that the seeded real data is untouched, and that **no scratch leaks** past cleanup; plus a direct single-worker reset/band-reuse test that asserts exact node counts before/after a reset.

## Docs

readme write-isolation section (scratch namespace, disjoint keys, sawtooth reset, per-sample verification, limitation) + `create_node`/`merge_miss` catalog rows + a runnable example; `synthetic-bench.example.toml` and CLI `--reset-every` help.

## Validation

`just ci` (build, clippy `-D warnings`, test), `just doc-check`, and `just coverage` against a Docker FalkorDB — all green (16 integration tests pass under coverage; the CLI runs `create_node`/`merge_miss` end-to-end and cleans up). A local `code-review` pass on the full diff (key-band disjointness, reset cadence, borrow-splitting in `invoke`, cleanup-on-error, i32 bounds, counter-read ordering) found no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Synthetic benchmarks now support opt-in write operations, including node creation and merge-miss workloads.
  - Added configurable write reset cadence via `--reset-every` or benchmark configuration.
  - Write workloads use isolated scratch data and verify mutations during measurement.
  - Benchmark results now capture server-reported mutation statistics.

- **Documentation**
  - Updated README and example configuration with write-operation guidance, isolation behavior, and reset settings.

- **Bug Fixes**
  - Transient review-service errors no longer fail the related commit-status check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->