### PR TITLE
feat(synthetic): create_edge/set_property/delete_node/merge_hit write ops (part 5c of #200)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,11 +4,12 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
-  # A transient CodeRabbit review error (most often "Review rate limited") must not turn the
-  # "CodeRabbit" commit-status check red and fail the whole PR — CodeRabbit still reviews and
-  # comments, we just don't gate the PR on a rate-limit hiccup. (Overrides the org default, which
-  # currently fails the status on such errors.)
-  fail_commit_status: false
+  # Don't post CodeRabbit's "CodeRabbit" commit-status check at all. `fail_commit_status: false`
+  # wasn't enough: when CodeRabbit is rate-limited it posts a "Review rate limited" *failure* status
+  # before it applies this config, so the only reliable way to stop that from failing a PR's checks
+  # is to disable the status mirror entirely. CodeRabbit still reviews and posts its inline comments
+  # + summary — only the pass/fail commit-status check is dropped.
+  commit_status: false
   auto_review:
     enabled: true
     drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,12 +4,11 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
-  # Don't post CodeRabbit's "CodeRabbit" commit-status check at all. `fail_commit_status: false`
-  # wasn't enough: when CodeRabbit is rate-limited it posts a "Review rate limited" *failure* status
-  # before it applies this config, so the only reliable way to stop that from failing a PR's checks
-  # is to disable the status mirror entirely. CodeRabbit still reviews and posts its inline comments
-  # + summary — only the pass/fail commit-status check is dropped.
-  commit_status: false
+  # A transient CodeRabbit review error (most often "Review rate limited") must not turn the
+  # "CodeRabbit" commit-status check red and fail the whole PR — CodeRabbit still reviews and
+  # comments, we just don't gate the PR on a rate-limit hiccup. (Overrides the org default, which
+  # currently fails the status on such errors.)
+  fail_commit_status: false
   auto_review:
     enabled: true
     drafts: false

--- a/readme.md
+++ b/readme.md
@@ -235,7 +235,7 @@ identical corpus.
 | `property_projection` | project scalar properties of an indexed node | `MATCH (n:User {id: $id}) RETURN n.id, n.age` |
 | `create_node` *(write)* | create a fresh scratch node each invocation | `CREATE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
 | `merge_miss` *(write)* | `MERGE` a fresh scratch node (always misses → creates) | `MERGE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
-| `create_edge` *(write)* | create a fresh edge between two scratch nodes | `MATCH (a:BenchScratch_<run> {id: $src}), (b {id: $dst}) CREATE (a)-[:BenchEdge]->(b)` |
+| `create_edge` *(write)* | create a fresh edge between two scratch nodes | `MATCH (a:BenchScratch_<run> {id: $src}), (b:BenchScratch_<run> {id: $dst}) CREATE (a)-[:BenchEdge]->(b)` |
 | `set_property` *(write)* | set one property on a fresh scratch node | `MATCH (n:BenchScratch_<run> {id: $id}) WHERE n.touched IS NULL SET n.touched = $id` |
 | `delete_node` *(write)* | delete a pre-created scratch node | `MATCH (n:BenchScratch_<run> {id: $id}) DELETE n` |
 | `merge_hit` *(write)* | `MERGE` an existing scratch node (always hits) | `MERGE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |

--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@ identical corpus.
 | `create_node` *(write)* | create a fresh scratch node each invocation | `CREATE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
 | `merge_miss` *(write)* | `MERGE` a fresh scratch node (always misses → creates) | `MERGE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
 | `create_edge` *(write)* | create a fresh edge between two scratch nodes | `MATCH (a:BenchScratch_<run> {id: $src}), (b:BenchScratch_<run> {id: $dst}) CREATE (a)-[:BenchEdge]->(b)` |
-| `set_property` *(write)* | set one property on a fresh scratch node | `MATCH (n:BenchScratch_<run> {id: $id}) WHERE n.touched IS NULL SET n.touched = $id` |
+| `set_property` *(write)* | set one property on a pre-created scratch node | `MATCH (n:BenchScratch_<run> {id: $id}) WHERE n.touched IS NULL SET n.touched = $id` |
 | `delete_node` *(write)* | delete a pre-created scratch node | `MATCH (n:BenchScratch_<run> {id: $id}) DELETE n` |
 | `merge_hit` *(write)* | `MERGE` an existing scratch node (always hits) | `MERGE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
 

--- a/readme.md
+++ b/readme.md
@@ -208,7 +208,8 @@ See [`synthetic-benchmark.md`](synthetic-benchmark.md) for the concurrency model
 #### Operation catalog
 
 Select operations with `--op <name>` (repeatable and comma-separated) or `--all-reads`. `--all-reads`
-selects every **read** op; **write** ops (`create_node`, `merge_miss`) are opt-in via `--op` so a
+selects every **read** op; **write** ops (`create_node`, `merge_miss`, `create_edge`, `set_property`,
+`delete_node`, `merge_hit`) are opt-in via `--op` so a
 sweep never mutates a graph unless you ask. All read ops except `return_const` target the benchmark's
 `:User {id, age}` / `(:User)-[:Friend]->(:User)` schema (with an index on `:User(id)`). Most draw
 their parameters from `:User` ids sampled out of
@@ -234,6 +235,10 @@ identical corpus.
 | `property_projection` | project scalar properties of an indexed node | `MATCH (n:User {id: $id}) RETURN n.id, n.age` |
 | `create_node` *(write)* | create a fresh scratch node each invocation | `CREATE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
 | `merge_miss` *(write)* | `MERGE` a fresh scratch node (always misses → creates) | `MERGE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
+| `create_edge` *(write)* | create a fresh edge between two scratch nodes | `MATCH (a:BenchScratch_<run> {id: $src}), (b {id: $dst}) CREATE (a)-[:BenchEdge]->(b)` |
+| `set_property` *(write)* | set one property on a fresh scratch node | `MATCH (n:BenchScratch_<run> {id: $id}) WHERE n.touched IS NULL SET n.touched = $id` |
+| `delete_node` *(write)* | delete a pre-created scratch node | `MATCH (n:BenchScratch_<run> {id: $id}) DELETE n` |
+| `merge_hit` *(write)* | `MERGE` an existing scratch node (always hits) | `MERGE (n:BenchScratch_<run> {id: $id}) RETURN n.id` |
 
 Because `OpName` is a clap `ValueEnum`, `--op <TAB>` completes the operation names once you've
 installed completion (`benchmark generate-auto-complete <shell>`), and `just synthetic-ops` (or
@@ -297,40 +302,58 @@ a `999999` placeholder version and the tool warns you to use a tagged image for 
 
 #### Write operations (steady-state isolation)
 
-Write ops (`create_node`, `merge_miss`, with more to come) measure mutation latency/throughput
-without the graph drifting between samples, so write numbers stay comparable across a long sweep.
-Only the operation itself is inside the timer; setup/reset/cleanup run in **untimed** hooks that
-abort the sample on failure. The isolation model:
+Write ops measure mutation latency/throughput without the graph drifting between samples, so write
+numbers stay comparable across a long sweep. Six ops are available: `create_node`, `merge_miss`,
+`create_edge`, `set_property`, `delete_node`, and `merge_hit`. Only the operation itself is inside
+the timer; setup/reset/cleanup run in **untimed** hooks that abort the sample on failure. The
+isolation model:
 
 - **Scratch namespace.** A run writes only to a **run-unique label** `BenchScratch_<run_token>` (a
   random per-run hex nonce), so a sweep never touches your real data or another run's scratch. The
   label is shared by all workers of a run (keeping the plan cache warm), and the run's scratch is
-  dropped on a fresh connection after each level — even if the level errored — so nothing leaks into
-  the next op/level.
+  dropped (`DETACH DELETE`, edges included) on a fresh connection after each level — even if the
+  level errored — so nothing leaks into the next op/level.
 - **Disjoint per-worker keys.** At concurrency `C`, worker `w` owns the key band
   `[w·reset_every, (w+1)·reset_every − 1]` and uses `window_key = w·reset_every + (seq mod
   reset_every)` for invocation `seq`. Bands never overlap, so concurrent writers never collide, and
-  within a window every key is unique — so `merge_miss` always misses (creates) and identities never
+  within a window every key is unique — so `merge_miss` always misses (creates), `delete_node`
+  deletes each node exactly once, `create_edge` never duplicates an edge, and identities never
   repeat. Keys are **run-independent** (only the label carries the nonce), so the workload stays
   comparable across runs; `(w+1)·reset_every` must fit `i32` (FalkorDB params), which bounds
   `reset_every × C`.
+- **Empty- vs populated-band ops.** `create_node`/`merge_miss` keep their band **empty** (they
+  create into it). The ops that need existing targets — `create_edge`, `set_property`, `delete_node`,
+  `merge_hit` — keep their band **populated**: an untimed setup pre-creates `reset_every` nodes (one
+  per key) so every invocation has a target.
 - **Run-level reset (sawtooth).** Every `reset_every` operations — counted over the **global**
-  warm-up + measured sequence — each worker runs an untimed reset that deletes its key band before
-  it is reused, bounding write drift to one sawtooth window. Tune the cadence with `--reset-every N`
-  (config `reset_every`, default 50000); a smaller `N` keeps the graph tighter but spends more time
-  resetting. `merge_miss` staying a miss across resets is the isolation guarantee: a shared key or a
-  missed reset would turn a `MERGE` into a hit, and the run would error.
+  warm-up + measured sequence — each worker runs an untimed reset before its band is reused, bounding
+  write drift to one sawtooth window. Empty-band ops clear the band; populated-band ops clear **and
+  refill** it with `reset_every` fresh clean nodes (so `delete_node` gets its nodes back and
+  `set_property` always writes a brand-new property). `merge_hit` never mutates, so its band is set
+  up once and its reset is a no-op. Tune the cadence with `--reset-every N` (config `reset_every`,
+  default 50000); a smaller `N` keeps the graph tighter but spends more time in setup/reset.
 - **Per-sample verification.** Each write checks FalkorDB's mutation counters against the operation's
-  intent (`create_node`/`merge_miss` ⇒ exactly one node created), so a silent no-op fails loudly
-  rather than producing a fast, misleading sample.
+  intent (`create_node`/`merge_miss` ⇒ one node created; `create_edge` ⇒ one relationship;
+  `set_property` ⇒ one property set; `delete_node` ⇒ one node deleted; `merge_hit` ⇒ **no** mutation
+  — a pure match), so a silent no-op fails loudly rather than producing a fast, misleading sample.
+  `set_property`'s `WHERE n.touched IS NULL` makes this self-checking: a broken reset would match
+  nothing and fail verification instead of silently measuring a redundant write.
 
-**Limitation:** this is closed-loop steady state, not a fixed arrival rate — the reset produces a
-sawtooth in graph size within each window; it bounds drift, it does not eliminate it.
+**Limitations.**
+- **Steady state, not a fixed arrival rate.** The reset produces a sawtooth in graph size within each
+  window; it bounds drift, it does not eliminate it.
+- **Reset is untimed but not free.** At high `C` a worker's reset (which can delete/recreate a whole
+  window of nodes) contends with other workers on the server and counts toward achieved throughput,
+  so keep `reset_every` modest for write sweeps.
+- **Scratch lookups are unindexed.** The populated-band ops (and `merge_miss`) match on the
+  run-unique label without an index, so they include a label-scoped lookup cost; a coordinated
+  run-level index is a possible future refinement.
 
 ```bash
-# measure the write ops over a concurrency sweep, resetting each worker's scratch every 50k ops
-just synthetic-bench --graph bench --op create_node,merge_miss \
-    --concurrency 1,8,32 --reset-every 50000 --samples 500
+# measure the write ops over a concurrency sweep, resetting each worker's scratch every 5k ops
+just synthetic-bench --graph bench \
+    --op create_node,merge_miss,create_edge,set_property,delete_node,merge_hit \
+    --concurrency 1,8,32 --reset-every 5000 --samples 500
 ```
 
 #### Generating a reproducible dataset

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -239,6 +239,70 @@ pub fn spec(op: OpName) -> OperationSpec {
                 render: write_merge_miss_render,
             }),
         },
+        OpName::CreateEdge => OperationSpec {
+            name: op,
+            kind: QueryType::Write,
+            description: "create a fresh edge between two of this worker's scratch nodes",
+            requirement: DatasetRequirement::None,
+            corpus: write_corpus_stub,
+            write: Some(WritePlan {
+                expected: ExpectedMutation::RelationshipCreated,
+                plan_tag: "create_edge.v1",
+                default_reset_every: DEFAULT_RESET_EVERY,
+                setup: write_reset_populated,
+                reset: write_reset_populated,
+                cleanup: write_cleanup_run,
+                render: write_create_edge_render,
+            }),
+        },
+        OpName::SetProperty => OperationSpec {
+            name: op,
+            kind: QueryType::Write,
+            description: "set a property on a fresh scratch node each invocation",
+            requirement: DatasetRequirement::None,
+            corpus: write_corpus_stub,
+            write: Some(WritePlan {
+                expected: ExpectedMutation::PropertySet,
+                plan_tag: "set_property.v1",
+                default_reset_every: DEFAULT_RESET_EVERY,
+                setup: write_reset_populated,
+                reset: write_reset_populated,
+                cleanup: write_cleanup_run,
+                render: write_set_property_render,
+            }),
+        },
+        OpName::DeleteNode => OperationSpec {
+            name: op,
+            kind: QueryType::Write,
+            description: "delete a pre-created scratch node each invocation",
+            requirement: DatasetRequirement::None,
+            corpus: write_corpus_stub,
+            write: Some(WritePlan {
+                expected: ExpectedMutation::NodeDeleted,
+                plan_tag: "delete_node.v1",
+                default_reset_every: DEFAULT_RESET_EVERY,
+                setup: write_reset_populated,
+                reset: write_reset_populated,
+                cleanup: write_cleanup_run,
+                render: write_delete_node_render,
+            }),
+        },
+        OpName::MergeHit => OperationSpec {
+            name: op,
+            kind: QueryType::Write,
+            description: "MERGE an existing scratch node each invocation (always hits)",
+            requirement: DatasetRequirement::None,
+            corpus: write_corpus_stub,
+            write: Some(WritePlan {
+                expected: ExpectedMutation::NodeMatched,
+                plan_tag: "merge_hit.v1",
+                default_reset_every: DEFAULT_RESET_EVERY,
+                setup: write_reset_populated,
+                reset: write_noop,
+                cleanup: write_cleanup_run,
+                render: write_merge_hit_render,
+            }),
+        },
     }
 }
 
@@ -248,11 +312,12 @@ pub const DEFAULT_RESET_EVERY: usize = 50_000;
 /// Delete only this worker's scratch rows (its key band) — used as both **setup** (a clean start,
 /// self-healing over any stale rows in this run's namespace) and **reset** (undo a window's
 /// accumulation). Scoped by the run-unique label *and* the worker's id band, so it can never touch
-/// another worker's or another run's data.
+/// another worker's or another run's data. `DETACH DELETE` so it also drops any edges an op left on
+/// its band nodes (e.g. `create_edge`); harmless for the edgeless ops.
 fn write_clear_band(scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
     let (lo, hi) = scratch.key_band();
     let text = format!(
-        "MATCH (n:{}) WHERE n.id >= $lo AND n.id <= $hi DELETE n",
+        "MATCH (n:{}) WHERE n.id >= $lo AND n.id <= $hi DETACH DELETE n",
         scratch.label()
     );
     Ok(vec![QueryBuilder::new()
@@ -263,9 +328,10 @@ fn write_clear_band(scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
 }
 
 /// Drop the whole run's scratch (every worker's rows for the run-unique label) — the coordinator
-/// runs this once after a level, on a fresh connection.
+/// runs this once after a level, on a fresh connection. `DETACH DELETE` so a run that created edges
+/// (`create_edge`) is fully cleared, edges included.
 fn write_cleanup_run(scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
-    let text = format!("MATCH (n:{}) DELETE n", scratch.label());
+    let text = format!("MATCH (n:{}) DETACH DELETE n", scratch.label());
     Ok(vec![QueryBuilder::new().text(text).build()])
 }
 
@@ -291,6 +357,108 @@ fn write_merge_miss_render(
     Ok(QueryBuilder::new()
         .text(text)
         .param("id", scratch.window_key(seq))
+        .build())
+}
+
+/// Create this worker's band nodes (`id` `lo..=hi`, one per key) so ops that need existing targets
+/// (`delete_node`, `set_property`, `merge_hit`, `create_edge`) have a full, clean band. Precondition:
+/// the band is empty (it is paired with [`write_clear_band`] in [`write_reset_populated`]).
+fn write_fill_band(scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
+    let (lo, hi) = scratch.key_band();
+    let text = format!(
+        "UNWIND range($lo, $hi) AS i CREATE (:{} {{id: i}})",
+        scratch.label()
+    );
+    Ok(vec![QueryBuilder::new()
+        .text(text)
+        .param("lo", lo)
+        .param("hi", hi)
+        .build()])
+}
+
+/// Reset (and initial setup) for write ops that consume or mutate a **populated** band: clear the
+/// worker's band (dropping any nodes + edges the window accumulated) then refill it with `R` fresh
+/// clean nodes, so every window starts from an identical clean state. Bounds drift to one sawtooth
+/// window exactly like the empty-band ops, just around a full band instead of an empty one.
+fn write_reset_populated(scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
+    let mut stmts = write_clear_band(scratch)?;
+    stmts.extend(write_fill_band(scratch)?);
+    Ok(stmts)
+}
+
+/// A no-op reset for a drift-free op (`merge_hit` only matches, never mutates): its band is set up
+/// once and never needs refreshing, so refilling `R` nodes every window would be pure waste.
+fn write_noop(_scratch: &WriteScratch) -> BenchmarkResult<Vec<Query>> {
+    Ok(vec![])
+}
+
+/// `delete_node`: delete this invocation's pre-created band node — exactly one (`window_key` is
+/// unique within a window, so each of the window's `R` nodes is deleted once, then the reset
+/// refills the band).
+fn write_delete_node_render(
+    scratch: &WriteScratch,
+    seq: u64,
+) -> BenchmarkResult<Query> {
+    let text = format!("MATCH (n:{} {{id: $id}}) DELETE n", scratch.label());
+    Ok(QueryBuilder::new()
+        .text(text)
+        .param("id", scratch.window_key(seq))
+        .build())
+}
+
+/// `set_property`: set one property on a pre-created band node. `WHERE n.touched IS NULL` makes the
+/// sample self-checking — the band is refilled each window with `touched`-less nodes, so a genuine
+/// first-write always sets exactly one property; if a broken reset left `touched` set, the match
+/// finds nothing, zero properties are set, and mutation verification fails loudly.
+fn write_set_property_render(
+    scratch: &WriteScratch,
+    seq: u64,
+) -> BenchmarkResult<Query> {
+    let text = format!(
+        "MATCH (n:{} {{id: $id}}) WHERE n.touched IS NULL SET n.touched = $id",
+        scratch.label()
+    );
+    Ok(QueryBuilder::new()
+        .text(text)
+        .param("id", scratch.window_key(seq))
+        .build())
+}
+
+/// `merge_hit`: `MERGE` a band node that was pre-created in setup, so it always matches (never
+/// creates). The band is populated once and never mutated, so no reset is needed.
+fn write_merge_hit_render(
+    scratch: &WriteScratch,
+    seq: u64,
+) -> BenchmarkResult<Query> {
+    let text = format!("MERGE (n:{} {{id: $id}}) RETURN n.id", scratch.label());
+    Ok(QueryBuilder::new()
+        .text(text)
+        .param("id", scratch.window_key(seq))
+        .build())
+}
+
+/// `create_edge`: create one fresh edge between two distinct band nodes (`src → src+1`, wrapping the
+/// band's top back to its bottom). Over a window the `R` sources yield `R` distinct ordered pairs —
+/// no duplicate edges — and the reset drops the accumulated edges by clearing+refilling the band.
+/// With `R == 1` the single node gets a self-loop. Endpoints stay inside this worker's band, so a
+/// reset's `DETACH DELETE` never touches another worker's data.
+fn write_create_edge_render(
+    scratch: &WriteScratch,
+    seq: u64,
+) -> BenchmarkResult<Query> {
+    let (lo, hi) = scratch.key_band();
+    let src = scratch.window_key(seq);
+    // Wrap the top of the band back to the bottom without ever computing `R` as i32 (R may exceed
+    // i32 while every band key still fits it).
+    let dst = if src == hi { lo } else { src + 1 };
+    let text = format!(
+        "MATCH (a:{l} {{id: $src}}), (b:{l} {{id: $dst}}) CREATE (a)-[:BenchEdge]->(b)",
+        l = scratch.label()
+    );
+    Ok(QueryBuilder::new()
+        .text(text)
+        .param("src", src)
+        .param("dst", dst)
         .build())
 }
 
@@ -586,14 +754,26 @@ mod tests {
 
     #[test]
     fn write_ops_carry_a_write_plan_and_write_kind() {
-        for op in [OpName::CreateNode, OpName::MergeMiss] {
+        use ExpectedMutation::*;
+        let expected = [
+            (OpName::CreateNode, NodeCreated),
+            (OpName::MergeMiss, NodeCreated),
+            (OpName::CreateEdge, RelationshipCreated),
+            (OpName::SetProperty, PropertySet),
+            (OpName::DeleteNode, NodeDeleted),
+            (OpName::MergeHit, NodeMatched),
+        ];
+        for (op, mutation) in expected {
             let s = spec(op);
             assert_eq!(s.kind, QueryType::Write, "{} is a write op", op.as_str());
             let plan = s.write.expect("write op carries a WritePlan");
-            assert_eq!(plan.expected, ExpectedMutation::NodeCreated);
+            assert_eq!(plan.expected, mutation, "{} expected mutation", op.as_str());
             assert_eq!(plan.default_reset_every, DEFAULT_RESET_EVERY);
         }
-        // A read op carries no write plan and stays QueryType::Read.
+        // Every catalog op agrees on kind vs. the presence of a write plan.
+        assert!(OpName::all()
+            .iter()
+            .all(|op| { (spec(*op).kind == QueryType::Write) == spec(*op).write.is_some() }));
         let read = spec(OpName::MatchByIndex);
         assert!(read.write.is_none());
         assert_eq!(read.kind, QueryType::Read);
@@ -632,7 +812,7 @@ mod tests {
         let q = &stmts[0];
         assert_eq!(
             q.text,
-            "MATCH (n:BenchScratch_f) WHERE n.id >= $lo AND n.id <= $hi DELETE n"
+            "MATCH (n:BenchScratch_f) WHERE n.id >= $lo AND n.id <= $hi DETACH DELETE n"
         );
         assert!(matches!(q.params.get("lo"), Some(QueryParam::Integer(30))));
         assert!(matches!(q.params.get("hi"), Some(QueryParam::Integer(39))));
@@ -645,7 +825,7 @@ mod tests {
         let scratch = WriteScratch::new(0x2a, 5, 10).unwrap();
         let stmts = write_cleanup_run(&scratch).unwrap();
         assert_eq!(stmts.len(), 1);
-        assert_eq!(stmts[0].text, "MATCH (n:BenchScratch_2a) DELETE n");
+        assert_eq!(stmts[0].text, "MATCH (n:BenchScratch_2a) DETACH DELETE n");
         assert!(stmts[0].params.is_empty());
     }
 
@@ -658,5 +838,101 @@ mod tests {
             .build_corpus(&mut rng, &DatasetHandle::default(), 0, 4)
             .expect("stub corpus builds without a dataset");
         assert_eq!(corpus.len(), 1);
+    }
+
+    #[test]
+    fn delete_node_render_deletes_the_window_key_node() {
+        use crate::query::QueryParam;
+        let scratch = WriteScratch::new(0x7, 1, 10).unwrap(); // band [10, 19]
+        let q = write_delete_node_render(&scratch, 4).unwrap(); // window_key = 10 + 4 = 14
+        assert_eq!(q.text, "MATCH (n:BenchScratch_7 {id: $id}) DELETE n");
+        assert!(matches!(q.params.get("id"), Some(QueryParam::Integer(14))));
+    }
+
+    #[test]
+    fn set_property_render_guards_on_a_fresh_node() {
+        use crate::query::QueryParam;
+        // The `WHERE n.touched IS NULL` guard makes the sample self-checking: a broken reset that
+        // left `touched` set would match nothing, set zero properties, and fail verification.
+        let scratch = WriteScratch::new(0x8, 0, 100).unwrap();
+        let q = write_set_property_render(&scratch, 5).unwrap();
+        assert_eq!(
+            q.text,
+            "MATCH (n:BenchScratch_8 {id: $id}) WHERE n.touched IS NULL SET n.touched = $id"
+        );
+        assert!(matches!(q.params.get("id"), Some(QueryParam::Integer(5))));
+    }
+
+    #[test]
+    fn merge_hit_render_merges_the_window_key_node() {
+        use crate::query::QueryParam;
+        let scratch = WriteScratch::new(0x9, 2, 10).unwrap(); // band [20, 29]
+        let q = write_merge_hit_render(&scratch, 3).unwrap(); // window_key = 20 + 3 = 23
+        assert_eq!(q.text, "MERGE (n:BenchScratch_9 {id: $id}) RETURN n.id");
+        assert!(matches!(q.params.get("id"), Some(QueryParam::Integer(23))));
+    }
+
+    #[test]
+    fn create_edge_render_connects_distinct_band_nodes_and_wraps_at_the_top() {
+        use crate::query::QueryParam;
+        let scratch = WriteScratch::new(0xA, 0, 5).unwrap(); // band [0, 4]
+        // Mid-band: src = window_key(2) = 2 → dst = src + 1 = 3.
+        let q = write_create_edge_render(&scratch, 2).unwrap();
+        assert_eq!(
+            q.text,
+            "MATCH (a:BenchScratch_a {id: $src}), (b:BenchScratch_a {id: $dst}) CREATE (a)-[:BenchEdge]->(b)"
+        );
+        assert!(matches!(q.params.get("src"), Some(QueryParam::Integer(2))));
+        assert!(matches!(q.params.get("dst"), Some(QueryParam::Integer(3))));
+        // Top of the band wraps back to the bottom: src = hi = 4 → dst = lo = 0.
+        let top = write_create_edge_render(&scratch, 4).unwrap();
+        assert!(matches!(top.params.get("src"), Some(QueryParam::Integer(4))));
+        assert!(matches!(top.params.get("dst"), Some(QueryParam::Integer(0))));
+    }
+
+    #[test]
+    fn create_edge_self_loops_when_band_width_is_one() {
+        use crate::query::QueryParam;
+        let scratch = WriteScratch::new(0xB, 3, 1).unwrap(); // band [3, 3]
+        let q = write_create_edge_render(&scratch, 9).unwrap(); // window_key = 3
+        assert!(matches!(q.params.get("src"), Some(QueryParam::Integer(3))));
+        assert!(matches!(q.params.get("dst"), Some(QueryParam::Integer(3))));
+    }
+
+    #[test]
+    fn fill_band_creates_one_node_per_key_via_range() {
+        use crate::query::QueryParam;
+        let scratch = WriteScratch::new(0xC, 2, 10).unwrap(); // band [20, 29]
+        let stmts = write_fill_band(&scratch).unwrap();
+        assert_eq!(stmts.len(), 1);
+        assert_eq!(
+            stmts[0].text,
+            "UNWIND range($lo, $hi) AS i CREATE (:BenchScratch_c {id: i})"
+        );
+        assert!(matches!(
+            stmts[0].params.get("lo"),
+            Some(QueryParam::Integer(20))
+        ));
+        assert!(matches!(
+            stmts[0].params.get("hi"),
+            Some(QueryParam::Integer(29))
+        ));
+    }
+
+    #[test]
+    fn reset_populated_clears_then_refills_the_band() {
+        let scratch = WriteScratch::new(0xD, 0, 10).unwrap();
+        let stmts = write_reset_populated(&scratch).unwrap();
+        // Two statements, in order: DETACH DELETE the band, then recreate it clean.
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].text.contains("DETACH DELETE n"));
+        assert!(stmts[1].text.contains("CREATE (:BenchScratch_d {id: i})"));
+    }
+
+    #[test]
+    fn noop_reset_is_empty() {
+        // merge_hit is drift-free, so its reset issues no statements.
+        let scratch = WriteScratch::new(0xE, 0, 10).unwrap();
+        assert!(write_noop(&scratch).unwrap().is_empty());
     }
 }

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -258,7 +258,7 @@ pub fn spec(op: OpName) -> OperationSpec {
         OpName::SetProperty => OperationSpec {
             name: op,
             kind: QueryType::Write,
-            description: "set a property on a fresh scratch node each invocation",
+            description: "set a property on a pre-created scratch node each invocation",
             requirement: DatasetRequirement::None,
             corpus: write_corpus_stub,
             write: Some(WritePlan {

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -448,8 +448,10 @@ fn write_create_edge_render(
 ) -> BenchmarkResult<Query> {
     let (lo, hi) = scratch.key_band();
     let src = scratch.window_key(seq);
-    // Wrap the top of the band back to the bottom without ever computing `R` as i32 (R may exceed
-    // i32 while every band key still fits it).
+    // Wrap the band's top back to its bottom. `src + 1` is only reached when `src < hi`, so it stays
+    // in `[lo, hi]` (≤ i32::MAX) and can't overflow — whereas a `% reset_every` form would need
+    // `reset_every` as i32, which isn't bounded to fit: `WriteScratch::new` caps the highest *key*
+    // `(worker_id + 1)·reset_every − 1` at i32::MAX, so at C=1 `reset_every` itself may be i32::MAX + 1.
     let dst = if src == hi { lo } else { src + 1 };
     let text = format!(
         "MATCH (a:{l} {{id: $src}}), (b:{l} {{id: $dst}}) CREATE (a)-[:BenchEdge]->(b)",

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -98,6 +98,14 @@ pub enum OpName {
     CreateNode,
     /// (write) `MERGE` a fresh scratch node each invocation — always misses, so always creates.
     MergeMiss,
+    /// (write) `CREATE` a fresh edge between two of this worker's scratch nodes.
+    CreateEdge,
+    /// (write) `SET` a property on a fresh scratch node each invocation.
+    SetProperty,
+    /// (write) `DELETE` a pre-created scratch node each invocation.
+    DeleteNode,
+    /// (write) `MERGE` an existing scratch node each invocation — always hits, so never creates.
+    MergeHit,
 }
 
 impl OpName {
@@ -129,6 +137,10 @@ impl OpName {
             OpName::PropertyProjection => "property_projection",
             OpName::CreateNode => "create_node",
             OpName::MergeMiss => "merge_miss",
+            OpName::CreateEdge => "create_edge",
+            OpName::SetProperty => "set_property",
+            OpName::DeleteNode => "delete_node",
+            OpName::MergeHit => "merge_hit",
         }
     }
 
@@ -158,6 +170,10 @@ impl OpName {
             OpName::PropertyProjection => 0x5052_4f50_5f50_524a,
             OpName::CreateNode => 0x4352_4541_5445_4e44,
             OpName::MergeMiss => 0x4d45_5247_455f_4d53,
+            OpName::CreateEdge => 0x4352_545f_4544_4745,
+            OpName::SetProperty => 0x5345_545f_5052_4f50,
+            OpName::DeleteNode => 0x4445_4c5f_4e4f_4445,
+            OpName::MergeHit => 0x4d45_5247_4548_4954,
         }
     }
 
@@ -863,50 +879,79 @@ async fn measure_level(
         .server_timeout_ms
         .max(i64::try_from(hook_deadline.as_millis()).unwrap_or(i64::MAX));
 
-    let mut workers = Vec::with_capacity(concurrency);
-    // One representative (plan, scratch) drives the post-level cleanup (the run label is shared, so
-    // any worker's scratch cleans the whole run).
-    let mut write_cleanup: Option<(WritePlan, WriteScratch)> = None;
-    for w in 0..concurrency {
-        let mut graph = open_graph(&config.endpoint, &config.graph).await?;
-        let uid_base = uid_alloc.fetch_add(block, Ordering::Relaxed);
-        let source = match &op_spec.write {
-            Some(plan) => {
-                let scratch = WriteScratch::new(run_token, w, config.reset_every)?;
-                // Untimed setup on this worker's own connection before the measurement window.
-                run_write_stmts(
-                    &mut graph,
-                    (plan.setup)(&scratch)?,
+    // For a write op, capture the cleanup handle up-front — *before* any worker's setup mutates the
+    // graph — so a mid-loop connection/setup failure still drops whatever scratch earlier workers
+    // created. The run label is shared, so worker 0's scratch cleans the whole run.
+    let mut write_cleanup: Option<(WritePlan, WriteScratch)> = match &op_spec.write {
+        Some(plan) => Some((*plan, WriteScratch::new(run_token, 0, config.reset_every)?)),
+        None => None,
+    };
+
+    // Build the workers (opening a connection and running each write op's untimed setup). Collected
+    // into a Result so a partway failure routes through the scratch cleanup below instead of leaking
+    // the nodes earlier workers already created.
+    let build_workers = async {
+        let mut workers = Vec::with_capacity(concurrency);
+        for w in 0..concurrency {
+            let mut graph = open_graph(&config.endpoint, &config.graph).await?;
+            let uid_base = uid_alloc.fetch_add(block, Ordering::Relaxed);
+            let source = match &op_spec.write {
+                Some(plan) => {
+                    let scratch = WriteScratch::new(run_token, w, config.reset_every)?;
+                    // Untimed setup on this worker's own connection before the measurement window.
+                    run_write_stmts(
+                        &mut graph,
+                        (plan.setup)(&scratch)?,
+                        hook_server_timeout_ms,
+                        hook_deadline,
+                    )
+                    .await?;
+                    WorkerSource::Write {
+                        plan: *plan,
+                        scratch,
+                    }
+                }
+                None => WorkerSource::Read {
+                    corpus: Arc::clone(corpus),
+                    corpus_offset: w % corpus.len(),
+                },
+            };
+            workers.push(GraphWorker {
+                graph,
+                kind: op_spec.kind,
+                mode,
+                run_token,
+                uid_base,
+                server_timeout_ms: config.server_timeout_ms,
+                client_deadline,
+                hook_server_timeout_ms,
+                hook_deadline,
+                source,
+            });
+        }
+        Ok::<_, crate::error::BenchmarkError>(workers)
+    }
+    .await;
+
+    let workers = match build_workers {
+        Ok(w) => w,
+        Err(e) => {
+            // Setup failed partway; best-effort drop whatever scratch was already created (the run
+            // error is what matters) before propagating it.
+            if let Some((plan, scratch)) = write_cleanup.take() {
+                let _ = run_scratch_cleanup(
+                    &config.endpoint,
+                    &config.graph,
+                    plan,
+                    &scratch,
                     hook_server_timeout_ms,
                     hook_deadline,
                 )
-                .await?;
-                if write_cleanup.is_none() {
-                    write_cleanup = Some((*plan, scratch.clone()));
-                }
-                WorkerSource::Write {
-                    plan: *plan,
-                    scratch,
-                }
+                .await;
             }
-            None => WorkerSource::Read {
-                corpus: Arc::clone(corpus),
-                corpus_offset: w % corpus.len(),
-            },
-        };
-        workers.push(GraphWorker {
-            graph,
-            kind: op_spec.kind,
-            mode,
-            run_token,
-            uid_base,
-            server_timeout_ms: config.server_timeout_ms,
-            client_deadline,
-            hook_server_timeout_ms,
-            hook_deadline,
-            source,
-        });
-    }
+            return Err(e);
+        }
+    };
 
     let run = run_closed_loop(workers, effective_warmup, config.samples).await;
 

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -100,7 +100,7 @@ pub enum OpName {
     MergeMiss,
     /// (write) `CREATE` a fresh edge between two of this worker's scratch nodes.
     CreateEdge,
-    /// (write) `SET` a property on a fresh scratch node each invocation.
+    /// (write) `SET` a property on a pre-created scratch node each invocation.
     SetProperty,
     /// (write) `DELETE` a pre-created scratch node each invocation.
     DeleteNode,

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -882,7 +882,7 @@ async fn measure_level(
     // For a write op, capture the cleanup handle up-front — *before* any worker's setup mutates the
     // graph — so a mid-loop connection/setup failure still drops whatever scratch earlier workers
     // created. The run label is shared, so worker 0's scratch cleans the whole run.
-    let mut write_cleanup: Option<(WritePlan, WriteScratch)> = match &op_spec.write {
+    let write_cleanup: Option<(WritePlan, WriteScratch)> = match &op_spec.write {
         Some(plan) => Some((*plan, WriteScratch::new(run_token, 0, config.reset_every)?)),
         None => None,
     };
@@ -933,27 +933,13 @@ async fn measure_level(
     }
     .await;
 
-    let workers = match build_workers {
-        Ok(w) => w,
-        Err(e) => {
-            // Setup failed partway; best-effort drop whatever scratch was already created (the run
-            // error is what matters) before propagating it.
-            if let Some((plan, scratch)) = write_cleanup.take() {
-                let _ = run_scratch_cleanup(
-                    &config.endpoint,
-                    &config.graph,
-                    plan,
-                    &scratch,
-                    hook_server_timeout_ms,
-                    hook_deadline,
-                )
-                .await;
-            }
-            return Err(e);
-        }
+    // Run the closed loop only if every worker built; otherwise carry the build/setup error forward
+    // so the single cleanup path below runs for both outcomes (a partially set-up populated band
+    // must never leak). The build/setup error is what we ultimately propagate.
+    let run = match build_workers {
+        Ok(workers) => run_closed_loop(workers, effective_warmup, config.samples).await,
+        Err(e) => Err(e),
     };
-
-    let run = run_closed_loop(workers, effective_warmup, config.samples).await;
 
     // Drop the run's scratch on a fresh connection, whether or not the level succeeded, so a write
     // level can't leave scratch behind for the next level/op. On the **success** path a cleanup

--- a/synthetic-bench.example.toml
+++ b/synthetic-bench.example.toml
@@ -16,7 +16,8 @@ nodes = 100000
 edges = 1000000
 
 # Operations to measure, using the same names as `--op` (see `benchmark synthetic list-ops`).
-# Read ops and write ops (e.g. `create_node`, `merge_miss`) can be mixed here.
+# Read ops and write ops (create_node, merge_miss, create_edge, set_property, delete_node,
+# merge_hit) can be mixed here.
 operations = ["match_by_index", "expand_hops_5", "aggregate_count"]
 
 # Measurement knobs (all optional; shown with their defaults).

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -740,6 +740,176 @@ async fn write_scratch_reset_reuses_its_band_without_duplicates() {
     drop_graph(graph).await;
 }
 
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn write_ops_5c_run_isolated_and_clean_up() {
+    // The four Part-5c write ops at C=8 over several reset windows. A green run is the isolation +
+    // correctness proof: every sample verifies its exact mutation (edge created / property set /
+    // node deleted / merge hit), so a cross-worker collision, a missed reset, a wrong target, or a
+    // broken refill would fail verification. Also assert the seeded data is untouched and the run's
+    // scratch (nodes *and* edges) is fully cleaned up.
+    let graph = "syn_it_writes_5c";
+    let seeded_users: i64 = 40;
+    seed_user_graph(graph, seeded_users).await;
+
+    let report = run(&Config {
+        graph: graph.to_string(),
+        ops: vec![
+            OpName::CreateEdge,
+            OpName::SetProperty,
+            OpName::DeleteNode,
+            OpName::MergeHit,
+        ],
+        samples: 150, // > reset_every ⇒ multiple sawtooth resets per worker
+        warmup: 20,
+        concurrency: vec![8],
+        reset_every: 40,
+        cache: CacheSelection::Cached,
+        ..base_config(graph)
+    })
+    .await
+    .expect("5c write sweep should succeed under isolation");
+
+    for name in ["create_edge", "set_property", "delete_node", "merge_hit"] {
+        let op = report
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} missing from report"));
+        let lvl = only_level(op);
+        assert_eq!(lvl.concurrency, 8);
+        let m = lvl
+            .cached
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name} missing cached metrics"));
+        assert!(
+            m.throughput_ops_per_sec > 0.0,
+            "{name} must report positive throughput"
+        );
+        assert!(m.metrics.server_ms.n > 0, "{name} must have samples");
+    }
+
+    // Isolation from real data + full cleanup: the seeded :User nodes are untouched, no scratch node
+    // of any label leaks, and no scratch :BenchEdge relationship survives the DETACH DELETE cleanup.
+    let mut g = open_graph(&endpoint(), graph).await.expect("reopen graph");
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH (u:User) RETURN count(u)").await,
+        seeded_users,
+        "seeded :User data must be untouched"
+    );
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await,
+        seeded_users,
+        "no scratch nodes may remain after cleanup"
+    );
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH ()-[r:BenchEdge]->() RETURN count(r)").await,
+        0,
+        "no scratch edges may remain after cleanup"
+    );
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn create_edge_builds_band_internal_edges_and_reset_drops_them() {
+    // Counters alone can't prove edge topology, so pin it directly against the server: fill a
+    // worker's band, run one window of create_edge, and assert exactly R band-internal edges exist
+    // (each op created one edge and no node), then a band reset drops every edge and node.
+    use benchmark::synthetic::writes::WriteScratch;
+
+    let graph = "syn_it_create_edge";
+    drop_graph(graph).await;
+    let mut g = open_graph(&endpoint(), graph).await.expect("open graph");
+
+    let reset_every = 5usize;
+    let scratch = WriteScratch::new(0xED9E, 0, reset_every).expect("scratch");
+    let label = scratch.label();
+    let (lo, hi) = scratch.key_band();
+
+    // Setup: fill the band with R clean nodes and confirm one distinct node per key.
+    run_and_drain(
+        &mut g,
+        QueryType::Write,
+        &format!("UNWIND range({lo}, {hi}) AS i CREATE (:{label} {{id: i}})"),
+        5_000,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("fill band");
+    assert_eq!(
+        scalar_i64(&mut g, &format!("MATCH (n:{label}) RETURN count(n)")).await,
+        reset_every as i64,
+        "fill creates one node per band key"
+    );
+    assert_eq!(
+        scalar_i64(&mut g, &format!("MATCH (n:{label}) RETURN count(DISTINCT n.id)")).await,
+        reset_every as i64,
+        "band keys are distinct (no duplicate merge-hit targets)"
+    );
+
+    // One window of create_edge: src → (src+1, wrapping the top back to the bottom).
+    for seq in 0..reset_every as u64 {
+        let src = scratch.window_key(seq);
+        let dst = if src == hi { lo } else { src + 1 };
+        let s = run_and_drain(
+            &mut g,
+            QueryType::Write,
+            &format!("MATCH (a:{label} {{id: {src}}}), (b:{label} {{id: {dst}}}) CREATE (a)-[:BenchEdge]->(b)"),
+            5_000,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("create edge");
+        assert_eq!(s.mutations.relationships_created, 1, "one edge per invocation");
+        assert_eq!(s.mutations.nodes_created, 0, "endpoints pre-exist");
+    }
+
+    // R distinct edges, every endpoint inside this worker's band (no cross-band leakage).
+    assert_eq!(
+        scalar_i64(
+            &mut g,
+            &format!("MATCH (:{label})-[r:BenchEdge]->(:{label}) RETURN count(r)")
+        )
+        .await,
+        reset_every as i64,
+        "one band-internal edge per window invocation"
+    );
+    assert_eq!(
+        scalar_i64(
+            &mut g,
+            &format!(
+                "MATCH (a:{label})-[:BenchEdge]->(b:{label}) \
+                 WHERE a.id < {lo} OR a.id > {hi} OR b.id < {lo} OR b.id > {hi} RETURN count(*)"
+            )
+        )
+        .await,
+        0,
+        "no edge escapes the worker's band"
+    );
+
+    // A band reset (DETACH DELETE) drops the accumulated edges and the nodes together.
+    run_and_drain(
+        &mut g,
+        QueryType::Write,
+        &format!("MATCH (n:{label}) WHERE n.id >= {lo} AND n.id <= {hi} DETACH DELETE n"),
+        5_000,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("reset detach-delete");
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH ()-[r:BenchEdge]->() RETURN count(r)").await,
+        0,
+        "the reset drops every accumulated edge"
+    );
+    assert_eq!(
+        scalar_i64(&mut g, &format!("MATCH (n:{label}) RETURN count(n)")).await,
+        0,
+        "the reset clears the band nodes"
+    );
+    drop_graph(graph).await;
+}
+
 /// Read a single-row `RETURN count(...)`/scalar i64.
 async fn scalar_i64(
     graph: &mut falkordb::AsyncGraph,


### PR DESCRIPTION
Completes **Part 5** of the synthetic per-operation benchmark epic (#200) — write operations with steady-state isolation (#205) — the final PR of the 3-stack (PR A #213, PR B #214, **PR C this one**). It adds the four remaining write ops, reusing the Part 5b isolation model (run-unique label `BenchScratch_<run_token>`, disjoint per-worker key bands, sawtooth reset, per-sample mutation-counter verification).

## The four new ops

The key addition is **populated-band** ops — ops that need a pre-existing target keep their key band full (an untimed setup pre-creates `reset_every` nodes; the reset clears **and refills** it), where 5b's ops kept the band empty.

| Op | Verify | Cypher | Band |
|---|---|---|---|
| `create_edge` | `RelationshipCreated` | `MATCH (a {id:$src}),(b {id:$dst}) CREATE (a)-[:BenchEdge]->(b)` | populated, refilled |
| `set_property` | `PropertySet` | `MATCH (n {id:$id}) WHERE n.touched IS NULL SET n.touched=$id` | populated, refilled |
| `delete_node` | `NodeDeleted` | `MATCH (n {id:$id}) DELETE n` | populated, refilled |
| `merge_hit` | `NodeMatched` | `MERGE (n {id:$id}) RETURN n.id` | populated once (no-op reset) |

- **`create_edge`** connects `src → src+1` within the band, wrapping the top back to the bottom (`dst = if src==hi {lo} else {src+1}`) — both endpoints stay in-band, a window yields `R` distinct edges (no duplicate accumulation), and `R==1` is a self-loop. The wrap form never computes `R` as `i32`, avoiding an overflow the naive `%R` would hit.
- **`set_property`**'s `WHERE n.touched IS NULL` makes each sample **self-checking**: because the band is refilled every window with `touched`-less nodes, a genuine first-write always sets one property; if a broken reset left `touched` set, the match finds nothing, zero properties are set, and verification fails **loudly** instead of silently measuring a redundant write.
- **`delete_node`** deletes each of the window's `R` pre-created nodes exactly once (`window_key` is unique within a window), then the boundary reset refills them.
- **`merge_hit`** MERGEs a node pre-created in setup, so it always matches (zero mutations); it never drifts, so its reset is a no-op (no churning `R` nodes/window).

## Supporting changes

- `write_clear_band` / `write_cleanup_run` now `DETACH DELETE` so `create_edge`'s edges are cleaned with their nodes (harmless for the edgeless ops).
- `measure_level` captures the scratch-cleanup handle **up-front** and routes a mid-loop worker setup/connection failure through cleanup, so a partially set-up populated band can't leak — newly relevant because setup now *creates* data (5b's setup only deleted).
- Write ops stay opt-in via `--op` (excluded from `--all-reads`).

## Design provenance

The design was **rubber-duck reviewed before coding**; that pass shaped the self-checking `set_property` guard, the overflow-free `create_edge` wrap arithmetic, the setup-failure cleanup fix, and the decision to cover edge/count topology (which mutation counters can't prove) with integration assertions. A local `code-review` pass on the full diff found no high-confidence issues. The reset-interference and unindexed-scratch-lookup characteristics are inherent to the steady-state model (and present since 5b); they're **documented as limitations** rather than addressed here (a run-level index / boundary barrier are candidate future refinements).

## Tests

- **Unit** — the exact render cypher + params for all four ops (mid-band edge, top-of-band wrap, `R==1` self-loop, the `IS NULL` guard, delete/merge targets) and the `fill`/`reset_populated`/`no-op` hooks; the write-plan/mutation table for all six write ops.
- **Integration (`#[ignore]`, docker)** — a `create_edge`+`set_property`+`delete_node`+`merge_hit` sweep at **C=8** over multiple reset windows (green run ⇒ every sample verified ⇒ isolation holds), asserting non-empty per-level stats, seeded data untouched, and **no scratch node *or edge*** left after cleanup; plus a direct `create_edge` test pinning edge **topology** (R distinct band-internal edges, one per op, none escaping the band) and that a reset drops every edge + node.

## Validation

`just ci` (build, clippy `-D warnings`, test), `just doc-check`, and `just coverage` against a Docker FalkorDB — all green (18 integration tests pass under coverage; the CLI runs all four ops end-to-end and cleans up to zero nodes/edges). Verified on FalkorDB 4.20.1 that every op's mutation counters match its `ExpectedMutation`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four optional synthetic benchmark write operations: creating edges, setting properties, deleting nodes, and merging matches.
  * Extended the supported write operation catalog with updated operation details and examples.
* **Bug Fixes**
  * Strengthened run and window cleanup so benchmark scratch data is fully removed, including any relationships created during write operations.
* **Documentation**
  * Updated the benchmark documentation and configuration examples, including clearer opt-in notes and revised steady-state isolation guidance.
* **Tests**
  * Added/expanded integration coverage (with isolation and cleanup correctness checks) for the new write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->