### PR TITLE
feat(synthetic): Criterion C=1 version baselines + save/compare (part 6b of #200)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,8 @@ Key recipes:
 | `just synthetic-bench-one <op>` | Sweep one operation over the concurrency curve (needs a live FalkorDB). |
 | `just synthetic-ops` | List the synthetic operations. |
 | `just synthetic-it` | Run the synthetic integration test against a live FalkorDB. |
+| `just synthetic-baseline <name>` | Save a Criterion C=1 latency baseline (per-op read latencies) for the current build/version (needs a live FalkorDB + `synthetic-bench.toml`). |
+| `just synthetic-compare <name>` | Compare the current build against a saved baseline — guards on `corpus_hash` (aborts on workload mismatch), then runs Criterion (needs a live FalkorDB). |
 | `just fmt` / `just fmt-check` | Format Rust in place / check formatting. |
 | `just run -- <args>` | Run the benchmark binary (e.g. `just run -- --help`). |
 | `just ui-install` | `npm ci` in `ui/`. |

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ prometheus.yml
 Results-*/
 csv_output/
 
+# synthetic per-operation benchmark: per-user config + saved version baselines (Part 6)
+synthetic-bench.toml
+/baselines/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
+ "criterion",
  "falkordb",
  "flate2",
  "futures",
@@ -251,6 +258,12 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -317,6 +330,33 @@ dependencies = [
  "parse-zoneinfo",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -477,10 +517,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -839,6 +942,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,10 +1297,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1556,6 +1690,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1812,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1929,6 +2097,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redis"
@@ -2666,6 +2854,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,14 +57,20 @@ falkordb = { path = "vendor/falkordb-rs" }
 name = "benchmark"
 path = "src/main.rs"
 
-
-
+# Criterion C=1 single-flight latency baselines for the synthetic read ops (Part 6b). `harness =
+# false` lets `benches/synthetic_ops.rs` provide its own `main` via `criterion_main!`.
+[[bench]]
+name = "synthetic_ops"
+harness = false
 
 
 [dev-dependencies]
 # `test-util` (not in tokio's `full`) enables `#[tokio::test(start_paused = true)]` so the
 # concurrency-engine throughput test drives a virtual clock deterministically.
 tokio = { version = "1.52.3", features = ["test-util"] }
+# Criterion powers the C=1 latency baselines (`just synthetic-baseline` / `synthetic-compare`):
+# `async_tokio` to drive the async client, `html_reports` for the browsable plots.
+criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
 
 [profile.release]
 opt-level = 3  # This is the default

--- a/Justfile
+++ b/Justfile
@@ -163,6 +163,31 @@ synthetic-ops:
 synthetic-it:
     cargo test --test synthetic_probe -- --ignored --nocapture
 
+# Save a Criterion C=1 single-flight latency baseline named <name>. (Re)generates the dataset from
+# `synthetic-bench.toml`, captures the run's corpus_hash + FalkorDB version into
+# `baselines/<name>.json`, then saves the Criterion baseline. Needs a live FalkorDB + a
+# `synthetic-bench.toml` with `nodes`/`edges`/`operations`. Run this on FalkorDB version A.
+synthetic-baseline name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p baselines
+    cargo run --quiet --bin benchmark -- synthetic run --generate --samples 1 --warmup 0 \
+        --concurrency 1 --out "baselines/{{name}}.json"
+    cargo bench --bench synthetic_ops -- --save-baseline "{{name}}"
+
+# Compare the current build against a saved baseline <name>: first GUARD that the workload still
+# matches the baseline's corpus_hash (aborting on mismatch), then run Criterion against the saved
+# baseline. Run this on FalkorDB version B (after upgrading) to see the per-op latency change.
+synthetic-compare name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    test -f "baselines/{{name}}.json" || { echo "no saved baseline 'baselines/{{name}}.json' — run 'just synthetic-baseline {{name}}' first"; exit 1; }
+    cargo run --quiet --bin benchmark -- synthetic run --generate --samples 1 --warmup 0 \
+        --concurrency 1 --out "baselines/{{name}}.current.json"
+    cargo run --quiet --bin benchmark -- synthetic baseline-guard \
+        --baseline "baselines/{{name}}.json" --current "baselines/{{name}}.current.json"
+    cargo bench --bench synthetic_ops -- --baseline "{{name}}"
+
 # === UI (Next.js dashboard in ui/) ===========================================
 
 # Install UI dependencies from the lockfile.

--- a/benches/synthetic_ops.rs
+++ b/benches/synthetic_ops.rs
@@ -42,15 +42,14 @@ fn resolve_endpoint(cfg: &FileConfig) -> String {
 /// The graph key to measure against — the config's `graph`, else the default (matching
 /// `benchmark synthetic run`, so it's the same graph the recipe generated into).
 fn resolve_graph(cfg: &FileConfig) -> String {
-    cfg.graph.clone().unwrap_or_else(|| "falkor".to_string())
+    cfg.graph
+        .clone()
+        .unwrap_or_else(|| benchmark::synthetic::DEFAULT_GRAPH.to_string())
 }
 
 /// The read ops to baseline: the config's `operations` (or every read op), keeping reads only.
 fn read_ops(cfg: &FileConfig) -> Vec<OpName> {
-    let ops = cfg
-        .operations
-        .clone()
-        .unwrap_or_else(|| OpName::all_reads().to_vec());
+    let ops = cfg.operations.clone().unwrap_or_else(OpName::all_reads);
     ops.into_iter()
         .filter(|op| op.kind() == QueryType::Read)
         .collect()

--- a/benches/synthetic_ops.rs
+++ b/benches/synthetic_ops.rs
@@ -28,7 +28,10 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 
 const SERVER_TIMEOUT_MS: i64 = 5_000;
-const CLIENT_DEADLINE: Duration = Duration::from_secs(5);
+/// Larger than the server-side timeout (matching the runner's 5000/6000 defaults): the client
+/// deadline wraps the whole execute+drain round-trip plus client overhead, so keeping it above
+/// `SERVER_TIMEOUT_MS` avoids spurious client-side timeouts.
+const CLIENT_DEADLINE: Duration = Duration::from_secs(6);
 
 /// The FalkorDB endpoint — resolved like `benchmark synthetic run`: the config's `endpoint`, else
 /// the local default. (Deliberately does NOT read `FALKORDB_HOST`/`PORT`, so the bench and the

--- a/benches/synthetic_ops.rs
+++ b/benches/synthetic_ops.rs
@@ -1,0 +1,146 @@
+//! Criterion C=1 single-flight latency baselines for the synthetic **read** operations, for
+//! tracking latency regressions across FalkorDB versions (see `just synthetic-baseline` /
+//! `synthetic-compare`, which gate this on a `corpus_hash` guard first).
+//!
+//! Requires a live FalkorDB holding a **generated** dataset — the recipes run `benchmark synthetic
+//! run --generate` first. The endpoint, graph, dataset dimensions (`seed`/`nodes`/`edges`) and
+//! `operations` all come from `synthetic-bench.toml` (defaulting to `falkor://127.0.0.1:6379` /
+//! `falkor`), resolved **exactly like `benchmark synthetic run`** so both halves of a
+//! baseline/compare recipe always target the same server and graph. The corpus is reproduced
+//! **byte-for-byte** from the same seed the `corpus_hash` fingerprints (`DatasetSpec::handle()` is
+//! what a generated run uses too). Each op is measured single-flight (one query in flight) — the
+//! honest C=1 latency Criterion's outlier handling + HTML plots are built for.
+//!
+//! Write ops are out of scope here: their per-invocation setup/reset lifecycle (Part 5) doesn't fit
+//! Criterion's iteration model.
+
+use benchmark::queries_repository::QueryType;
+use benchmark::synthetic::catalog::spec;
+use benchmark::synthetic::config::FileConfig;
+use benchmark::synthetic::dataset::DatasetSpec;
+use benchmark::synthetic::op_runner::run_and_drain;
+use benchmark::synthetic::{open_graph, OpName};
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::runtime::Runtime;
+
+const SERVER_TIMEOUT_MS: i64 = 5_000;
+const CLIENT_DEADLINE: Duration = Duration::from_secs(5);
+
+/// The FalkorDB endpoint — resolved like `benchmark synthetic run`: the config's `endpoint`, else
+/// the local default. (Deliberately does NOT read `FALKORDB_HOST`/`PORT`, so the bench and the
+/// `synthetic run --generate` step of the same recipe always target the same server.)
+fn resolve_endpoint(cfg: &FileConfig) -> String {
+    cfg.endpoint
+        .clone()
+        .unwrap_or_else(|| "falkor://127.0.0.1:6379".to_string())
+}
+
+/// The graph key to measure against — the config's `graph`, else the default (matching
+/// `benchmark synthetic run`, so it's the same graph the recipe generated into).
+fn resolve_graph(cfg: &FileConfig) -> String {
+    cfg.graph.clone().unwrap_or_else(|| "falkor".to_string())
+}
+
+/// The read ops to baseline: the config's `operations` (or every read op), keeping reads only.
+fn read_ops(cfg: &FileConfig) -> Vec<OpName> {
+    let ops = cfg
+        .operations
+        .clone()
+        .unwrap_or_else(|| OpName::all_reads().to_vec());
+    ops.into_iter()
+        .filter(|op| op.kind() == QueryType::Read)
+        .collect()
+}
+
+fn bench_synthetic_ops(c: &mut Criterion) {
+    let cfg = FileConfig::load(None)
+        .expect("read synthetic-bench.toml")
+        .unwrap_or_default();
+    let endpoint = resolve_endpoint(&cfg);
+    let graph = resolve_graph(&cfg);
+    let seed = cfg.seed.unwrap_or(0);
+    let (nodes, edges) = match (cfg.nodes, cfg.edges) {
+        (Some(n), Some(e)) => (n, e),
+        _ => panic!(
+            "synthetic baselines need a generated dataset — set `nodes` and `edges` in \
+             synthetic-bench.toml and generate the graph with `benchmark synthetic run --generate` \
+             (the baseline/compare recipes do this for you)"
+        ),
+    };
+    let dataset = DatasetSpec { seed, nodes, edges };
+    dataset.validate().expect("valid dataset spec");
+    // The same deterministic handle a generated run builds, so the corpus matches the corpus_hash.
+    let handle = dataset.handle();
+
+    let ops = read_ops(&cfg);
+    assert!(
+        !ops.is_empty(),
+        "no read operations selected for the baseline"
+    );
+
+    let rt = Runtime::new().expect("tokio runtime");
+    let mut group = c.benchmark_group("synthetic");
+
+    for op in ops {
+        let s = spec(op);
+        let mut rng = StdRng::seed_from_u64(seed ^ op.salt());
+        let corpus = s
+            .build_corpus(&mut rng, &handle, 0, 1)
+            .unwrap_or_else(|e| panic!("corpus for {}: {e}", op.as_str()));
+        // Pre-render the cached-mode cypher for each corpus entry so query building isn't timed.
+        let cyphers: Arc<Vec<String>> = Arc::new(corpus.iter().map(|q| q.to_cypher()).collect());
+        let endpoint = endpoint.clone();
+        let graph = graph.clone();
+
+        group.bench_function(format!("{}/total_ms", op.as_str()), |b| {
+            b.to_async(&rt).iter_custom(|iters| {
+                let cyphers = Arc::clone(&cyphers);
+                let endpoint = endpoint.clone();
+                let graph = graph.clone();
+                async move {
+                    // One dedicated connection per measurement batch (its open cost is amortized
+                    // over `iters` and lands outside the timer below), driven single-flight — the
+                    // honest C=1 latency.
+                    let mut conn = open_graph(&endpoint, &graph)
+                        .await
+                        .expect("open FalkorDB connection");
+                    // Prime the plan cache so the first measured iteration isn't a compile.
+                    run_and_drain(
+                        &mut conn,
+                        QueryType::Read,
+                        &cyphers[0],
+                        SERVER_TIMEOUT_MS,
+                        CLIENT_DEADLINE,
+                    )
+                    .await
+                    .expect("prime query");
+
+                    let start = Instant::now();
+                    for i in 0..iters {
+                        let cypher = &cyphers[(i as usize) % cyphers.len()];
+                        // Propagate (panic) on any error so a timeout/failure can't masquerade as a
+                        // dramatic speed-up in the measurement.
+                        run_and_drain(
+                            &mut conn,
+                            QueryType::Read,
+                            cypher,
+                            SERVER_TIMEOUT_MS,
+                            CLIENT_DEADLINE,
+                        )
+                        .await
+                        .expect("benchmarked query must succeed");
+                    }
+                    start.elapsed()
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_synthetic_ops);
+criterion_main!(benches);

--- a/benches/synthetic_ops.rs
+++ b/benches/synthetic_ops.rs
@@ -123,7 +123,9 @@ fn bench_synthetic_ops(c: &mut Criterion) {
 
                     let start = Instant::now();
                     for i in 0..iters {
-                        let cypher = &cyphers[(i as usize) % cyphers.len()];
+                        // Reduce in u64 before the cast so the index is correct even on 32-bit
+                        // targets (where `i as usize` would truncate a large `iters`).
+                        let cypher = &cyphers[(i % cyphers.len() as u64) as usize];
                         // Propagate (panic) on any error so a timeout/failure can't masquerade as a
                         // dramatic speed-up in the measurement.
                         run_and_drain(

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,10 @@ coverage:
 
 # The Next.js dashboard (ui/) and the vendored FalkorDB client (vendor/) are not
 # part of the Rust crate's unit tests, so they're excluded from coverage reporting.
+# The Criterion harness (benches/) is a live-server bench, not run under `cargo test`,
+# so its substantive logic lives in the (covered) library and the harness is excluded.
 ignore:
   - "ui"
   - "vendor"
   - "scripts"
+  - "benches"

--- a/readme.md
+++ b/readme.md
@@ -420,6 +420,45 @@ To run the integration test against a live server:
 just synthetic-it     # uses FALKORDB_HOST/FALKORDB_PORT, default 127.0.0.1:6379
 ```
 
+#### Version-comparison baselines (Criterion, C=1)
+
+To track a **read** operation's latency **between FalkorDB versions**, save a
+[Criterion](https://github.com/bheisler/criterion.rs) C=1 single-flight baseline on one version and
+compare against it on another. The workload (dataset + operations) comes from `synthetic-bench.toml`,
+so both runs measure exactly the same thing — and `synthetic-compare` **guards** that with the
+`corpus_hash` before it will compare, refusing to put mismatched workloads side by side.
+
+```bash
+# on FalkorDB version A (needs a synthetic-bench.toml with nodes/edges/operations)
+just synthetic-baseline v4.2.1
+# ...upgrade FalkorDB, then on version B:
+just synthetic-compare v4.2.1
+```
+
+```text
+⚠ server image changed: falkordb@sha256:aaa… → falkordb@sha256:bbb…
+baseline guard: OK — same workload, safe to compare
+synthetic/match_by_index/total_ms
+    time:   [297 µs 303 µs 310 µs]
+    change: [-9.4% -8.1% -6.7%] (p = 0.00 < 0.05)   Performance has improved.
+```
+
+How it works:
+
+- **`just synthetic-baseline <name>`** (re)generates the dataset from `synthetic-bench.toml`, captures
+  that run's `corpus_hash` + FalkorDB module version into `baselines/<name>.json`, then saves the
+  Criterion baseline `<name>` (single-flight C=1 read latencies + browsable HTML plots under
+  `target/criterion/`).
+- **`just synthetic-compare <name>`** captures the current run's identity, runs the **guard**
+  (`benchmark synthetic baseline-guard`) — which **aborts** if the `corpus_hash` differs (or is
+  absent, i.e. an external, unfingerprintable graph) — then runs Criterion against the saved baseline.
+- The **FalkorDB version is the subject** of the comparison, so a version change is *recorded and
+  displayed*, never a reason to abort; the guard only warns when the two versions are identical (no
+  delta to measure) or the dev `999999` placeholder (use tagged images). The **workload** is the hard
+  gate. Baselines therefore require a **generated** dataset (so the workload is fingerprintable);
+  write ops are out of scope (their per-invocation reset lifecycle doesn't fit Criterion's model).
+- `synthetic-bench.toml` and `baselines/` are git-ignored (per-user config + local baselines).
+
 ### UI dashboard (`ui/`)
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -335,6 +335,15 @@ pub enum SyntheticCommands {
     },
     #[command(about = "list the available operations")]
     ListOps,
+    #[command(
+        about = "guard a version comparison: abort if the saved baseline and the current run measured different workloads (corpus_hash mismatch)"
+    )]
+    BaselineGuard {
+        #[arg(long, help = "path to the saved baseline's synthetic report JSON")]
+        baseline: String,
+        #[arg(long, help = "path to the current run's synthetic report JSON")]
+        current: String,
+    },
 }
 
 fn parse_write_ratio(val: &str) -> Result<f32, String> {

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -1,0 +1,197 @@
+//! Version-comparison baselines: the guard that `synthetic-compare` runs before invoking Criterion,
+//! refusing to compare two runs whose **workload** differs.
+//!
+//! FalkorDB's **version** is the *subject* of a version comparison (a baseline captured on v4.2.1
+//! vs a candidate on v4.3.0), so a version change is *recorded and displayed*, never rejected.
+//! The **workload** — identified by [`corpus_hash`](crate::synthetic::report::DatasetInfo) — is the
+//! hard gate: a different (or absent) hash means the two runs measured different things and the
+//! latency comparison would be meaningless. Keeping this logic in the library (rather than the
+//! Criterion bench harness) makes it unit-testable.
+
+use crate::synthetic::report::{Report, ServerInfo};
+use serde::{Deserialize, Serialize};
+
+/// The workload + environment identity of a run (extracted from its [`Report`]) that a
+/// version-comparison must agree on — or knowingly differ on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BaselineKey {
+    /// Workload fingerprint (dataset knobs + ops in order + query bodies + sampled pools). `None`
+    /// for an external graph that couldn't be fingerprinted — such a run can't be safely compared.
+    pub corpus_hash: Option<String>,
+    /// FalkorDB graph-module version (recorded for display; expected to differ across versions).
+    pub module_graph_ver: Option<u64>,
+    /// Operator-supplied server image identity, when provided.
+    pub server_image: Option<String>,
+}
+
+impl BaselineKey {
+    /// Extract the comparison key from a run's report.
+    pub fn from_report(report: &Report) -> Self {
+        BaselineKey {
+            corpus_hash: report.meta.dataset.as_ref().map(|d| d.corpus_hash.clone()),
+            module_graph_ver: report.meta.server.module_graph_ver,
+            server_image: report.meta.server.server_image.clone(),
+        }
+    }
+}
+
+/// The result of guarding a candidate run against a saved baseline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardOutcome {
+    /// Safe to compare. `warnings` are advisory (e.g. identical or placeholder versions).
+    Proceed { warnings: Vec<String> },
+    /// Must **not** compare (workload mismatch or unfingerprintable workload).
+    Abort { reason: String },
+}
+
+/// Guard a `candidate` run against a saved `baseline` before comparing their latencies.
+///
+/// The **workload** (`corpus_hash`) is a hard gate — a different or absent hash means the runs
+/// measured different things, so we abort. The FalkorDB **version** is only advisory: comparing
+/// across versions is the whole point, so a version change is recorded (as a `Proceed` with no
+/// warning); identical or placeholder versions produce advisory warnings.
+pub fn guard(
+    baseline: &BaselineKey,
+    candidate: &BaselineKey,
+) -> GuardOutcome {
+    match (&baseline.corpus_hash, &candidate.corpus_hash) {
+        (Some(a), Some(b)) if a == b => {}
+        (Some(a), Some(b)) => {
+            return GuardOutcome::Abort {
+                reason: format!(
+                    "corpus_hash mismatch — the workload changed since the baseline was saved \
+                     (baseline {a}, candidate {b}); re-save the baseline for the current workload"
+                ),
+            };
+        }
+        _ => {
+            return GuardOutcome::Abort {
+                reason: "missing corpus_hash — a comparable baseline needs a generated dataset \
+                         (`--generate`) so the workload can be fingerprinted"
+                    .to_string(),
+            };
+        }
+    }
+
+    let mut warnings = Vec::new();
+    if baseline.module_graph_ver == candidate.module_graph_ver {
+        warnings.push(format!(
+            "baseline and candidate ran the same FalkorDB module version ({}) — there is no \
+             version delta to measure",
+            ver_str(candidate.module_graph_ver)
+        ));
+    }
+    if baseline.module_graph_ver == Some(ServerInfo::PLACEHOLDER_VER)
+        || candidate.module_graph_ver == Some(ServerInfo::PLACEHOLDER_VER)
+    {
+        warnings.push(
+            "a FalkorDB module version is the dev placeholder — use tagged release images for a \
+             meaningful version comparison"
+                .to_string(),
+        );
+    }
+    if let (Some(a), Some(b)) = (&baseline.server_image, &candidate.server_image) {
+        if a != b {
+            warnings.push(format!("server image changed: {a} → {b}"));
+        }
+    }
+    GuardOutcome::Proceed { warnings }
+}
+
+/// Human-readable FalkorDB module version (`"4.20.1"`), or `"unknown"` when absent.
+fn ver_str(v: Option<u64>) -> String {
+    v.map(crate::synthetic::provenance::decode_module_version)
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(corpus: Option<&str>, ver: Option<u64>) -> BaselineKey {
+        BaselineKey {
+            corpus_hash: corpus.map(|s| s.to_string()),
+            module_graph_ver: ver,
+            server_image: None,
+        }
+    }
+
+    #[test]
+    fn proceeds_when_workload_matches_across_versions() {
+        let base = key(Some("sha256:abc"), Some(42001));
+        let cand = key(Some("sha256:abc"), Some(42002)); // upgraded FalkorDB
+        match guard(&base, &cand) {
+            GuardOutcome::Proceed { warnings } => {
+                // A version change is expected — no same-version warning.
+                assert!(!warnings.iter().any(|w| w.contains("same FalkorDB module version")));
+            }
+            other => panic!("expected Proceed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn aborts_on_corpus_hash_mismatch() {
+        let base = key(Some("sha256:abc"), Some(42001));
+        let cand = key(Some("sha256:def"), Some(42001));
+        match guard(&base, &cand) {
+            GuardOutcome::Abort { reason } => assert!(reason.contains("corpus_hash mismatch")),
+            other => panic!("expected Abort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn aborts_when_a_corpus_hash_is_absent() {
+        // An external graph (no generated dataset) has no corpus_hash ⇒ unsafe to compare.
+        assert!(matches!(
+            guard(&key(None, Some(42001)), &key(Some("sha256:abc"), Some(42001))),
+            GuardOutcome::Abort { .. }
+        ));
+        assert!(matches!(
+            guard(&key(Some("sha256:abc"), Some(42001)), &key(None, Some(42001))),
+            GuardOutcome::Abort { .. }
+        ));
+    }
+
+    #[test]
+    fn warns_on_identical_version() {
+        let k = key(Some("sha256:abc"), Some(42001));
+        match guard(&k, &k) {
+            GuardOutcome::Proceed { warnings } => {
+                assert!(warnings.iter().any(|w| w.contains("same FalkorDB module version")));
+            }
+            other => panic!("expected Proceed with a warning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn warns_on_placeholder_version() {
+        let base = key(Some("sha256:abc"), Some(ServerInfo::PLACEHOLDER_VER));
+        let cand = key(Some("sha256:abc"), Some(42002));
+        match guard(&base, &cand) {
+            GuardOutcome::Proceed { warnings } => {
+                assert!(warnings.iter().any(|w| w.contains("dev placeholder")));
+            }
+            other => panic!("expected Proceed with a placeholder warning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn warns_on_server_image_change() {
+        let base = BaselineKey {
+            corpus_hash: Some("sha256:abc".to_string()),
+            module_graph_ver: Some(42001),
+            server_image: Some("falkordb@sha256:aaa".to_string()),
+        };
+        let cand = BaselineKey {
+            corpus_hash: Some("sha256:abc".to_string()),
+            module_graph_ver: Some(42002),
+            server_image: Some("falkordb@sha256:bbb".to_string()),
+        };
+        match guard(&base, &cand) {
+            GuardOutcome::Proceed { warnings } => {
+                assert!(warnings.iter().any(|w| w.contains("server image changed")));
+            }
+            other => panic!("expected Proceed, got {other:?}"),
+        }
+    }
+}

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -74,7 +74,10 @@ pub fn guard(
     }
 
     let mut warnings = Vec::new();
-    if baseline.module_graph_ver == candidate.module_graph_ver {
+    // Only warn "same version" when both versions are actually *known* and equal — two unknown
+    // (`None`) versions are not a known match, so don't claim there's no delta to measure.
+    if baseline.module_graph_ver.is_some() && baseline.module_graph_ver == candidate.module_graph_ver
+    {
         warnings.push(format!(
             "baseline and candidate ran the same FalkorDB module version ({}) — there is no \
              version delta to measure",
@@ -160,6 +163,21 @@ mod tests {
                 assert!(warnings.iter().any(|w| w.contains("same FalkorDB module version")));
             }
             other => panic!("expected Proceed with a warning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_versions_do_not_claim_a_same_version_match() {
+        // Both versions unknown (None) is not a *known* match, so we must not warn "no delta".
+        let base = key(Some("sha256:abc"), None);
+        let cand = key(Some("sha256:abc"), None);
+        match guard(&base, &cand) {
+            GuardOutcome::Proceed { warnings } => {
+                assert!(!warnings
+                    .iter()
+                    .any(|w| w.contains("same FalkorDB module version")));
+            }
+            other => panic!("expected Proceed, got {other:?}"),
         }
     }
 

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1483,7 +1483,7 @@ mod tests {
         })
         .await
         .expect_err("corpus_hash mismatch must abort");
-        assert!(format!("{err:?}").contains("corpus_hash mismatch"));
+        assert!(format!("{err}").contains("corpus_hash mismatch"));
         for p in [base, ok, bad] {
             let _ = std::fs::remove_file(p);
         }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod catalog;
 pub mod config;
+pub mod baseline;
 pub mod dataset;
 pub mod engine;
 pub mod host;
@@ -1103,6 +1104,40 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
         crate::cli::SyntheticCommands::ListOps => {
             print!("{}", list_ops());
             Ok(())
+        }
+        crate::cli::SyntheticCommands::BaselineGuard { baseline, current } => {
+            baseline_guard(&baseline, &current)
+        }
+    }
+}
+
+/// Guard a version comparison: load the saved baseline and current run reports, compare their
+/// workload identity, and **abort** (return an error ⇒ non-zero exit) when the workloads differ, so
+/// `synthetic-compare` never compares latencies across mismatched benchmarks. Advisory notes (a
+/// version/image change, an identical or placeholder version) are printed but do not abort.
+fn baseline_guard(
+    baseline_path: &str,
+    current_path: &str,
+) -> BenchmarkResult<()> {
+    let load = |path: &str| -> BenchmarkResult<crate::synthetic::report::Report> {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| OtherError(format!("could not read report '{}': {}", path, e)))?;
+        serde_json::from_str(&text)
+            .map_err(|e| OtherError(format!("invalid synthetic report '{}': {}", path, e)))
+    };
+    let baseline = baseline::BaselineKey::from_report(&load(baseline_path)?);
+    let current = baseline::BaselineKey::from_report(&load(current_path)?);
+
+    match baseline::guard(&baseline, &current) {
+        baseline::GuardOutcome::Proceed { warnings } => {
+            for w in &warnings {
+                eprintln!("⚠ {}", w);
+            }
+            println!("baseline guard: OK — same workload, safe to compare");
+            Ok(())
+        }
+        baseline::GuardOutcome::Abort { reason } => {
+            Err(OtherError(format!("baseline guard: ABORT — {}", reason)))
         }
     }
 }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1446,6 +1446,49 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn baseline_guard_command_gates_on_corpus_hash() {
+        // Hermetic: writes minimal report JSONs and drives the `baseline-guard` subcommand (which
+        // only reads files + applies the guard — no server).
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir();
+        let write_report = |hash: &str, ver: u64| -> String {
+            let p = dir.join(format!(
+                "bg-{}-{}.json",
+                std::process::id(),
+                SEQ.fetch_add(1, Ordering::Relaxed)
+            ));
+            let json = format!(
+                r#"{{"meta":{{"tool_version":"0.1.0","endpoint":"x","samples":1,"warmup":0,"server_timeout_ms":5000,"client_deadline_ms":6000,"connection":"c","started_at_epoch_secs":0,"server":{{"module_graph_ver":{ver}}},"dataset":{{"seed":1,"nodes":10,"edges":20,"corpus_hash":"{hash}"}}}},"operations":{{}}}}"#
+            );
+            std::fs::write(&p, json).unwrap();
+            p.to_string_lossy().into_owned()
+        };
+        let base = write_report("sha256:same", 42001);
+        // Same workload + same version ⇒ guard proceeds with an advisory warning (exercises the
+        // warning-print path).
+        let ok = write_report("sha256:same", 42001);
+        assert!(run_command(crate::cli::SyntheticCommands::BaselineGuard {
+            baseline: base.clone(),
+            current: ok.clone(),
+        })
+        .await
+        .is_ok());
+        // Different workload ⇒ guard aborts.
+        let bad = write_report("sha256:different", 42002);
+        let err = run_command(crate::cli::SyntheticCommands::BaselineGuard {
+            baseline: base.clone(),
+            current: bad.clone(),
+        })
+        .await
+        .expect_err("corpus_hash mismatch must abort");
+        assert!(format!("{err:?}").contains("corpus_hash mismatch"));
+        for p in [base, ok, bad] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
     #[test]
     fn markdown_path_swaps_json_suffix_or_appends() {
         assert_eq!(markdown_path("synthetic-report.json"), "synthetic-report.md");


### PR DESCRIPTION
Completes **Part 6** of the synthetic per-operation benchmark epic (#200) — reporting polish + version baselines (#206). This is **PR B: version baselines** (PR A #218, reporting polish, is merged).

## What this adds

**Track a read op's latency between FalkorDB versions**, guarded against comparing mismatched workloads:

```bash
# on FalkorDB version A  (synthetic-bench.toml has nodes/edges/operations)
just synthetic-baseline v4.2.1
# ...upgrade FalkorDB, then on version B:
just synthetic-compare v4.2.1
```
```text
baseline guard: OK — same workload, safe to compare
synthetic/match_by_index/total_ms   change: [-9.4% -8.1% -6.7%] (p=0.00 < 0.05)   Performance has improved.
```

- **`benches/synthetic_ops.rs`** — a Criterion harness (`async_tokio` + `html_reports`, `harness=false`) that benchmarks each **read** op **single-flight at C=1** against a live FalkorDB. It rebuilds the corpus deterministically from the config's dataset spec via `DatasetSpec::handle()` — **the same handle a generated run uses** (`generate_and_load` returns `spec.handle()`), so the benched workload is exactly what `corpus_hash` fingerprints. The per-batch connection open + plan-cache prime land *outside* the timer; a query error panics (a timeout can never masquerade as a speed-up). Writes are out of scope (their per-invocation reset lifecycle doesn't fit Criterion's iteration model).
- **`baseline` guard (library)** — `BaselineKey` + `guard()`: the **workload** (`corpus_hash`) is a hard gate (abort on mismatch, or when absent — an external graph can't be fingerprinted), while the **FalkorDB version is the *subject* of the comparison**, so a version change is *recorded/displayed*, never an abort. Identical or `999999`-placeholder versions (and server-image changes) produce advisory warnings. Kept in the library so it's **unit-tested** (7 tests) rather than living in the bench.
- **`benchmark synthetic baseline-guard --baseline <json> --current <json>`** — the guard as a subcommand (non-zero exit on abort), so `synthetic-compare` gates Criterion on it.
- **`just synthetic-baseline <name>` / `synthetic-compare <name>`** — baseline captures the run's `corpus_hash` + version and saves the Criterion baseline; compare captures the current identity, **runs the guard first** (aborts before Criterion on a workload mismatch), then compares.

## Why the version guard is advisory, not an abort

#206 literally says *"aborts on corpus_hash **and** version mismatch"*, but aborting on a version mismatch would defeat the stated goal (compare latency *between versions*). Per the rubber-duck, the workload is the hard gate and the version is recorded — this is what makes `save v4.2.1` → upgrade → `compare v4.2.1` actually work.

## Tests / validation

- Unit: 6 `guard()` tests (proceed across versions, abort on hash mismatch/absence, warnings for identical/placeholder version + image change) + a hermetic `baseline-guard` subcommand test.
- **End-to-end** (FalkorDB 4.20.1): `synthetic-baseline` → `synthetic-compare` on the same build reports **"No change in performance detected"**; changing the workload makes the guard **abort before Criterion** (non-zero). 
- `codecov.yml` ignores `benches/` (a live-server bench, not run under `cargo test` — its logic lives in the covered library); `.gitignore` covers `synthetic-bench.toml` + `/baselines/`.
- `just ci` (build, clippy `-D warnings` incl. the bench via `--all-targets`, test — 144 unit tests), `just doc-check`, and `just coverage` against a Docker FalkorDB — all green. A local `code-review` pass caught (and this PR fixes) an endpoint-resolution mismatch between the bench and the `synthetic run --generate` step; the bench now resolves endpoint/graph identically to `synthetic run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synthetic single-flight (C=1) read-latency benchmarking with per-operation results and HTML reports.
  * Added baseline save/compare automation and a guarded compare flow that enforces workload identity while emitting warnings for environment/version differences.
* **Documentation**
  * Documented how to generate baselines from `synthetic-bench.toml`, store them, and run guarded comparisons (with noted scope limits).
* **Tests**
  * Added unit and integration-style tests covering baseline guard proceed/abort and warning behavior.
* **Chores**
  * Ignored synthetic benchmark outputs and excluded benchmark artifacts from coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->