### PR TITLE
ci(coderabbit): don't fail the PR check on CodeRabbit review rate limits

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,11 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
+  # A transient CodeRabbit review error (most often "Review rate limited") must not turn the
+  # "CodeRabbit" commit-status check red and fail the whole PR — CodeRabbit still reviews and
+  # comments, we just don't gate the PR on a rate-limit hiccup. (Overrides the org default, which
+  # currently fails the status on such errors.)
+  fail_commit_status: false
   auto_review:
     enabled: true
     drafts: false


### PR DESCRIPTION
## Problem

CodeRabbit posts a `CodeRabbit` **commit-status check** on each PR. When its review hits a transient error — most commonly **"Review rate limited"** — that status is set to **failure**, which turns the whole PR's checks red and shows "Some checks were not successful", even though nothing is wrong with the code. This happened on #214 (every other gate green; only `CodeRabbit — Review rate limited` was red).

## Fix

Set `reviews.fail_commit_status: false` in `.coderabbit.yaml`. Per the [CodeRabbit config reference](https://docs.coderabbit.ai/reference/configuration), this flag controls whether a **review error fails the commit-status surface**; its schema default is `false`, so the failures we see come from an org-level override — this repo-level setting overrides it back.

Effect:
- CodeRabbit **still reviews** every PR and posts its inline comments + summary (unchanged).
- A rate-limit / review error **no longer fails** the `CodeRabbit` status check, so it can't gate the PR.
- A successful review still reports normally.

If we later decide we don't want the `CodeRabbit` status check at all, the follow-up lever is `reviews.commit_status: false` (drops the check surface entirely). This PR keeps the check but just stops transient errors from failing it.

## Validation

`.coderabbit.yaml` parses and `reviews.fail_commit_status` is a valid key in CodeRabbit's published schema (`schema.v2.json`). CodeRabbit reads this config when it reviews the PR.
