### PR TITLE
feat(synthetic): record-once / replay-identically for cross-version comparison

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,7 +41,11 @@ Key recipes:
 | `just synthetic-bench-one <op>` | Sweep one operation over the concurrency curve (needs a live FalkorDB). |
 | `just synthetic-ops` | List the synthetic operations. |
 | `just synthetic-it` | Run the synthetic integration test against a live FalkorDB. |
-| `just synthetic-baseline <name>` | Save a Criterion C=1 latency baseline (per-op read latencies) for the current build/version (needs a live FalkorDB + `synthetic-bench.toml`). |
+| `just synthetic-record <name>` | Record a workload bundle **offline** (dataset load-script + measured commands + `workload_hash`) into `recordings/<name>/` for cross-version replay. |
+| `just synthetic-replay <name> <endpoint>` | Load the recorded graph + measure the recorded commands (fixed-length, deterministic); writes a report + per-op `result_digest`. |
+| `just synthetic-compare-versions <name> <A> <B>` | Replay one recorded bundle against two FalkorDB versions and guard (aborts unless `workload_hash` **and** result digests match). |
+| `just synthetic-sanity` | Self-contained tool sanity: record twice (asserts identical `workload_hash`) + replay + guard against a throwaway Docker FalkorDB. |
+| `just synthetic-baseline <name>` | Save a Criterion C=1 latency baseline (per-op read latencies) for the current build/version (needs a live FalkorDB + `synthetic-bench.toml`). Single-version tracker; prefer record/replay for cross-version. |
 | `just synthetic-compare <name>` | Compare the current build against a saved baseline — guards on `corpus_hash` (aborts on workload mismatch), then runs Criterion (needs a live FalkorDB). |
 | `just fmt` / `just fmt-check` | Format Rust in place / check formatting. |
 | `just run -- <args>` | Run the benchmark binary (e.g. `just run -- --help`). |

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ csv_output/
 # synthetic per-operation benchmark: per-user config + saved version baselines (Part 6)
 synthetic-bench.toml
 /baselines/
+# recorded workload bundles (record/replay) — regenerable, not committed
+/recordings/
 

--- a/Justfile
+++ b/Justfile
@@ -212,8 +212,17 @@ synthetic-replay name endpoint *args:
     shift || true                          # drop `name`
     shift || true                          # drop `endpoint`
     if [ "${1:-}" = "--" ]; then shift; fi
-    cargo run --quiet --bin benchmark -- synthetic replay --recording "recordings/{{name}}" \
-        --endpoint "{{endpoint}}" --out "recordings/{{name}}/report.json" "$@"
+    # Default the report path, but let a forwarded --out override it (avoid a duplicate Clap arg).
+    has_out=0
+    for arg in "$@"; do
+        case "$arg" in --out|--out=*) has_out=1 ;; esac
+    done
+    cmd=(cargo run --quiet --bin benchmark -- synthetic replay \
+        --recording "recordings/{{name}}" --endpoint "{{endpoint}}")
+    if [ "$has_out" -eq 0 ]; then
+        cmd+=(--out "recordings/{{name}}/report.json")
+    fi
+    "${cmd[@]}" "$@"
 
 # Compare two FalkorDB versions on the SAME recorded bundle: replay it (load + count-verify) against
 # each endpoint, then GUARD that the workload_hash + per-op result digests match (a version delta is
@@ -245,6 +254,9 @@ synthetic-sanity:
         if docker exec falkordb-sanity redis-cli ping >/dev/null 2>&1; then break; fi
         sleep 1
     done
+    if ! docker exec falkordb-sanity redis-cli ping >/dev/null 2>&1; then
+        echo "SANITY FAIL: FalkorDB did not become ready within 30s"; exit 1
+    fi
     endpoint="falkor://127.0.0.1:6380"
     ops="match_by_index,expand_1_hop,aggregate_count"
     # Record the identical workload twice, independently.

--- a/Justfile
+++ b/Justfile
@@ -188,6 +188,83 @@ synthetic-compare name:
         --baseline "baselines/{{name}}.json" --current "baselines/{{name}}.current.json"
     cargo bench --bench synthetic_ops -- --baseline "{{name}}"
 
+# --- Record / replay: the SAME workload (graph + commands) across FalkorDB versions -----------
+# The baseline/compare recipes above re-generate the graph + re-derive the commands each run; for a
+# rigorous cross-version comparison, record the workload ONCE and replay that identical bundle.
+
+# Record a workload bundle OFFLINE (no server) into `recordings/<name>/`: the dataset load-script
+# (graph.jsonl), the measured commands (commands/<op>.jsonl) and a length-framed workload_hash.
+# Reads `synthetic-bench.toml` (nodes/edges/operations/seed/graph) unless overridden, e.g.
+# `just synthetic-record demo --op match_by_index,expand_1_hop --nodes 1000 --edges 5000`.
+synthetic-record name *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    shift || true                          # drop `name` (just also passes it in $@)
+    if [ "${1:-}" = "--" ]; then shift; fi
+    cargo run --quiet --bin benchmark -- synthetic record --out-dir "recordings/{{name}}" "$@"
+
+# Replay a recorded bundle against an endpoint: load the recorded graph + measure the recorded
+# commands with a fixed-length deterministic runner, writing recordings/<name>/report.json. Extra
+# flags forward to `synthetic replay` (e.g. --graph, --no-load, --samples, --out).
+synthetic-replay name endpoint *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    shift || true                          # drop `name`
+    shift || true                          # drop `endpoint`
+    if [ "${1:-}" = "--" ]; then shift; fi
+    cargo run --quiet --bin benchmark -- synthetic replay --recording "recordings/{{name}}" \
+        --endpoint "{{endpoint}}" --out "recordings/{{name}}/report.json" "$@"
+
+# Compare two FalkorDB versions on the SAME recorded bundle: replay it (load + count-verify) against
+# each endpoint, then GUARD that the workload_hash + per-op result digests match (a version delta is
+# expected and allowed). Record the bundle first with `just synthetic-record <name> …`. Reports land
+# in recordings/<name>/{version-a,version-b}.json for a side-by-side latency read.
+synthetic-compare-versions name endpoint_a endpoint_b:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    test -d "recordings/{{name}}" || { echo "no recording 'recordings/{{name}}' — run 'just synthetic-record {{name}} …' first"; exit 1; }
+    cargo run --quiet --bin benchmark -- synthetic replay --recording "recordings/{{name}}" \
+        --endpoint "{{endpoint_a}}" --out "recordings/{{name}}/version-a.json"
+    cargo run --quiet --bin benchmark -- synthetic replay --recording "recordings/{{name}}" \
+        --endpoint "{{endpoint_b}}" --out "recordings/{{name}}/version-b.json"
+    cargo run --quiet --bin benchmark -- synthetic baseline-guard \
+        --baseline "recordings/{{name}}/version-a.json" --current "recordings/{{name}}/version-b.json"
+
+# Self-contained sanity check for the synthetic tool itself: spin up a throwaway Docker FalkorDB,
+# RECORD a small workload TWICE (asserting the two workload_hashes are identical — deterministic
+# recording), then REPLAY it (load) and re-replay (no-load) and GUARD (workload_hash + result
+# digests must match). Passes iff recording is deterministic and the replay pipeline completes +
+# guards clean; latency is NOT asserted (environment noise). Tears the server down afterwards.
+synthetic-sanity:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    docker rm -f falkordb-sanity >/dev/null 2>&1 || true
+    docker run -d --name falkordb-sanity -p 6380:6379 falkordb/falkordb:latest >/dev/null
+    trap 'docker rm -f falkordb-sanity >/dev/null 2>&1 || true; rm -rf recordings/_sanity_a recordings/_sanity_b' EXIT
+    for i in $(seq 1 30); do
+        if docker exec falkordb-sanity redis-cli ping >/dev/null 2>&1; then break; fi
+        sleep 1
+    done
+    endpoint="falkor://127.0.0.1:6380"
+    ops="match_by_index,expand_1_hop,aggregate_count"
+    # Record the identical workload twice, independently.
+    cargo run --quiet --bin benchmark -- synthetic record --graph sanity --op "$ops" \
+        --seed 7 --nodes 1000 --edges 5000 --out-dir recordings/_sanity_a
+    cargo run --quiet --bin benchmark -- synthetic record --graph sanity --op "$ops" \
+        --seed 7 --nodes 1000 --edges 5000 --out-dir recordings/_sanity_b
+    ha=$(grep '"workload_hash"' recordings/_sanity_a/manifest.json | sed -E 's/.*"(sha256:[a-f0-9]+)".*/\1/')
+    hb=$(grep '"workload_hash"' recordings/_sanity_b/manifest.json | sed -E 's/.*"(sha256:[a-f0-9]+)".*/\1/')
+    if [ "$ha" != "$hb" ]; then echo "SANITY FAIL: recording is not deterministic ($ha != $hb)"; exit 1; fi
+    echo "deterministic recording OK: $ha"
+    # Replay (load) then re-replay (no-load) against the same server, and guard the two.
+    cargo run --quiet --bin benchmark -- synthetic replay --recording recordings/_sanity_a \
+        --endpoint "$endpoint" --samples 300 --warmup 50 --out recordings/_sanity_a/ref.json
+    cargo run --quiet --bin benchmark -- synthetic replay --recording recordings/_sanity_a \
+        --endpoint "$endpoint" --no-load --samples 300 --warmup 50 --out recordings/_sanity_a/cand.json
+    cargo run --quiet --bin benchmark -- synthetic baseline-guard \
+        --baseline recordings/_sanity_a/ref.json --current recordings/_sanity_a/cand.json
+    echo "synthetic-sanity OK"
+
 # === UI (Next.js dashboard in ui/) ===========================================
 
 # Install UI dependencies from the lockfile.

--- a/docs/synthetic-benchmark-tutorial.md
+++ b/docs/synthetic-benchmark-tutorial.md
@@ -1,0 +1,153 @@
+# Synthetic benchmark tutorial: comparing FalkorDB versions on an identical workload
+
+This tutorial shows how to use the **synthetic per-operation benchmark** to compare two FalkorDB
+versions fairly, using the **record / replay** workflow. It walks through recording a workload,
+replaying it, comparing two versions, and the built-in self-sanity check — and explains the
+run-to-run latency noise you will see and why it is *not* a workload difference.
+
+All commands are driven through [`just`](../Justfile) recipes (the same ones CI uses). Every step
+links its **expected output** under [`docs/synthetic/`](synthetic/).
+
+## Why record / replay
+
+To compare two FalkorDB versions, the **graph** and the **measured commands** must be *identical* —
+otherwise you are comparing two different workloads, not two versions. The older
+`just synthetic-baseline` / `synthetic-compare` recipes **re-generate the graph and re-derive the
+commands on every run**. The dataset itself is generated from a portable, version-stable mixer, but
+the measured command corpus is drawn with an RNG whose exact sequence is not guaranteed stable
+across tool rebuilds — and regenerating the graph each run also makes the server redo heavy write
+work and land in a slightly different state. Both are avoidable sources of noise.
+
+**Record / replay splits the benchmark into three phases and reuses the same artifacts everywhere:**
+
+1. **generate input** — `synthetic record` writes the dataset load-script *and* the measured
+   commands to a **bundle** on disk (offline; no server needed).
+2. **load** — `synthetic replay` drops + loads + **verifies** the recorded graph into a server.
+3. **run** — the same command replays with a **fixed-length, deterministic** runner.
+
+Because both versions load the same recorded graph and run the same recorded commands, the only
+variable left is the FalkorDB version.
+
+## Prerequisites
+
+- A reachable FalkorDB (e.g. `docker run -d -p 6379:6379 falkordb/falkordb:latest`).
+- The toolchain the repo uses (`just`, a Rust toolchain, `protoc`). See the [README](../readme.md).
+
+## Step 1 — Record the workload (offline)
+
+Recording contacts **no server** — it is a pure function of the dataset knobs and the seed:
+
+```bash
+just synthetic-record demo --graph tutorial_demo \
+  --op match_by_index,expand_1_hop,aggregate_count \
+  --seed 42 --nodes 1000 --edges 5000
+```
+
+This writes a bundle to `recordings/demo/`:
+
+```text
+recordings/demo/
+├── manifest.json              # versions, knobs, ops, and the workload_hash
+├── graph.jsonl                # the ordered load statements (index + node/edge UNWIND batches)
+└── commands/
+    ├── match_by_index.jsonl   # the fully-rendered measured queries, one per line
+    ├── expand_1_hop.jsonl
+    └── aggregate_count.jsonl
+```
+
+Expected `manifest.json`: [`docs/synthetic/sample-recording-manifest.json`](synthetic/sample-recording-manifest.json).
+The `workload_hash` is a length-framed SHA-256 over the header, **every graph statement**, and
+**every command** — so any later edit to the graph *or* the commands is detected when the bundle is
+loaded. `just synthetic-record` reads `synthetic-bench.toml` for defaults, so once you have a config
+you can simply run `just synthetic-record demo`.
+
+## Step 2 — Replay against one version
+
+Replaying loads the recorded graph (drop + load + count-verify) and then measures the recorded
+commands with a fixed number of invocations:
+
+```bash
+just synthetic-replay demo falkor://127.0.0.1:6379 -- --samples 500 --warmup 100
+```
+
+Expected report:
+
+- Markdown (PR-pasteable): [`docs/synthetic/sample-replay-report.md`](synthetic/sample-replay-report.md)
+- JSON (full detail, incl. per-op `result_digest`): [`docs/synthetic/sample-replay-report.json`](synthetic/sample-replay-report.json)
+
+Each operation reports a single `C=1` cached level (honest single-flight latency). The JSON also
+carries a per-op **`result_digest`** — a hash of the result *cardinality* across the recorded
+commands — used by the guard (Step 3) to reject a version that returns different results.
+
+## Step 3 — Compare two versions
+
+Start the two versions on different ports, record once, then compare:
+
+```bash
+# version A on :6379, version B on :6380
+just synthetic-record demo --graph tutorial_demo \
+  --op match_by_index,expand_1_hop,aggregate_count --seed 42 --nodes 1000 --edges 5000
+just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:6380
+```
+
+`synthetic-compare-versions` replays the **same bundle** against each endpoint (writing
+`recordings/demo/version-a.json` and `version-b.json`) and then **guards** the comparison. The guard:
+
+- **aborts** unless the two runs' `workload_hash` match (they do, by construction — same bundle);
+- **aborts** unless every op's `result_digest` matches (so a version that returns wrong or empty
+  results faster can't look like an improvement);
+- treats the FalkorDB **version** difference as expected (recorded, never rejected).
+
+A full record → replay → guard transcript (hostname redacted to `bench-host`) is in
+[`docs/synthetic/sample-console.txt`](synthetic/sample-console.txt). Open the two `version-*.json`
+reports (or their `.md` siblings) side by side to read the per-op latency delta.
+
+## Step 4 — Self-sanity check the tool
+
+`just synthetic-sanity` is a self-contained check of the tool itself. It spins up a throwaway Docker
+FalkorDB, **records the same workload twice** and asserts the two `workload_hash`es are identical
+(proving recording is deterministic), then replays it (load) and re-replays it (no-load) against the
+same server and guards the two reports:
+
+```bash
+just synthetic-sanity
+# … → "deterministic recording OK: sha256:…"  then  "synthetic-sanity OK"
+```
+
+It passes iff recording is deterministic and the replay pipeline completes and guards clean. It does
+**not** assert latencies (see the next section).
+
+## Understanding the run-to-run latency noise
+
+If you replay the **same bundle against the same version twice**, the per-op latencies still wobble
+— on a laptop with Docker Desktop, empirically ~±5–13%. This is **environment noise** (CPU-frequency
+scaling, the Docker VM, background load), **not** a workload difference:
+
+- the `workload_hash` is identical across the two runs (same graph + same commands), and
+- every op's `result_digest` is identical (same results).
+
+So the workload is provably identical; only the measured wall-clock varies. That is why the guard
+gates on **workload identity + result correctness** (hard) and leaves **latency** advisory.
+
+To get a trustworthy latency delta between versions:
+
+- run on a **stable, dedicated host** (bare metal or a quiet VM), not a laptop under load;
+- use **more samples** (`--samples`) to tighten the estimate;
+- compare medians/p90 across the two `version-*.json` reports and treat sub-~10% deltas on noisy
+  hardware as inconclusive.
+
+## Reference
+
+| Recipe | Purpose |
+| --- | --- |
+| `just synthetic-record <name> [flags]` | Record a workload bundle **offline** into `recordings/<name>/`. |
+| `just synthetic-replay <name> <endpoint> [-- flags]` | Load the recorded graph + measure the recorded commands. |
+| `just synthetic-compare-versions <name> <endpointA> <endpointB>` | Replay one bundle against two versions + guard. |
+| `just synthetic-sanity` | Self-contained tool sanity (deterministic record + replay + guard). |
+
+The `just synthetic-baseline` / `synthetic-compare` recipes remain as a **single-version** local
+latency tracker built on Criterion; they regenerate per run and are not the cross-version
+comparator (Criterion adapts its iteration count to observed latency, so a faster/slower version
+would run a different command sequence). Use record / replay for comparing versions.
+
+See the [README](../readme.md) for the operation catalog and `synthetic run` details.

--- a/docs/synthetic/sample-console.txt
+++ b/docs/synthetic/sample-console.txt
@@ -29,6 +29,7 @@ match_by_index
 # replay a second version the same way (here shown against the same server), then guard:
 $ benchmark synthetic replay --recording recordings/demo --no-load \
     --endpoint falkor://127.0.0.1:6379 --samples 500 --warmup 100 --out recordings/demo/version-b.json
+(prints the same per-op summary table as the first replay — omitted here for brevity)
 report written to recordings/demo/version-b.json
 markdown written to recordings/demo/version-b.md
 

--- a/docs/synthetic/sample-console.txt
+++ b/docs/synthetic/sample-console.txt
@@ -14,17 +14,23 @@ dataset — seed 42  nodes 1000  edges 5000  corpus_hash sha256:57638f31c17b7be5
 aggregate_count
   [cached — plan reused, execution only]
     C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
-    1              1772     0.094 / 0.130 / 0.146 / 0.167     0.523 / 0.694 / 0.752 / 0.841     0.0  <- knee
+    1              1969     0.089 / 0.113 / 0.126 / 0.145     0.472 / 0.600 / 0.646 / 0.726     0.0  <- knee
 
 expand_1_hop
   [cached — plan reused, execution only]
     C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
-    1              1706     0.088 / 0.130 / 0.146 / 0.165     0.548 / 0.709 / 0.764 / 0.937     0.0  <- knee
+    1              1726     0.089 / 0.133 / 0.146 / 0.175     0.531 / 0.745 / 0.824 / 0.957     0.0  <- knee
 
 match_by_index
   [cached — plan reused, execution only]
     C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
-    1              2039     0.043 / 0.060 / 0.068 / 0.081     0.457 / 0.577 / 0.645 / 0.755     0.0  <- knee
+    1              2615     0.039 / 0.052 / 0.060 / 0.069     0.362 / 0.451 / 0.479 / 0.532     0.0  <- knee
+
+# replay a second version the same way (here shown against the same server), then guard:
+$ benchmark synthetic replay --recording recordings/demo --no-load \
+    --endpoint falkor://127.0.0.1:6379 --samples 500 --warmup 100 --out recordings/demo/version-b.json
+report written to recordings/demo/version-b.json
+markdown written to recordings/demo/version-b.md
 
 $ benchmark synthetic baseline-guard \
     --baseline recordings/demo/version-a.json --current recordings/demo/version-b.json

--- a/docs/synthetic/sample-console.txt
+++ b/docs/synthetic/sample-console.txt
@@ -1,0 +1,31 @@
+$ benchmark synthetic record --graph tutorial_demo \
+    --op match_by_index,expand_1_hop,aggregate_count --seed 42 --nodes 1000 --edges 5000 \
+    --out-dir recordings/demo
+recorded 3 op(s) into recordings/demo (workload_hash sha256:57638f31c17b7be582ca3c15f7e3c4ad050189e4200f5af478f6711658dd5eb5)
+
+$ benchmark synthetic replay --recording recordings/demo \
+    --endpoint falkor://127.0.0.1:6379 --samples 500 --warmup 100 --out recordings/demo/version-a.json
+
+synthetic benchmark — endpoint falkor://127.0.0.1:6379  graph tutorial_demo  samples 500  warmup 100  concurrency [1]  seed 42  connection pool(size=1)
+server — falkordb module ver 4.20.1  redis 8.6.3  CACHE_SIZE 25
+client host — bench-host · macOS 26.5.2 Tahoe · Apple M1 Pro (10c/10t) · 16.0 GiB · arm64
+dataset — seed 42  nodes 1000  edges 5000  corpus_hash sha256:57638f31c17b7be582ca3c15f7e3c4ad050189e4200f5af478f6711658dd5eb5
+
+aggregate_count
+  [cached — plan reused, execution only]
+    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
+    1              1772     0.094 / 0.130 / 0.146 / 0.167     0.523 / 0.694 / 0.752 / 0.841     0.0  <- knee
+
+expand_1_hop
+  [cached — plan reused, execution only]
+    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
+    1              1706     0.088 / 0.130 / 0.146 / 0.165     0.548 / 0.709 / 0.764 / 0.937     0.0  <- knee
+
+match_by_index
+  [cached — plan reused, execution only]
+    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
+    1              2039     0.043 / 0.060 / 0.068 / 0.081     0.457 / 0.577 / 0.645 / 0.755     0.0  <- knee
+
+$ benchmark synthetic baseline-guard \
+    --baseline recordings/demo/version-a.json --current recordings/demo/version-b.json
+baseline guard: OK — same workload, safe to compare

--- a/docs/synthetic/sample-recording-manifest.json
+++ b/docs/synthetic/sample-recording-manifest.json
@@ -1,0 +1,29 @@
+{
+  "format_version": 1,
+  "generator_version": "synthbench/v2",
+  "tool_version": "0.1.0",
+  "dataset": {
+    "seed": 42,
+    "nodes": 1000,
+    "edges": 5000
+  },
+  "graph": "tutorial_demo",
+  "corpus_seed": 42,
+  "batch_size": 1000,
+  "ops": [
+    {
+      "name": "match_by_index",
+      "count": 256
+    },
+    {
+      "name": "expand_1_hop",
+      "count": 256
+    },
+    {
+      "name": "aggregate_count",
+      "count": 256
+    }
+  ],
+  "workload_hash": "sha256:57638f31c17b7be582ca3c15f7e3c4ad050189e4200f5af478f6711658dd5eb5",
+  "created_at_epoch_secs": 1784704984
+}

--- a/docs/synthetic/sample-replay-report.json
+++ b/docs/synthetic/sample-replay-report.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": 2,
+  "meta": {
+    "tool_version": "0.1.0",
+    "endpoint": "falkor://127.0.0.1:6379",
+    "graph": "tutorial_demo",
+    "samples": 500,
+    "warmup": 100,
+    "concurrency": [
+      1
+    ],
+    "seed": 42,
+    "corpus_size": 256,
+    "server_timeout_ms": 5000,
+    "client_deadline_ms": 6000,
+    "connection": "pool(size=1)",
+    "started_at_epoch_secs": 1784704984,
+    "server": {
+      "module_graph_ver": 42001,
+      "cache_size": 25,
+      "redis_version": "8.6.3",
+      "redis_build_id": "313de0794c1dcd59",
+      "redis_git_sha1": "00000000",
+      "run_id": "6f355549c5aa2543b9abe5822767ec8c0b1a8c2a",
+      "os": "Linux 6.12.76-linuxkit aarch64",
+      "arch_bits": "64",
+      "server_image": null
+    },
+    "host": {
+      "hostname": "bench-host",
+      "os": "macOS 26.5.2 Tahoe",
+      "kernel": "25.5.0",
+      "arch": "arm64",
+      "cpu": "Apple M1 Pro",
+      "physical_cores": 10,
+      "logical_cores": 10,
+      "total_memory_bytes": 17179869184
+    },
+    "dataset": {
+      "seed": 42,
+      "nodes": 1000,
+      "edges": 5000,
+      "corpus_hash": "sha256:57638f31c17b7be582ca3c15f7e3c4ad050189e4200f5af478f6711658dd5eb5"
+    }
+  },
+  "operations": {
+    "aggregate_count": {
+      "levels": [
+        {
+          "concurrency": 1,
+          "cached": {
+            "throughput_ops_per_sec": 1777.9099973884634,
+            "metrics": {
+              "server_ms": {
+                "n": 480,
+                "removed": 20,
+                "min": 0.065625,
+                "mean": 0.09802106666666652,
+                "median": 0.09364549999999999,
+                "p90": 0.12329550000000002,
+                "p95": 0.13281904999999986,
+                "p99": 0.15774481999999992,
+                "max": 0.170167,
+                "stddev": 0.01822080641189413
+              },
+              "total_ms": {
+                "n": 480,
+                "removed": 20,
+                "min": 0.394959,
+                "mean": 0.5433213083333334,
+                "median": 0.5228545,
+                "p90": 0.6680208000000001,
+                "p95": 0.7341440999999999,
+                "p99": 0.8234375399999997,
+                "max": 0.934667,
+                "stddev": 0.09331834456570741
+              },
+              "non_internal_ms": {
+                "n": 480,
+                "removed": 20,
+                "min": 0.312625,
+                "mean": 0.44530024166666665,
+                "median": 0.4269585,
+                "p90": 0.5513452000000001,
+                "p95": 0.6175920499999998,
+                "p99": 0.7074113199999996,
+                "max": 0.833041,
+                "stddev": 0.08312607390231073
+              },
+              "cached_false_rate": 0.0,
+              "cached_unknown": 0
+            }
+          }
+        }
+      ],
+      "result_digest": "sha256:b5c83860437f5b1c699ae3843dc9ca78a9e6ddf0438174b9325921f1138b55a4"
+    },
+    "expand_1_hop": {
+      "levels": [
+        {
+          "concurrency": 1,
+          "cached": {
+            "throughput_ops_per_sec": 1779.548360378061,
+            "metrics": {
+              "server_ms": {
+                "n": 485,
+                "removed": 15,
+                "min": 0.060667,
+                "mean": 0.09268782886597943,
+                "median": 0.088375,
+                "p90": 0.1186668,
+                "p95": 0.13210859999999994,
+                "p99": 0.15009499999999995,
+                "max": 0.158583,
+                "stddev": 0.017949651588658157
+              },
+              "total_ms": {
+                "n": 485,
+                "removed": 15,
+                "min": 0.422708,
+                "mean": 0.5512735298969071,
+                "median": 0.5264580000000001,
+                "p90": 0.6700668,
+                "p95": 0.7527918,
+                "p99": 0.8246517199999999,
+                "max": 0.9128339999999999,
+                "stddev": 0.0907228566400642
+              },
+              "non_internal_ms": {
+                "n": 485,
+                "removed": 15,
+                "min": 0.342041,
+                "mean": 0.458585701030928,
+                "median": 0.437708,
+                "p90": 0.5587831999999999,
+                "p95": 0.6358923999999995,
+                "p99": 0.6942431599999999,
+                "max": 0.809083,
+                "stddev": 0.0793617465274545
+              },
+              "cached_false_rate": 0.0,
+              "cached_unknown": 0
+            }
+          }
+        }
+      ],
+      "result_digest": "sha256:b1a89fe0081c3f086b06d0ae211de0d2e45c96d6dce70cb35b1ecf136340036a"
+    },
+    "match_by_index": {
+      "levels": [
+        {
+          "concurrency": 1,
+          "cached": {
+            "throughput_ops_per_sec": 2067.7925797263274,
+            "metrics": {
+              "server_ms": {
+                "n": 481,
+                "removed": 19,
+                "min": 0.025667,
+                "mean": 0.04565903950103954,
+                "median": 0.043417,
+                "p90": 0.060125,
+                "p95": 0.067667,
+                "p99": 0.07849179999999999,
+                "max": 0.083708,
+                "stddev": 0.010343709657601965
+              },
+              "total_ms": {
+                "n": 481,
+                "removed": 19,
+                "min": 0.355292,
+                "mean": 0.47356442203742183,
+                "median": 0.452625,
+                "p90": 0.58025,
+                "p95": 0.622,
+                "p99": 0.7101493999999998,
+                "max": 0.771666,
+                "stddev": 0.07520148271309599
+              },
+              "non_internal_ms": {
+                "n": 481,
+                "removed": 19,
+                "min": 0.319292,
+                "mean": 0.42790538253638233,
+                "median": 0.407167,
+                "p90": 0.5258340000000001,
+                "p95": 0.566166,
+                "p99": 0.6613658,
+                "max": 0.7005,
+                "stddev": 0.06967016314721602
+              },
+              "cached_false_rate": 0.0,
+              "cached_unknown": 0
+            }
+          }
+        }
+      ],
+      "result_digest": "sha256:28e92e5f668d2c1e90a0bd15c209ef370424135588dbf650595afc3a2991754a"
+    }
+  }
+}

--- a/docs/synthetic/sample-replay-report.md
+++ b/docs/synthetic/sample-replay-report.md
@@ -1,0 +1,40 @@
+# Synthetic per-operation benchmark
+
+| field | value |
+|---|---|
+| tool | v0.1.0 |
+| endpoint / graph | `falkor://127.0.0.1:6379` / `tutorial_demo` |
+| FalkorDB module | 4.20.1 |
+| redis | 8.6.3 |
+| CACHE_SIZE | 25 |
+| client host | macOS 26.5.2 Tahoe · Apple M1 Pro (10c/10t) · 16.0 GiB · arm64 |
+| samples / warmup | 500 / 100 |
+| concurrency | 1 |
+| cache seed | 42 |
+| connection | pool(size=1) |
+| dataset | seed 42 · 1000 nodes · 5000 edges |
+| corpus_hash | `sha256:57638f31c17b7be582ca3c15f7e3c4ad050189e4200f5af478f6711658dd5eb5` |
+
+## `aggregate_count`
+
+_cached — plan reused, execution only_
+
+| C | throughput (ops/s) | server p50/p90/p95/p99 (ms) | total p50/p90/p95/p99 (ms) | miss% | |
+|---:|---:|---|---|---:|---|
+| 1 | 1778 | 0.094 / 0.123 / 0.133 / 0.158 | 0.523 / 0.668 / 0.734 / 0.823 | 0.0 | ⬅ knee |
+
+## `expand_1_hop`
+
+_cached — plan reused, execution only_
+
+| C | throughput (ops/s) | server p50/p90/p95/p99 (ms) | total p50/p90/p95/p99 (ms) | miss% | |
+|---:|---:|---|---|---:|---|
+| 1 | 1780 | 0.088 / 0.119 / 0.132 / 0.150 | 0.526 / 0.670 / 0.753 / 0.825 | 0.0 | ⬅ knee |
+
+## `match_by_index`
+
+_cached — plan reused, execution only_
+
+| C | throughput (ops/s) | server p50/p90/p95/p99 (ms) | total p50/p90/p95/p99 (ms) | miss% | |
+|---:|---:|---|---|---:|---|
+| 1 | 2068 | 0.043 / 0.060 / 0.068 / 0.078 | 0.453 / 0.580 / 0.622 / 0.710 | 0.0 | ⬅ knee |

--- a/readme.md
+++ b/readme.md
@@ -420,13 +420,48 @@ To run the integration test against a live server:
 just synthetic-it     # uses FALKORDB_HOST/FALKORDB_PORT, default 127.0.0.1:6379
 ```
 
+#### Record / replay: the same workload across versions (recommended)
+
+For a rigorous comparison of two FalkorDB versions, **record the workload once** — the dataset
+load-script *and* the measured commands — then **replay that identical bundle** against each version.
+Unlike the Criterion baselines below (which regenerate the graph and re-derive the commands each
+run), replay loads the recorded graph and replays the recorded commands with a fixed-length,
+deterministic runner, so the only variable is the FalkorDB version. See the full walkthrough in the
+[synthetic benchmark tutorial](docs/synthetic-benchmark-tutorial.md).
+
+```bash
+# 1. record a bundle OFFLINE (no server) into recordings/demo/
+just synthetic-record demo --graph tutorial_demo \
+  --op match_by_index,expand_1_hop,aggregate_count --seed 42 --nodes 1000 --edges 5000
+# 2. compare version A (:6379) vs version B (:6380) on that identical bundle
+just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:6380
+```
+
+- **`just synthetic-record <name> [flags]`** writes `recordings/<name>/` = `manifest.json` +
+  `graph.jsonl` (load statements) + `commands/<op>.jsonl`, plus a length-framed **`workload_hash`**
+  over the graph *and* the commands (so any later edit is detected on load). It is **offline** — a
+  pure function of the seed + knobs — and reads `synthetic-bench.toml` for defaults.
+- **`just synthetic-replay <name> <endpoint> [-- flags]`** drops + loads + **count-verifies** the
+  recorded graph, then measures the recorded commands (`C=1` cached), writing a report plus a per-op
+  **`result_digest`** (a hash of the result cardinality). `--no-load` skips the reload for a
+  load-once / run-many flow (still count-verifying first).
+- **`just synthetic-compare-versions <name> <A> <B>`** replays the same bundle against both endpoints
+  and **guards** the pair: it aborts unless the `workload_hash` **and** every op's `result_digest`
+  match, so a version returning wrong/empty results faster can't masquerade as an improvement. The
+  version difference itself is expected and recorded.
+- **`just synthetic-sanity`** self-checks the tool: it records the same workload twice (asserting an
+  identical `workload_hash` — deterministic recording), then replays + guards against a throwaway
+  Docker FalkorDB. Latency is not asserted (it is environment-dependent noise — see the tutorial).
+- `recordings/` is git-ignored (regenerable bundles).
+
 #### Version-comparison baselines (Criterion, C=1)
 
 To track a **read** operation's latency **between FalkorDB versions**, save a
 [Criterion](https://github.com/bheisler/criterion.rs) C=1 single-flight baseline on one version and
 compare against it on another. The workload (dataset + operations) comes from `synthetic-bench.toml`,
 so both runs measure exactly the same thing — and `synthetic-compare` **guards** that with the
-`corpus_hash` before it will compare, refusing to put mismatched workloads side by side.
+`corpus_hash` before it will compare, refusing to put mismatched workloads side by side. (This path
+regenerates per run; for a rigorous cross-version comparison prefer **record / replay** above.)
 
 ```bash
 # on FalkorDB version A (needs a synthetic-bench.toml with nodes/edges/operations)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -362,7 +362,7 @@ pub enum SyntheticCommands {
         all_reads: bool,
         #[arg(
             long,
-            help = "seed for the dataset and the per-operation corpora (same seed ⇒ identical bundle; default 0)"
+            help = "seed for the dataset and the per-operation corpora (same seed + same tool build ⇒ identical bundle; default 0)"
         )]
         seed: Option<u64>,
         #[arg(long, help = "dataset node count")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -336,6 +336,90 @@ pub enum SyntheticCommands {
     #[command(about = "list the available operations")]
     ListOps,
     #[command(
+        about = "record a workload bundle OFFLINE (no server): the dataset load-script + measured commands, so the exact same graph and commands can be replayed across FalkorDB versions"
+    )]
+    Record {
+        #[arg(
+            long = "config",
+            help = "path to a synthetic-bench.toml config (auto-detected in the CWD if present); CLI flags override it"
+        )]
+        config: Option<String>,
+        #[arg(long, help = "graph key the recorded commands target (default falkor)")]
+        graph: Option<String>,
+        #[arg(
+            long = "op",
+            value_enum,
+            value_delimiter = ',',
+            num_args = 1..,
+            help = "read operation(s) to record; repeatable and comma-separated. Overrides the config's operations."
+        )]
+        ops: Vec<OpName>,
+        #[arg(
+            long,
+            conflicts_with = "ops",
+            help = "record every read operation (mutually exclusive with --op)"
+        )]
+        all_reads: bool,
+        #[arg(
+            long,
+            help = "seed for the dataset and the per-operation corpora (same seed ⇒ identical bundle; default 0)"
+        )]
+        seed: Option<u64>,
+        #[arg(long, help = "dataset node count")]
+        nodes: Option<usize>,
+        #[arg(long, help = "dataset edge count, must be >= nodes")]
+        edges: Option<usize>,
+        #[arg(
+            long = "out-dir",
+            help = "directory to write the recording bundle into (manifest.json + graph.jsonl + commands/)"
+        )]
+        out_dir: String,
+    },
+    #[command(
+        about = "replay a recorded bundle against an endpoint: load the recorded graph + measure the recorded commands with a fixed-length deterministic runner"
+    )]
+    Replay {
+        #[arg(
+            long = "recording",
+            help = "path to a recording bundle directory (produced by `synthetic record`)"
+        )]
+        recording: String,
+        #[arg(long, help = "FalkorDB endpoint (default falkor://127.0.0.1:6379)")]
+        endpoint: Option<String>,
+        #[arg(
+            long,
+            help = "graph key to load into / measure against (default: the recording's graph)"
+        )]
+        graph: Option<String>,
+        #[arg(
+            long = "no-load",
+            help = "skip loading the recorded graph; only count-verify the already-loaded graph (for load-once / run-many). DESTRUCTIVE without it: replay drops+reloads the graph."
+        )]
+        no_load: bool,
+        #[arg(long, help = "measured invocations per operation (default 1000)")]
+        samples: Option<usize>,
+        #[arg(long, help = "warm-up invocations per operation, discarded (default 200)")]
+        warmup: Option<usize>,
+        #[arg(
+            long,
+            help = "FalkorDB server-side per-query timeout in ms (default 5000)"
+        )]
+        server_timeout_ms: Option<i64>,
+        #[arg(long, help = "client-side deadline per query in ms (default 6000)")]
+        client_deadline_ms: Option<u64>,
+        #[arg(
+            long,
+            help = "path to write the JSON report (default synthetic-report.json)"
+        )]
+        out: Option<String>,
+        #[arg(
+            long,
+            env = "FALKOR_SERVER_IMAGE",
+            help = "operator-supplied server image identity (e.g. falkordb/falkordb:v4.2.1@sha256:...), recorded verbatim"
+        )]
+        server_image: Option<String>,
+    },
+    #[command(
         about = "guard a version comparison: abort if the saved baseline and the current run measured different workloads (corpus_hash mismatch)"
     )]
     BaselineGuard {

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -83,18 +83,30 @@ pub fn guard(
         }
     }
 
-    // Result-correctness gate: for every op measured (with a result digest) in BOTH runs, the two
-    // versions must return the same result cardinality — otherwise a version returning wrong or
-    // empty results faster could masquerade as an improvement. (Digests are present for `synthetic
-    // replay` runs; a `synthetic run` report has none, so this is a no-op there.)
+    // Result-correctness gate: for every op the baseline recorded a result digest for, the
+    // candidate must record the *same* digest — otherwise a version returning wrong or empty
+    // results faster could masquerade as an improvement. A candidate that is missing a digest the
+    // baseline has is also a mismatch (fail closed, matching the docs' "every op" guarantee).
+    // Digests are present for `synthetic replay` runs; a `synthetic run` baseline has none, so the
+    // loop is a no-op there (and such runs already differ on `corpus_hash` above).
     for (op, base_dig) in &baseline.result_digests {
-        if let Some(cand_dig) = candidate.result_digests.get(op) {
-            if base_dig != cand_dig {
+        match candidate.result_digests.get(op) {
+            Some(cand_dig) if cand_dig == base_dig => {}
+            Some(cand_dig) => {
                 return GuardOutcome::Abort {
                     reason: format!(
                         "result mismatch for op '{op}' — baseline and candidate returned different \
                          result cardinalities (baseline {base_dig}, candidate {cand_dig}), so their \
                          latencies are not comparable"
+                    ),
+                };
+            }
+            None => {
+                return GuardOutcome::Abort {
+                    reason: format!(
+                        "candidate is missing a result digest for op '{op}' that the baseline \
+                         recorded — the runs aren't comparable (re-run the candidate with \
+                         `synthetic replay`)"
                     ),
                 };
             }
@@ -181,6 +193,19 @@ mod tests {
         let base = key_with_digests(Some("sha256:abc"), &[("expand_1_hop", "sha256:aaa")]);
         let cand = key_with_digests(Some("sha256:abc"), &[("expand_1_hop", "sha256:aaa")]);
         assert!(matches!(guard(&base, &cand), GuardOutcome::Proceed { .. }));
+    }
+
+    #[test]
+    fn aborts_when_candidate_missing_a_baseline_digest() {
+        // The baseline recorded a digest for an op the candidate has none for → fail closed.
+        let base = key_with_digests(Some("sha256:abc"), &[("expand_1_hop", "sha256:aaa")]);
+        let cand = key_with_digests(Some("sha256:abc"), &[]);
+        match guard(&base, &cand) {
+            GuardOutcome::Abort { reason } => {
+                assert!(reason.contains("missing a result digest for op 'expand_1_hop'"), "got: {reason}");
+            }
+            other => panic!("expected Abort, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -10,6 +10,7 @@
 
 use crate::synthetic::report::{Report, ServerInfo};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// The workload + environment identity of a run (extracted from its [`Report`]) that a
 /// version-comparison must agree on — or knowingly differ on.
@@ -22,6 +23,10 @@ pub struct BaselineKey {
     pub module_graph_ver: Option<u64>,
     /// Operator-supplied server image identity, when provided.
     pub server_image: Option<String>,
+    /// Per-op result-cardinality digests (present for `synthetic replay` runs). Compared op-by-op:
+    /// two versions must agree, or a wrong/empty-but-faster result could look like a win.
+    #[serde(default)]
+    pub result_digests: BTreeMap<String, String>,
 }
 
 impl BaselineKey {
@@ -31,6 +36,11 @@ impl BaselineKey {
             corpus_hash: report.meta.dataset.as_ref().map(|d| d.corpus_hash.clone()),
             module_graph_ver: report.meta.server.module_graph_ver,
             server_image: report.meta.server.server_image.clone(),
+            result_digests: report
+                .operations
+                .iter()
+                .filter_map(|(name, op)| op.result_digest.clone().map(|d| (name.clone(), d)))
+                .collect(),
         }
     }
 }
@@ -70,6 +80,24 @@ pub fn guard(
                          (`--generate`) so the workload can be fingerprinted"
                     .to_string(),
             };
+        }
+    }
+
+    // Result-correctness gate: for every op measured (with a result digest) in BOTH runs, the two
+    // versions must return the same result cardinality — otherwise a version returning wrong or
+    // empty results faster could masquerade as an improvement. (Digests are present for `synthetic
+    // replay` runs; a `synthetic run` report has none, so this is a no-op there.)
+    for (op, base_dig) in &baseline.result_digests {
+        if let Some(cand_dig) = candidate.result_digests.get(op) {
+            if base_dig != cand_dig {
+                return GuardOutcome::Abort {
+                    reason: format!(
+                        "result mismatch for op '{op}' — baseline and candidate returned different \
+                         result cardinalities (baseline {base_dig}, candidate {cand_dig}), so their \
+                         latencies are not comparable"
+                    ),
+                };
+            }
         }
     }
 
@@ -116,7 +144,43 @@ mod tests {
             corpus_hash: corpus.map(|s| s.to_string()),
             module_graph_ver: ver,
             server_image: None,
+            result_digests: BTreeMap::new(),
         }
+    }
+
+    fn key_with_digests(
+        corpus: Option<&str>,
+        digests: &[(&str, &str)],
+    ) -> BaselineKey {
+        BaselineKey {
+            corpus_hash: corpus.map(|s| s.to_string()),
+            module_graph_ver: Some(42001),
+            server_image: None,
+            result_digests: digests
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn aborts_on_result_digest_mismatch() {
+        // Same workload, but an op returned a different result cardinality across versions.
+        let base = key_with_digests(Some("sha256:abc"), &[("expand_1_hop", "sha256:aaa")]);
+        let cand = key_with_digests(Some("sha256:abc"), &[("expand_1_hop", "sha256:bbb")]);
+        match guard(&base, &cand) {
+            GuardOutcome::Abort { reason } => {
+                assert!(reason.contains("result mismatch for op 'expand_1_hop'"), "got: {reason}");
+            }
+            other => panic!("expected Abort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn proceeds_when_result_digests_match() {
+        let base = key_with_digests(Some("sha256:abc"), &[("expand_1_hop", "sha256:aaa")]);
+        let cand = key_with_digests(Some("sha256:abc"), &[("expand_1_hop", "sha256:aaa")]);
+        assert!(matches!(guard(&base, &cand), GuardOutcome::Proceed { .. }));
     }
 
     #[test]
@@ -199,11 +263,13 @@ mod tests {
             corpus_hash: Some("sha256:abc".to_string()),
             module_graph_ver: Some(42001),
             server_image: Some("falkordb@sha256:aaa".to_string()),
+            result_digests: BTreeMap::new(),
         };
         let cand = BaselineKey {
             corpus_hash: Some("sha256:abc".to_string()),
             module_graph_ver: Some(42002),
             server_image: Some("falkordb@sha256:bbb".to_string()),
+            result_digests: BTreeMap::new(),
         };
         match guard(&base, &cand) {
             GuardOutcome::Proceed { warnings } => {

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -224,6 +224,102 @@ pub fn corpus_hash(
     format!("sha256:{:x}", h.finalize())
 }
 
+/// The phase a load statement belongs to, so a recorded bundle can label statements and a loader
+/// can report which phase failed. All three run identically (execute + drain), but the ordering
+/// (index first, then nodes, then edges) matters and is preserved by [`load_statements`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadPhase {
+    Index,
+    Nodes,
+    Edges,
+}
+
+impl LoadPhase {
+    /// A stable lowercase tag used in the recorded `graph.jsonl` and its hash.
+    pub fn tag(self) -> &'static str {
+        match self {
+            LoadPhase::Index => "index",
+            LoadPhase::Nodes => "nodes",
+            LoadPhase::Edges => "edges",
+        }
+    }
+
+    /// Parse a [`LoadPhase`] from its [`tag`](Self::tag) (reading a recorded `graph.jsonl`).
+    pub fn from_tag(tag: &str) -> Option<LoadPhase> {
+        match tag {
+            "index" => Some(LoadPhase::Index),
+            "nodes" => Some(LoadPhase::Nodes),
+            "edges" => Some(LoadPhase::Edges),
+            _ => None,
+        }
+    }
+}
+
+/// The `:User(id)` index DDL — created before any data so every insert maintains it.
+const INDEX_STMT: &str = "CREATE INDEX FOR (u:User) ON (u.id)";
+
+/// One node `UNWIND` batch covering ids `lo..=hi` (inclusive, 1-based).
+fn node_batch(
+    spec: &DatasetSpec,
+    lo: i32,
+    hi: i32,
+) -> String {
+    let mut maps = String::new();
+    for id in lo..=hi {
+        if id != lo {
+            maps.push(',');
+        }
+        let _ = write!(maps, "{{id:{},age:{}}}", id, spec.node_age(id));
+    }
+    format!("UNWIND [{}] AS row CREATE (u:User) SET u = row", maps)
+}
+
+/// One edge `UNWIND` batch covering edge indices `lo..hi` (half-open).
+fn edge_batch(
+    spec: &DatasetSpec,
+    lo: usize,
+    hi: usize,
+) -> String {
+    let mut maps = String::new();
+    for e in lo..hi {
+        if e != lo {
+            maps.push(',');
+        }
+        let (src, dst) = spec.edge_at(e);
+        let _ = write!(maps, "{{src:{},dst:{}}}", src, dst);
+    }
+    format!(
+        "UNWIND [{}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend]->(m)",
+        maps
+    )
+}
+
+/// The exact ordered sequence of load statements that builds `spec`'s dataset: the index DDL, then
+/// `batch_size`-sized node `UNWIND` batches, then edge batches. **Lazy** — each batch string is
+/// built on demand as the iterator advances, so only one batch is materialized at a time (no
+/// full-script `Vec`). Shared by the live loader ([`generate_and_load`]) and the offline recorder
+/// so a replay loads a byte-identical graph to what a `--generate` run would. Callers must pass a
+/// validated `spec` (`spec.validate()`) and `batch_size >= 1`.
+pub(crate) fn load_statements(
+    spec: &DatasetSpec,
+    batch_size: usize,
+) -> impl Iterator<Item = (LoadPhase, String)> + '_ {
+    debug_assert!(batch_size >= 1, "batch_size must be >= 1");
+    let nodes = spec.nodes as i32;
+    let edges = spec.edges;
+    let index = std::iter::once((LoadPhase::Index, INDEX_STMT.to_string()));
+    let node_batches = (1..=nodes).step_by(batch_size).map(move |lo| {
+        // Widen to i64 so `lo + batch_size` can't overflow i32 near the id ceiling.
+        let hi = ((lo as i64) + (batch_size as i64) - 1).min(nodes as i64) as i32;
+        (LoadPhase::Nodes, node_batch(spec, lo, hi))
+    });
+    let edge_batches = (0..edges).step_by(batch_size).map(move |lo| {
+        let hi = (lo + batch_size).min(edges);
+        (LoadPhase::Edges, edge_batch(spec, lo, hi))
+    });
+    index.chain(node_batches).chain(edge_batches)
+}
+
 /// Generate the dataset described by `spec` and bulk-load it into `graph`, **replacing** whatever
 /// was there (the graph key is dropped first). Creates the `:User(id)` index, loads nodes then
 /// edges in `batch_size` `UNWIND` batches, verifies the final counts, and returns the seeded
@@ -239,7 +335,32 @@ pub(crate) async fn generate_and_load(
     if batch_size == 0 {
         return Err(OtherError("dataset batch_size must be greater than 0".to_string()));
     }
+    // Same drop → load statements → verify path a replay uses, fed the freshly-generated
+    // statements (so `--generate` and a recorded replay build byte-identical graphs).
+    load_dataset(
+        graph,
+        load_statements(spec, batch_size),
+        spec,
+        load_deadline,
+        server_timeout_ms,
+    )
+    .await?;
+    Ok(spec.handle())
+}
 
+/// Drop `graph`, execute an ordered `statements` stream into it, then verify it holds exactly
+/// `spec`'s node/edge counts. Shared by [`generate_and_load`] (fed the generated statements) and a
+/// recorded replay (fed the recorded `graph.jsonl`), so both build + verify identically.
+pub(crate) async fn load_dataset<I>(
+    graph: &mut AsyncGraph,
+    statements: I,
+    spec: &DatasetSpec,
+    load_deadline: Duration,
+    server_timeout_ms: i64,
+) -> BenchmarkResult<()>
+where
+    I: IntoIterator<Item = (LoadPhase, String)>,
+{
     // Clean slate: drop the graph key so we don't load on top of stale data. A "graph doesn't
     // exist yet" error is expected and ignored; anything else (auth/network/wrong type) must abort
     // rather than silently loading into a graph we couldn't clear. Bounded by the load deadline.
@@ -249,120 +370,76 @@ pub(crate) async fn generate_and_load(
             let msg = format!("{:?}", e);
             if !crate::synthetic::is_empty_graph_key(&msg) {
                 return Err(OtherError(format!(
-                    "failed to drop graph before generating dataset: {}",
+                    "failed to drop graph before loading dataset: {}",
                     msg
                 )));
             }
         }
         Err(e) => {
             return Err(OtherError(format!(
-                "dropping graph before generating dataset timed out: {}",
+                "dropping graph before loading dataset timed out: {}",
                 e
             )))
         }
     }
 
-    // (Re)create the id index before any data so every insert maintains it and it's operational
-    // throughout.
-    exec_drain(
-        graph,
-        "CREATE INDEX FOR (u:User) ON (u.id)",
-        server_timeout_ms,
-        load_deadline,
-    )
-    .await
-    .map_err(|e| OtherError(format!("failed to create :User(id) index: {}", e)))?;
-
-    // Nodes: UNWIND [{id,age},...] AS row CREATE (u:User) SET u = row
-    let mut batch = String::new();
-    let mut in_batch = 0usize;
-    for id in 1..=spec.nodes as i32 {
-        if in_batch > 0 {
-            batch.push(',');
-        }
-        // write! appends directly into the batch buffer (no per-row temporary String).
-        let _ = write!(batch, "{{id:{},age:{}}}", id, spec.node_age(id));
-        in_batch += 1;
-        if in_batch == batch_size {
-            flush_nodes(graph, &batch, server_timeout_ms, load_deadline).await?;
-            batch.clear();
-            in_batch = 0;
-        }
-    }
-    if in_batch > 0 {
-        flush_nodes(graph, &batch, server_timeout_ms, load_deadline).await?;
-        batch.clear();
+    for (phase, stmt) in statements {
+        exec_drain(graph, &stmt, server_timeout_ms, load_deadline)
+            .await
+            .map_err(|e| OtherError(format!("dataset load failed during {} phase: {}", phase.tag(), e)))?;
     }
 
-    // Edges: UNWIND [{src,dst},...] AS row MATCH (n:User{id:row.src}),(m:User{id:row.dst}) CREATE ...
-    in_batch = 0;
-    for e in 0..spec.edges {
-        let (src, dst) = spec.edge_at(e);
-        if in_batch > 0 {
-            batch.push(',');
-        }
-        let _ = write!(batch, "{{src:{},dst:{}}}", src, dst);
-        in_batch += 1;
-        if in_batch == batch_size {
-            flush_edges(graph, &batch, server_timeout_ms, load_deadline).await?;
-            batch.clear();
-            in_batch = 0;
-        }
-    }
-    if in_batch > 0 {
-        flush_edges(graph, &batch, server_timeout_ms, load_deadline).await?;
-    }
+    verify_counts(graph, spec, server_timeout_ms, load_deadline).await
+}
 
-    // Verify the load produced exactly the requested counts before anyone measures against it.
-    let node_count = count(graph, "MATCH (n:User) RETURN count(n)", server_timeout_ms, load_deadline).await?;
+/// Verify `graph` holds exactly `spec`'s `:User` node and `:Friend` edge counts (an absent/empty
+/// graph counts as `0`, so the mismatch message is helpful rather than a raw "empty key" error).
+pub(crate) async fn verify_counts(
+    graph: &mut AsyncGraph,
+    spec: &DatasetSpec,
+    server_timeout_ms: i64,
+    deadline: Duration,
+) -> BenchmarkResult<()> {
+    let node_count = count_or_empty(graph, "MATCH (n:User) RETURN count(n)", server_timeout_ms, deadline).await?;
     if node_count != spec.nodes as i64 {
         return Err(OtherError(format!(
-            "dataset load produced {} nodes, expected {}",
+            "graph has {} :User nodes, expected {}",
             node_count, spec.nodes
         )));
     }
-    let edge_count = count(
+    let edge_count = count_or_empty(
         graph,
         "MATCH (:User)-[e:Friend]->(:User) RETURN count(e)",
         server_timeout_ms,
-        load_deadline,
+        deadline,
     )
     .await?;
     if edge_count != spec.edges as i64 {
         return Err(OtherError(format!(
-            "dataset load produced {} edges, expected {}",
+            "graph has {} :Friend edges, expected {}",
             edge_count, spec.edges
         )));
     }
-
-    Ok(spec.handle())
+    Ok(())
 }
 
-async fn flush_nodes(
+/// Run a scalar `count` query, treating an absent/empty graph key as a count of `0` (so verifying
+/// against an unloaded graph reports a count mismatch rather than a raw redis "empty key" error).
+async fn count_or_empty(
     graph: &mut AsyncGraph,
-    maps: &str,
+    cypher: &str,
     server_timeout_ms: i64,
     deadline: Duration,
-) -> BenchmarkResult<()> {
-    let q = format!("UNWIND [{}] AS row CREATE (u:User) SET u = row", maps);
-    exec_drain(graph, &q, server_timeout_ms, deadline).await
-}
-
-async fn flush_edges(
-    graph: &mut AsyncGraph,
-    maps: &str,
-    server_timeout_ms: i64,
-    deadline: Duration,
-) -> BenchmarkResult<()> {
-    let q = format!(
-        "UNWIND [{}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend]->(m)",
-        maps
-    );
-    exec_drain(graph, &q, server_timeout_ms, deadline).await
+) -> BenchmarkResult<i64> {
+    match count(graph, cypher, server_timeout_ms, deadline).await {
+        Ok(n) => Ok(n),
+        Err(e) if crate::synthetic::is_empty_graph_key(&format!("{}", e)) => Ok(0),
+        Err(e) => Err(e),
+    }
 }
 
 /// Execute a write query and drain its (empty) result set, bounded by `deadline`.
-async fn exec_drain(
+pub(crate) async fn exec_drain(
     graph: &mut AsyncGraph,
     cypher: &str,
     server_timeout_ms: i64,
@@ -386,7 +463,7 @@ async fn exec_drain(
 }
 
 /// Run a `RETURN count(...)` scalar query and read the single i64 result.
-async fn count(
+pub(crate) async fn count(
     graph: &mut AsyncGraph,
     cypher: &str,
     server_timeout_ms: i64,
@@ -431,6 +508,73 @@ mod tests {
         assert!(spec(1, i32::MAX as usize + 1, i32::MAX as usize + 1)
             .validate()
             .is_err());
+    }
+
+    #[test]
+    fn load_statements_are_ordered_and_batched() {
+        // 5 nodes, 6 edges, batch 2 → index + ceil(5/2)=3 node batches + ceil(6/2)=3 edge batches.
+        let s = spec(3, 5, 6);
+        let stmts: Vec<(LoadPhase, String)> = load_statements(&s, 2).collect();
+        let phases: Vec<LoadPhase> = stmts.iter().map(|(p, _)| *p).collect();
+        assert_eq!(
+            phases,
+            vec![
+                LoadPhase::Index,
+                LoadPhase::Nodes,
+                LoadPhase::Nodes,
+                LoadPhase::Nodes,
+                LoadPhase::Edges,
+                LoadPhase::Edges,
+                LoadPhase::Edges,
+            ]
+        );
+        // The index DDL comes first, verbatim.
+        assert_eq!(stmts[0].1, INDEX_STMT);
+        // First node batch has ids 1,2 with their deterministic ages; last has the lone id 5.
+        assert_eq!(
+            stmts[1].1,
+            format!(
+                "UNWIND [{{id:1,age:{}}},{{id:2,age:{}}}] AS row CREATE (u:User) SET u = row",
+                s.node_age(1),
+                s.node_age(2)
+            )
+        );
+        assert_eq!(
+            stmts[3].1,
+            format!(
+                "UNWIND [{{id:5,age:{}}}] AS row CREATE (u:User) SET u = row",
+                s.node_age(5)
+            )
+        );
+        // First edge batch covers edge indices 0,1 (the ring backbone start).
+        let (e0s, e0d) = s.edge_at(0);
+        let (e1s, e1d) = s.edge_at(1);
+        assert_eq!(
+            stmts[4].1,
+            format!(
+                "UNWIND [{{src:{e0s},dst:{e0d}}},{{src:{e1s},dst:{e1d}}}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend]->(m)"
+            )
+        );
+    }
+
+    #[test]
+    fn load_statements_are_deterministic_and_reproduce_generate() {
+        // Same spec ⇒ byte-identical statement stream (the record/replay guarantee).
+        let s = spec(42, 100, 250);
+        let a: Vec<_> = load_statements(&s, 32).collect();
+        let b: Vec<_> = load_statements(&spec(42, 100, 250), 32).collect();
+        assert_eq!(a, b);
+        // A different seed changes the stream (ages/edges differ).
+        let c: Vec<_> = load_statements(&spec(43, 100, 250), 32).collect();
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn load_statements_batch_size_one_yields_one_statement_per_row() {
+        let s = spec(1, 3, 3);
+        let stmts: Vec<_> = load_statements(&s, 1).collect();
+        // index + 3 node batches + 3 edge batches.
+        assert_eq!(stmts.len(), 1 + 3 + 3);
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -23,6 +23,8 @@ pub mod engine;
 pub mod host;
 pub mod op_runner;
 pub mod provenance;
+pub mod recording;
+pub mod replay;
 pub mod report;
 pub mod stats;
 pub mod writes;
@@ -149,6 +151,12 @@ impl OpName {
     /// Whether this operation reads or writes (selects `RO_QUERY` vs `QUERY`).
     pub fn kind(self) -> QueryType {
         spec(self).kind
+    }
+
+    /// Parse an [`OpName`] from its stable [`as_str`](Self::as_str) tag (e.g. reading a recorded
+    /// bundle's manifest/command files). `None` for an unknown tag.
+    pub fn from_tag(tag: &str) -> Option<OpName> {
+        OpName::all().iter().copied().find(|op| op.as_str() == tag)
     }
 
     /// A one-line description for `list-ops` and the report.
@@ -322,7 +330,7 @@ pub fn list_ops() -> String {
 /// credentials passed in a `falkor://user:pass@host` URL never leak into `synthetic-report.json`.
 /// If the endpoint can't be parsed as a URL it's replaced with a placeholder (rather than echoed
 /// verbatim, which could still contain credentials).
-fn redact_endpoint(endpoint: &str) -> String {
+pub(crate) fn redact_endpoint(endpoint: &str) -> String {
     match url::Url::parse(endpoint) {
         Ok(mut url) => {
             if url.password().is_some() {
@@ -808,7 +816,10 @@ async fn measure_op(
         });
     }
 
-    Ok(OperationReport { levels })
+    Ok(OperationReport {
+        levels,
+        result_digest: None,
+    })
 }
 
 /// Run a list of untimed write statements (setup/reset/cleanup) to completion on `graph`.
@@ -979,7 +990,9 @@ async fn measure_level(
 /// computed over that single shared retained cohort. This keeps their sample counts identical and
 /// preserves the invariant that, since every raw pair has `total >= server`, the retained
 /// aggregates do too. Cache-health stats are computed over the same retained cohort.
-fn summarize_samples(samples: &[OpSample]) -> BenchmarkResult<crate::synthetic::report::MetricSet> {
+pub(crate) fn summarize_samples(
+    samples: &[OpSample]
+) -> BenchmarkResult<crate::synthetic::report::MetricSet> {
     let server: Vec<f64> = samples.iter().map(|s| s.server_ms).collect();
     let total: Vec<f64> = samples.iter().map(|s| s.total_ms).collect();
 
@@ -1032,12 +1045,21 @@ pub async fn run_and_report(config: &Config) -> BenchmarkResult<()> {
     }
     let report = run(config).await?;
     println!("{}", report.to_console());
+    write_report(&report, &config.out).await
+}
+
+/// Print nothing extra, but write the JSON report to `out` **and** the pasteable Markdown alongside
+/// it (`<out>.md`). Shared by [`run_and_report`] and `synthetic replay`.
+pub(crate) async fn write_report(
+    report: &crate::synthetic::report::Report,
+    out: &str,
+) -> BenchmarkResult<()> {
     let json = report.to_json()?;
-    tokio::fs::write(&config.out, json).await?;
-    info!("wrote {}", config.out);
-    println!("report written to {}", config.out);
+    tokio::fs::write(out, json).await?;
+    info!("wrote {}", out);
+    println!("report written to {}", out);
     // A PR-pasteable Markdown report alongside the JSON: `<out>.md` (replacing a `.json` suffix).
-    let md_path = markdown_path(&config.out);
+    let md_path = markdown_path(out);
     tokio::fs::write(&md_path, report.to_markdown()).await?;
     info!("wrote {}", md_path);
     println!("markdown written to {}", md_path);
@@ -1104,6 +1126,84 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
         crate::cli::SyntheticCommands::ListOps => {
             print!("{}", list_ops());
             Ok(())
+        }
+        crate::cli::SyntheticCommands::Record {
+            config: config_path,
+            graph,
+            ops,
+            all_reads,
+            seed,
+            nodes,
+            edges,
+            out_dir,
+        } => {
+            // Reuse the run-config resolution (with generate=true) to validate + resolve the
+            // dataset knobs, graph and read-op selection, then record OFFLINE (no server).
+            let overrides = config::CliOverrides {
+                endpoint: None,
+                graph,
+                ops,
+                all_reads,
+                samples: None,
+                warmup: None,
+                concurrency: Vec::new(),
+                reset_every: None,
+                seed,
+                cache: None,
+                server_timeout_ms: None,
+                client_deadline_ms: None,
+                out: None,
+                server_image: None,
+                generate: true,
+                nodes,
+                edges,
+            };
+            let file = config::FileConfig::load(config_path.as_deref())?;
+            let resolved = config::resolve(overrides, file)?;
+            let spec = resolved.dataset.ok_or_else(|| {
+                OtherError("record requires --nodes/--edges (or a config) to generate a dataset".to_string())
+            })?;
+            let manifest = recording::record(
+                &spec,
+                &resolved.graph,
+                &resolved.ops,
+                resolved.seed,
+                DATASET_LOAD_BATCH,
+                std::path::Path::new(&out_dir),
+            )?;
+            println!(
+                "recorded {} op(s) into {} (workload_hash {})",
+                manifest.ops.len(),
+                out_dir,
+                manifest.workload_hash
+            );
+            Ok(())
+        }
+        crate::cli::SyntheticCommands::Replay {
+            recording,
+            endpoint,
+            graph,
+            no_load,
+            samples,
+            warmup,
+            server_timeout_ms,
+            client_deadline_ms,
+            out,
+            server_image,
+        } => {
+            let replay_config = replay::ReplayConfig {
+                recording_dir: std::path::PathBuf::from(recording),
+                endpoint: endpoint.unwrap_or_else(|| "falkor://127.0.0.1:6379".to_string()),
+                graph,
+                load: !no_load,
+                samples: samples.unwrap_or(1000),
+                warmup: warmup.unwrap_or(200),
+                server_timeout_ms: server_timeout_ms.unwrap_or(5_000),
+                client_deadline_ms: client_deadline_ms.unwrap_or(6_000),
+                out: out.unwrap_or_else(|| "synthetic-report.json".to_string()),
+                server_image,
+            };
+            replay::run_and_report(&replay_config).await
         }
         crate::cli::SyntheticCommands::BaselineGuard { baseline, current } => {
             baseline_guard(&baseline, &current)

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -1,0 +1,627 @@
+//! Record-once / replay-identically: serialize a synthetic workload — the dataset **load script**
+//! and the per-operation **measured commands** — to a portable on-disk *bundle*, so the exact same
+//! graph and command stream can be loaded and run against multiple FalkorDB versions.
+//!
+//! ## Why
+//! Comparing two FalkorDB versions requires the graph and the measured commands to be **identical**.
+//! Re-generating the graph and re-deriving the commands on every run (the pre-record flow) relies on
+//! that derivation being byte-stable across tool rebuilds — the dataset is (portable `splitmix64`),
+//! but the command corpus is drawn with `rand::StdRng`, whose sequence is *not* guaranteed stable
+//! across `rand` versions. Recording captures both **once** so a replay never re-derives.
+//!
+//! ## Bundle layout (`<dir>/`)
+//! - `manifest.json` — [`Manifest`]: versions, dataset knobs, graph name, corpus seed, the ops and
+//!   their command counts, and the [`Manifest::workload_hash`].
+//! - `graph.jsonl` — one [`GraphRecord`] per line: the ordered load statements
+//!   ([`crate::synthetic::dataset::load_statements`]) a loader executes (drop + these + verify).
+//! - `commands/<op>.jsonl` — one [`CommandRecord`] per line: the fully-rendered measured queries.
+//!
+//! The [`Manifest::workload_hash`] is a **length-framed** SHA-256 over the header, every graph
+//! record, and every op's commands (in order) — so any edit to the graph *or* the commands is
+//! detected on [`load`] (the integrity gate), and two runs are only compared when it matches.
+//!
+//! Recording is **offline** (a pure function of the spec + seed) — no server is contacted.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::queries_repository::QueryType;
+use crate::synthetic::catalog::spec;
+use crate::synthetic::dataset::{load_statements, DatasetSpec, LoadPhase, GENERATOR_VERSION};
+use crate::synthetic::OpName;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// On-disk bundle format version. Bumped when the bundle layout changes incompatibly.
+pub const RECORDING_FORMAT_VERSION: u32 = 1;
+
+/// The dataset knobs a bundle was recorded from (mirrors [`DatasetSpec`], but owned + serde).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetKnobs {
+    pub seed: u64,
+    pub nodes: usize,
+    pub edges: usize,
+}
+
+impl DatasetKnobs {
+    fn spec(&self) -> DatasetSpec {
+        DatasetSpec {
+            seed: self.seed,
+            nodes: self.nodes,
+            edges: self.edges,
+        }
+    }
+}
+
+/// One recorded operation and how many commands it has.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpEntry {
+    pub name: String,
+    pub count: usize,
+}
+
+/// The bundle manifest (`manifest.json`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Manifest {
+    /// On-disk bundle format version (see [`RECORDING_FORMAT_VERSION`]).
+    pub format_version: u32,
+    /// The dataset generator's algorithm version ([`GENERATOR_VERSION`]) at record time.
+    pub generator_version: String,
+    /// The `benchmark` crate version that wrote the bundle.
+    pub tool_version: String,
+    /// Dataset knobs the graph was generated from.
+    pub dataset: DatasetKnobs,
+    /// The graph key the commands target (and a loader loads into by default).
+    pub graph: String,
+    /// The seed the per-operation command corpora were drawn with.
+    pub corpus_seed: u64,
+    /// Load batch size the `graph.jsonl` statements were batched at (recorded for transparency).
+    pub batch_size: usize,
+    /// The recorded operations, in execution order, with their command counts.
+    pub ops: Vec<OpEntry>,
+    /// Length-framed SHA-256 (`sha256:…`) over the whole workload (header + graph + commands).
+    /// Equal iff two bundles describe byte-identical work.
+    pub workload_hash: String,
+    /// When the bundle was recorded (epoch seconds; excluded from [`Self::workload_hash`]).
+    pub created_at_epoch_secs: u64,
+}
+
+/// One line of `graph.jsonl`: a load statement and the phase it belongs to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphRecord {
+    pub seq: usize,
+    pub phase: String,
+    pub cypher: String,
+}
+
+/// One line of `commands/<op>.jsonl`: a fully-rendered measured query.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandRecord {
+    pub seq: usize,
+    pub kind: String,
+    pub cypher: String,
+}
+
+/// A loaded bundle held in memory, ready to load into a server and replay.
+#[derive(Debug, Clone)]
+pub struct Bundle {
+    pub manifest: Manifest,
+    /// The ordered load statements (`graph.jsonl`).
+    pub graph_statements: Vec<(LoadPhase, String)>,
+    /// Each recorded op's ordered commands, in the manifest's op order.
+    pub commands: Vec<(OpName, Vec<String>)>,
+}
+
+/// Length-framed workload hasher. Every part is prefixed with its byte length (u64 LE) before the
+/// bytes, so no concatenation of parts can collide with a different split (e.g. `["ab","c"]` and
+/// `["a","bc"]` hash differently). Record (streaming) and [`load`] (from memory) feed it in the
+/// same order, so they agree iff the content matches.
+struct WorkloadHasher(Sha256);
+
+impl WorkloadHasher {
+    /// Start a hasher seeded with the bundle header (everything but the graph/command bodies).
+    fn new(
+        format_version: u32,
+        generator_version: &str,
+        dataset: &DatasetKnobs,
+        graph: &str,
+        corpus_seed: u64,
+    ) -> Self {
+        let mut h = WorkloadHasher(Sha256::new());
+        h.part(b"synthbench-recording");
+        h.part(&format_version.to_le_bytes());
+        h.part(generator_version.as_bytes());
+        h.part(&dataset.seed.to_le_bytes());
+        h.part(&(dataset.nodes as u64).to_le_bytes());
+        h.part(&(dataset.edges as u64).to_le_bytes());
+        h.part(graph.as_bytes());
+        h.part(&corpus_seed.to_le_bytes());
+        h
+    }
+
+    /// Feed one length-framed part.
+    fn part(
+        &mut self,
+        bytes: &[u8],
+    ) {
+        self.0.update((bytes.len() as u64).to_le_bytes());
+        self.0.update(bytes);
+    }
+
+    /// Feed one graph load statement (tagged `G` so it can't alias a command).
+    fn graph_record(
+        &mut self,
+        phase_tag: &str,
+        cypher: &str,
+    ) {
+        self.part(b"G");
+        self.part(phase_tag.as_bytes());
+        self.part(cypher.as_bytes());
+    }
+
+    /// Feed one operation header (name + command count, tagged `O`).
+    fn op_header(
+        &mut self,
+        name: &str,
+        count: usize,
+    ) {
+        self.part(b"O");
+        self.part(name.as_bytes());
+        self.part(&(count as u64).to_le_bytes());
+    }
+
+    /// Feed one measured command (tagged `C`).
+    fn command(
+        &mut self,
+        cypher: &str,
+    ) {
+        self.part(b"C");
+        self.part(cypher.as_bytes());
+    }
+
+    fn finalize(self) -> String {
+        format!("sha256:{:x}", self.0.finalize())
+    }
+}
+
+/// De-duplicate ops preserving first-occurrence order (matching how a run executes them).
+fn dedup_ops(ops: &[OpName]) -> Vec<OpName> {
+    let mut seen = std::collections::BTreeSet::new();
+    ops.iter()
+        .copied()
+        .filter(|op| seen.insert(op.as_str()))
+        .collect()
+}
+
+/// Render one operation's measured command corpus exactly as a run/bench derives it: seed
+/// `corpus_seed ^ op.salt()`, build the corpus from the spec's handle, render each to its cached
+/// cypher. Shared by [`record`] so a recorded command list matches what a generated run would send.
+pub fn render_commands(
+    op: OpName,
+    dataset: &DatasetSpec,
+    corpus_seed: u64,
+) -> BenchmarkResult<Vec<String>> {
+    let handle = dataset.handle();
+    let mut rng = StdRng::seed_from_u64(corpus_seed ^ op.salt());
+    let corpus = spec(op).build_corpus(&mut rng, &handle, 0, 1)?;
+    Ok(corpus.iter().map(|q| q.to_cypher()).collect())
+}
+
+/// Record a workload bundle to `out_dir` (created if absent). **Offline** — no server is contacted.
+///
+/// Writes `graph.jsonl` (the [`load_statements`] for `dataset`), `commands/<op>.jsonl` for each op,
+/// and `manifest.json` with the [`Manifest::workload_hash`]. `ops` are de-duplicated (first
+/// occurrence wins); **write ops are rejected** (v1 records read ops only). Returns the manifest.
+pub fn record(
+    dataset: &DatasetSpec,
+    graph: &str,
+    ops: &[OpName],
+    corpus_seed: u64,
+    batch_size: usize,
+    out_dir: &Path,
+) -> BenchmarkResult<Manifest> {
+    dataset.validate()?;
+    if batch_size == 0 {
+        return Err(OtherError("record batch_size must be greater than 0".to_string()));
+    }
+    let ops = dedup_ops(ops);
+    if ops.is_empty() {
+        return Err(OtherError(
+            "no operations to record — pass at least one read --op".to_string(),
+        ));
+    }
+    if let Some(op) = ops.iter().find(|op| spec(**op).kind == QueryType::Write) {
+        return Err(OtherError(format!(
+            "recording write op '{}' is not supported yet (v1 records read ops only)",
+            op.as_str()
+        )));
+    }
+
+    let knobs = DatasetKnobs {
+        seed: dataset.seed,
+        nodes: dataset.nodes,
+        edges: dataset.edges,
+    };
+    let commands_dir = out_dir.join("commands");
+    std::fs::create_dir_all(&commands_dir)
+        .map_err(|e| OtherError(format!("creating {}: {}", commands_dir.display(), e)))?;
+
+    let mut hasher = WorkloadHasher::new(
+        RECORDING_FORMAT_VERSION,
+        GENERATOR_VERSION,
+        &knobs,
+        graph,
+        corpus_seed,
+    );
+
+    // graph.jsonl — streamed straight from the lazy statement iterator (one batch in memory).
+    let graph_path = out_dir.join("graph.jsonl");
+    {
+        let mut w = BufWriter::new(create_file(&graph_path)?);
+        for (seq, (phase, stmt)) in load_statements(dataset, batch_size).enumerate() {
+            hasher.graph_record(phase.tag(), &stmt);
+            let rec = GraphRecord {
+                seq,
+                phase: phase.tag().to_string(),
+                cypher: stmt,
+            };
+            write_jsonl(&mut w, &graph_path, &rec)?;
+        }
+        w.flush()
+            .map_err(|e| OtherError(format!("flushing {}: {}", graph_path.display(), e)))?;
+    }
+
+    // commands/<op>.jsonl.
+    let mut op_entries = Vec::with_capacity(ops.len());
+    for op in &ops {
+        let cyphers = render_commands(*op, dataset, corpus_seed)?;
+        hasher.op_header(op.as_str(), cyphers.len());
+        let path = commands_dir.join(format!("{}.jsonl", op.as_str()));
+        let mut w = BufWriter::new(create_file(&path)?);
+        for (seq, cypher) in cyphers.iter().enumerate() {
+            hasher.command(cypher);
+            let rec = CommandRecord {
+                seq,
+                kind: "read".to_string(),
+                cypher: cypher.clone(),
+            };
+            write_jsonl(&mut w, &path, &rec)?;
+        }
+        w.flush()
+            .map_err(|e| OtherError(format!("flushing {}: {}", path.display(), e)))?;
+        op_entries.push(OpEntry {
+            name: op.as_str().to_string(),
+            count: cyphers.len(),
+        });
+    }
+
+    let manifest = Manifest {
+        format_version: RECORDING_FORMAT_VERSION,
+        generator_version: GENERATOR_VERSION.to_string(),
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        dataset: knobs,
+        graph: graph.to_string(),
+        corpus_seed,
+        batch_size,
+        ops: op_entries,
+        workload_hash: hasher.finalize(),
+        created_at_epoch_secs: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    };
+    let manifest_path = out_dir.join("manifest.json");
+    let json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| OtherError(format!("serializing manifest: {}", e)))?;
+    std::fs::write(&manifest_path, json)
+        .map_err(|e| OtherError(format!("writing {}: {}", manifest_path.display(), e)))?;
+    Ok(manifest)
+}
+
+/// Load a bundle from `dir`, **verifying its integrity**: the manifest's format version must match,
+/// every op's command count must match, and the [`Manifest::workload_hash`] recomputed from the
+/// on-disk graph + commands must equal the stored one — so a corrupted or hand-edited bundle is
+/// rejected rather than silently replayed.
+pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
+    let manifest: Manifest = {
+        let path = dir.join("manifest.json");
+        let bytes = std::fs::read(&path)
+            .map_err(|e| OtherError(format!("reading {}: {}", path.display(), e)))?;
+        serde_json::from_slice(&bytes)
+            .map_err(|e| OtherError(format!("parsing {}: {}", path.display(), e)))?
+    };
+    if manifest.format_version != RECORDING_FORMAT_VERSION {
+        return Err(OtherError(format!(
+            "unsupported recording format_version {} (this build expects {})",
+            manifest.format_version, RECORDING_FORMAT_VERSION
+        )));
+    }
+
+    // graph.jsonl → ordered (phase, cypher).
+    let graph_path = dir.join("graph.jsonl");
+    let graph_records: Vec<GraphRecord> = read_jsonl(&graph_path)?;
+    let mut graph_statements = Vec::with_capacity(graph_records.len());
+    for rec in &graph_records {
+        let phase = LoadPhase::from_tag(&rec.phase).ok_or_else(|| {
+            OtherError(format!(
+                "{}: unknown load phase '{}'",
+                graph_path.display(),
+                rec.phase
+            ))
+        })?;
+        graph_statements.push((phase, rec.cypher.clone()));
+    }
+
+    // commands/<op>.jsonl for each op named in the manifest, in order.
+    let mut commands = Vec::with_capacity(manifest.ops.len());
+    for entry in &manifest.ops {
+        let op = OpName::from_tag(&entry.name)
+            .ok_or_else(|| OtherError(format!("manifest names unknown op '{}'", entry.name)))?;
+        let path = dir.join("commands").join(format!("{}.jsonl", entry.name));
+        let recs: Vec<CommandRecord> = read_jsonl(&path)?;
+        if recs.len() != entry.count {
+            return Err(OtherError(format!(
+                "{}: has {} commands but manifest says {}",
+                path.display(),
+                recs.len(),
+                entry.count
+            )));
+        }
+        commands.push((op, recs.into_iter().map(|r| r.cypher).collect::<Vec<_>>()));
+    }
+
+    // Recompute the workload hash from the on-disk content and gate on it.
+    let mut hasher = WorkloadHasher::new(
+        manifest.format_version,
+        &manifest.generator_version,
+        &manifest.dataset,
+        &manifest.graph,
+        manifest.corpus_seed,
+    );
+    for (phase, cypher) in &graph_statements {
+        hasher.graph_record(phase.tag(), cypher);
+    }
+    for ((_, cyphers), entry) in commands.iter().zip(&manifest.ops) {
+        hasher.op_header(&entry.name, cyphers.len());
+        for cypher in cyphers {
+            hasher.command(cypher);
+        }
+    }
+    let recomputed = hasher.finalize();
+    if recomputed != manifest.workload_hash {
+        return Err(OtherError(format!(
+            "recording integrity check failed for {}: workload_hash mismatch \
+             (manifest {}, recomputed {}) — the bundle is corrupted or was edited",
+            dir.display(),
+            manifest.workload_hash,
+            recomputed
+        )));
+    }
+
+    Ok(Bundle {
+        manifest,
+        graph_statements,
+        commands,
+    })
+}
+
+impl Bundle {
+    /// The dataset spec the bundle was recorded from.
+    pub fn spec(&self) -> DatasetSpec {
+        self.manifest.dataset.spec()
+    }
+}
+
+fn create_file(path: &Path) -> BenchmarkResult<std::fs::File> {
+    std::fs::File::create(path).map_err(|e| OtherError(format!("creating {}: {}", path.display(), e)))
+}
+
+fn write_jsonl<T: Serialize, W: Write>(
+    w: &mut W,
+    path: &Path,
+    value: &T,
+) -> BenchmarkResult<()> {
+    let line =
+        serde_json::to_string(value).map_err(|e| OtherError(format!("serializing a record: {}", e)))?;
+    writeln!(w, "{}", line).map_err(|e| OtherError(format!("writing {}: {}", path.display(), e)))
+}
+
+fn read_jsonl<T: for<'de> Deserialize<'de>>(path: &Path) -> BenchmarkResult<Vec<T>> {
+    let file =
+        std::fs::File::open(path).map_err(|e| OtherError(format!("reading {}: {}", path.display(), e)))?;
+    let mut out = Vec::new();
+    for (i, line) in BufReader::new(file).lines().enumerate() {
+        let line = line.map_err(|e| OtherError(format!("reading {}: {}", path.display(), e)))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: T = serde_json::from_str(&line).map_err(|e| {
+            OtherError(format!("{}: bad JSON on line {}: {}", path.display(), i + 1, e))
+        })?;
+        out.push(value);
+    }
+    Ok(out)
+}
+
+/// A convenience for tests/tools: a unique temp directory path (not created). Unique even across
+/// concurrent callers in one process (a process-wide counter), so parallel tests can't collide.
+pub fn temp_bundle_dir(prefix: &str) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("{}-{}-{}-{}", prefix, std::process::id(), nanos, seq))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_ops() -> Vec<OpName> {
+        vec![OpName::MatchByIndex, OpName::Expand1Hop, OpName::AggregateCount]
+    }
+
+    fn record_to_temp(seed: u64) -> (PathBuf, Manifest) {
+        let dir = temp_bundle_dir("synthrec-test");
+        let spec = DatasetSpec {
+            seed,
+            nodes: 200,
+            edges: 600,
+        };
+        let manifest = record(&spec, "gtest", &read_ops(), seed, 64, &dir).unwrap();
+        (dir, manifest)
+    }
+
+    #[test]
+    fn record_then_load_round_trips() {
+        let (dir, manifest) = record_to_temp(7);
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.manifest, manifest);
+        assert_eq!(bundle.manifest.graph, "gtest");
+        assert_eq!(bundle.manifest.ops.len(), 3);
+        // graph statements equal the generator's statements for the same spec/batch.
+        let spec = bundle.spec();
+        let want: Vec<(LoadPhase, String)> = load_statements(&spec, 64).collect();
+        assert_eq!(bundle.graph_statements, want);
+        // commands equal what a run would derive for each op.
+        for (op, cyphers) in &bundle.commands {
+            assert_eq!(*cyphers, render_commands(*op, &spec, manifest.corpus_seed).unwrap());
+            assert!(!cyphers.is_empty());
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn recording_is_deterministic_across_two_records() {
+        // The sanity check's core: the same config records to an identical workload_hash.
+        let (dir_a, man_a) = record_to_temp(42);
+        let (dir_b, man_b) = record_to_temp(42);
+        assert_eq!(man_a.workload_hash, man_b.workload_hash);
+        // A different seed changes the hash (different data + commands).
+        let (dir_c, man_c) = record_to_temp(43);
+        assert_ne!(man_a.workload_hash, man_c.workload_hash);
+        for d in [dir_a, dir_b, dir_c] {
+            std::fs::remove_dir_all(&d).ok();
+        }
+    }
+
+    #[test]
+    fn load_rejects_a_tampered_command() {
+        let (dir, _man) = record_to_temp(1);
+        // Flip a byte in one command line — counts still match, but the hash won't.
+        let path = dir.join("commands").join("match_by_index.jsonl");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let tampered = text.replacen("RETURN", "return", 1);
+        assert_ne!(text, tampered, "expected a RETURN to rewrite");
+        std::fs::write(&path, tampered).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(
+            format!("{}", err).contains("integrity check failed"),
+            "unexpected error: {err}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_tampered_graph_statement() {
+        let (dir, _man) = record_to_temp(2);
+        let path = dir.join("graph.jsonl");
+        let text = std::fs::read_to_string(&path).unwrap();
+        // Change an age value in the first node batch.
+        let tampered = text.replacen("age:", "age:1", 1);
+        std::fs::write(&path, tampered).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{}", err).contains("integrity check failed"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_command_count_mismatch() {
+        let (dir, _man) = record_to_temp(3);
+        // Drop the last command line from one op file → count no longer matches the manifest.
+        let path = dir.join("commands").join("expand_1_hop.jsonl");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let mut lines: Vec<&str> = text.lines().collect();
+        lines.pop();
+        std::fs::write(&path, lines.join("\n")).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{}", err).contains("manifest says"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rejects_write_ops() {
+        let dir = temp_bundle_dir("synthrec-write");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let err = record(&spec, "g", &[OpName::CreateNode], 1, 8, &dir).unwrap_err();
+        assert!(format!("{}", err).contains("write op"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_dedups_ops_and_rejects_empty() {
+        let dir = temp_bundle_dir("synthrec-dedup");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let manifest = record(
+            &spec,
+            "g",
+            &[OpName::MatchByIndex, OpName::MatchByIndex],
+            1,
+            8,
+            &dir,
+        )
+        .unwrap();
+        assert_eq!(manifest.ops.len(), 1);
+        std::fs::remove_dir_all(&dir).ok();
+
+        let dir2 = temp_bundle_dir("synthrec-empty");
+        assert!(record(&spec, "g", &[], 1, 8, &dir2).is_err());
+    }
+
+    #[test]
+    fn workload_hash_is_length_framed() {
+        // ["ab","c"] and ["a","bc"] must not collide — the length prefix disambiguates.
+        let mut h1 = WorkloadHasher(Sha256::new());
+        h1.part(b"ab");
+        h1.part(b"c");
+        let mut h2 = WorkloadHasher(Sha256::new());
+        h2.part(b"a");
+        h2.part(b"bc");
+        assert_ne!(h1.finalize(), h2.finalize());
+    }
+
+    #[test]
+    fn load_missing_dir_errors() {
+        let err = load(&temp_bundle_dir("synthrec-missing")).unwrap_err();
+        assert!(format!("{err}").contains("manifest.json"), "got: {err}");
+    }
+
+    #[test]
+    fn load_rejects_bad_format_version() {
+        let (dir, _man) = record_to_temp(5);
+        let path = dir.join("manifest.json");
+        let text = std::fs::read_to_string(&path).unwrap();
+        // Bump the on-disk format version past what this build supports.
+        let bad = text.replacen("\"format_version\": 1", "\"format_version\": 9999", 1);
+        assert_ne!(text, bad, "expected the format_version to rewrite");
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{err}").contains("format_version"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -1,0 +1,301 @@
+//! Replay a recorded workload (see [`crate::synthetic::recording`]) against a FalkorDB endpoint.
+//!
+//! Unlike `synthetic run --generate` (which regenerates the graph and re-derives the commands every
+//! run) and the Criterion baseline (whose iteration count adapts to observed latency), a replay
+//! **loads the recorded graph** and measures the **recorded command stream** with a **fixed-length,
+//! deterministic** runner — the same graph and the same measured sequence on every version, so two
+//! versions' reports are genuinely comparable.
+//!
+//! The measured latency itself is still subject to environment noise; the *hard* guarantees a replay
+//! provides are integrity (the bundle's `workload_hash` is verified on load), graph fidelity (drop +
+//! load + count-verify), and result correctness (a per-op result-cardinality digest), leaving
+//! latency to be compared advisorily by the [`crate::synthetic::baseline`] guard.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::falkor::falkor_endpoint_to_redis_url;
+use crate::queries_repository::QueryType;
+use crate::synthetic::catalog::CORPUS_SIZE;
+use crate::synthetic::dataset::{self, DatasetSpec};
+use crate::synthetic::op_runner::{run_and_drain, OpSample};
+use crate::synthetic::recording::{self, Bundle};
+use crate::synthetic::report::{
+    DatasetInfo, LevelMetrics, LevelReport, Meta, OperationReport, Report, ServerInfo, SCHEMA_VERSION,
+};
+use crate::synthetic::{
+    open_graph, provenance, redact_endpoint, summarize_samples, write_report, OpName,
+};
+use falkordb::AsyncGraph;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tracing::{info, warn};
+
+/// How to replay a recorded bundle.
+#[derive(Debug, Clone)]
+pub struct ReplayConfig {
+    /// Directory of the recorded bundle (see [`recording::load`]).
+    pub recording_dir: PathBuf,
+    /// FalkorDB endpoint to replay against.
+    pub endpoint: String,
+    /// Graph key to load into / measure against. `None` ⇒ the bundle manifest's graph.
+    pub graph: Option<String>,
+    /// When `true` (default), drop + load + verify the recorded graph before measuring. When
+    /// `false`, skip loading but still **count-verify** the already-loaded graph (so a load-once /
+    /// run-many flow can't drift onto the wrong graph).
+    pub load: bool,
+    /// Measured invocations per operation (deterministic cycle over the recorded commands).
+    pub samples: usize,
+    /// Warm-up invocations per operation, discarded.
+    pub warmup: usize,
+    pub server_timeout_ms: i64,
+    pub client_deadline_ms: u64,
+    /// Where to write the JSON report (Markdown alongside as `<out>.md`).
+    pub out: String,
+    /// Operator-supplied server image identity, recorded verbatim.
+    pub server_image: Option<String>,
+}
+
+/// Replay `config`'s bundle and build a [`Report`] (a single C=1 cached level per op).
+pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
+    if config.samples == 0 {
+        return Err(OtherError("replay --samples must be greater than 0".to_string()));
+    }
+    let bundle = recording::load(&config.recording_dir)?;
+    let spec = bundle.spec();
+    let graph_name = config
+        .graph
+        .clone()
+        .unwrap_or_else(|| bundle.manifest.graph.clone());
+
+    let started_at_epoch_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let client_deadline = Duration::from_millis(config.client_deadline_ms);
+    let mut graph = open_graph(&config.endpoint, &graph_name).await?;
+
+    // Server provenance (best-effort: log and continue on failure).
+    let redis_url = falkor_endpoint_to_redis_url(Some(&config.endpoint));
+    let server = match provenance::collect(&redis_url, config.server_image.clone()).await {
+        Ok(info) => info,
+        Err(e) => {
+            warn!("could not collect server provenance: {}", e);
+            ServerInfo {
+                server_image: config.server_image.clone(),
+                ..Default::default()
+            }
+        }
+    };
+
+    if config.load {
+        load_recorded_graph(&mut graph, &bundle, &spec, config).await?;
+    } else {
+        // Load-once / run-many: don't reload, but confirm the right graph is present.
+        dataset::verify_counts(&mut graph, &spec, config.server_timeout_ms, client_deadline)
+            .await
+            .map_err(|e| {
+                OtherError(format!(
+                    "{} — load the recording first (don't pass --no-load)",
+                    e
+                ))
+            })?;
+    }
+
+    let mut operations = BTreeMap::new();
+    for (op, cyphers) in &bundle.commands {
+        let op_report = measure_op(&mut graph, *op, cyphers, config, client_deadline).await?;
+        operations.insert(op.as_str().to_string(), op_report);
+    }
+
+    Ok(Report {
+        schema_version: SCHEMA_VERSION,
+        meta: Meta {
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            endpoint: redact_endpoint(&config.endpoint),
+            graph: graph_name,
+            samples: config.samples,
+            warmup: config.warmup,
+            concurrency: vec![1],
+            seed: bundle.manifest.corpus_seed,
+            corpus_size: CORPUS_SIZE,
+            server_timeout_ms: config.server_timeout_ms,
+            client_deadline_ms: config.client_deadline_ms,
+            connection: "pool(size=1)".to_string(),
+            started_at_epoch_secs,
+            server,
+            host: crate::synthetic::host::collect(),
+            // The bundle's workload_hash is the comparison key: it attests the graph *and* the
+            // commands, so the existing guard compares replays of the same bundle safely.
+            dataset: Some(DatasetInfo {
+                seed: spec.seed,
+                nodes: spec.nodes,
+                edges: spec.edges,
+                corpus_hash: bundle.manifest.workload_hash.clone(),
+            }),
+        },
+        operations,
+    })
+}
+
+/// Replay, print the console summary, and write the JSON + Markdown report.
+pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
+    let report = run(config).await?;
+    println!("{}", report.to_console());
+    write_report(&report, &config.out).await
+}
+
+/// Drop `graph`, execute the bundle's recorded load statements, and verify the node/edge counts.
+async fn load_recorded_graph(
+    graph: &mut AsyncGraph,
+    bundle: &Bundle,
+    spec: &DatasetSpec,
+    config: &ReplayConfig,
+) -> BenchmarkResult<()> {
+    // Bulk loads do real server-side work, so give them a generous deadline and a matching
+    // server-side timeout (mirroring `synthetic run --generate`).
+    let load_deadline = Duration::from_millis(config.client_deadline_ms.max(60_000));
+    let load_server_timeout_ms = config
+        .server_timeout_ms
+        .max(i64::try_from(load_deadline.as_millis()).unwrap_or(i64::MAX));
+
+    info!(
+        "loading recorded graph ({} statements) into '{}'",
+        bundle.graph_statements.len(),
+        bundle.manifest.graph
+    );
+
+    // Drop + load the recorded statements + verify counts — the exact path `--generate` uses.
+    dataset::load_dataset(
+        graph,
+        bundle.graph_statements.iter().cloned(),
+        spec,
+        load_deadline,
+        load_server_timeout_ms,
+    )
+    .await
+}
+
+/// Measure one operation: prime the plan cache, capture a result-cardinality digest, run a fixed
+/// warm-up then a fixed measured cycle over the recorded commands, and summarize.
+async fn measure_op(
+    graph: &mut AsyncGraph,
+    op: OpName,
+    cyphers: &[String],
+    config: &ReplayConfig,
+    client_deadline: Duration,
+) -> BenchmarkResult<OperationReport> {
+    if cyphers.is_empty() {
+        return Err(OtherError(format!("op '{}' has no recorded commands", op.as_str())));
+    }
+    let st = config.server_timeout_ms;
+
+    // Prime the plan cache so the first measured iteration isn't a compile.
+    run_and_drain(graph, QueryType::Read, &cyphers[0], st, client_deadline)
+        .await
+        .map_err(|e| OtherError(format!("priming '{}': {}", op.as_str(), e)))?;
+
+    // Untimed cardinality pass over every distinct command → the result digest (correctness gate).
+    let mut cardinalities = Vec::with_capacity(cyphers.len());
+    for cypher in cyphers {
+        let sample = run_and_drain(graph, QueryType::Read, cypher, st, client_deadline)
+            .await
+            .map_err(|e| OtherError(format!("verifying '{}': {}", op.as_str(), e)))?;
+        cardinalities.push(sample.rows);
+    }
+    let result_digest = cardinality_digest(op, &cardinalities);
+
+    // Warm-up (discarded), then the fixed-length measured cycle.
+    for i in 0..config.warmup {
+        let cypher = &cyphers[i % cyphers.len()];
+        run_and_drain(graph, QueryType::Read, cypher, st, client_deadline)
+            .await
+            .map_err(|e| OtherError(format!("warm-up '{}': {}", op.as_str(), e)))?;
+    }
+
+    let mut samples: Vec<OpSample> = Vec::with_capacity(config.samples);
+    let start = Instant::now();
+    for i in 0..config.samples {
+        let cypher = &cyphers[i % cyphers.len()];
+        let sample = run_and_drain(graph, QueryType::Read, cypher, st, client_deadline)
+            .await
+            .map_err(|e| OtherError(format!("measuring '{}': {}", op.as_str(), e)))?;
+        samples.push(sample);
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    let throughput_ops_per_sec = if elapsed > 0.0 {
+        samples.len() as f64 / elapsed
+    } else {
+        0.0
+    };
+
+    let metrics = summarize_samples(&samples)?;
+    Ok(OperationReport {
+        levels: vec![LevelReport {
+            concurrency: 1,
+            cached: Some(LevelMetrics {
+                throughput_ops_per_sec,
+                metrics,
+            }),
+            uncached: None,
+            compilation_ms_median: None,
+        }],
+        result_digest: Some(result_digest),
+    })
+}
+
+/// A `sha256:…` digest over an operation's per-command result cardinality (row counts), in command
+/// order. Deterministic given the same graph + recorded commands, and length-framed so it can't
+/// alias a different op's digest.
+fn cardinality_digest(
+    op: OpName,
+    rows: &[usize],
+) -> String {
+    let mut h = Sha256::new();
+    let name = op.as_str().as_bytes();
+    h.update((name.len() as u64).to_le_bytes());
+    h.update(name);
+    h.update((rows.len() as u64).to_le_bytes());
+    for &r in rows {
+        h.update((r as u64).to_le_bytes());
+    }
+    format!("sha256:{:x}", h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cardinality_digest_is_deterministic_and_sensitive() {
+        let a = cardinality_digest(OpName::MatchByIndex, &[1, 1, 1]);
+        let b = cardinality_digest(OpName::MatchByIndex, &[1, 1, 1]);
+        assert_eq!(a, b);
+        // A different cardinality vector changes the digest.
+        assert_ne!(a, cardinality_digest(OpName::MatchByIndex, &[1, 0, 1]));
+        // The op name is part of the digest (same rows, different op).
+        assert_ne!(a, cardinality_digest(OpName::Expand1Hop, &[1, 1, 1]));
+        assert!(a.starts_with("sha256:"));
+    }
+
+    #[tokio::test]
+    async fn run_rejects_zero_samples() {
+        // Guarded before any disk/server access, so this stays hermetic.
+        let config = ReplayConfig {
+            recording_dir: PathBuf::from("/nonexistent/recording"),
+            endpoint: "falkor://127.0.0.1:6379".to_string(),
+            graph: None,
+            load: true,
+            samples: 0,
+            warmup: 0,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: "unused.json".to_string(),
+            server_image: None,
+        };
+        let err = run(&config).await.unwrap_err();
+        assert!(format!("{err}").contains("samples must be greater than 0"), "got: {err}");
+    }
+}

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -15,7 +15,6 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
-use crate::synthetic::catalog::CORPUS_SIZE;
 use crate::synthetic::dataset::{self, DatasetSpec};
 use crate::synthetic::op_runner::{run_and_drain, OpSample};
 use crate::synthetic::recording::{self, Bundle};
@@ -110,6 +109,15 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         operations.insert(op.as_str().to_string(), op_report);
     }
 
+    // The corpus size is what the bundle actually recorded per op (not the compile-time constant),
+    // so a report reflects the replayed commands even if the recorder used a different count.
+    let corpus_size = bundle
+        .commands
+        .iter()
+        .map(|(_, cyphers)| cyphers.len())
+        .max()
+        .unwrap_or(0);
+
     Ok(Report {
         schema_version: SCHEMA_VERSION,
         meta: Meta {
@@ -120,7 +128,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             warmup: config.warmup,
             concurrency: vec![1],
             seed: bundle.manifest.corpus_seed,
-            corpus_size: CORPUS_SIZE,
+            corpus_size,
             server_timeout_ms: config.server_timeout_ms,
             client_deadline_ms: config.client_deadline_ms,
             connection: "pool(size=1)".to_string(),

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -200,7 +200,8 @@ async fn measure_op(
         .await
         .map_err(|e| OtherError(format!("priming '{}': {}", op.as_str(), e)))?;
 
-    // Untimed cardinality pass over every distinct command → the result digest (correctness gate).
+    // Untimed cardinality pass over every recorded command (in order) → the result digest that the
+    // guard uses as a correctness gate.
     let mut cardinalities = Vec::with_capacity(cyphers.len());
     for cypher in cyphers {
         let sample = run_and_drain(graph, QueryType::Read, cypher, st, client_deadline)

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -91,7 +91,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     };
 
     if config.load {
-        load_recorded_graph(&mut graph, &bundle, &spec, config).await?;
+        load_recorded_graph(&mut graph, &bundle, &graph_name, &spec, config).await?;
     } else {
         // Load-once / run-many: don't reload, but confirm the right graph is present.
         dataset::verify_counts(&mut graph, &spec, config.server_timeout_ms, client_deadline)
@@ -151,6 +151,7 @@ pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
 async fn load_recorded_graph(
     graph: &mut AsyncGraph,
     bundle: &Bundle,
+    graph_name: &str,
     spec: &DatasetSpec,
     config: &ReplayConfig,
 ) -> BenchmarkResult<()> {
@@ -161,10 +162,12 @@ async fn load_recorded_graph(
         .server_timeout_ms
         .max(i64::try_from(load_deadline.as_millis()).unwrap_or(i64::MAX));
 
+    // Log the graph actually being loaded (the resolved target, which `--graph` can override — not
+    // necessarily the bundle's recorded graph name).
     info!(
         "loading recorded graph ({} statements) into '{}'",
         bundle.graph_statements.len(),
-        bundle.manifest.graph
+        graph_name
     );
 
     // Drop + load the recorded statements + verify counts — the exact path `--generate` uses.

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -203,13 +203,9 @@ async fn measure_op(
     }
     let st = config.server_timeout_ms;
 
-    // Prime the plan cache so the first measured iteration isn't a compile.
-    run_and_drain(graph, QueryType::Read, &cyphers[0], st, client_deadline)
-        .await
-        .map_err(|e| OtherError(format!("priming '{}': {}", op.as_str(), e)))?;
-
     // Untimed cardinality pass over every recorded command (in order) → the result digest that the
-    // guard uses as a correctness gate.
+    // guard uses as a correctness gate. This also primes the plan cache for *every* command (so the
+    // measured cycle below never pays a first-time compile), which is why there's no separate prime.
     let mut cardinalities = Vec::with_capacity(cyphers.len());
     for cypher in cyphers {
         let sample = run_and_drain(graph, QueryType::Read, cypher, st, client_deadline)

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -171,6 +171,12 @@ pub struct LevelReport {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OperationReport {
     pub levels: Vec<LevelReport>,
+    /// A `sha256:…` digest of this operation's **result cardinality** across its recorded commands
+    /// (present only for a `synthetic replay` run). Two versions that return a different number of
+    /// rows for the same recorded command produce different digests, so a version returning wrong
+    /// or empty results faster can't masquerade as an improvement. `None` for a `synthetic run`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_digest: Option<String>,
 }
 
 impl OperationReport {
@@ -625,6 +631,7 @@ mod tests {
                         compilation_ms_median: Some(0.06),
                     },
                 ],
+                result_digest: None,
             },
         );
         Report {
@@ -889,6 +896,7 @@ mod tests {
                         compilation_ms_median: None,
                     },
                 ],
+                result_digest: None,
             },
         );
         ops.insert(
@@ -900,6 +908,7 @@ mod tests {
                     uncached: Some(sample_level_metrics(50.0)),
                     compilation_ms_median: None,
                 }],
+                result_digest: None,
             },
         );
         ops.insert(
@@ -920,6 +929,7 @@ mod tests {
                         compilation_ms_median: None,
                     },
                 ],
+                result_digest: None,
             },
         );
         r.operations = ops;

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -935,3 +935,159 @@ async fn explain(
     let plan = graph.explain(cypher).execute().await.expect("explain");
     plan.plan().to_vec()
 }
+
+// ---------------------------------------------------------------------------
+// Record / replay (record-once, replay-identically across versions).
+// ---------------------------------------------------------------------------
+
+use benchmark::synthetic::baseline::{guard, BaselineKey, GuardOutcome};
+use benchmark::synthetic::recording::{self, temp_bundle_dir};
+use benchmark::synthetic::replay::{self, ReplayConfig};
+
+fn replay_config(dir: &std::path::Path, graph: &str, out: &str, load: bool) -> ReplayConfig {
+    ReplayConfig {
+        recording_dir: dir.to_path_buf(),
+        endpoint: endpoint(),
+        graph: Some(graph.to_string()),
+        load,
+        samples: 200,
+        warmup: 30,
+        server_timeout_ms: 5_000,
+        client_deadline_ms: 6_000,
+        out: out.to_string(),
+        server_image: None,
+    }
+}
+
+/// record (offline) → replay --load → replay --no-load produces byte-identical workload identity
+/// (workload_hash + per-op result digests), and the guard proceeds — the whole cross-version basis.
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn record_then_replay_roundtrips_and_guard_proceeds() {
+    let graph = "syn_it_replay";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-rec");
+    let spec = DatasetSpec {
+        seed: 9,
+        nodes: 500,
+        edges: 1500,
+    };
+    let ops = vec![OpName::MatchByIndex, OpName::Expand1Hop, OpName::AggregateCount];
+    recording::record(&spec, graph, &ops, spec.seed, 256, &dir).expect("record");
+
+    // Replay #1 loads the recorded graph; #2 reuses it (no-load), count-verifying first.
+    let ref_out = dir.join("ref.json").to_string_lossy().into_owned();
+    let cand_out = dir.join("cand.json").to_string_lossy().into_owned();
+    let a = replay::run(&replay_config(&dir, graph, &ref_out, true))
+        .await
+        .expect("replay --load");
+    let b = replay::run(&replay_config(&dir, graph, &cand_out, false))
+        .await
+        .expect("replay --no-load");
+
+    // Same workload identity: the workload_hash (stamped as corpus_hash) matches.
+    let ha = a.meta.dataset.as_ref().expect("dataset a").corpus_hash.clone();
+    let hb = b.meta.dataset.as_ref().expect("dataset b").corpus_hash.clone();
+    assert_eq!(ha, hb, "workload_hash must match across replays");
+
+    // Every op has a result digest, and they match across the two replays.
+    for op in ["match_by_index", "expand_1_hop", "aggregate_count"] {
+        let da = a.operations[op].result_digest.as_ref().expect("digest a");
+        let db = b.operations[op].result_digest.as_ref().expect("digest b");
+        assert_eq!(da, db, "result digest for {op} must match");
+        // A single C=1 cached level was measured.
+        let lvl = only_level(&a.operations[op]);
+        assert_eq!(lvl.concurrency, 1);
+        assert!(lvl.cached.is_some());
+    }
+
+    // The guard proceeds (same workload + matching result digests).
+    match guard(&BaselineKey::from_report(&a), &BaselineKey::from_report(&b)) {
+        GuardOutcome::Proceed { .. } => {}
+        GuardOutcome::Abort { reason } => panic!("guard aborted unexpectedly: {reason}"),
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// replay --no-load against a graph that doesn't hold the recorded dataset fails closed (the
+/// count-verify rejects it) rather than silently measuring the wrong graph.
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn replay_no_load_fails_closed_on_wrong_graph() {
+    let graph = "syn_it_replay_missing";
+    drop_graph(graph).await; // ensure it's empty / absent
+    let dir = temp_bundle_dir("syn-it-rec-missing");
+    let spec = DatasetSpec {
+        seed: 3,
+        nodes: 300,
+        edges: 900,
+    };
+    recording::record(&spec, graph, &[OpName::MatchByIndex], spec.seed, 256, &dir).expect("record");
+
+    let out = dir.join("r.json").to_string_lossy().into_owned();
+    let err = replay::run(&replay_config(&dir, graph, &out, false))
+        .await
+        .expect_err("replay --no-load on an unloaded graph must fail");
+    assert!(
+        format!("{err}").contains("load the recording first"),
+        "expected a count-verify failure, got: {err}"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Drive the CLI arms end-to-end: `run_command(Record)` (offline) then `run_command(Replay)`
+/// (load + measure + write report), covering config resolution + report writing.
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn record_and_replay_via_run_command() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::run_command;
+
+    let graph = "syn_it_cli_replay";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-cli");
+    let out_dir = dir.to_string_lossy().into_owned();
+
+    run_command(SyntheticCommands::Record {
+        config: None,
+        graph: Some(graph.to_string()),
+        ops: vec![OpName::MatchByIndex, OpName::AggregateCount],
+        all_reads: false,
+        seed: Some(11),
+        nodes: Some(400),
+        edges: Some(1200),
+        out_dir: out_dir.clone(),
+    })
+    .await
+    .expect("record via run_command");
+    assert!(dir.join("manifest.json").exists());
+
+    let report_out = dir.join("cli.json").to_string_lossy().into_owned();
+    run_command(SyntheticCommands::Replay {
+        recording: out_dir,
+        endpoint: Some(endpoint()),
+        graph: None,
+        no_load: false,
+        samples: Some(150),
+        warmup: Some(20),
+        server_timeout_ms: None,
+        client_deadline_ms: None,
+        out: Some(report_out.clone()),
+        server_image: None,
+    })
+    .await
+    .expect("replay via run_command");
+
+    let written = std::fs::read_to_string(&report_out).expect("report exists");
+    assert!(written.contains("match_by_index"));
+    assert!(written.contains("result_digest"));
+    // The Markdown sibling is written too.
+    assert!(std::path::Path::new(&report_out.replace(".json", ".md")).exists());
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}


### PR DESCRIPTION
## Why

Comparing two FalkorDB versions requires the **graph** and the **measured commands** to be *identical* — otherwise you compare two workloads, not two versions. The existing `synthetic-baseline`/`compare` recipes **re-generate the graph and re-derive the commands every run**: the dataset is version-stable, but the command corpus is drawn with `rand::StdRng` (sequence not guaranteed stable across tool rebuilds), and regenerating each run makes the server redo write work and land in a different state. Both are avoidable noise.

A self-comparison (`latest` vs itself) empirically wobbles ~±5–13% per op — that is **environment noise** (laptop + Docker VM, CPU-freq scaling), not a workload difference, but the old flow couldn't *prove* that.

## What

**Record once → load + run those identical files against each version.**

- **`synthetic record`** (offline, no server) writes `recordings/<name>/` = `manifest.json` + `graph.jsonl` (load statements) + `commands/<op>.jsonl`, plus a length-framed **`workload_hash`** over the graph *and* the commands (tamper-evident on load).
- **`synthetic replay`** drops + loads + **count-verifies** the recorded graph, then measures the recorded commands with a **fixed-length deterministic runner** (not Criterion, whose iteration count adapts to observed latency), capturing a per-op **`result_digest`** (result cardinality). `--no-load` supports load-once / run-many.
- The **guard** aborts unless the `workload_hash` **and** every `result_digest` match (so a version returning wrong/empty results faster can't look like a win); the version delta itself is expected. Latency stays advisory.

Split "generate input" from "load" **across the bench** — every comparison path reuses the same bundle, nothing regenerates per run.

### Recipes
- `just synthetic-record <name> [flags]` — offline bundle build
- `just synthetic-replay <name> <endpoint> [-- flags]` — load + measure
- `just synthetic-compare-versions <name> <A> <B>` — replay one bundle vs two versions + guard
- `just synthetic-sanity` — self-contained tool sanity (record twice, assert identical `workload_hash`; replay + guard on a throwaway Docker FalkorDB)

The Criterion `synthetic-baseline`/`compare` remain as a single-version tracker (doc-clarified).

## Docs & sample outputs
- `docs/synthetic-benchmark-tutorial.md` — full walkthrough, linking committed **expected outputs** under `docs/synthetic/` (manifest, replay report `.md`/`.json`, console transcript; hostname redacted).
- `readme.md` + `.github/copilot-instructions.md` recipe tables synced.

## Validation
- `just ci` (build + clippy + test), `just doc-check`, `just coverage` all green.
- `just synthetic-sanity` passes end-to-end.
- New unit + `#[ignore]` integration tests (record→replay round-trip, guard proceeds, `--no-load` fails closed, CLI arms). Every changed file ≥92% line coverage.
- Local `code-review` pass: no significant issues.

Scope: v1 records **read** ops / C=1 latency. Closed-loop C>1 throughput and write-op recording are noted follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synthetic benchmark record/replay workflows to run the same workload across FalkorDB endpoints and versions.
  * Added offline workload bundles with integrity checking, deterministic replay, per-operation result verification, version comparison, and determinism sanity checks.
* **Documentation**
  * Added a synthetic benchmark tutorial plus sample console output, recording manifest, and replay report files.
  * Updated the README with recommended cross-version benchmarking guidance.
* **Bug Fixes**
  * Strengthened comparison safety to fail closed on workload or per-operation result mismatches.
* **Chores**
  * Updated ignore rules for generated recording artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->