### PR TITLE
ci(coderabbit): remove the no-op fail_commit_status override

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,11 +4,6 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
-  # A transient CodeRabbit review error (most often "Review rate limited") must not turn the
-  # "CodeRabbit" commit-status check red and fail the whole PR — CodeRabbit still reviews and
-  # comments, we just don't gate the PR on a rate-limit hiccup. (Overrides the org default, which
-  # currently fails the status on such errors.)
-  fail_commit_status: false
   auto_review:
     enabled: true
     drafts: false


### PR DESCRIPTION
Removes `reviews.fail_commit_status: false` from `.coderabbit.yaml`.

It was added in #214 to stop CodeRabbit's `Review rate limited` status from failing PR checks, but it turned out to be a **no-op**: when CodeRabbit is rate-limited it posts that failure commit status **before** it reads `.coderabbit.yaml`, so the flag never applies. Verified on #216 — both `fail_commit_status: false` **and** `commit_status: false` were ignored (the failure recurred on the very commit that set them).

The `Review rate limited` status is **transient** (it passes when CodeRabbit isn't rate-limited) and **non-blocking** (`master` is unprotected and CodeRabbit isn't a required check), so no repo config is needed here. This just deletes the dead override; CodeRabbit reviews and comments are unaffected.
