### PR TITLE
feat(synthetic): Markdown report + client-host metadata (part 6a of #200)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,13 @@ language: en-US
 reviews:
   profile: chill
   request_changes_workflow: false
+  # Don't post CodeRabbit's "CodeRabbit" commit-status check at all. A transient "Review rate
+  # limited" status shows up red before CodeRabbit reads this config, and `fail_commit_status: false`
+  # doesn't govern it, so the only reliable fix is to disable the status mirror entirely (same fix as
+  # FalkorDB/JFalkorDB). CodeRabbit still posts its review comments + walkthrough — only the pass/fail
+  # commit-status check is dropped, so a rate-limit hiccup can't turn a PR's checks red. Takes effect
+  # repo-wide once merged to the default branch.
+  commit_status: false
   auto_review:
     enabled: true
     drafts: false

--- a/readme.md
+++ b/readme.md
@@ -274,6 +274,7 @@ Sample output (one block per selected op; one table row per concurrency level, p
 synthetic benchmark — endpoint falkor://127.0.0.1:6379  graph main  samples 500  warmup 100  concurrency [1,4,16,32]  seed 42  connection pool(size=1) per worker
 server — falkordb module ver 4.20.1  redis 8.6.3  CACHE_SIZE 25
 server image: falkordb/falkordb@sha256:9042fdc4...
+client host — bench-01 · Linux 6.8 Ubuntu 24.04 · Intel(R) Xeon(R) (8c/16t) · 32.0 GiB · x86_64
 
 match_by_index
   [cached — plan reused, execution only]

--- a/readme.md
+++ b/readme.md
@@ -293,12 +293,19 @@ match_by_index
 expand_1_hop
   ...
 report written to synthetic-report.json
+markdown written to synthetic-report.md
 ```
+
+Alongside the JSON, the tool writes a **PR-pasteable Markdown report** (`<out>.md`, e.g.
+`synthetic-report.md`) — a metadata table plus the same per-op latency-vs-throughput tables, ready
+to drop into a pull request.
 
 The report's `meta.server` block records the FalkorDB module version, `redis_version`/`build_id`,
 `CACHE_SIZE`, and the operator-supplied `--server-image` (FalkorDB does not expose a graph-module
 git SHA to clients, so the image digest is the reproducible build identity). A `:edge` image reports
 a `999999` placeholder version and the tool warns you to use a tagged image for comparisons.
+`meta.host` records the **client** machine that ran the probe (OS, CPU, cores, memory, arch, via
+`sysinfo`); the hostname is kept in the JSON/console but omitted from the Markdown.
 
 #### Write operations (steady-state isolation)
 

--- a/src/synthetic/host.rs
+++ b/src/synthetic/host.rs
@@ -1,0 +1,62 @@
+//! Best-effort collection of the **client** host metadata (via `sysinfo`) recorded in a report's
+//! [`Meta::host`](crate::synthetic::report::Meta::host) — the machine driving the benchmark, as
+//! opposed to the FalkorDB server described by
+//! [`ServerInfo`](crate::synthetic::report::ServerInfo).
+
+use crate::synthetic::report::HostInfo;
+use sysinfo::System;
+
+/// Collect the client host metadata. Best-effort: any field `sysinfo` can't determine on this
+/// platform is left `None` (or `0` for the always-available counts), never an error.
+pub fn collect() -> HostInfo {
+    let sys = System::new_all();
+    let cpu = sys
+        .cpus()
+        .first()
+        .map(|c| c.brand().trim().to_string())
+        .filter(|s| !s.is_empty());
+    HostInfo {
+        hostname: non_empty(System::host_name()),
+        os: non_empty(System::long_os_version()),
+        kernel: non_empty(System::kernel_version()),
+        arch: {
+            let a = System::cpu_arch();
+            if a.trim().is_empty() {
+                None
+            } else {
+                Some(a)
+            }
+        },
+        cpu,
+        physical_cores: System::physical_core_count(),
+        logical_cores: sys.cpus().len(),
+        total_memory_bytes: sys.total_memory(),
+    }
+}
+
+/// Map an `Option<String>` to `None` when the string is missing or blank.
+fn non_empty(s: Option<String>) -> Option<String> {
+    s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collect_populates_always_available_fields() {
+        // Best-effort fields (hostname/os/cpu) can be absent on some platforms/CI, so only assert
+        // the ones sysinfo reliably provides everywhere.
+        let h = collect();
+        assert!(h.logical_cores >= 1, "at least one logical CPU");
+        assert!(h.total_memory_bytes > 0, "some physical memory");
+        if let Some(pc) = h.physical_cores {
+            assert!(pc >= 1);
+            assert!(
+                pc <= h.logical_cores,
+                "physical cores ({pc}) can't exceed logical ({})",
+                h.logical_cores
+            );
+        }
+    }
+}

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -19,6 +19,7 @@ pub mod catalog;
 pub mod config;
 pub mod dataset;
 pub mod engine;
+pub mod host;
 pub mod op_runner;
 pub mod provenance;
 pub mod report;
@@ -527,6 +528,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             connection: "pool(size=1) per worker".to_string(),
             started_at_epoch_secs,
             server,
+            host: host::collect(),
             dataset: dataset_info,
         },
         operations,
@@ -1033,7 +1035,21 @@ pub async fn run_and_report(config: &Config) -> BenchmarkResult<()> {
     tokio::fs::write(&config.out, json).await?;
     info!("wrote {}", config.out);
     println!("report written to {}", config.out);
+    // A PR-pasteable Markdown report alongside the JSON: `<out>.md` (replacing a `.json` suffix).
+    let md_path = markdown_path(&config.out);
+    tokio::fs::write(&md_path, report.to_markdown()).await?;
+    info!("wrote {}", md_path);
+    println!("markdown written to {}", md_path);
     Ok(())
+}
+
+/// The Markdown report path for a JSON `out` path: swap a trailing `.json` for `.md`, else append
+/// `.md` (e.g. `synthetic-report.json` → `synthetic-report.md`, `report` → `report.md`).
+fn markdown_path(out: &str) -> String {
+    match out.strip_suffix(".json") {
+        Some(stem) => format!("{stem}.md"),
+        None => format!("{out}.md"),
+    }
 }
 
 /// Execute a parsed `synthetic` subcommand. This keeps `main.rs` a thin shell: it loads the
@@ -1393,6 +1409,15 @@ mod tests {
         for op in OpName::value_variants() {
             assert!(listing.contains(op.as_str()));
         }
+    }
+
+    #[test]
+    fn markdown_path_swaps_json_suffix_or_appends() {
+        assert_eq!(markdown_path("synthetic-report.json"), "synthetic-report.md");
+        assert_eq!(markdown_path("/tmp/out/report.json"), "/tmp/out/report.md");
+        assert_eq!(markdown_path("report"), "report.md");
+        // Only a trailing `.json` is swapped; anything else just gets `.md` appended.
+        assert_eq!(markdown_path("weird.jsonx"), "weird.jsonx.md");
     }
 
     #[tokio::test]

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -44,6 +44,30 @@ impl ServerInfo {
     }
 }
 
+/// The client host the probe ran on (best-effort via `sysinfo`). Every field is optional because
+/// `sysinfo` can't always determine them and availability varies by platform, so a missing value
+/// is `None`/`0` rather than an error. This is the **client** machine driving the benchmark, not
+/// the FalkorDB server (whose OS/arch live in [`ServerInfo`]).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HostInfo {
+    /// Client hostname (kept out of the pasteable Markdown, present in JSON/console).
+    pub hostname: Option<String>,
+    /// Long OS name, e.g. `"macOS 15.1"` / `"Linux 6.8 Ubuntu 24.04"`.
+    pub os: Option<String>,
+    /// Kernel version string.
+    pub kernel: Option<String>,
+    /// CPU architecture, e.g. `"aarch64"` / `"x86_64"`.
+    pub arch: Option<String>,
+    /// CPU brand string, e.g. `"Apple M2"` / `"Intel(R) Xeon(R) …"`.
+    pub cpu: Option<String>,
+    /// Physical core count (`None` if `sysinfo` can't determine it).
+    pub physical_cores: Option<usize>,
+    /// Logical CPU count.
+    pub logical_cores: usize,
+    /// Total physical memory in bytes.
+    pub total_memory_bytes: u64,
+}
+
 /// Run-level metadata: how and against what the probe ran.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Meta {
@@ -74,6 +98,10 @@ pub struct Meta {
     pub connection: String,
     pub started_at_epoch_secs: u64,
     pub server: ServerInfo,
+    /// The client host the probe ran on. `#[serde(default)]` so pre-Part-6 reports (which lacked it)
+    /// still deserialize, defaulting to an empty [`HostInfo`].
+    #[serde(default)]
+    pub host: HostInfo,
     /// Present only when the probe generated its own reproducible dataset (Part 3). Absent for an
     /// externally-provided graph, whose contents we can't fingerprint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -253,6 +281,10 @@ impl Report {
         if let Some(img) = &self.meta.server.server_image {
             out.push_str(&format!("server image: {}\n", img));
         }
+        let host_line = host_summary(&self.meta.host, true);
+        if !host_line.is_empty() {
+            out.push_str(&format!("client host — {}\n", host_line));
+        }
         if let Some(d) = &self.meta.dataset {
             out.push_str(&format!(
                 "dataset — seed {}  nodes {}  edges {}  corpus_hash {}\n",
@@ -265,6 +297,191 @@ impl Report {
         }
         out
     }
+
+    /// Render the report as GitHub-flavoured **Markdown** (a metadata table + one latency-vs-
+    /// throughput table per operation and cache mode), suitable for pasting into a PR. Shares the
+    /// numeric row model with [`Report::to_console`] so the two never disagree.
+    pub fn to_markdown(&self) -> String {
+        let m = &self.meta;
+        let mut out = String::from("# Synthetic per-operation benchmark\n\n");
+
+        let module_ver = m
+            .server
+            .module_graph_ver
+            .map(crate::synthetic::provenance::decode_module_version)
+            .unwrap_or_else(|| "unknown".to_string());
+        let module_note = if m.server.is_placeholder() {
+            " ⚠️ dev placeholder — use a tagged image for comparisons"
+        } else {
+            ""
+        };
+        let concurrency = if m.concurrency.is_empty() {
+            "1".to_string()
+        } else {
+            m.concurrency
+                .iter()
+                .map(|c| c.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        out.push_str("| field | value |\n|---|---|\n");
+        out.push_str(&format!("| tool | v{} |\n", m.tool_version));
+        out.push_str(&format!(
+            "| endpoint / graph | `{}` / `{}` |\n",
+            m.endpoint, m.graph
+        ));
+        out.push_str(&format!(
+            "| FalkorDB module | {}{} |\n",
+            module_ver, module_note
+        ));
+        if let Some(redis) = &m.server.redis_version {
+            out.push_str(&format!("| redis | {} |\n", redis));
+        }
+        if let Some(cs) = m.server.cache_size {
+            out.push_str(&format!("| CACHE_SIZE | {} |\n", cs));
+        }
+        if let Some(img) = &m.server.server_image {
+            out.push_str(&format!("| server image | `{}` |\n", img));
+        }
+        // Client host: omit the hostname from the pasteable Markdown (it can be sensitive; it stays
+        // in the JSON and console).
+        let host_line = host_summary(&m.host, false);
+        if !host_line.is_empty() {
+            out.push_str(&format!("| client host | {} |\n", host_line));
+        }
+        out.push_str(&format!("| samples / warmup | {} / {} |\n", m.samples, m.warmup));
+        out.push_str(&format!("| concurrency | {} |\n", concurrency));
+        out.push_str(&format!("| cache seed | {} |\n", m.seed));
+        out.push_str(&format!("| connection | {} |\n", m.connection));
+        if let Some(d) = &m.dataset {
+            out.push_str(&format!(
+                "| dataset | seed {} · {} nodes · {} edges |\n",
+                d.seed, d.nodes, d.edges
+            ));
+            out.push_str(&format!("| corpus_hash | `{}` |\n", d.corpus_hash));
+        }
+
+        for (name, op) in &self.operations {
+            out.push_str(&format!("\n## `{}`\n", name));
+            render_op_levels_markdown(&mut out, op);
+        }
+        out
+    }
+}
+
+/// A one-line client-host summary (` · `-joined, skipping unknown fields). With `with_hostname`,
+/// the hostname is prefixed — used for the local console but not the pasteable Markdown.
+fn host_summary(
+    h: &crate::synthetic::report::HostInfo,
+    with_hostname: bool,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if with_hostname {
+        if let Some(name) = &h.hostname {
+            parts.push(name.clone());
+        }
+    }
+    if let Some(os) = &h.os {
+        parts.push(os.clone());
+    }
+    if let Some(cpu) = &h.cpu {
+        let cores = match h.physical_cores {
+            Some(p) => format!("{}c/{}t", p, h.logical_cores),
+            None => format!("{}t", h.logical_cores),
+        };
+        parts.push(format!("{} ({})", cpu, cores));
+    } else if h.logical_cores > 0 {
+        parts.push(format!("{} threads", h.logical_cores));
+    }
+    if h.total_memory_bytes > 0 {
+        parts.push(format!(
+            "{:.1} GiB",
+            h.total_memory_bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+        ));
+    }
+    if let Some(arch) = &h.arch {
+        parts.push(arch.clone());
+    }
+    parts.join(" · ")
+}
+
+/// One cache-plan condition a sweep is measured under. Selects the matching per-level metrics and
+/// its label in each renderer, so the console and Markdown tables share one source of truth.
+#[derive(Clone, Copy, PartialEq)]
+enum CacheView {
+    Cached,
+    Uncached,
+}
+
+impl CacheView {
+    fn pick(self, level: &LevelReport) -> Option<&LevelMetrics> {
+        match self {
+            CacheView::Cached => level.cached.as_ref(),
+            CacheView::Uncached => level.uncached.as_ref(),
+        }
+    }
+
+    fn console_label(self) -> &'static str {
+        match self {
+            CacheView::Cached => "cached — plan reused, execution only",
+            CacheView::Uncached => "uncached — plan-cache miss each run, execution + compilation",
+        }
+    }
+
+    fn markdown_label(self) -> &'static str {
+        match self {
+            CacheView::Cached => "cached — plan reused, execution only",
+            CacheView::Uncached => "uncached — plan-cache miss each run, execution + compilation",
+        }
+    }
+}
+
+/// One rendered row of an operation's latency-vs-throughput table: the numbers both the console and
+/// Markdown renderers format, extracted once so the two can't drift.
+struct LevelRow {
+    concurrency: usize,
+    throughput: f64,
+    /// server-time percentiles [p50, p90, p95, p99] (ms).
+    server: [f64; 4],
+    /// total round-trip percentiles [p50, p90, p95, p99] (ms).
+    total: [f64; 4],
+    miss_pct: f64,
+    /// Number of samples whose cache flag was absent (a `0.0` miss% may just mean "unknown").
+    cached_unknown: usize,
+    /// Whether this level is the sweep's saturation knee (highest achieved throughput across modes).
+    is_knee: bool,
+}
+
+/// The `(cache mode, rows)` tables present for an operation, cached before uncached. A mode with no
+/// measured level is omitted. The shared model behind both [`render_op_levels`] and
+/// [`render_op_levels_markdown`].
+fn op_mode_tables(op: &OperationReport) -> Vec<(CacheView, Vec<LevelRow>)> {
+    let knee = op.knee_concurrency();
+    [CacheView::Cached, CacheView::Uncached]
+        .into_iter()
+        .filter_map(|mode| {
+            let rows: Vec<LevelRow> = op
+                .levels
+                .iter()
+                .filter_map(|level| {
+                    let m = mode.pick(level)?;
+                    let s = &m.metrics.server_ms;
+                    let t = &m.metrics.total_ms;
+                    Some(LevelRow {
+                        concurrency: level.concurrency,
+                        throughput: m.throughput_ops_per_sec,
+                        server: [s.median, s.p90, s.p95, s.p99],
+                        total: [t.median, t.p90, t.p95, t.p99],
+                        miss_pct: m.metrics.cached_false_rate * 100.0,
+                        cached_unknown: m.metrics.cached_unknown,
+                        is_knee: knee == Some(level.concurrency),
+                    })
+                })
+                .collect();
+            (!rows.is_empty()).then_some((mode, rows))
+        })
+        .collect()
 }
 
 /// Render one operation's concurrency sweep as a latency-vs-throughput table per cache mode,
@@ -274,45 +491,26 @@ fn render_op_levels(
     out: &mut String,
     op: &OperationReport,
 ) {
-    let knee = op.knee_concurrency();
-    for (mode_label, pick) in [
-        (
-            "cached — plan reused, execution only",
-            (|l: &LevelReport| l.cached.as_ref()) as fn(&LevelReport) -> Option<&LevelMetrics>,
-        ),
-        (
-            "uncached — plan-cache miss each run, execution + compilation",
-            (|l: &LevelReport| l.uncached.as_ref()) as fn(&LevelReport) -> Option<&LevelMetrics>,
-        ),
-    ] {
-        if !op.levels.iter().any(|l| pick(l).is_some()) {
-            continue;
-        }
-        out.push_str(&format!("  [{}]\n", mode_label));
+    for (mode, rows) in op_mode_tables(op) {
+        out.push_str(&format!("  [{}]\n", mode.console_label()));
         out.push_str(
             "    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%\n",
         );
-        for level in &op.levels {
-            let Some(m) = pick(level) else { continue };
-            let knee_mark = if knee == Some(level.concurrency) {
-                "  <- knee"
-            } else {
-                ""
-            };
+        for r in rows {
             out.push_str(&format!(
                 "  {:>3}   {:>15.0}   {:>7.3} /{:>6.3} /{:>6.3} /{:>6.3}   {:>7.3} /{:>6.3} /{:>6.3} /{:>6.3}   {:>5.1}{}\n",
-                level.concurrency,
-                m.throughput_ops_per_sec,
-                m.metrics.server_ms.median,
-                m.metrics.server_ms.p90,
-                m.metrics.server_ms.p95,
-                m.metrics.server_ms.p99,
-                m.metrics.total_ms.median,
-                m.metrics.total_ms.p90,
-                m.metrics.total_ms.p95,
-                m.metrics.total_ms.p99,
-                m.metrics.cached_false_rate * 100.0,
-                knee_mark,
+                r.concurrency,
+                r.throughput,
+                r.server[0],
+                r.server[1],
+                r.server[2],
+                r.server[3],
+                r.total[0],
+                r.total[1],
+                r.total[2],
+                r.total[3],
+                r.miss_pct,
+                if r.is_knee { "  <- knee" } else { "" },
             ));
         }
     }
@@ -321,6 +519,53 @@ fn render_op_levels(
         for level in &op.levels {
             if let Some(comp) = level.compilation_ms_median {
                 out.push_str(&format!("    C={:<4} {:.3}\n", level.concurrency, comp));
+            }
+        }
+    }
+}
+
+/// Render one operation's sweep as GitHub-flavoured Markdown tables (one per cache mode) plus a
+/// compilation-cost table, sharing [`op_mode_tables`] with the console renderer.
+fn render_op_levels_markdown(
+    out: &mut String,
+    op: &OperationReport,
+) {
+    for (mode, rows) in op_mode_tables(op) {
+        // Surface "unknown cache stats" so a 0.0 miss% isn't mistaken for "definitely cached".
+        let any_unknown = rows.iter().any(|r| r.cached_unknown > 0);
+        out.push_str(&format!("\n_{}_\n\n", mode.markdown_label()));
+        out.push_str(
+            "| C | throughput (ops/s) | server p50/p90/p95/p99 (ms) | total p50/p90/p95/p99 (ms) | miss% | |\n",
+        );
+        out.push_str("|---:|---:|---|---|---:|---|\n");
+        for r in rows {
+            out.push_str(&format!(
+                "| {} | {:.0} | {:.3} / {:.3} / {:.3} / {:.3} | {:.3} / {:.3} / {:.3} / {:.3} | {}{:.1} | {} |\n",
+                r.concurrency,
+                r.throughput,
+                r.server[0],
+                r.server[1],
+                r.server[2],
+                r.server[3],
+                r.total[0],
+                r.total[1],
+                r.total[2],
+                r.total[3],
+                if r.cached_unknown > 0 { "~" } else { "" },
+                r.miss_pct,
+                if r.is_knee { "⬅ knee" } else { "" },
+            ));
+        }
+        if any_unknown {
+            out.push_str("\n> `~` miss% includes samples with no cache stat reported.\n");
+        }
+    }
+    if op.levels.iter().any(|l| l.compilation_ms_median.is_some()) {
+        out.push_str("\ncompilation_ms (median uncached − cached server time):\n\n");
+        out.push_str("| C | compilation_ms |\n|---:|---:|\n");
+        for level in &op.levels {
+            if let Some(comp) = level.compilation_ms_median {
+                out.push_str(&format!("| {} | {:.3} |\n", level.concurrency, comp));
             }
         }
     }
@@ -392,6 +637,16 @@ mod tests {
                     cache_size: Some(25),
                     redis_version: Some("8.6.3".to_string()),
                     ..Default::default()
+                },
+                host: HostInfo {
+                    hostname: Some("bench-host".to_string()),
+                    os: Some("Linux 6.8 Ubuntu 24.04".to_string()),
+                    kernel: Some("6.8.0-40-generic".to_string()),
+                    arch: Some("aarch64".to_string()),
+                    cpu: Some("Test CPU @ 3.2GHz".to_string()),
+                    physical_cores: Some(8),
+                    logical_cores: 16,
+                    total_memory_bytes: 34_359_738_368,
                 },
                 dataset: None,
             },
@@ -469,6 +724,121 @@ mod tests {
         assert!(out.contains("CACHE_SIZE 25"));
         // The operator-supplied image identity is echoed when present.
         assert!(out.contains("server image: falkordb/falkordb:v4.2.1@sha256:deadbeef"));
+    }
+
+    #[test]
+    fn markdown_contains_metadata_and_tables() {
+        let mut r = sample_report();
+        r.meta.server.server_image = Some("falkordb/falkordb:v4.2.1@sha256:deadbeef".to_string());
+        let md = r.to_markdown();
+        assert!(md.contains("# Synthetic per-operation benchmark"));
+        assert!(md.contains("| FalkorDB module | 4.20.1 |"));
+        assert!(md.contains("| server image | `falkordb/falkordb:v4.2.1@sha256:deadbeef` |"));
+        assert!(md.contains("| concurrency | 1, 8 |"));
+        // The client-host summary is present, but the hostname is NOT (kept out of pasteable md).
+        assert!(md.contains("Test CPU @ 3.2GHz (8c/16t)"));
+        assert!(
+            !md.contains("bench-host"),
+            "hostname must stay out of the markdown"
+        );
+        // Per-op section, markdown table header, both cache modes, knee, and compilation table.
+        assert!(md.contains("## `return_const`"));
+        assert!(md.contains("| C | throughput (ops/s) |"));
+        assert!(md.contains("cached — plan reused"));
+        assert!(md.contains("uncached — plan-cache miss"));
+        assert!(md.contains("⬅ knee"));
+        assert!(md.contains("compilation_ms"));
+    }
+
+    #[test]
+    fn markdown_and_console_agree_on_numbers() {
+        // The shared row model means a level's throughput renders identically in both surfaces.
+        let r = sample_report();
+        let (console, md) = (r.to_console(), r.to_markdown());
+        for needle in ["2950", "return_const"] {
+            assert!(
+                console.contains(needle) && md.contains(needle),
+                "both surfaces must render {needle}"
+            );
+        }
+    }
+
+    #[test]
+    fn host_summary_hides_hostname_unless_requested() {
+        let h = HostInfo {
+            hostname: Some("secret-box".to_string()),
+            os: Some("Linux 6.8".to_string()),
+            kernel: None,
+            arch: Some("x86_64".to_string()),
+            cpu: Some("CPU X".to_string()),
+            physical_cores: Some(4),
+            logical_cores: 8,
+            total_memory_bytes: 16 * 1024 * 1024 * 1024,
+        };
+        let with = host_summary(&h, true);
+        let without = host_summary(&h, false);
+        assert!(with.contains("secret-box"));
+        assert!(!without.contains("secret-box"), "hostname omitted when not requested");
+        assert!(without.contains("CPU X (4c/8t)"));
+        assert!(without.contains("16.0 GiB"));
+        assert!(without.contains("x86_64"));
+    }
+
+    #[test]
+    fn host_summary_without_cpu_reports_thread_count() {
+        let h = HostInfo {
+            cpu: None,
+            logical_cores: 4,
+            total_memory_bytes: 8 * 1024 * 1024 * 1024,
+            ..Default::default()
+        };
+        let s = host_summary(&h, false);
+        assert!(s.contains("4 threads"), "falls back to a thread count: {s}");
+        assert!(s.contains("8.0 GiB"));
+    }
+
+    #[test]
+    fn host_summary_cpu_without_physical_cores_shows_threads_only() {
+        let h = HostInfo {
+            cpu: Some("CPU Y".to_string()),
+            physical_cores: None,
+            logical_cores: 6,
+            total_memory_bytes: 4 * 1024 * 1024 * 1024,
+            ..Default::default()
+        };
+        assert!(host_summary(&h, false).contains("CPU Y (6t)"));
+    }
+
+    #[test]
+    fn markdown_flags_placeholder_version_and_default_concurrency() {
+        let mut r = sample_report();
+        r.meta.server.module_graph_ver = Some(ServerInfo::PLACEHOLDER_VER);
+        r.meta.concurrency.clear(); // no sweep configured ⇒ header shows the implicit single level
+        let md = r.to_markdown();
+        assert!(md.contains("dev placeholder"));
+        assert!(md.contains("| concurrency | 1 |"));
+    }
+
+    #[test]
+    fn markdown_renders_dataset_and_unknown_cache_marker() {
+        let mut r = sample_report();
+        r.meta.dataset = Some(DatasetInfo {
+            seed: 7,
+            nodes: 100,
+            edges: 200,
+            corpus_hash: "sha256:abc123".to_string(),
+        });
+        // Force an "unknown cache stat" sample so the `~` marker + note render.
+        if let Some(op) = r.operations.get_mut("return_const") {
+            if let Some(lm) = op.levels[0].cached.as_mut() {
+                lm.metrics.cached_unknown = 3;
+            }
+        }
+        let md = r.to_markdown();
+        assert!(md.contains("| dataset | seed 7 · 100 nodes · 200 edges |"));
+        assert!(md.contains("| corpus_hash | `sha256:abc123` |"));
+        assert!(md.contains('~'), "unknown-cache miss% is marked with ~");
+        assert!(md.contains("no cache stat reported"));
     }
 
     #[test]

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -565,7 +565,9 @@ fn render_op_levels_markdown(
             ));
         }
         if any_unknown {
-            out.push_str("\n> `~` miss% includes samples with no cache stat reported.\n");
+            out.push_str(
+                "\n> `~` some samples reported no cache stat (counted separately); the miss% is computed over the samples with a known cache stat only.\n",
+            );
         }
     }
     if op.levels.iter().any(|l| l.compilation_ms_median.is_some()) {
@@ -859,7 +861,7 @@ mod tests {
         assert!(md.contains("| dataset | seed 7 · 100 nodes · 200 edges |"));
         assert!(md.contains("| corpus_hash | `sha256:abc123` |"));
         assert!(md.contains('~'), "unknown-cache miss% is marked with ~");
-        assert!(md.contains("no cache stat reported"));
+        assert!(md.contains("known cache stat only"));
     }
 
     #[test]

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -326,40 +326,41 @@ impl Report {
         };
 
         out.push_str("| field | value |\n|---|---|\n");
-        out.push_str(&format!("| tool | v{} |\n", m.tool_version));
+        out.push_str(&format!("| tool | v{} |\n", md_cell(&m.tool_version)));
         out.push_str(&format!(
             "| endpoint / graph | `{}` / `{}` |\n",
-            m.endpoint, m.graph
+            md_cell(&m.endpoint),
+            md_cell(&m.graph)
         ));
         out.push_str(&format!(
             "| FalkorDB module | {}{} |\n",
             module_ver, module_note
         ));
         if let Some(redis) = &m.server.redis_version {
-            out.push_str(&format!("| redis | {} |\n", redis));
+            out.push_str(&format!("| redis | {} |\n", md_cell(redis)));
         }
         if let Some(cs) = m.server.cache_size {
             out.push_str(&format!("| CACHE_SIZE | {} |\n", cs));
         }
         if let Some(img) = &m.server.server_image {
-            out.push_str(&format!("| server image | `{}` |\n", img));
+            out.push_str(&format!("| server image | `{}` |\n", md_cell(img)));
         }
         // Client host: omit the hostname from the pasteable Markdown (it can be sensitive; it stays
         // in the JSON and console).
         let host_line = host_summary(&m.host, false);
         if !host_line.is_empty() {
-            out.push_str(&format!("| client host | {} |\n", host_line));
+            out.push_str(&format!("| client host | {} |\n", md_cell(&host_line)));
         }
         out.push_str(&format!("| samples / warmup | {} / {} |\n", m.samples, m.warmup));
         out.push_str(&format!("| concurrency | {} |\n", concurrency));
         out.push_str(&format!("| cache seed | {} |\n", m.seed));
-        out.push_str(&format!("| connection | {} |\n", m.connection));
+        out.push_str(&format!("| connection | {} |\n", md_cell(&m.connection)));
         if let Some(d) = &m.dataset {
             out.push_str(&format!(
                 "| dataset | seed {} · {} nodes · {} edges |\n",
                 d.seed, d.nodes, d.edges
             ));
-            out.push_str(&format!("| corpus_hash | `{}` |\n", d.corpus_hash));
+            out.push_str(&format!("| corpus_hash | `{}` |\n", md_cell(&d.corpus_hash)));
         }
 
         for (name, op) in &self.operations {
@@ -368,6 +369,13 @@ impl Report {
         }
         out
     }
+}
+
+/// Escape a value for a GitHub-flavoured Markdown **table cell**: an unescaped `|` ends the cell
+/// (even inside a code span) and a newline breaks the row, so escape the former and fold the latter
+/// to `<br>`. `\r` is dropped so a CRLF doesn't yield a doubled break.
+fn md_cell(s: &str) -> String {
+    s.replace('|', "\\|").replace('\r', "").replace('\n', "<br>")
 }
 
 /// A one-line client-host summary (` · `-joined, skipping unknown fields). With `with_hostname`,
@@ -817,6 +825,19 @@ mod tests {
         let md = r.to_markdown();
         assert!(md.contains("dev placeholder"));
         assert!(md.contains("| concurrency | 1 |"));
+    }
+
+    #[test]
+    fn markdown_escapes_pipe_and_newline_in_cells() {
+        let mut r = sample_report();
+        r.meta.graph = "a|b\nc".to_string();
+        r.meta.endpoint = "falkor://h|x".to_string();
+        let md = r.to_markdown();
+        // A raw `|`/newline in a user-provided value must not leak into the table (it would break
+        // the row/columns); it is escaped to `\|` and folded to `<br>`.
+        assert!(md.contains("a\\|b<br>c"), "graph pipe/newline escaped: {md}");
+        assert!(md.contains("falkor://h\\|x"));
+        assert!(!md.contains("a|b"), "no raw pipe survives in a cell");
     }
 
     #[test]


### PR DESCRIPTION
Part 6 of the synthetic per-operation benchmark epic (#200) — **reporting polish + version baselines** (#206) — lands as **two PRs**. This is **PR A: reporting polish** (PR B will add the Criterion C=1 baselines + `synthetic-baseline`/`synthetic-compare`).

## What this PR adds

- **`Report::to_markdown()`** — a **PR-pasteable Markdown report**: a metadata table (tool, endpoint/graph, FalkorDB module version + placeholder warning, redis, `CACHE_SIZE`, server image, client host, samples/warmup, concurrency, seed, connection, dataset + `corpus_hash`) followed by one **latency-vs-throughput table per operation and cache mode** (C · throughput · server p50/p90/p95/p99 · total p50/p90/p95/p99 · miss% · knee), plus the derived `compilation_ms`. Written to **`<out>.md`** alongside the JSON (`synthetic-report.json` → `synthetic-report.md`).
- **`Meta.host` (`HostInfo` via `sysinfo`)** — the **client** machine that ran the probe: OS, kernel, CPU brand, physical + logical cores, total memory, arch. All fields best-effort/optional (`sysinfo` can't always determine them, and availability varies by platform), so a missing value is `None`/`0`, never an error.
- **One shared row model** (`CacheView` / `LevelRow` / `op_mode_tables`) behind both the console and Markdown renderers, so the two tables can never drift. The existing `to_console()` output is **unchanged** (it just gains a `client host — …` line), and Markdown additionally surfaces `cached_unknown` (a `0%` miss% can mean "no cache stat reported", now marked `~`).

## Privacy note

The **hostname** is recorded in the JSON and printed to the local console, but **omitted from the pasteable Markdown** (it can be sensitive when dropped into a public PR). The Markdown host line is `OS · CPU (Nc/Mt) · mem · arch`.

## Scoping

**git SHA** run-metadata (listed in #206) is intentionally **deferred** — there's no reliable build-time source for it in this repo yet (no `build.rs`), per discussion. Everything else from #206's metadata list (module version, host, `corpus_hash`, connection, `non_internal_ms`/`cached_false_rate`/`cached_unknown`) is now present.

## Tests

Unit: Markdown content (metadata table, per-op tables, knee, `compilation_ms`, dataset/`corpus_hash`, placeholder-version note, unknown-cache marker); console↔markdown numeric agreement (proves the shared model); `host_summary` hostname gating + cpu/core fallbacks; `markdown_path` suffix handling; old-report backward-compat deserialization (no `host` field ⇒ `HostInfo::default()`). Sample output verified end-to-end via the CLI against FalkorDB 4.20.1 (hostname present in JSON, absent from `.md`; memory correctly rendered in GiB).

## Validation

`just ci` (build, clippy `-D warnings`, test — 136 unit tests), `just doc-check`, and `just coverage` against a Docker FalkorDB — all green. A local `code-review` pass verified the console output stayed byte-compatible after the shared-model refactor and confirmed the `sysinfo` 0.39 semantics (`total_memory` is bytes; `cpu_arch`/`physical_core_count` used correctly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Benchmark reports now include client host details such as operating system, CPU, architecture, core counts, and memory.
  - Synthetic benchmark runs now generate a shareable Markdown report alongside the JSON report.
  - Markdown reports include metadata, per-operation performance tables, compilation costs, and clearer cache-stat indicators.
  - Console output now displays a concise client host summary.

- **Documentation**
  - Updated benchmark documentation with new sample output, report formats, and available metadata details.

- **Chores**
  - Disabled CodeRabbit’s mirrored commit-status check to prevent misleading transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->