### PR TITLE
feat(synthetic): per-op regression report (thresholds + report --regression + run --label) [Part A]

### DIFF
--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -100,11 +100,12 @@ precedence + the verdict function are pure logic → **unit-tested** (faster, ex
 over, per-op vs per-op×C precedence, floor suppression, divergence → N/A, zero/missing baseline →
 N/A).
 
-### A3. Explicit non-fatal regression mode — `report --regression`
+### A3. Non-fatal regression mode — `report --diff … --regression`
 
-Add a dedicated mode rather than overloading the strict `--diff` guard. New invocation
-`synthetic report --regression --baseline <base.json> --candidate <cand.json> [--thresholds
-<file>] [--out <md>]` (or, equivalently, `report --diff … --regression`), which:
+Add a non-fatal, colored mode alongside the strict `--diff` guard. Invocation (the second report
+`B` is the **candidate**, the first `A` is the **baseline**):
+`synthetic report --diff <baseline.json> <candidate.json> --regression [--thresholds <file>]
+[--out <md>]`, which:
 
 - **Splits the guard** (today `baseline::guard` conflates the two — src/synthetic/baseline.rs):
   - a **comparability mismatch** ⇒ *globally not comparable* → the whole table is rendered as
@@ -144,7 +145,8 @@ of a table. This keeps correctness/infra failures visible without ever blocking 
 
 ### A5. Two baselines in one report
 
-Keep the tool's unit of work a single pair (`--baseline`, `--candidate`). The **workflow** invokes
+Keep the tool's unit of work a single pair (`report --diff <baseline> <candidate> --regression`).
+The **workflow** invokes
 it once per baseline (`main→pr`, `release→pr`) and concatenates the two tables under one sticky
 comment. (A combined multi-baseline subcommand is a possible future consolidation, out of scope.)
 
@@ -194,9 +196,9 @@ every tool/infra failure is caught and turned into a "benchmark unavailable" com
      --server-image pr@sha256:… --concurrency 1,2,4,8,16,32 --cache both --samples 200 --warmup 50
      --out pr.json`; **`docker rm -f`** (guaranteed cleanup via trap).
    - repeat for `main` (`--label main`) and, if present, `release` (`--label "release X.Y.Z"`).
-4. **Diff + color (non-fatal):** `benchmark synthetic report --regression --baseline main.json
-   --candidate pr.json --thresholds .github/synthetic-thresholds.toml --out syn-main.md`, and
-   likewise for release. Each call catches failure → "unavailable" fragment.
+4. **Diff + color (non-fatal):** `benchmark synthetic report --diff main.json pr.json --regression
+   --thresholds .github/synthetic-thresholds.toml --out syn-main.md` (the second report, `pr.json`,
+   is the candidate), and likewise for release. Each call catches failure → "unavailable" fragment.
 5. **Publish (non-blocking):** assemble one body (arch-specific marker — see B3). **Both** the
    job-summary step and the sticky-PR-comment step (`pull-requests: write`) are guarded by
    `if: always()`; a missing report, a comment-write failure, or a read-only fork token (fork PRs
@@ -274,7 +276,7 @@ Identical recorded workload, each build measured back-to-back on one VM (one con
 
 ## 8. Deliverables checklist (on approval)
 
-**`FalkorDB/benchmark`:** `run --label`; `report --regression` (non-fatal, colored 🟢/🔴/N/A,
+**`FalkorDB/benchmark`:** `run --label`; `report --diff … --regression` (non-fatal, colored 🟢/🔴/N/A,
 p50=total-median verdict with `budget_pct` + `floor_ms`); **split guard** on a **comparability
 manifest** (`workload_hash` + `generator_version` + samples/warmup + sweep + applied server
 settings, recorded in the report → global not-comparable on mismatch; per-op digest mismatch =

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -117,7 +117,7 @@ Add a dedicated mode rather than overloading the strict `--diff` guard. New invo
   `candidate_p50 > baseline_p50 × (1 + budget_pct/100)`; else 🟢. Zero/missing baseline → N/A.
 - Emits a per-op **verdict line** and an overall count (`🔴 2 of 108 cells over budget: …`) so the
   "suspect calls that got worse" are immediately visible, plus the full per-op × cache × concurrency
-  table with a 🟢/🔴/N-A column and the two runs' `--label`s as headers.
+  table with a 🟢/🔴/N/A column and the two runs' `--label`s as headers.
 
 ### A4. Fail-soft is the *job's* responsibility, not the tool's
 
@@ -133,7 +133,7 @@ Keep the tool's unit of work a single pair (`--baseline`, `--candidate`). The **
 it once per baseline (`main→pr`, `release→pr`) and concatenates the two tables under one sticky
 comment. (A combined multi-baseline subcommand is a possible future consolidation, out of scope.)
 
-### A5. Release + docs
+### A6. Release + docs
 
 - Update `readme.md`, `.github/copilot-instructions.md` recipe/flag tables, and the cookbook with
   `--label` and `--thresholds`.
@@ -246,7 +246,7 @@ Non-blocking.
 
 ## 8. Deliverables checklist (on approval)
 
-**`FalkorDB/benchmark`:** `run --label`; `report --regression` (non-fatal, colored 🟢/🔴/N-A,
+**`FalkorDB/benchmark`:** `run --label`; `report --regression` (non-fatal, colored 🟢/🔴/N/A,
 p50=total-median verdict with `budget_pct` + `floor_ms`); **split guard** (workload/config mismatch
 = global not-comparable; per-op digest mismatch = per-op N/A, no abort — strict `--diff` unchanged);
 threshold TOML parsing + validation + precedence; unit tests (≥ 90 % patch); docs

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -29,7 +29,7 @@ at a glance (🟢 good / 🔴 regressed). It never fails the PR.
 | Verdict rule | 🟢 if PR is **faster** *or* **slower within budget**; 🔴 if slower beyond budget **and** the absolute p50 delta exceeds a noise floor; diverged op → correctness-🔴, perf verdict **N/A**. |
 | Metric definition | `p50` = the **total-latency median** (`total_ms` p50) of a cell. |
 | Tool ref | a **separate** `SYNTHETIC_BENCHMARK_REF` **pinned to an immutable commit SHA** (tagged for reference) — the A/B's `BENCHMARK_REF=v2.2` is left untouched. |
-| Failure handling | the synthetic job is **allowed-to-fail / always concludes green**; any tool/infra failure posts a "benchmark unavailable" note instead of blocking. |
+| Failure handling | the synthetic job is **non-blocking** (allowed-to-fail / not a required check); any tool/infra failure posts a "benchmark unavailable" note instead of blocking. |
 | Trigger scope | PR-triggered runs only (dispatch has no PR); **arch-specific** comment markers to avoid x86/arm races. |
 
 ## 3. Context from recon (why the design is shaped this way)
@@ -169,7 +169,8 @@ comment. (A combined multi-baseline subcommand is a possible future consolidatio
 
 Add a job (reusing the A/B's GCE-VM provisioning) on **its own VM** of the same type, with a
 **unique runner label** so no A/B variant is ever scheduled onto it, running **one container at a
-time**. It is **allowed-to-fail / always concludes green** (`continue-on-error` + non-required);
+time**. It is **non-blocking** (`continue-on-error` + not a required check, so a failure never
+blocks the merge);
 every tool/infra failure is caught and turned into a "benchmark unavailable" comment (A4).
 
 1. **Resolve immutable images.** Wait for the PR's RC build **for the event's exact head SHA** (not
@@ -196,7 +197,7 @@ every tool/infra failure is caught and turned into a "benchmark unavailable" com
    job-summary step and the sticky-PR-comment step (`pull-requests: write`) are guarded by
    `if: always()`; a missing report, a comment-write failure, or a read-only fork token (fork PRs
    get a read-only `GITHUB_TOKEN` regardless of the declared permission) is handled by **warning and
-   exiting 0**, so publication can never stop the always-concludes-green job.
+   exiting 0**, so publication can never stop the non-blocking job.
 
 ### B3. Trigger, serialization, and the tool ref
 

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -34,8 +34,8 @@ at a glance (🟢 good / 🔴 regressed). It never fails the PR.
 
 ## 3. Context from recon (why the design is shaped this way)
 
-- **Images** (all `ghcr.io/falkordb/falkordb-server:<tag>`, `EXPOSE 6379`, `redis-server
-  --loadmodule …/falkordb.so`, no auth → `falkor://host:6379`):
+- **Images** (all `ghcr.io/falkordb/falkordb-server:<tag>`, `EXPOSE 6379`, no auth, running
+  `redis-server --loadmodule …/falkordb.so` → reachable at `falkor://host:6379`):
   - PR build: `rc-pr-<N>` — published **early** by `rust-pr.yml` (before tests).
   - main build: `edge-rs` — retagged on every merge to `main` by `rust-push.yml`.
   - release build: `<X.Y.Z>` — only on a GitHub `release: published` event via `release-image.yml`;
@@ -109,12 +109,14 @@ Add a dedicated mode rather than overloading the strict `--diff` guard. New invo
   - a **comparability mismatch** ⇒ *globally not comparable* → the whole table is rendered as
     `⚠ not comparable`. The **comparability manifest** — the behavior-affecting inputs that must
     match for a latency comparison to be valid — is: the `workload_hash` (recorded graph +
-    commands), the `generator_version` (tool workload version), `samples`/`warmup`, the concurrency
-    sweep + cache modes, and the controlled **server settings** that affect throughput (e.g.
-    `MAX_QUEUED_QUERIES`). The report JSON already records the first four; the design **adds the
-    applied server settings to the report** so a mismatch is *detectable*, not assumed. In the CI
-    flow these are identical by construction (same recorded bundle → one manifest hash copied into
-    every report; same sweep; same settings applied to every container), so this should never trip
+    commands; it also folds in the `generator_version`, since the recording manifest is hashed into
+    it, so the tool version is covered transitively — no separate report field needed),
+    `samples`/`warmup`, the concurrency sweep + cache modes, and the controlled **server settings**
+    that affect throughput (e.g. `MAX_QUEUED_QUERIES`). The report JSON already records the
+    `workload_hash`, samples/warmup and sweep; the design **adds the applied server settings to the
+    report** so a mismatch is *detectable*, not assumed. In the CI flow these are identical by
+    construction (same recorded bundle → one manifest hash copied into every report; same sweep;
+    same settings applied to every container), so this should never trip
     for PR-vs-main — but the check fails safe;
   - a **per-op `result_digest` mismatch** ⇒ only *that* op is correctness-🔴 with `⚠ results
     differ`, its perf verdict **N/A** (a different result means different work — the latency Δ is

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -21,14 +21,14 @@ at a glance (🟢 good / 🔴 regressed). It never fails the PR.
 | Baselines | **PR vs main** always. **PR vs last release** only when a release image exists (none today → PR-vs-main only). |
 | Names in the report | `pr`, `main`, `release X.Y.Z`. |
 | Verdict metric | **p50 latency** (primary); throughput shown for context. |
-| Default budget | **10 %** slowdown before 🔴; overridable **per-command** and **per-command×concurrency**. |
+| Default budget | **10 %** slowdown before 🔴; overridable **per-operation** and **per-operation×concurrency**. |
 | Threshold config | **TOML file in `falkordb-rs-next-gen`** (tool ships built-in defaults). |
 | Result divergence | **Non-fatal**: mark diverged ops 🔴 with `⚠ results differ`, keep going. |
 | Coloring | 🟢 / 🔴 emoji per cell in the Markdown table. |
 | Sweep | full concurrency `1,2,4,8,16,32` × both cache modes (matches merged `synthetic-verify`). |
 | Verdict rule | 🟢 if PR is **faster** *or* **slower within budget**; 🔴 if slower beyond budget **and** the absolute p50 delta exceeds a noise floor; diverged op → correctness-🔴, perf verdict **N/A**. |
 | Metric definition | `p50` = the **total-latency median** (`total_ms` p50) of a cell. |
-| Tool ref | a **separate** `SYNTHETIC_BENCHMARK_REF` (new tag) — the A/B's `BENCHMARK_REF=v2.2` is left untouched. |
+| Tool ref | a **separate** `SYNTHETIC_BENCHMARK_REF` **pinned to an immutable commit SHA** (tagged for reference) — the A/B's `BENCHMARK_REF=v2.2` is left untouched. |
 | Failure handling | the synthetic job is **allowed-to-fail / always concludes green**; any tool/infra failure posts a "benchmark unavailable" note instead of blocking. |
 | Trigger scope | PR-triggered runs only (dispatch has no PR); **arch-specific** comment markers to avoid x86/arm races. |
 
@@ -148,8 +148,10 @@ comment. (A combined multi-baseline subcommand is a possible future consolidatio
 
 - Update `readme.md`, `.github/copilot-instructions.md` recipe/flag tables, and the cookbook with
   `--label` and `--thresholds`.
-- Cut a **new benchmark tag** (post-`v2.2`, containing `synthetic` + this feature) so
-  `falkordb-rs-next-gen` can bump `BENCHMARK_REF` to a pinned SHA/tag.
+- Cut a **new benchmark tag** (post-`v2.2`, containing `synthetic` + this feature) and pin
+  `falkordb-rs-next-gen`'s `SYNTHETIC_BENCHMARK_REF` to that tag's **immutable commit SHA** (with a
+  `# vX.Y.Z` comment, matching the existing `BENCHMARK_REF = deca7752 # v2.2` convention) so CI can
+  never execute changed benchmark code without a corresponding change in `falkordb-rs-next-gen`.
 - Patch coverage ≥ 90 % on the new logic (`just coverage`).
 
 ## 5. Part B — changes in `FalkorDB/falkordb-rs-next-gen` (the CI)
@@ -190,9 +192,11 @@ every tool/infra failure is caught and turned into a "benchmark unavailable" com
 4. **Diff + color (non-fatal):** `benchmark synthetic report --regression --baseline main.json
    --candidate pr.json --thresholds .github/synthetic-thresholds.toml --out syn-main.md`, and
    likewise for release. Each call catches failure → "unavailable" fragment.
-5. **Publish (non-blocking):** assemble one body (arch-specific marker — see B3), **upsert a sticky
-   PR comment** (`pull-requests: write`) + job summary, `if: always()`, best-effort (a read-only
-   fork token warns, never fails).
+5. **Publish (non-blocking):** assemble one body (arch-specific marker — see B3). **Both** the
+   job-summary step and the sticky-PR-comment step (`pull-requests: write`) are guarded by
+   `if: always()`; a missing report, a comment-write failure, or a read-only fork token (fork PRs
+   get a read-only `GITHUB_TOKEN` regardless of the declared permission) is handled by **warning and
+   exiting 0**, so publication can never stop the always-concludes-green job.
 
 ### B3. Trigger, serialization, and the tool ref
 
@@ -202,9 +206,10 @@ every tool/infra failure is caught and turned into a "benchmark unavailable" com
   "≤ 1 benchmark per machine" without contending with A/B variant VMs.
 - **Arch-specific markers** to avoid x86/arm comment races (mirroring the A/B's
   `-arm` marker): `<!-- synthetic-benchmark -->` / `<!-- synthetic-benchmark-arm -->`.
-- **Separate `SYNTHETIC_BENCHMARK_REF`** (a new benchmark tag with `synthetic` + this feature) and a
-  **separate checkout**, so the A/B's `BENCHMARK_REF=v2.2` (coupled to the legacy `ab-compare`
-  vendor mode + its trend continuity) is left completely untouched.
+- **Separate `SYNTHETIC_BENCHMARK_REF`** pinned to an **immutable commit SHA** (with a `# vX.Y.Z`
+  comment, like `BENCHMARK_REF = deca7752 # v2.2`) and a **separate checkout**, so the A/B's
+  `BENCHMARK_REF=v2.2` (coupled to the legacy `ab-compare` vendor mode + its trend continuity) is
+  left completely untouched.
 
 ### B4. "No release yet" handling
 
@@ -262,8 +267,8 @@ p50=total-median verdict with `budget_pct` + `floor_ms`); **split guard** on a *
 manifest** (`workload_hash` + `generator_version` + samples/warmup + sweep + applied server
 settings, recorded in the report → global not-comparable on mismatch; per-op digest mismatch =
 per-op N/A, no abort — strict `--diff` unchanged); threshold TOML parsing + validation + precedence;
-unit tests (≥ 90 % patch); docs (readme/copilot-instructions/cookbook); **new tag** for
-`SYNTHETIC_BENCHMARK_REF`.
+unit tests (≥ 90 % patch); docs (readme/copilot-instructions/cookbook); **new tag + its immutable
+commit SHA** for `SYNTHETIC_BENCHMARK_REF`.
 
 **`FalkorDB/falkordb-rs-next-gen`:** `.github/synthetic-thresholds.toml` +
 `.github/synthetic-workload.toml`; a new **synthetic-A/B job** in the benchmark pipeline (own

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -75,7 +75,7 @@ overrides. `p50` means the cell's **total-latency median** (`total_ms` p50). For
 # Regression budget for the per-PR synthetic check. A cell is 🔴 only if the PR's p50 is slower
 # than the baseline by MORE than budget_pct AND the absolute p50 increase exceeds floor_ms (a
 # noise guard for sub-millisecond ops). Faster — or slower within either bound — is 🟢.
-# Precedence: [op.<name>.concurrency.<C>] > [op.<name>] > [default].
+# Precedence per field: the matching C under [op.<name>].concurrency > [op.<name>] > [default].
 
 [default]
 metric     = "p50"   # p50 (implemented). throughput|both reserved for a later iteration.
@@ -91,9 +91,13 @@ concurrency = { 16 = 30.0, 32 = 40.0 }
 ```
 
 Parsing **validates** the file (unknown op keys and non-positive/invalid budgets are hard errors so
-a typo can't silently disable a budget) and resolves precedence. Parsing + precedence + the verdict
-function are pure logic → **unit-tested** (faster, exactly at budget, just over, per-op vs per-op×C
-precedence, floor suppression, divergence → N/A, zero/missing baseline → N/A).
+a typo can't silently disable a budget). **Resolution contract** — the config is a single inline
+representation (`[op.<name>]` with an optional `concurrency = { <C> = <pct>, … }` inline table); for
+each `(op, C)` and each field (`budget_pct`, `floor_ms`, `metric`) the tool takes
+`op.<op>.concurrency.<C>` if present, else `op.<op>.<field>`, else `default.<field>`. Parsing +
+precedence + the verdict function are pure logic → **unit-tested** (faster, exactly at budget, just
+over, per-op vs per-op×C precedence, floor suppression, divergence → N/A, zero/missing baseline →
+N/A).
 
 ### A3. Explicit non-fatal regression mode — `report --regression`
 
@@ -102,9 +106,16 @@ Add a dedicated mode rather than overloading the strict `--diff` guard. New invo
 <file>] [--out <md>]` (or, equivalently, `report --diff … --regression`), which:
 
 - **Splits the guard** (today `baseline::guard` conflates the two — src/synthetic/baseline.rs):
-  - a **`workload_hash`/config mismatch** ⇒ *globally not comparable* → the whole table is rendered
-    as `⚠ not comparable` (this should never happen for PR-vs-main since both replay the **same**
-    recorded bundle, which copies one manifest hash into every report — but we fail safe);
+  - a **comparability mismatch** ⇒ *globally not comparable* → the whole table is rendered as
+    `⚠ not comparable`. The **comparability manifest** — the behavior-affecting inputs that must
+    match for a latency comparison to be valid — is: the `workload_hash` (recorded graph +
+    commands), the `generator_version` (tool workload version), `samples`/`warmup`, the concurrency
+    sweep + cache modes, and the controlled **server settings** that affect throughput (e.g.
+    `MAX_QUEUED_QUERIES`). The report JSON already records the first four; the design **adds the
+    applied server settings to the report** so a mismatch is *detectable*, not assumed. In the CI
+    flow these are identical by construction (same recorded bundle → one manifest hash copied into
+    every report; same sweep; same settings applied to every container), so this should never trip
+    for PR-vs-main — but the check fails safe;
   - a **per-op `result_digest` mismatch** ⇒ only *that* op is correctness-🔴 with `⚠ results
     differ`, its perf verdict **N/A** (a different result means different work — the latency Δ is
     kept only as a dim diagnostic, excluded from the "over budget" count). No abort.
@@ -247,10 +258,12 @@ Non-blocking.
 ## 8. Deliverables checklist (on approval)
 
 **`FalkorDB/benchmark`:** `run --label`; `report --regression` (non-fatal, colored 🟢/🔴/N/A,
-p50=total-median verdict with `budget_pct` + `floor_ms`); **split guard** (workload/config mismatch
-= global not-comparable; per-op digest mismatch = per-op N/A, no abort — strict `--diff` unchanged);
-threshold TOML parsing + validation + precedence; unit tests (≥ 90 % patch); docs
-(readme/copilot-instructions/cookbook); **new tag** for `SYNTHETIC_BENCHMARK_REF`.
+p50=total-median verdict with `budget_pct` + `floor_ms`); **split guard** on a **comparability
+manifest** (`workload_hash` + `generator_version` + samples/warmup + sweep + applied server
+settings, recorded in the report → global not-comparable on mismatch; per-op digest mismatch =
+per-op N/A, no abort — strict `--diff` unchanged); threshold TOML parsing + validation + precedence;
+unit tests (≥ 90 % patch); docs (readme/copilot-instructions/cookbook); **new tag** for
+`SYNTHETIC_BENCHMARK_REF`.
 
 **`FalkorDB/falkordb-rs-next-gen`:** `.github/synthetic-thresholds.toml` +
 `.github/synthetic-workload.toml`; a new **synthetic-A/B job** in the benchmark pipeline (own

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -43,7 +43,7 @@ at a glance (🟢 good / 🔴 regressed). It never fails the PR.
 - **Existing A/B benchmark** (`benchmark.yml` → reusable `_benchmark.yml`): label-triggered
   (`benchmark-{small,medium,large}[-arm]`) / `/benchmark` comment / dispatch; provisions ephemeral
   **GCE VMs** (one per size×variant); already uses **`FalkorDB/benchmark`** but pinned at
-  `BENCHMARK_REF = deca7752 (v2.2)`, which **predates the `synthetic` subcommand**, in the
+  `BENCHMARK_REF = deca7752 # v2.2`, which **predates the `synthetic` subcommand**, in the
   `ab-compare` *vendor* mode; publishes a gh-pages dashboard + a sticky comment
   `<!-- ab-benchmark-comment -->`. It is **informational**, not a gate.
 - **No latency-threshold/gating config** exists in either repo today.

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -1,6 +1,7 @@
 # Design: per-PR synthetic benchmark regression report for `falkordb-rs-next-gen`
 
-**Status:** proposed (awaiting approval before implementation).
+**Status:** approved. Part A (the `FalkorDB/benchmark` tool) is implemented in this PR; Part B (the
+`falkordb-rs-next-gen` CI workflow + config) follows in that repo.
 **Scope:** changes in **two** repos — `FalkorDB/benchmark` (the tool) and
 `FalkorDB/falkordb-rs-next-gen` (the CI that consumes it).
 
@@ -211,6 +212,11 @@ every tool/infra failure is caught and turned into a "benchmark unavailable" com
   than one benchmark running — neither on a machine nor across the pipeline.
 - **Arch-specific markers** to avoid x86/arm comment races (mirroring the A/B's
   `-arm` marker): `<!-- synthetic-benchmark -->` / `<!-- synthetic-benchmark-arm -->`.
+- **Serialize same-arch runs.** A workflow `concurrency:` group keyed by PR **and** architecture
+  (e.g. `synthetic-bench-${{ pr }}-${{ arch }}`, `cancel-in-progress: true`) ensures two concurrent
+  same-arch runs for one PR (a re-added label, or a new push) can't update the sticky comment out
+  of order — x86 and arm stay independent via the group key + their own markers. Mirrors the A/B's
+  own concurrency group.
 - **Separate `SYNTHETIC_BENCHMARK_REF`** pinned to an **immutable commit SHA** (with a `# vX.Y.Z`
   comment, like `BENCHMARK_REF = deca7752 # v2.2`) and a **separate checkout**, so the A/B's
   `BENCHMARK_REF=v2.2` (coupled to the legacy `ab-compare` vendor mode + its trend continuity) is

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -112,10 +112,11 @@ Add a dedicated mode rather than overloading the strict `--diff` guard. New invo
     match for a latency comparison to be valid — is: the `workload_hash` (recorded graph +
     commands; it also folds in the `generator_version`, since the recording manifest is hashed into
     it, so the tool version is covered transitively — no separate report field needed),
-    `samples`/`warmup`, the concurrency sweep + cache modes, and the controlled **server settings**
-    that affect throughput (e.g. `MAX_QUEUED_QUERIES`). The report JSON already records the
-    `workload_hash`, samples/warmup and sweep; the design **adds the applied server settings to the
-    report** so a mismatch is *detectable*, not assumed. In the CI flow these are identical by
+    `samples`/`warmup`, the concurrency sweep, and the controlled **server settings** that affect
+    throughput (e.g. `MAX_QUEUED_QUERIES`). The report JSON already records the `workload_hash`,
+    samples/warmup and sweep; the design **adds the applied server settings to the report** so a
+    mismatch is *detectable*, not assumed. (Cache-mode differences aren't a global block — a mode
+    measured by only one run surfaces as **per-cell N/A**.) In the CI flow these are identical by
     construction (same recorded bundle → one manifest hash copied into every report; same sweep;
     same settings applied to every container), so this should never trip
     for PR-vs-main — but the check fails safe;

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -17,7 +17,7 @@ at a glance (🟢 good / 🔴 regressed). It never fails the PR.
 | Decision | Choice |
 |---|---|
 | Blocking? | **No** — informational report only; never fails the PR. |
-| Relationship to the existing A/B benchmark | **Add to it**, never remove it. Same machine *type*, own VM, sequenced before/after; **never >1 benchmark per machine at once**. |
+| Relationship to the existing A/B benchmark | **Add to it**, never remove it. Same machine *type*, own VM, **sequenced (never in parallel with the A/B — chained via `needs:`)**; **never >1 benchmark per machine at once**. |
 | Baselines | **PR vs main** always. **PR vs last release** only when a release image exists (none today → PR-vs-main only). |
 | Names in the report | `pr`, `main`, `release X.Y.Z`. |
 | Verdict metric | **p50 latency** (primary); throughput shown for context. |
@@ -202,9 +202,11 @@ every tool/infra failure is caught and turned into a "benchmark unavailable" com
 ### B3. Trigger, serialization, and the tool ref
 
 - **PR-triggered only.** Runs with the A/B benchmark (same `benchmark-*` labels / `/benchmark` /
-  PR-scoped dispatch). Skip on plain `workflow_dispatch` with no PR (no PR number/image). Because it
-  has its **own** uniquely-labelled VM and runs containers strictly sequentially, it satisfies
-  "≤ 1 benchmark per machine" without contending with A/B variant VMs.
+  PR-scoped dispatch). Skip on plain `workflow_dispatch` with no PR (no PR number/image).
+- **Sequenced, never in parallel with the A/B.** The synthetic job is chained relative to the A/B
+  jobs (via `needs:` — it runs strictly **before or after** them, never concurrently), and on its
+  **own** uniquely-labelled VM it runs containers strictly one at a time. So there is never more
+  than one benchmark running — neither on a machine nor across the pipeline.
 - **Arch-specific markers** to avoid x86/arm comment races (mirroring the A/B's
   `-arm` marker): `<!-- synthetic-benchmark -->` / `<!-- synthetic-benchmark-arm -->`.
 - **Separate `SYNTHETIC_BENCHMARK_REF`** pinned to an **immutable commit SHA** (with a `# vX.Y.Z`

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -1,0 +1,269 @@
+# Design: per-PR synthetic benchmark regression report for `falkordb-rs-next-gen`
+
+**Status:** proposed (awaiting approval before implementation).
+**Scope:** changes in **two** repos — `FalkorDB/benchmark` (the tool) and
+`FalkorDB/falkordb-rs-next-gen` (the CI that consumes it).
+
+## 1. Goal
+
+On each `falkordb-rs-next-gen` PR benchmark run, produce a **non-blocking, colored** report that
+compares the PR's engine build against **main** — and, once semver releases exist, against the
+**last release** — on an *identical, pre-recorded* synthetic workload, executed **same-machine,
+one container at a time**, so that per-operation slowdowns beyond a configurable budget are obvious
+at a glance (🟢 good / 🔴 regressed). It never fails the PR.
+
+## 2. Decisions (confirmed)
+
+| Decision | Choice |
+|---|---|
+| Blocking? | **No** — informational report only; never fails the PR. |
+| Relationship to the existing A/B benchmark | **Add to it**, never remove it. Same machine *type*, own VM, sequenced before/after; **never >1 benchmark per machine at once**. |
+| Baselines | **PR vs main** always. **PR vs last release** only when a release image exists (none today → PR-vs-main only). |
+| Names in the report | `pr`, `main`, `release X.Y.Z`. |
+| Verdict metric | **p50 latency** (primary); throughput shown for context. |
+| Default budget | **10 %** slowdown before 🔴; overridable **per-command** and **per-command×concurrency**. |
+| Threshold config | **TOML file in `falkordb-rs-next-gen`** (tool ships built-in defaults). |
+| Result divergence | **Non-fatal**: mark diverged ops 🔴 with `⚠ results differ`, keep going. |
+| Coloring | 🟢 / 🔴 emoji per cell in the Markdown table. |
+| Sweep | full concurrency `1,2,4,8,16,32` × both cache modes (matches merged `synthetic-verify`). |
+| Verdict rule | 🟢 if PR is **faster** *or* **slower within budget**; 🔴 if slower beyond budget **and** the absolute p50 delta exceeds a noise floor; diverged op → correctness-🔴, perf verdict **N/A**. |
+| Metric definition | `p50` = the **total-latency median** (`total_ms` p50) of a cell. |
+| Tool ref | a **separate** `SYNTHETIC_BENCHMARK_REF` (new tag) — the A/B's `BENCHMARK_REF=v2.2` is left untouched. |
+| Failure handling | the synthetic job is **allowed-to-fail / always concludes green**; any tool/infra failure posts a "benchmark unavailable" note instead of blocking. |
+| Trigger scope | PR-triggered runs only (dispatch has no PR); **arch-specific** comment markers to avoid x86/arm races. |
+
+## 3. Context from recon (why the design is shaped this way)
+
+- **Images** (all `ghcr.io/falkordb/falkordb-server:<tag>`, `EXPOSE 6379`, `redis-server
+  --loadmodule …/falkordb.so`, no auth → `falkor://host:6379`):
+  - PR build: `rc-pr-<N>` — published **early** by `rust-pr.yml` (before tests).
+  - main build: `edge-rs` — retagged on every merge to `main` by `rust-push.yml`.
+  - release build: `<X.Y.Z>` — only on a GitHub `release: published` event via `release-image.yml`;
+    **none exist** (Cargo version is the `99.99.99` sentinel, no tags/releases).
+- **Existing A/B benchmark** (`benchmark.yml` → reusable `_benchmark.yml`): label-triggered
+  (`benchmark-{small,medium,large}[-arm]`) / `/benchmark` comment / dispatch; provisions ephemeral
+  **GCE VMs** (one per size×variant); already uses **`FalkorDB/benchmark`** but pinned at
+  `BENCHMARK_REF = deca7752 (v2.2)`, which **predates the `synthetic` subcommand**, in the
+  `ab-compare` *vendor* mode; publishes a gh-pages dashboard + a sticky comment
+  `<!-- ab-benchmark-comment -->`. It is **informational**, not a gate.
+- **No latency-threshold/gating config** exists in either repo today.
+- The PR image is awaited by `benchmark.yml`'s `wait-for-rc-image` (polls the registry, cross-checks
+  the "Rust PR" run, 85-min timeout).
+
+## 4. Part A — changes in `FalkorDB/benchmark` (the tool)
+
+The tool already has: offline `record`; `run --recording` (closed-loop sweep × cache, per-op
+`result_digest`, `verify_concurrent`); `report --diff A.json B.json` that **guards**
+(`workload_hash` + digests) and renders a per-op×cache×concurrency Markdown table with
+`Δ = 100·(B−A)/A`. It has **no** run label, **no** thresholds, and **aborts** on divergence.
+
+### A1. Name the runs — `run --label <name>`
+
+Add `--label <name>` to `synthetic run` (e.g. `--label pr`, `--label main`, `--label "release
+1.2.3"`), stored in the report JSON (`meta`). `report --diff` uses the two runs' labels as the
+column headers (falling back to `A (baseline)` / `B (candidate)` when absent), so the table reads
+`main` vs `pr` instead of `A`/`B`. `--server-image` stays (image identity row).
+
+### A2. Threshold config (built-in defaults + overridable TOML)
+
+New optional flag `--thresholds <file.toml>` (see A3 for the mode flag it accompanies). The tool
+ships a built-in default (budget 10 %, `metric = "p50"`, a small absolute floor); the file
+overrides. `p50` means the cell's **total-latency median** (`total_ms` p50). Format (lives in
+`falkordb-rs-next-gen`, TOML to match `synthetic-bench.toml`):
+
+```toml
+# Regression budget for the per-PR synthetic check. A cell is 🔴 only if the PR's p50 is slower
+# than the baseline by MORE than budget_pct AND the absolute p50 increase exceeds floor_ms (a
+# noise guard for sub-millisecond ops). Faster — or slower within either bound — is 🟢.
+# Precedence: [op.<name>.concurrency.<C>] > [op.<name>] > [default].
+
+[default]
+metric     = "p50"   # p50 (implemented). throughput|both reserved for a later iteration.
+budget_pct = 10.0
+floor_ms   = 0.5     # ignore slowdowns whose absolute p50 delta is below this (noise on fast ops)
+
+[op.match_by_index]
+budget_pct = 12.0    # fastest op — a touch more headroom for high-C jitter
+
+[op.expand_hops_5]
+budget_pct  = 20.0
+concurrency = { 16 = 30.0, 32 = 40.0 }
+```
+
+Parsing **validates** the file (unknown op keys and non-positive/invalid budgets are hard errors so
+a typo can't silently disable a budget) and resolves precedence. Parsing + precedence + the verdict
+function are pure logic → **unit-tested** (faster, exactly at budget, just over, per-op vs per-op×C
+precedence, floor suppression, divergence → N/A, zero/missing baseline → N/A).
+
+### A3. Explicit non-fatal regression mode — `report --regression`
+
+Add a dedicated mode rather than overloading the strict `--diff` guard. New invocation
+`synthetic report --regression --baseline <base.json> --candidate <cand.json> [--thresholds
+<file>] [--out <md>]` (or, equivalently, `report --diff … --regression`), which:
+
+- **Splits the guard** (today `baseline::guard` conflates the two — src/synthetic/baseline.rs):
+  - a **`workload_hash`/config mismatch** ⇒ *globally not comparable* → the whole table is rendered
+    as `⚠ not comparable` (this should never happen for PR-vs-main since both replay the **same**
+    recorded bundle, which copies one manifest hash into every report — but we fail safe);
+  - a **per-op `result_digest` mismatch** ⇒ only *that* op is correctness-🔴 with `⚠ results
+    differ`, its perf verdict **N/A** (a different result means different work — the latency Δ is
+    kept only as a dim diagnostic, excluded from the "over budget" count). No abort.
+- **Never exits non-zero** for regressions or divergence (informational). The strict guard/abort
+  behavior is **unchanged** for plain `report --diff` (so the benchmark repo's own
+  `synthetic-verify` gate is untouched). `--regression` works with built-in defaults even without a
+  `--thresholds` file.
+- Per comparable cell, verdict on `p50`: `slower = candidate_p50 > baseline_p50`;
+  🔴 iff `slower` **and** `(candidate_p50 − baseline_p50) > floor_ms` **and**
+  `candidate_p50 > baseline_p50 × (1 + budget_pct/100)`; else 🟢. Zero/missing baseline → N/A.
+- Emits a per-op **verdict line** and an overall count (`🔴 2 of 108 cells over budget: …`) so the
+  "suspect calls that got worse" are immediately visible, plus the full per-op × cache × concurrency
+  table with a 🟢/🔴/N-A column and the two runs' `--label`s as headers.
+
+### A4. Fail-soft is the *job's* responsibility, not the tool's
+
+The tool must **not** hide malformed input or infra failures: `synthetic run` still aborts on load
+failures / query errors / timeouts (src/synthetic/replay.rs), and `report` still errors on
+unreadable/covertly-wrong JSON. The **CI job** (Part B) is what makes the check non-blocking — it
+runs allowed-to-fail and, on any tool/infra error, publishes a "benchmark unavailable" note instead
+of a table. This keeps correctness/infra failures visible without ever blocking the PR.
+
+### A5. Two baselines in one report
+
+Keep the tool's unit of work a single pair (`--baseline`, `--candidate`). The **workflow** invokes
+it once per baseline (`main→pr`, `release→pr`) and concatenates the two tables under one sticky
+comment. (A combined multi-baseline subcommand is a possible future consolidation, out of scope.)
+
+### A5. Release + docs
+
+- Update `readme.md`, `.github/copilot-instructions.md` recipe/flag tables, and the cookbook with
+  `--label` and `--thresholds`.
+- Cut a **new benchmark tag** (post-`v2.2`, containing `synthetic` + this feature) so
+  `falkordb-rs-next-gen` can bump `BENCHMARK_REF` to a pinned SHA/tag.
+- Patch coverage ≥ 90 % on the new logic (`just coverage`).
+
+## 5. Part B — changes in `FalkorDB/falkordb-rs-next-gen` (the CI)
+
+### B1. Config files
+
+- `.github/synthetic-thresholds.toml` — the A2 threshold budget (10 % default + illustrative
+  per-op overrides). The project owns its regression budget here.
+- `.github/synthetic-workload.toml` — a pinned, versioned workload (`seed`, `graph`, `nodes`,
+  `edges`) plus `samples`/`warmup`, so `record` is reproducible and the query volume is bounded
+  (recording needs `--nodes/--edges` — the tool errors without them). Start modest (e.g. medium
+  10k/50k, `--samples 200 --warmup 50`, matching `synthetic-verify`) and tune for VM runtime.
+
+### B2. A new "synthetic A/B" job in the benchmark pipeline
+
+Add a job (reusing the A/B's GCE-VM provisioning) on **its own VM** of the same type, with a
+**unique runner label** so no A/B variant is ever scheduled onto it, running **one container at a
+time**. It is **allowed-to-fail / always concludes green** (`continue-on-error` + non-required);
+every tool/infra failure is caught and turned into a "benchmark unavailable" comment (A4).
+
+1. **Resolve immutable images.** Wait for the PR's RC build **for the event's exact head SHA** (not
+   merely tag existence — reuse `wait-for-rc-image`), then resolve every tag to a **digest**
+   (`docker buildx imagetools inspect`) *once*, up front: `pr@sha256:…` (from `rc-pr-<N>`),
+   `main@sha256:…` (from `edge-rs`), and the release digest if a semver image exists. Measure the
+   **digests** (mutable tags can move mid-job) and pass them to `--server-image` so the report
+   records exactly what ran.
+2. **Record once** (offline, deterministic): `benchmark synthetic record --op all --config
+   .github/synthetic-workload.toml --out-dir rec` (read ops only; writes aren't recordable or
+   comparable across versions).
+3. **Measure each build sequentially** — start → prep → measure → **stop** before the next:
+   - `docker run -d -p 6379:6379 <digest>`; **poll readiness** (`redis-cli ping`); **set
+     `GRAPH.CONFIG SET MAX_QUEUED_QUERIES 1000`** (the C=32 uncached sweep trips the default queue
+     limit — same fix as `synthetic-verify`) and any other controlled DB settings;
+     `benchmark synthetic run --recording rec --endpoint falkor://127.0.0.1:6379 --label pr
+     --server-image pr@sha256:… --concurrency 1,2,4,8,16,32 --cache both --samples 200 --warmup 50
+     --out pr.json`; **`docker rm -f`** (guaranteed cleanup via trap).
+   - repeat for `main` (`--label main`) and, if present, `release` (`--label "release X.Y.Z"`).
+4. **Diff + color (non-fatal):** `benchmark synthetic report --regression --baseline main.json
+   --candidate pr.json --thresholds .github/synthetic-thresholds.toml --out syn-main.md`, and
+   likewise for release. Each call catches failure → "unavailable" fragment.
+5. **Publish (non-blocking):** assemble one body (arch-specific marker — see B3), **upsert a sticky
+   PR comment** (`pull-requests: write`) + job summary, `if: always()`, best-effort (a read-only
+   fork token warns, never fails).
+
+### B3. Trigger, serialization, and the tool ref
+
+- **PR-triggered only.** Runs with the A/B benchmark (same `benchmark-*` labels / `/benchmark` /
+  PR-scoped dispatch). Skip on plain `workflow_dispatch` with no PR (no PR number/image). Because it
+  has its **own** uniquely-labelled VM and runs containers strictly sequentially, it satisfies
+  "≤ 1 benchmark per machine" without contending with A/B variant VMs.
+- **Arch-specific markers** to avoid x86/arm comment races (mirroring the A/B's
+  `-arm` marker): `<!-- synthetic-benchmark -->` / `<!-- synthetic-benchmark-arm -->`.
+- **Separate `SYNTHETIC_BENCHMARK_REF`** (a new benchmark tag with `synthetic` + this feature) and a
+  **separate checkout**, so the A/B's `BENCHMARK_REF=v2.2` (coupled to the legacy `ab-compare`
+  vendor mode + its trend continuity) is left completely untouched.
+
+### B4. "No release yet" handling
+
+The job resolves the highest semver tag under `ghcr.io/falkordb/falkordb-server`; if none, it runs
+and reports **PR-vs-main only** (today's state). When releases begin, PR-vs-release appears
+automatically with the correct `release X.Y.Z` name. An image that's too old to load the recorded
+bundle is reported **unavailable**, not compared.
+
+## 6. Example rendered comment (illustrative)
+
+```markdown
+<!-- synthetic-benchmark -->
+### 🧪 Synthetic per-op regression — PR vs main (same machine)
+
+Identical recorded workload, each build measured back-to-back on one VM (one container at a time).
+🟢 = faster or within budget · 🔴 = slower than budget · N/A = results differ or not comparable.
+Non-blocking.
+
+**pr vs main** — 🔴 2 of 108 cells over budget (match_by_index @ C=16); 1 op with differing results
+
+| op | C | cache | main p50 (ms) | pr p50 (ms) | Δp50 | verdict |
+|---|--:|---|--:|--:|--:|:--:|
+| match_by_index | 16 | cached | 2.21 | 2.65 | +19.9% | 🔴 |
+| match_by_index | 32 | cached | 5.15 | 4.58 | −11.0% | 🟢 |
+| expand_hops_5 | 8 | cached | 1.90 | 1.88 | _(−1%)_ | N/A ⚠ results differ |
+| … | | | | | | |
+```
+
+## 7. Risks / mitigations
+
+- **Same-machine noise vs a 10 % budget** (we measured ±10–13 % run-to-run on the *fastest* op at
+  C=32): the single default budget could be red-happy. Mitigations baked in: (a) p50 (tail-robust);
+  (b) an **absolute `floor_ms`** so sub-millisecond ops aren't flagged on relative jitter alone;
+  (c) **per-op / per-op×concurrency budgets** for known-noisy cells. **Recommended calibration
+  step** before turning it on: run a few **A/A** comparisons (same image twice) per arch and set
+  `budget_pct`/`floor_ms` from the observed noise, so a red means signal, not jitter. Optionally
+  repeat AB/BA to cancel fixed-order bias (future).
+- **Result divergence across versions** (a next-gen build may legitimately differ from main): the
+  split guard makes it **per-op N/A + correctness-🔴**, never an abort or a bogus latency verdict.
+- **Mutable tags / wrong build:** resolved to **digests up front**, and the RC image is waited on
+  for the **exact head SHA** — so a moved `edge-rs`/`rc-pr-<N>` can't silently swap the build.
+- **Tool/infra failure blocking the PR:** the **job** is allowed-to-fail and always posts a result;
+  the tool keeps surfacing real failures (no silent hiding).
+- **`rc` image not ready:** reuse `wait-for-rc-image` (proven, 85-min timeout).
+- **Legacy A/B breakage:** avoided by a **separate `SYNTHETIC_BENCHMARK_REF`** — `BENCHMARK_REF`
+  stays at `v2.2`.
+- **Cost:** one extra VM per benchmark run — acceptable (label-triggered, like the A/B).
+- **`edge-rs` freshness:** it is the last *merged* main, which can lag the PR base by a few commits;
+  acceptable for a per-PR trend signal (and it's exactly what the A/B uses as variant B).
+
+## 8. Deliverables checklist (on approval)
+
+**`FalkorDB/benchmark`:** `run --label`; `report --regression` (non-fatal, colored 🟢/🔴/N-A,
+p50=total-median verdict with `budget_pct` + `floor_ms`); **split guard** (workload/config mismatch
+= global not-comparable; per-op digest mismatch = per-op N/A, no abort — strict `--diff` unchanged);
+threshold TOML parsing + validation + precedence; unit tests (≥ 90 % patch); docs
+(readme/copilot-instructions/cookbook); **new tag** for `SYNTHETIC_BENCHMARK_REF`.
+
+**`FalkorDB/falkordb-rs-next-gen`:** `.github/synthetic-thresholds.toml` +
+`.github/synthetic-workload.toml`; a new **synthetic-A/B job** in the benchmark pipeline (own
+uniquely-labelled VM, allowed-to-fail; wait-for-rc-by-SHA → resolve images to **digests** →
+`record` once → **sequential** per-build measure with `MAX_QUEUED_QUERIES` raised + readiness poll +
+guaranteed cleanup → per-baseline `report --regression` → arch-marked sticky comment + summary,
+non-blocking); `SYNTHETIC_BENCHMARK_REF` pin (separate from `BENCHMARK_REF`); PR-vs-release
+auto-enabled when a release image exists. **Calibrate** `budget_pct`/`floor_ms` from A/A runs before
+enabling.
+
+## 9. Out of scope (for this iteration)
+
+- Gating/failing the PR on regression (kept informational).
+- A combined multi-baseline `report --regression` subcommand (two `report --diff` calls for now).
+- Write-op comparison (reads only; writes aren't recordable/deterministically comparable).
+- gh-pages trend storage for the synthetic numbers (the A/B dashboard remains the trend home).

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -226,8 +226,8 @@ bundle is reported **unavailable**, not compared.
 ### 🧪 Synthetic per-op regression — PR vs main (same machine)
 
 Identical recorded workload, each build measured back-to-back on one VM (one container at a time).
-🟢 = faster or within budget · 🔴 = slower than budget · N/A = results differ or not comparable.
-Non-blocking.
+🟢 = faster or within budget · 🔴 = slower than budget **or** results differ · N/A = no perf verdict
+(results differ or not comparable). Non-blocking.
 
 **pr vs main** — 🔴 2 of 108 cells over budget (match_by_index @ C=16); 1 op with differing results
 
@@ -235,7 +235,7 @@ Non-blocking.
 |---|--:|---|--:|--:|--:|:--:|
 | match_by_index | 16 | cached | 2.21 | 2.65 | +19.9% | 🔴 |
 | match_by_index | 32 | cached | 5.15 | 4.58 | −11.0% | 🟢 |
-| expand_hops_5 | 8 | cached | 1.90 | 1.88 | _(−1%)_ | N/A ⚠ results differ |
+| expand_hops_5 | 8 | cached | 1.90 | 1.88 | _(−1%)_ | 🔴 N/A ⚠ results differ |
 | … | | | | | | |
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -451,13 +451,23 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   values). It also **verifies results are identical at the highest concurrency** (an untimed
   concurrent pass) so a wrong result under concurrency is a hard fail. `--no-load` skips the reload
   for a load-once / run-many flow (still count-verifying first). `just synthetic-replay <name>
-  <endpoint>` wraps this.
+  <endpoint>` wraps this. Pass **`--label <name>`** (e.g. `pr`/`main`) to name the run — the label
+  becomes the column header in `report --diff`/`--regression`.
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is
   expected and recorded), then writes a **Markdown diff** across every op × cache-mode × concurrency
   level (throughput + total-latency p50/p90/p95/p99 with deltas). `just synthetic-compare-versions`
   runs `run --recording` against both endpoints then `report --diff`.
+- **`benchmark synthetic report --diff <A.json> <B.json> --regression [--thresholds t.toml]`** is a
+  **non-fatal, colored** variant for a per-PR regression report: each op × cache-mode × concurrency
+  cell gets a **🟢 / 🔴 / N/A** verdict on **p50** — 🟢 if the candidate (B) is faster or slower
+  within budget, 🔴 if slower beyond it. The budget is a `budget_pct` plus an absolute `floor_ms`
+  noise guard, defaulting to 10 % / 0.5 ms and overridable per-operation and per-operation×concurrency
+  in a TOML file (`[default]` + `[op.<name>]` with a `concurrency` inline table). Unlike `--diff`,
+  it **never aborts**: an op whose `result_digest` differs is shown 🔴 with a `⚠ results differ`
+  note and a perf verdict of **N/A** (a mismatched workload/config renders the whole report
+  *not comparable*).
 - **`just synthetic-sanity`** self-checks the tool: it records the same workload twice (asserting an
   identical `workload_hash` — deterministic recording), then `run --recording` at C=1,4 + `report
   --diff` (incl. the C>1 result verification) against a throwaway Docker FalkorDB. Latency is not

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -563,7 +563,7 @@ pub enum SyntheticCommands {
         thresholds: Option<String>,
         #[arg(
             long,
-            help = "Markdown output path: the diff (default synthetic-diff.md) with --diff, or the re-rendered report's Markdown when re-rendering a single report"
+            help = "Markdown output path: the diff (default synthetic-diff.md) with --diff, the regression report (default synthetic-regression.md) with --diff --regression, or the re-rendered report's Markdown when re-rendering a single report"
         )]
         out: Option<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -468,6 +468,11 @@ pub enum SyntheticCommands {
         server_image: Option<String>,
         #[arg(
             long,
+            help = "display name for this run (e.g. pr / main / 'release 1.2.3'), recorded into the report and used as the column header in report --diff/--regression"
+        )]
+        label: Option<String>,
+        #[arg(
+            long,
             help = "GENERATE a reproducible dataset into --graph before measuring. DESTRUCTIVE: drops and rewrites the graph. Requires --nodes/--edges (or config)."
         )]
         generate: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -550,6 +550,19 @@ pub enum SyntheticCommands {
         diff: Vec<String>,
         #[arg(
             long,
+            requires = "diff",
+            help = "with --diff: emit a NON-FATAL, colored regression report (per-cell 🟢/🔴/N/A by p50 budget; diverged ops are marked, never aborted) instead of the strict diff. Candidate is the second (B) report."
+        )]
+        regression: bool,
+        #[arg(
+            long,
+            value_name = "FILE",
+            requires = "regression",
+            help = "TOML thresholds file for --regression (default: built-in 10% budget, 0.5ms floor; per-op + per-op×concurrency overrides)"
+        )]
+        thresholds: Option<String>,
+        #[arg(
+            long,
             help = "Markdown output path: the diff (default synthetic-diff.md) with --diff, or the re-rendered report's Markdown when re-rendering a single report"
         )]
         out: Option<String>,

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -225,18 +225,25 @@ pub fn regression_guard(
         }
     }
 
-    // 2. Per-op result divergence — reported, never fatal. An op the baseline recorded a digest for
-    //    that the candidate doesn't match (or is missing) is diverged.
+    // 2. Per-op result divergence — reported, never fatal. Over the *union* of ops: two present
+    //    digests that differ, or an asymmetric one-side-only digest, is diverged (we can't verify
+    //    correctness). Two absent digests carry no correctness info (e.g. a non-recording run) and
+    //    are left comparable, matching the strict guard.
     let mut diverged_ops = BTreeSet::new();
-    for (op, bop) in &baseline.operations {
-        let Some(bd) = &bop.result_digest else {
-            continue;
+    let all_ops: BTreeSet<&String> = baseline
+        .operations
+        .keys()
+        .chain(candidate.operations.keys())
+        .collect();
+    for op in all_ops {
+        let bd = baseline.operations.get(op).and_then(|o| o.result_digest.as_ref());
+        let cd = candidate.operations.get(op).and_then(|o| o.result_digest.as_ref());
+        let diverged = match (bd, cd) {
+            (Some(a), Some(b)) => a != b,
+            (None, None) => false,
+            _ => true, // asymmetric: only one side recorded a digest
         };
-        let cd = candidate
-            .operations
-            .get(op)
-            .and_then(|o| o.result_digest.as_ref());
-        if cd != Some(bd) {
+        if diverged {
             diverged_ops.insert(op.clone());
         }
     }
@@ -540,6 +547,26 @@ mod regression_guard_tests {
             RegressionGuard::Comparable { diverged_ops, .. } => {
                 assert!(diverged_ops.contains("match_by_index"));
             }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn asymmetric_digest_is_diverged_but_both_absent_is_comparable() {
+        // baseline None, candidate Some ⇒ diverged (can't verify correctness).
+        let a = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", None)]);
+        let b = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", Some("d1"))]);
+        match regression_guard(&a, &b) {
+            RegressionGuard::Comparable { diverged_ops, .. } => {
+                assert!(diverged_ops.contains("match_by_index"));
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+        // Both absent ⇒ no correctness info, not diverged.
+        let a2 = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", None)]);
+        let b2 = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", None)]);
+        match regression_guard(&a2, &b2) {
+            RegressionGuard::Comparable { diverged_ops, .. } => assert!(diverged_ops.is_empty()),
             other => panic!("expected Comparable, got {other:?}"),
         }
     }

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -10,7 +10,7 @@
 
 use crate::synthetic::report::{Report, ServerInfo};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The workload + environment identity of a run (extracted from its [`Report`]) that a
 /// version-comparison must agree on — or knowingly differ on.
@@ -145,6 +145,134 @@ pub fn guard(
 fn ver_str(v: Option<u64>) -> String {
     v.map(crate::synthetic::provenance::decode_module_version)
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// The result of the non-fatal comparability check used by `report --regression`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegressionGuard {
+    /// The runs measured the same workload/configuration and can be compared. `diverged_ops` are
+    /// operations whose result digests differ (the caller renders those N/A, not a latency
+    /// verdict); `warnings` are advisory (version/image).
+    Comparable {
+        diverged_ops: BTreeSet<String>,
+        warnings: Vec<String>,
+    },
+    /// The runs are not comparable at all (different workload or run configuration); the whole
+    /// report should be rendered as "not comparable".
+    NotComparable { reason: String },
+}
+
+/// Comparability guard for the **non-fatal** `report --regression` mode.
+///
+/// Unlike [`guard`], a per-op result-digest mismatch does **not** abort the whole comparison — it's
+/// reported per-op via `diverged_ops` (the caller shows those ops N/A). Only a *comparability*
+/// mismatch in the behaviour-affecting inputs (workload_hash, samples/warmup, concurrency sweep)
+/// makes the whole pair [`RegressionGuard::NotComparable`].
+pub fn regression_guard(
+    baseline: &Report,
+    candidate: &Report,
+) -> RegressionGuard {
+    // 1. Comparability manifest: the inputs that must match for a latency comparison to be valid.
+    let bh = baseline.meta.dataset.as_ref().map(|d| d.workload_hash.as_str());
+    let ch = candidate.meta.dataset.as_ref().map(|d| d.workload_hash.as_str());
+    match (bh, ch) {
+        (Some(a), Some(b)) if a == b => {}
+        (Some(_), Some(_)) => {
+            return RegressionGuard::NotComparable {
+                reason: "workload_hash differs — the two runs measured different workloads"
+                    .to_string(),
+            }
+        }
+        _ => {
+            return RegressionGuard::NotComparable {
+                reason: "missing workload_hash — comparing needs recorded (`--recording`) runs so \
+                         the workload can be fingerprinted"
+                    .to_string(),
+            }
+        }
+    }
+    if baseline.meta.samples != candidate.meta.samples
+        || baseline.meta.warmup != candidate.meta.warmup
+    {
+        return RegressionGuard::NotComparable {
+            reason: format!(
+                "sampling differs — baseline {}/{} vs candidate {}/{} (samples/warmup)",
+                baseline.meta.samples,
+                baseline.meta.warmup,
+                candidate.meta.samples,
+                candidate.meta.warmup
+            ),
+        };
+    }
+    let bc = sorted_levels(&baseline.meta.concurrency);
+    let cc = sorted_levels(&candidate.meta.concurrency);
+    if bc != cc {
+        return RegressionGuard::NotComparable {
+            reason: format!("concurrency sweep differs — baseline {bc:?} vs candidate {cc:?}"),
+        };
+    }
+
+    // 2. Per-op result divergence — reported, never fatal. An op the baseline recorded a digest for
+    //    that the candidate doesn't match (or is missing) is diverged.
+    let mut diverged_ops = BTreeSet::new();
+    for (op, bop) in &baseline.operations {
+        let Some(bd) = &bop.result_digest else {
+            continue;
+        };
+        let cd = candidate
+            .operations
+            .get(op)
+            .and_then(|o| o.result_digest.as_ref());
+        if cd != Some(bd) {
+            diverged_ops.insert(op.clone());
+        }
+    }
+
+    RegressionGuard::Comparable {
+        diverged_ops,
+        warnings: advisory_warnings(baseline, candidate),
+    }
+}
+
+/// Sorted, deduped concurrency levels for the comparability comparison.
+fn sorted_levels(levels: &[usize]) -> Vec<usize> {
+    let mut v: Vec<usize> = levels.to_vec();
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
+/// Advisory (non-blocking) version/image notes shared by the regression report.
+fn advisory_warnings(
+    baseline: &Report,
+    candidate: &Report,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    let bv = baseline.meta.server.module_graph_ver;
+    let cv = candidate.meta.server.module_graph_ver;
+    if bv.is_some() && bv == cv {
+        warnings.push(format!(
+            "baseline and candidate ran the same FalkorDB module version ({}) — there is no \
+             version delta to measure",
+            ver_str(cv)
+        ));
+    }
+    if bv == Some(ServerInfo::PLACEHOLDER_VER) || cv == Some(ServerInfo::PLACEHOLDER_VER) {
+        warnings.push(
+            "a FalkorDB module version is the dev placeholder — use tagged release images for a \
+             meaningful version comparison"
+                .to_string(),
+        );
+    }
+    if let (Some(a), Some(b)) = (
+        &baseline.meta.server.server_image,
+        &candidate.meta.server.server_image,
+    ) {
+        if a != b {
+            warnings.push(format!("server image changed: {a} → {b}"));
+        }
+    }
+    warnings
 }
 
 #[cfg(test)]
@@ -302,5 +430,120 @@ mod tests {
             }
             other => panic!("expected Proceed, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod regression_guard_tests {
+    use super::*;
+    use crate::synthetic::report::{
+        DatasetInfo, Meta, OperationReport, Report, ServerInfo, SCHEMA_VERSION,
+    };
+
+    #[allow(clippy::too_many_arguments)]
+    fn rep(
+        hash: &str,
+        samples: usize,
+        warmup: usize,
+        concurrency: Vec<usize>,
+        ver: Option<u64>,
+        image: Option<&str>,
+        ops: &[(&str, Option<&str>)],
+    ) -> Report {
+        let mut operations = BTreeMap::new();
+        for (name, dig) in ops {
+            operations.insert(
+                name.to_string(),
+                OperationReport {
+                    levels: vec![],
+                    result_digest: dig.map(|s| s.to_string()),
+                },
+            );
+        }
+        Report {
+            schema_version: SCHEMA_VERSION,
+            meta: Meta {
+                tool_version: "t".to_string(),
+                endpoint: "e".to_string(),
+                graph: "g".to_string(),
+                samples,
+                warmup,
+                concurrency,
+                seed: 0,
+                corpus_size: 0,
+                server_timeout_ms: 5000,
+                client_deadline_ms: 6000,
+                connection: "c".to_string(),
+                started_at_epoch_secs: 0,
+                server: ServerInfo {
+                    module_graph_ver: ver,
+                    server_image: image.map(|s| s.to_string()),
+                    ..Default::default()
+                },
+                host: Default::default(),
+                dataset: Some(DatasetInfo {
+                    seed: 0,
+                    nodes: 1,
+                    edges: 1,
+                    workload_hash: hash.to_string(),
+                }),
+                label: None,
+            },
+            operations,
+        }
+    }
+
+    #[test]
+    fn comparable_when_manifest_matches_no_divergence() {
+        let a = rep("h", 100, 50, vec![1, 4], Some(42001), Some("main"), &[("match_by_index", Some("d1"))]);
+        let b = rep("h", 100, 50, vec![1, 4], Some(42002), Some("pr"), &[("match_by_index", Some("d1"))]);
+        match regression_guard(&a, &b) {
+            RegressionGuard::Comparable { diverged_ops, warnings } => {
+                assert!(diverged_ops.is_empty());
+                assert!(warnings.iter().any(|w| w.contains("server image changed")));
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn per_op_divergence_is_reported_not_fatal() {
+        let a = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", Some("d1")), ("expand_1_hop", Some("e1"))]);
+        let b = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", Some("d1")), ("expand_1_hop", Some("DIFFERENT"))]);
+        match regression_guard(&a, &b) {
+            RegressionGuard::Comparable { diverged_ops, .. } => {
+                assert_eq!(diverged_ops.len(), 1);
+                assert!(diverged_ops.contains("expand_1_hop"));
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn candidate_missing_digest_is_diverged() {
+        let a = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", Some("d1"))]);
+        let b = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", None)]);
+        match regression_guard(&a, &b) {
+            RegressionGuard::Comparable { diverged_ops, .. } => {
+                assert!(diverged_ops.contains("match_by_index"));
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workload_mismatch_is_not_comparable() {
+        let a = rep("h1", 100, 50, vec![1], None, None, &[]);
+        let b = rep("h2", 100, 50, vec![1], None, None, &[]);
+        assert!(matches!(regression_guard(&a, &b), RegressionGuard::NotComparable { .. }));
+    }
+
+    #[test]
+    fn sampling_or_sweep_mismatch_is_not_comparable() {
+        let base = rep("h", 100, 50, vec![1, 4], None, None, &[]);
+        let diff_samples = rep("h", 200, 50, vec![1, 4], None, None, &[]);
+        assert!(matches!(regression_guard(&base, &diff_samples), RegressionGuard::NotComparable { .. }));
+        let diff_sweep = rep("h", 100, 50, vec![1, 4, 8], None, None, &[]);
+        assert!(matches!(regression_guard(&base, &diff_sweep), RegressionGuard::NotComparable { .. }));
     }
 }

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -185,8 +185,9 @@ pub fn regression_guard(
         }
         _ => {
             return RegressionGuard::NotComparable {
-                reason: "missing workload_hash — comparing needs recorded (`--recording`) runs so \
-                         the workload can be fingerprinted"
+                reason: "missing workload_hash — both runs must have a fingerprinted workload \
+                         (a `--recording` or `--generate` run); an externally-loaded graph can't \
+                         be compared"
                     .to_string(),
             }
         }

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -211,6 +211,18 @@ pub fn regression_guard(
             reason: format!("concurrency sweep differs — baseline {bc:?} vs candidate {cc:?}"),
         };
     }
+    // Server settings that affect sustained throughput (recorded when readable). Only a *known*
+    // difference is disqualifying — an unread setting (None) can't be compared, so we don't block.
+    if let (Some(bq), Some(cq)) = (
+        baseline.meta.server.max_queued_queries,
+        candidate.meta.server.max_queued_queries,
+    ) {
+        if bq != cq {
+            return RegressionGuard::NotComparable {
+                reason: format!("MAX_QUEUED_QUERIES differs — baseline {bq} vs candidate {cq}"),
+            };
+        }
+    }
 
     // 2. Per-op result divergence — reported, never fatal. An op the baseline recorded a digest for
     //    that the candidate doesn't match (or is missing) is diverged.
@@ -545,5 +557,17 @@ mod regression_guard_tests {
         assert!(matches!(regression_guard(&base, &diff_samples), RegressionGuard::NotComparable { .. }));
         let diff_sweep = rep("h", 100, 50, vec![1, 4, 8], None, None, &[]);
         assert!(matches!(regression_guard(&base, &diff_sweep), RegressionGuard::NotComparable { .. }));
+    }
+
+    #[test]
+    fn differing_max_queued_queries_is_not_comparable_but_unread_is_ok() {
+        let mut a = rep("h", 100, 50, vec![1], None, None, &[]);
+        let mut b = rep("h", 100, 50, vec![1], None, None, &[]);
+        a.meta.server.max_queued_queries = Some(1000);
+        b.meta.server.max_queued_queries = Some(25);
+        assert!(matches!(regression_guard(&a, &b), RegressionGuard::NotComparable { .. }));
+        // One side unread (None) can't be compared, so it does not disqualify.
+        b.meta.server.max_queued_queries = None;
+        assert!(matches!(regression_guard(&a, &b), RegressionGuard::Comparable { .. }));
     }
 }

--- a/src/synthetic/config.rs
+++ b/src/synthetic/config.rs
@@ -89,6 +89,7 @@ pub struct CliOverrides {
     pub client_deadline_ms: Option<u64>,
     pub out: Option<String>,
     pub server_image: Option<String>,
+    pub label: Option<String>,
     /// Explicit destructive consent to generate + load a dataset into `graph`.
     pub generate: bool,
     pub nodes: Option<usize>,
@@ -188,6 +189,7 @@ pub fn resolve(
         cache: cli.cache.or(file.cache).unwrap_or(default_cache),
         out: cli.out.or(file.out).unwrap_or(default_out),
         server_image: cli.server_image,
+        label: cli.label,
         dataset,
     })
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -3,8 +3,11 @@
 //! as pasteable Markdown. Used by `synthetic report --diff` after the [`crate::synthetic::baseline`]
 //! guard confirms the two runs measured the same workload.
 
+use crate::synthetic::baseline::RegressionGuard;
 use crate::synthetic::provenance::decode_module_version;
 use crate::synthetic::report::{md_cell, LevelMetrics, LevelReport, Report};
+use crate::synthetic::thresholds::{Thresholds, Verdict};
+use crate::synthetic::OpName;
 use std::collections::BTreeSet;
 
 /// Which cache mode of a [`LevelReport`] to read.
@@ -214,6 +217,181 @@ fn row2(
     ));
 }
 
+// ==== Non-fatal regression report ===============================================================
+
+/// Render the **non-fatal** `report --regression` markdown: per-cell 🟢/🔴/N/A verdicts on p50
+/// (total-latency median) against the threshold budget, with throughput shown for context. Ops the
+/// `guard` flags as diverged get a perf verdict of N/A (correctness-🔴). A `NotComparable` guard
+/// renders a single "not comparable" note. Never errors.
+pub fn regression_markdown(
+    baseline: &Report,
+    candidate: &Report,
+    guard: &RegressionGuard,
+    thresholds: &Thresholds,
+) -> String {
+    let la = col_label(baseline, "baseline");
+    let lb = col_label(candidate, "candidate");
+    let mut head = String::new();
+    head.push_str(&format!(
+        "### 🧪 Synthetic per-op regression — {} vs {} (same machine)\n\n",
+        md_cell(&lb),
+        md_cell(&la)
+    ));
+    head.push_str(&format!("| field | {} | {} |\n|---|---|---|\n", md_cell(&la), md_cell(&lb)));
+    row2(&mut head, "FalkorDB module", &ver(baseline), &ver(candidate));
+    row2(
+        &mut head,
+        "server image",
+        baseline.meta.server.server_image.as_deref().unwrap_or("—"),
+        candidate.meta.server.server_image.as_deref().unwrap_or("—"),
+    );
+    row2(&mut head, "workload_hash", &opt_hash(baseline), &opt_hash(candidate));
+    row2(
+        &mut head,
+        "samples / warmup",
+        &format!("{} / {}", baseline.meta.samples, baseline.meta.warmup),
+        &format!("{} / {}", candidate.meta.samples, candidate.meta.warmup),
+    );
+
+    let (diverged, warnings) = match guard {
+        RegressionGuard::NotComparable { reason } => {
+            head.push_str(&format!(
+                "\n> ⚠ **not comparable** — {}. No latency verdict is shown.\n",
+                md_cell(reason)
+            ));
+            return head;
+        }
+        RegressionGuard::Comparable { diverged_ops, warnings } => (diverged_ops, warnings),
+    };
+
+    // Render the per-op tables into `body`, counting regressed cells as we go.
+    let mut body = String::new();
+    let mut regressed = 0usize;
+    let mut comparable_cells = 0usize;
+    let ops: BTreeSet<&String> = baseline
+        .operations
+        .keys()
+        .chain(candidate.operations.keys())
+        .collect();
+    for op in ops {
+        let op_diverged = diverged.contains(op);
+        body.push_str(&format!(
+            "\n#### `{op}`{}\n",
+            if op_diverged { "  —  ⚠ results differ (perf verdict N/A)" } else { "" }
+        ));
+        let opname = OpName::from_tag(op);
+        for mode in [Mode::Cached, Mode::Uncached] {
+            render_regression_mode(
+                &mut body, baseline, candidate, op, opname, mode, op_diverged, thresholds, &la,
+                &lb, &mut regressed, &mut comparable_cells,
+            );
+        }
+    }
+
+    // Assemble: header + summary + warnings + legend + body.
+    let mut out = head;
+    let summary = if regressed == 0 {
+        format!("🟢 no p50 regression beyond budget across {comparable_cells} comparable cell(s)")
+    } else {
+        format!("🔴 {regressed} of {comparable_cells} comparable cell(s) over budget")
+    };
+    out.push_str(&format!("\n**{} vs {}** — {}\n", md_cell(&lb), md_cell(&la), summary));
+    if !diverged.is_empty() {
+        let names: Vec<&str> = diverged.iter().map(String::as_str).collect();
+        out.push_str(&format!(
+            "\n_⚠ {} op(s) with differing results (perf N/A): {}_\n",
+            diverged.len(),
+            names.join(", ")
+        ));
+    }
+    for w in warnings {
+        out.push_str(&format!("\n> ⚠ {}\n", md_cell(w)));
+    }
+    out.push_str(
+        "\n🟢 = faster or within budget · 🔴 = slower than budget **or** results differ · \
+         N/A = no perf verdict. Non-blocking.\n",
+    );
+    out.push_str(&body);
+    out
+}
+
+/// Render one op × cache-mode regression table with a verdict column, accumulating the
+/// regressed/comparable cell counts.
+#[allow(clippy::too_many_arguments)]
+fn render_regression_mode(
+    out: &mut String,
+    a: &Report,
+    b: &Report,
+    op: &str,
+    opname: Option<OpName>,
+    mode: Mode,
+    op_diverged: bool,
+    thresholds: &Thresholds,
+    la: &str,
+    lb: &str,
+    regressed: &mut usize,
+    comparable_cells: &mut usize,
+) {
+    let mut levels: BTreeSet<usize> = BTreeSet::new();
+    for rep in [a, b] {
+        if let Some(opr) = rep.operations.get(op) {
+            for lvl in &opr.levels {
+                if mode.pick(lvl).is_some() {
+                    levels.insert(lvl.concurrency);
+                }
+            }
+        }
+    }
+    if levels.is_empty() {
+        return;
+    }
+    out.push_str(&format!("\n_{}_\n\n", mode.label()));
+    out.push_str(&format!(
+        "| C | {la} p50 (ms) | {lb} p50 (ms) | Δp50 | {la} tput | {lb} tput | Δtput | verdict |\n\
+         |---:|---:|---:|---:|---:|---:|---:|:--:|\n"
+    ));
+    for c in levels {
+        let am = level_metrics(a, op, c, mode);
+        let bm = level_metrics(b, op, c, mode);
+        let ap = am.map(|m| m.metrics.total_ms.median);
+        let bp = bm.map(|m| m.metrics.total_ms.median);
+        let a_s = ap.map(|v| format!("{v:.3}")).unwrap_or_else(|| "—".to_string());
+        let b_s = bp.map(|v| format!("{v:.3}")).unwrap_or_else(|| "—".to_string());
+        let dp50 = match (ap, bp) {
+            (Some(x), Some(y)) => pct(x, y),
+            _ => "—".to_string(),
+        };
+        let a_tp = am
+            .map(|m| format!("{:.0}", m.throughput_ops_per_sec))
+            .unwrap_or_else(|| "—".to_string());
+        let b_tp = bm
+            .map(|m| format!("{:.0}", m.throughput_ops_per_sec))
+            .unwrap_or_else(|| "—".to_string());
+        let dtp = match (am, bm) {
+            (Some(x), Some(y)) => pct(x.throughput_ops_per_sec, y.throughput_ops_per_sec),
+            _ => "—".to_string(),
+        };
+        let verdict = if op_diverged {
+            "🔴 N/A".to_string()
+        } else {
+            match (ap, bp, opname) {
+                (Some(x), Some(y), Some(name)) => {
+                    let v = thresholds.resolve(name, c).verdict(x, y);
+                    *comparable_cells += 1;
+                    if v == Verdict::Regressed {
+                        *regressed += 1;
+                    }
+                    v.emoji().to_string()
+                }
+                _ => "N/A".to_string(),
+            }
+        };
+        out.push_str(&format!(
+            "| {c} | {a_s} | {b_s} | {dp50} | {a_tp} | {b_tp} | {dtp} | {verdict} |\n"
+        ));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -349,5 +527,50 @@ mod tests {
         let md = diff_markdown(&a, &b, &[]);
         assert!(md.contains("left\\|right"), "pipe not escaped: {md}");
         assert!(!md.contains("`left|right`"), "raw pipe leaked into a cell");
+    }
+
+    #[test]
+    fn regression_marks_within_budget_green_and_over_budget_red() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        // within budget: +5% and +0.05 ms (below the 0.5 ms floor) => green
+        let b_ok = report(42002, 1.05, 1000.0);
+        let g = regression_guard(&a, &b_ok);
+        let md = regression_markdown(&a, &b_ok, &g, &Thresholds::builtin());
+        assert!(md.contains("🟢"), "{md}");
+        assert!(md.contains("no p50 regression"), "{md}");
+        // over budget: +100% and +1 ms => red
+        let b_bad = report(42002, 2.0, 500.0);
+        let g2 = regression_guard(&a, &b_bad);
+        let md2 = regression_markdown(&a, &b_bad, &g2, &Thresholds::builtin());
+        assert!(md2.contains("🔴"), "{md2}");
+        assert!(md2.contains("1 of 1 comparable cell(s) over budget"), "{md2}");
+    }
+
+    #[test]
+    fn regression_marks_diverged_op_na_not_fatal() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        b.operations.get_mut("match_by_index").unwrap().result_digest =
+            Some("sha256:bb".to_string());
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        assert!(md.contains("results differ"), "{md}");
+        assert!(md.contains("🔴 N/A"), "{md}");
+    }
+
+    #[test]
+    fn regression_not_comparable_when_workload_differs() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        b.meta.dataset.as_mut().unwrap().workload_hash = "sha256:zzz".to_string();
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        assert!(md.contains("not comparable"), "{md}");
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -239,7 +239,7 @@ pub fn regression_markdown(
     let lb = col_label(candidate, "candidate");
     let mut head = String::new();
     head.push_str(&format!(
-        "### 🧪 Synthetic per-op regression — {} vs {} (same machine)\n\n",
+        "### 🧪 Synthetic per-op regression — {} vs {}\n\n",
         md_cell(&lb),
         md_cell(&la)
     ));

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -387,9 +387,15 @@ fn render_regression_mode(
             match (ap, bp, opname) {
                 (Some(x), Some(y), Some(name)) => {
                     let v = thresholds.resolve(name, c).verdict(x, y);
-                    *comparable_cells += 1;
-                    if v == Verdict::Regressed {
-                        *regressed += 1;
+                    match v {
+                        Verdict::Regressed => {
+                            *regressed += 1;
+                            *comparable_cells += 1;
+                        }
+                        // A real (comparable) 🟢 cell.
+                        Verdict::Ok => *comparable_cells += 1,
+                        // Zero/non-finite baseline ⇒ no verdict; not a comparable cell.
+                        Verdict::NotApplicable => {}
                     }
                     v.emoji().to_string()
                 }
@@ -599,5 +605,17 @@ mod tests {
         let g = regression_guard(&a, &b);
         let reg = regression_markdown(&a, &b, &g, &Thresholds::builtin());
         assert!(reg.contains("v1\\|x") && reg.contains("v2\\|y"), "regression headers not escaped: {reg}");
+    }
+
+    #[test]
+    fn regression_na_cells_are_not_counted_as_comparable() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        // A zero baseline p50 ⇒ the cell's verdict is N/A; it must NOT inflate the comparable count.
+        let a = report(42001, 0.0, 1000.0);
+        let b = report(42002, 1.0, 1000.0);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        assert!(md.contains("across 0 comparable cell(s)"), "{md}");
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -295,12 +295,18 @@ pub fn regression_markdown(
         }
     }
 
-    // Assemble: header + summary + warnings + legend + body.
+    // Assemble: header + summary + warnings + legend + body. The top-line is 🟢 only when there
+    // is neither a p50 regression NOR a correctness (result) divergence.
     let mut out = head;
-    let summary = if regressed == 0 {
-        format!("🟢 no p50 regression beyond budget across {comparable_cells} comparable cell(s)")
-    } else {
+    let summary = if regressed > 0 {
         format!("🔴 {regressed} of {comparable_cells} comparable cell(s) over budget")
+    } else if !diverged.is_empty() {
+        format!(
+            "🔴 no p50 regression beyond budget, but {} op(s) have differing results (correctness)",
+            diverged.len()
+        )
+    } else {
+        format!("🟢 no p50 regression beyond budget across {comparable_cells} comparable cell(s)")
     };
     out.push_str(&format!("\n**{} vs {}** — {}\n", md_cell(&lb), md_cell(&la), summary));
     if !diverged.is_empty() {
@@ -577,6 +583,9 @@ mod tests {
         let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
         assert!(md.contains("results differ"), "{md}");
         assert!(md.contains("🔴 N/A"), "{md}");
+        // The top-line summary must be 🔴 (correctness), not a misleading 🟢.
+        assert!(md.contains("differing results (correctness)"), "{md}");
+        assert!(!md.contains("🟢 no p50 regression"), "summary should not be green: {md}");
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -44,7 +44,9 @@ pub fn diff_markdown(
     let lb = col_label(candidate, "B");
     out.push_str(&format!("# Synthetic benchmark diff — {la} → {lb}\n\n"));
     out.push_str(&format!(
-        "| field | {la} (baseline) | {lb} (candidate) |\n|---|---|---|\n"
+        "| field | {} (baseline) | {} (candidate) |\n|---|---|---|\n",
+        md_cell(&la),
+        md_cell(&lb)
     ));
     row2(&mut out, "FalkorDB module", &ver(baseline), &ver(candidate));
     row2(
@@ -124,8 +126,8 @@ fn render_mode(
         return;
     }
     out.push_str(&format!("\n_{}_\n\n", mode.label()));
-    let la = col_label(a, "A");
-    let lb = col_label(b, "B");
+    let la = md_cell(&col_label(a, "A"));
+    let lb = md_cell(&col_label(b, "B"));
     out.push_str(&format!(
         "| C | {la} total p50/p90/p95/p99 (ms) | {lb} total p50/p90/p95/p99 (ms) | Δp50 | {la} tput (ops/s) | {lb} tput (ops/s) | Δtput |\n\
          |---:|---|---|---:|---:|---:|---:|\n",
@@ -347,8 +349,12 @@ fn render_regression_mode(
     }
     out.push_str(&format!("\n_{}_\n\n", mode.label()));
     out.push_str(&format!(
-        "| C | {la} p50 (ms) | {lb} p50 (ms) | Δp50 | {la} tput | {lb} tput | Δtput | verdict |\n\
-         |---:|---:|---:|---:|---:|---:|---:|:--:|\n"
+        "| C | {} p50 (ms) | {} p50 (ms) | Δp50 | {} tput | {} tput | Δtput | verdict |\n\
+         |---:|---:|---:|---:|---:|---:|---:|:--:|\n",
+        md_cell(la),
+        md_cell(lb),
+        md_cell(la),
+        md_cell(lb),
     ));
     for c in levels {
         let am = level_metrics(a, op, c, mode);
@@ -572,5 +578,22 @@ mod tests {
         let g = regression_guard(&a, &b);
         let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
         assert!(md.contains("not comparable"), "{md}");
+    }
+
+    #[test]
+    fn labels_with_pipes_are_escaped_in_headers() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let mut a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.2, 1000.0);
+        a.meta.label = Some("v1|x".to_string());
+        b.meta.label = Some("v2|y".to_string());
+        // diff headers (field header + per-op header)
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("v1\\|x") && md.contains("v2\\|y"), "diff headers not escaped: {md}");
+        // regression headers (field header + per-op header)
+        let g = regression_guard(&a, &b);
+        let reg = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        assert!(reg.contains("v1\\|x") && reg.contains("v2\\|y"), "regression headers not escaped: {reg}");
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -42,7 +42,11 @@ pub fn diff_markdown(
     let mut out = String::new();
     let la = col_label(baseline, "A");
     let lb = col_label(candidate, "B");
-    out.push_str(&format!("# Synthetic benchmark diff — {la} → {lb}\n\n"));
+    out.push_str(&format!(
+        "# Synthetic benchmark diff — {} → {}\n\n",
+        md_cell(&la),
+        md_cell(&lb)
+    ));
     out.push_str(&format!(
         "| field | {} (baseline) | {} (candidate) |\n|---|---|---|\n",
         md_cell(&la),

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -101,7 +101,8 @@ pub fn diff_markdown(
     out
 }
 
-/// The display name for a run's column: its `--label` if set, else the `fallback` (`A`/`B`).
+/// The display name for a run's column: its `--label` if set, else the caller-supplied `fallback`
+/// (`A`/`B` for `diff_markdown`; `baseline`/`candidate` for the regression report).
 fn col_label(r: &Report, fallback: &str) -> String {
     r.meta.label.clone().unwrap_or_else(|| fallback.to_string())
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -37,8 +37,12 @@ pub fn diff_markdown(
     warnings: &[String],
 ) -> String {
     let mut out = String::new();
-    out.push_str("# Synthetic benchmark diff — A → B\n\n");
-    out.push_str("| field | A (baseline) | B (candidate) |\n|---|---|---|\n");
+    let la = col_label(baseline, "A");
+    let lb = col_label(candidate, "B");
+    out.push_str(&format!("# Synthetic benchmark diff — {la} → {lb}\n\n"));
+    out.push_str(&format!(
+        "| field | {la} (baseline) | {lb} (candidate) |\n|---|---|---|\n"
+    ));
     row2(&mut out, "FalkorDB module", &ver(baseline), &ver(candidate));
     row2(
         &mut out,
@@ -66,8 +70,8 @@ pub fn diff_markdown(
     );
 
     out.push_str(
-        "\n_Δ is 100·(B−A)/A. **Latency: lower is better** (a positive Δ = slower / regressed); \
-         **throughput: higher is better**. `—` = not measured in that run._\n",
+        "\n_Δ is 100·(candidate−baseline)/baseline. **Latency: lower is better** (a positive Δ = \
+         slower / regressed); **throughput: higher is better**. `—` = not measured in that run._\n",
     );
     for w in warnings {
         out.push_str(&format!("\n> ⚠ {w}\n"));
@@ -86,6 +90,11 @@ pub fn diff_markdown(
         }
     }
     out
+}
+
+/// The display name for a run's column: its `--label` if set, else the `fallback` (`A`/`B`).
+fn col_label(r: &Report, fallback: &str) -> String {
+    r.meta.label.clone().unwrap_or_else(|| fallback.to_string())
 }
 
 /// Render one op × cache-mode table (rows = concurrency levels present in either run). Skipped
@@ -112,10 +121,12 @@ fn render_mode(
         return;
     }
     out.push_str(&format!("\n_{}_\n\n", mode.label()));
-    out.push_str(
-        "| C | A total p50/p90/p95/p99 (ms) | B total p50/p90/p95/p99 (ms) | Δp50 | A tput (ops/s) | B tput (ops/s) | Δtput |\n\
+    let la = col_label(a, "A");
+    let lb = col_label(b, "B");
+    out.push_str(&format!(
+        "| C | {la} total p50/p90/p95/p99 (ms) | {lb} total p50/p90/p95/p99 (ms) | Δp50 | {la} tput (ops/s) | {lb} tput (ops/s) | Δtput |\n\
          |---:|---|---|---:|---:|---:|---:|\n",
-    );
+    ));
     for c in levels {
         let am = level_metrics(a, op, c, mode);
         let bm = level_metrics(b, op, c, mode);
@@ -276,6 +287,7 @@ mod tests {
                     edges: 20,
                     workload_hash: "sha256:abc".to_string(),
                 }),
+                label: None,
             },
             operations,
         }
@@ -294,6 +306,18 @@ mod tests {
         assert!(md.contains("+10.0%"), "expected latency +10%: {md}");
         assert!(md.contains("-10.0%"), "expected throughput -10%: {md}");
         assert!(md.contains("⚠ server image changed"));
+    }
+
+    #[test]
+    fn diff_uses_run_labels_as_headers() {
+        let mut a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.1, 900.0);
+        a.meta.label = Some("main".to_string());
+        b.meta.label = Some("pr".to_string());
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("diff — main → pr"), "title: {md}");
+        assert!(md.contains("| main (baseline) | pr (candidate) |"), "header: {md}");
+        assert!(md.contains("main total p50") && md.contains("pr tput"), "op header: {md}");
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -28,6 +28,7 @@ pub mod recording;
 pub mod replay;
 pub mod report;
 pub mod stats;
+pub mod thresholds;
 pub mod writes;
 
 use crate::error::BenchmarkError::OtherError;
@@ -294,6 +295,8 @@ pub struct Config {
     pub cache: CacheSelection,
     pub out: String,
     pub server_image: Option<String>,
+    /// Optional display name for this run (e.g. `pr`/`main`), recorded into the report.
+    pub label: Option<String>,
     /// When `Some`, generate a reproducible synthetic dataset (Part 3) into `graph`, **replacing**
     /// its contents, before measuring. Gated behind explicit CLI consent (`--generate`).
     pub dataset: Option<DatasetSpec>,
@@ -315,6 +318,7 @@ impl Default for Config {
             cache: CacheSelection::Both,
             out: "synthetic-report.json".to_string(),
             server_image: None,
+            label: None,
             dataset: None,
         }
     }
@@ -546,6 +550,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             server,
             host: host::collect(),
             dataset: dataset_info,
+            label: config.label.clone(),
         },
         operations,
     })
@@ -1106,6 +1111,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             client_deadline_ms,
             out,
             server_image,
+            label,
             generate,
             nodes,
             edges,
@@ -1142,6 +1148,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                     client_deadline_ms: client_deadline_ms.unwrap_or(6_000),
                     out: out.unwrap_or_else(|| "synthetic-report.json".to_string()),
                     server_image,
+                    label,
                 };
                 return replay::run_and_report(&replay_config).await;
             }
@@ -1160,6 +1167,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 client_deadline_ms,
                 out,
                 server_image,
+                label,
                 generate,
                 nodes,
                 edges,
@@ -1201,6 +1209,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 client_deadline_ms: None,
                 out: None,
                 server_image: None,
+                label: None,
                 generate: true,
                 nodes,
                 edges,
@@ -1533,6 +1542,7 @@ mod tests {
             client_deadline_ms: Some(6_000),
             out: Some("unused.json".to_string()),
             server_image: None,
+            label: None,
             generate: false,
             nodes: None,
             edges: None,
@@ -1574,6 +1584,7 @@ mod tests {
             client_deadline_ms: Some(6_000),
             out: Some("unused.json".to_string()),
             server_image: None,
+            label: None,
             generate: false,
             nodes: None,
             edges: None,
@@ -1607,6 +1618,7 @@ mod tests {
             client_deadline_ms: None,
             out: None,
             server_image: None,
+            label: None,
             generate: true,
             nodes: None,
             edges: None,

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1722,6 +1722,49 @@ mod tests {
         let _ = std::fs::remove_file(&diff_out);
     }
 
+    #[tokio::test]
+    async fn report_regression_command_is_non_fatal_on_divergence() {
+        // Hermetic: two reports with the SAME workload_hash but a differing result digest for one
+        // op. `report --diff --regression` must NOT error (unlike strict --diff) — it renders the
+        // op as "results differ" and returns Ok.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir();
+        let write = |label: &str, digest: &str| -> String {
+            let p = dir.join(format!(
+                "reg-{}-{}.json",
+                std::process::id(),
+                SEQ.fetch_add(1, Ordering::Relaxed)
+            ));
+            let json = format!(
+                r#"{{"meta":{{"tool_version":"0.1.0","endpoint":"x","samples":1,"warmup":0,"concurrency":[1],"server_timeout_ms":5000,"client_deadline_ms":6000,"connection":"c","started_at_epoch_secs":0,"server":{{"module_graph_ver":42001}},"dataset":{{"seed":1,"nodes":10,"edges":20,"corpus_hash":"sha256:same"}},"label":"{label}"}},"operations":{{"match_by_index":{{"levels":[],"result_digest":"{digest}"}}}}}}"#
+            );
+            std::fs::write(&p, json).unwrap();
+            p.to_string_lossy().into_owned()
+        };
+        let a = write("main", "sha256:aa");
+        let b = write("pr", "sha256:bb"); // diverged result
+        let out = dir
+            .join(format!("reg-out-{}.md", std::process::id()))
+            .to_string_lossy()
+            .into_owned();
+        assert!(run_command(crate::cli::SyntheticCommands::Report {
+            input: None,
+            regression: true,
+            thresholds: None,
+            diff: vec![a.clone(), b.clone()],
+            out: Some(out.clone()),
+        })
+        .await
+        .is_ok());
+        let md = std::fs::read_to_string(&out).unwrap();
+        assert!(md.contains("results differ"), "{md}");
+        assert!(md.contains("main") && md.contains("pr"), "labels in header: {md}");
+        for p in [a, b, out] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
     #[test]
     fn markdown_path_swaps_json_suffix_or_appends() {
         assert_eq!(markdown_path("synthetic-report.json"), "synthetic-report.md");

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1235,8 +1235,8 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             );
             Ok(())
         }
-        crate::cli::SyntheticCommands::Report { input, diff, out } => {
-            report_command(input, diff, out).await
+        crate::cli::SyntheticCommands::Report { input, diff, regression, thresholds, out } => {
+            report_command(input, diff, regression, thresholds, out).await
         }
     }
 }
@@ -1248,6 +1248,8 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
 async fn report_command(
     input: Option<String>,
     diff: Vec<String>,
+    regression: bool,
+    thresholds: Option<String>,
     out: Option<String>,
 ) -> BenchmarkResult<()> {
     let load = |path: &str| -> BenchmarkResult<crate::synthetic::report::Report> {
@@ -1260,6 +1262,22 @@ async fn report_command(
     if diff.len() == 2 {
         let a = load(&diff[0])?;
         let b = load(&diff[1])?;
+
+        // NON-FATAL regression mode: colored per-cell verdicts, never aborts on divergence.
+        if regression {
+            let budgets = match thresholds {
+                Some(path) => crate::synthetic::thresholds::Thresholds::from_file(&path)?,
+                None => crate::synthetic::thresholds::Thresholds::builtin(),
+            };
+            let guard = baseline::regression_guard(&a, &b);
+            let md = diff::regression_markdown(&a, &b, &guard, &budgets);
+            let out_path = out.unwrap_or_else(|| "synthetic-regression.md".to_string());
+            tokio::fs::write(&out_path, &md).await?;
+            println!("{}", md);
+            println!("regression report written to {}", out_path);
+            return Ok(());
+        }
+
         let warnings = match baseline::guard(
             &baseline::BaselineKey::from_report(&a),
             &baseline::BaselineKey::from_report(&b),
@@ -1633,6 +1651,8 @@ mod tests {
     async fn report_requires_input_or_diff() {
         let err = run_command(crate::cli::SyntheticCommands::Report {
             input: None,
+            regression: false,
+            thresholds: None,
             diff: vec![],
             out: None,
         })
@@ -1677,6 +1697,8 @@ mod tests {
             .into_owned();
         assert!(run_command(crate::cli::SyntheticCommands::Report {
             input: None,
+            regression: false,
+            thresholds: None,
             diff: vec![base.clone(), ok.clone()],
             out: Some(diff_out.clone()),
         })
@@ -1686,6 +1708,8 @@ mod tests {
         let bad = write_report("sha256:different", 42002);
         let err = run_command(crate::cli::SyntheticCommands::Report {
             input: None,
+            regression: false,
+            thresholds: None,
             diff: vec![base.clone(), bad.clone()],
             out: Some(diff_out.clone()),
         })

--- a/src/synthetic/provenance.rs
+++ b/src/synthetic/provenance.rs
@@ -77,6 +77,18 @@ pub async fn collect(
         Err(e) => warn!("provenance: GRAPH.CONFIG GET CACHE_SIZE failed: {}", e),
     }
 
+    // The queued-query limit bounds sustained throughput under load — part of the comparability
+    // manifest, so two runs compared for regression must agree on it.
+    match redis::cmd("GRAPH.CONFIG")
+        .arg("GET")
+        .arg("MAX_QUEUED_QUERIES")
+        .query_async::<redis::Value>(&mut conn)
+        .await
+    {
+        Ok(v) => info.max_queued_queries = parse_config_get_u64(&v),
+        Err(e) => warn!("provenance: GRAPH.CONFIG GET MAX_QUEUED_QUERIES failed: {}", e),
+    }
+
     Ok(info)
 }
 

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -63,6 +63,8 @@ pub struct ReplayConfig {
     pub out: String,
     /// Operator-supplied server image identity, recorded verbatim.
     pub server_image: Option<String>,
+    /// Optional display name for this run (e.g. `pr`/`main`), recorded into the report.
+    pub label: Option<String>,
 }
 
 /// Replay `config`'s bundle: load the recorded graph, then measure the recorded commands through the
@@ -166,6 +168,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         cache: config.cache,
         out: config.out.clone(),
         server_image: config.server_image.clone(),
+        label: config.label.clone(),
         dataset: None,
     };
     let run_token = rand::random_range(0..=u64::MAX);
@@ -242,6 +245,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                 edges: dataset_spec.edges,
                 workload_hash: bundle.manifest.workload_hash.clone(),
             }),
+            label: config.label.clone(),
         },
         operations,
     })
@@ -392,6 +396,7 @@ mod tests {
             client_deadline_ms: 6_000,
             out: "unused.json".to_string(),
             server_image: None,
+            label: None,
         };
         let err = run(&config).await.unwrap_err();
         assert!(format!("{err}").contains("samples must be greater than 0"), "got: {err}");

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -22,6 +22,10 @@ pub struct ServerInfo {
     /// The server's query plan-cache size (`GRAPH.CONFIG GET CACHE_SIZE`), for context on the
     /// cached-vs-uncached comparison. `None` if it couldn't be read.
     pub cache_size: Option<u64>,
+    /// The server's queued-query limit (`GRAPH.CONFIG GET MAX_QUEUED_QUERIES`). Part of the
+    /// comparability manifest (it bounds sustained throughput under load). `None` if unreadable.
+    #[serde(default)]
+    pub max_queued_queries: Option<u64>,
     pub redis_version: Option<String>,
     pub redis_build_id: Option<String>,
     pub redis_git_sha1: Option<String>,

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -106,6 +106,10 @@ pub struct Meta {
     /// externally-provided graph, whose contents we can't fingerprint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dataset: Option<DatasetInfo>,
+    /// Operator-supplied display name for this run (e.g. `pr`, `main`, `release 1.2.3`). Used as the
+    /// column header in `report --diff`/`--regression`; falls back to `A`/`B` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// Provenance for a synthetic dataset: its knobs and the `workload_hash` that identifies the whole
@@ -669,6 +673,7 @@ mod tests {
                     total_memory_bytes: 34_359_738_368,
                 },
                 dataset: None,
+                label: None,
             },
             operations,
         }

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -6,8 +6,9 @@
 //! sub-millisecond ops). Faster — or slower within either bound — is **🟢**. A missing/zero
 //! baseline is **N/A**.
 //!
-//! The budget is resolved per `(op, concurrency)` with precedence
-//! `op.<name>.concurrency.<C>` > `op.<name>` > `[default]`, per field. The config ships a built-in
+//! The budget is resolved per `(op, concurrency)`; the **per-concurrency** override applies to
+//! `budget_pct` only, with precedence `op.<name>.concurrency.<C>` > `op.<name>` > `[default]`,
+//! while `floor_ms`/`metric` resolve at `op.<name>` > `[default]`. The config ships a built-in
 //! default (10 %, `floor_ms = 0.5`, `metric = "p50"`) and is overridable from a TOML file that
 //! lives in the consuming repo (e.g. `falkordb-rs-next-gen`).
 

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -193,6 +193,11 @@ impl Thresholds {
                 let c: usize = c_str.parse().map_err(|_| {
                     format!("[op.{name}].concurrency has a non-integer key '{c_str}'")
                 })?;
+                if c == 0 {
+                    return Err(format!(
+                        "[op.{name}].concurrency has an invalid level 0 (must be ≥ 1)"
+                    ));
+                }
                 let pct = check_budget(pct, &format!("[op.{name}].concurrency.{c}"))?;
                 per_concurrency_budget_pct.insert(c, pct);
             }
@@ -343,6 +348,15 @@ concurrency = { 32 = 40.0 }
         )
         .unwrap_err();
         assert!(err.contains("non-integer key 'fast'"), "{err}");
+    }
+
+    #[test]
+    fn rejects_zero_concurrency_key() {
+        let err = Thresholds::from_toml_str(
+            "[op.match_by_index]\nconcurrency = { 0 = 40.0 }\n",
+        )
+        .unwrap_err();
+        assert!(err.contains("invalid level 0"), "{err}");
     }
 
     #[test]

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -350,4 +350,31 @@ concurrency = { 32 = 40.0 }
         // deny_unknown_fields guards typos like `budjet_pct`.
         assert!(Thresholds::from_toml_str("[default]\nbudjet_pct = 10.0\n").is_err());
     }
+
+    #[test]
+    fn verdict_emoji_covers_all_variants() {
+        assert_eq!(Verdict::Ok.emoji(), "🟢");
+        assert_eq!(Verdict::Regressed.emoji(), "🔴");
+        assert_eq!(Verdict::NotApplicable.emoji(), "N/A");
+    }
+
+    #[test]
+    fn default_equals_builtin() {
+        let b = Thresholds::default().resolve(OpName::MatchByIndex, 1);
+        assert_eq!(b.budget_pct, DEFAULT_BUDGET_PCT);
+        assert_eq!(b.floor_ms, DEFAULT_FLOOR_MS);
+        assert_eq!(b.metric, Metric::P50);
+    }
+
+    #[test]
+    fn from_file_reads_validates_and_errors_on_missing() {
+        let dir = std::env::temp_dir();
+        let p = dir.join(format!("thr-{}.toml", std::process::id()));
+        // op-level metric override exercises the op metric validation path.
+        std::fs::write(&p, "[op.match_by_index]\nmetric = \"p50\"\nbudget_pct = 7.0\n").unwrap();
+        let t = Thresholds::from_file(p.to_str().unwrap()).unwrap();
+        assert_eq!(t.resolve(OpName::MatchByIndex, 1).budget_pct, 7.0);
+        let _ = std::fs::remove_file(&p);
+        assert!(Thresholds::from_file("/no/such/thresholds-xyz.toml").is_err());
+    }
 }

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -393,7 +393,12 @@ concurrency = { 32 = 40.0 }
     #[test]
     fn from_file_reads_validates_and_errors_on_missing() {
         let dir = std::env::temp_dir();
-        let p = dir.join(format!("thr-{}.toml", std::process::id()));
+        // Unique per (process, nanos) so parallel tests can't collide on the temp file name.
+        let uniq = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = dir.join(format!("thr-{}-{}.toml", std::process::id(), uniq));
         // op-level metric override exercises the op metric validation path.
         std::fs::write(&p, "[op.match_by_index]\nmetric = \"p50\"\nbudget_pct = 7.0\n").unwrap();
         let t = Thresholds::from_file(p.to_str().unwrap()).unwrap();

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -69,9 +69,14 @@ pub struct ResolvedBudget {
 
 impl ResolvedBudget {
     /// Verdict for a cell given the baseline and candidate p50 (ms). A non-finite or non-positive
-    /// baseline (or non-finite candidate) yields [`Verdict::NotApplicable`].
+    /// baseline **or candidate** yields [`Verdict::NotApplicable`] (latencies are strictly positive,
+    /// so a `0`/negative/NaN reading is a missing/invalid metric, not a real speedup).
     pub fn verdict(&self, baseline_p50: f64, candidate_p50: f64) -> Verdict {
-        if !baseline_p50.is_finite() || baseline_p50 <= 0.0 || !candidate_p50.is_finite() {
+        if !baseline_p50.is_finite()
+            || baseline_p50 <= 0.0
+            || !candidate_p50.is_finite()
+            || candidate_p50 <= 0.0
+        {
             return Verdict::NotApplicable;
         }
         let slower = candidate_p50 > baseline_p50;
@@ -287,6 +292,10 @@ mod tests {
         // zero/non-finite baseline => N/A
         assert_eq!(b.verdict(0.0, 1.0), Verdict::NotApplicable);
         assert_eq!(b.verdict(f64::NAN, 1.0), Verdict::NotApplicable);
+        // zero/negative/non-finite candidate => N/A (invalid latency, not a speedup)
+        assert_eq!(b.verdict(1.0, 0.0), Verdict::NotApplicable);
+        assert_eq!(b.verdict(1.0, -1.0), Verdict::NotApplicable);
+        assert_eq!(b.verdict(1.0, f64::INFINITY), Verdict::NotApplicable);
     }
 
     #[test]

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -1,0 +1,353 @@
+//! Regression thresholds for `synthetic report --regression`.
+//!
+//! A cell (operation × concurrency × cache-mode) is flagged **🔴 regressed** only when the
+//! candidate's p50 (the total-latency median) is slower than the baseline by **more than**
+//! `budget_pct` **and** the absolute p50 increase exceeds `floor_ms` (a noise guard for
+//! sub-millisecond ops). Faster — or slower within either bound — is **🟢**. A missing/zero
+//! baseline is **N/A**.
+//!
+//! The budget is resolved per `(op, concurrency)` with precedence
+//! `op.<name>.concurrency.<C>` > `op.<name>` > `[default]`, per field. The config ships a built-in
+//! default (10 %, `floor_ms = 0.5`, `metric = "p50"`) and is overridable from a TOML file that
+//! lives in the consuming repo (e.g. `falkordb-rs-next-gen`).
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::synthetic::OpName;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// Built-in default slowdown budget (percent) before a cell is flagged.
+pub const DEFAULT_BUDGET_PCT: f64 = 10.0;
+/// Built-in default absolute p50 floor (ms): slowdowns below this are treated as noise.
+pub const DEFAULT_FLOOR_MS: f64 = 0.5;
+
+/// The verdict metric. Only [`Metric::P50`] is implemented today; the others are reserved and
+/// **rejected at load time** so a config can't silently select an unimplemented rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Metric {
+    /// Total-latency median (`total_ms` p50) — the implemented verdict metric.
+    #[default]
+    P50,
+    /// Reserved for a later iteration.
+    Throughput,
+    /// Reserved for a later iteration.
+    Both,
+}
+
+/// The per-cell verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Faster, or slower within budget/floor.
+    Ok,
+    /// Slower than the budget (and beyond the noise floor).
+    Regressed,
+    /// No usable baseline (missing/zero/non-finite) — no verdict.
+    NotApplicable,
+}
+
+impl Verdict {
+    /// The emoji shown in the report's verdict column.
+    pub fn emoji(self) -> &'static str {
+        match self {
+            Verdict::Ok => "🟢",
+            Verdict::Regressed => "🔴",
+            Verdict::NotApplicable => "N/A",
+        }
+    }
+}
+
+/// The budget resolved for one `(op, concurrency)` cell.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResolvedBudget {
+    pub metric: Metric,
+    pub budget_pct: f64,
+    pub floor_ms: f64,
+}
+
+impl ResolvedBudget {
+    /// Verdict for a cell given the baseline and candidate p50 (ms). A non-finite or non-positive
+    /// baseline (or non-finite candidate) yields [`Verdict::NotApplicable`].
+    pub fn verdict(&self, baseline_p50: f64, candidate_p50: f64) -> Verdict {
+        if !baseline_p50.is_finite() || baseline_p50 <= 0.0 || !candidate_p50.is_finite() {
+            return Verdict::NotApplicable;
+        }
+        let slower = candidate_p50 > baseline_p50;
+        let over_budget = candidate_p50 > baseline_p50 * (1.0 + self.budget_pct / 100.0);
+        let over_floor = (candidate_p50 - baseline_p50) > self.floor_ms;
+        if slower && over_budget && over_floor {
+            Verdict::Regressed
+        } else {
+            Verdict::Ok
+        }
+    }
+}
+
+// ---- On-disk (raw) TOML shape ------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct RawDefault {
+    metric: Option<Metric>,
+    budget_pct: Option<f64>,
+    floor_ms: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawOp {
+    metric: Option<Metric>,
+    budget_pct: Option<f64>,
+    floor_ms: Option<f64>,
+    /// Per-concurrency `budget_pct` overrides, keyed by the concurrency level `C` (TOML keys are
+    /// strings, parsed to `usize` on load).
+    #[serde(default)]
+    concurrency: BTreeMap<String, f64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    #[serde(default)]
+    default: RawDefault,
+    #[serde(default)]
+    op: BTreeMap<String, RawOp>,
+}
+
+// ---- Validated config --------------------------------------------------------------------------
+
+/// A validated per-operation override.
+#[derive(Debug, Clone, Default)]
+struct OpThresholds {
+    metric: Option<Metric>,
+    budget_pct: Option<f64>,
+    floor_ms: Option<f64>,
+    /// Per-concurrency `budget_pct` overrides.
+    per_concurrency_budget_pct: BTreeMap<usize, f64>,
+}
+
+/// Validated regression thresholds: a `[default]` plus per-operation overrides.
+#[derive(Debug, Clone)]
+pub struct Thresholds {
+    default: ResolvedBudget,
+    ops: BTreeMap<OpName, OpThresholds>,
+}
+
+impl Default for Thresholds {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+impl Thresholds {
+    /// The built-in defaults (10 %, `floor_ms = 0.5`, `metric = p50`, no per-op overrides).
+    pub fn builtin() -> Self {
+        Thresholds {
+            default: ResolvedBudget {
+                metric: Metric::P50,
+                budget_pct: DEFAULT_BUDGET_PCT,
+                floor_ms: DEFAULT_FLOOR_MS,
+            },
+            ops: BTreeMap::new(),
+        }
+    }
+
+    /// Load + validate thresholds from a TOML file, layering it over the built-in defaults.
+    pub fn from_file(path: &str) -> BenchmarkResult<Self> {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| OtherError(format!("could not read thresholds '{path}': {e}")))?;
+        Self::from_toml_str(&text)
+            .map_err(|e| OtherError(format!("invalid thresholds '{path}': {e}")))
+    }
+
+    /// Parse + validate thresholds from a TOML string (used by [`Self::from_file`] and tests).
+    /// Returns a bare message on error (the file path is added by the caller).
+    pub fn from_toml_str(text: &str) -> Result<Self, String> {
+        let raw: RawConfig = toml::from_str(text).map_err(|e| e.to_string())?;
+
+        let default = ResolvedBudget {
+            metric: check_metric(raw.default.metric.unwrap_or_default())?,
+            budget_pct: check_budget(raw.default.budget_pct.unwrap_or(DEFAULT_BUDGET_PCT), "[default].budget_pct")?,
+            floor_ms: check_floor(raw.default.floor_ms.unwrap_or(DEFAULT_FLOOR_MS), "[default].floor_ms")?,
+        };
+
+        let mut ops = BTreeMap::new();
+        for (name, raw_op) in raw.op {
+            let op = OpName::from_tag(&name).ok_or_else(|| {
+                format!("unknown operation '{name}' in [op.{name}] — see `synthetic list-ops`")
+            })?;
+            if let Some(m) = raw_op.metric {
+                check_metric(m)?;
+            }
+            let budget_pct = raw_op
+                .budget_pct
+                .map(|v| check_budget(v, &format!("[op.{name}].budget_pct")))
+                .transpose()?;
+            let floor_ms = raw_op
+                .floor_ms
+                .map(|v| check_floor(v, &format!("[op.{name}].floor_ms")))
+                .transpose()?;
+            let mut per_concurrency_budget_pct = BTreeMap::new();
+            for (c_str, pct) in raw_op.concurrency {
+                let c: usize = c_str.parse().map_err(|_| {
+                    format!("[op.{name}].concurrency has a non-integer key '{c_str}'")
+                })?;
+                let pct = check_budget(pct, &format!("[op.{name}].concurrency.{c}"))?;
+                per_concurrency_budget_pct.insert(c, pct);
+            }
+            ops.insert(
+                op,
+                OpThresholds {
+                    metric: raw_op.metric,
+                    budget_pct,
+                    floor_ms,
+                    per_concurrency_budget_pct,
+                },
+            );
+        }
+
+        Ok(Thresholds { default, ops })
+    }
+
+    /// Resolve the budget for one `(op, concurrency)` cell. Precedence per field:
+    /// `op.<op>.concurrency.<C>` (budget only) > `op.<op>` > `[default]`.
+    pub fn resolve(&self, op: OpName, concurrency: usize) -> ResolvedBudget {
+        let over = self.ops.get(&op);
+        let budget_pct = over
+            .and_then(|o| o.per_concurrency_budget_pct.get(&concurrency).copied())
+            .or_else(|| over.and_then(|o| o.budget_pct))
+            .unwrap_or(self.default.budget_pct);
+        let floor_ms = over
+            .and_then(|o| o.floor_ms)
+            .unwrap_or(self.default.floor_ms);
+        let metric = over
+            .and_then(|o| o.metric)
+            .unwrap_or(self.default.metric);
+        ResolvedBudget {
+            metric,
+            budget_pct,
+            floor_ms,
+        }
+    }
+}
+
+fn check_metric(m: Metric) -> Result<Metric, String> {
+    match m {
+        Metric::P50 => Ok(m),
+        Metric::Throughput | Metric::Both => Err(
+            "metric must be \"p50\" — \"throughput\"/\"both\" are reserved for a later iteration"
+                .to_string(),
+        ),
+    }
+}
+
+fn check_budget(v: f64, what: &str) -> Result<f64, String> {
+    if !v.is_finite() || v < 0.0 {
+        return Err(format!("{what} must be a finite, non-negative percent (got {v})"));
+    }
+    Ok(v)
+}
+
+fn check_floor(v: f64, what: &str) -> Result<f64, String> {
+    if !v.is_finite() || v < 0.0 {
+        return Err(format!("{what} must be a finite, non-negative number of ms (got {v})"));
+    }
+    Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_defaults_are_10pct_half_ms_p50() {
+        let t = Thresholds::builtin();
+        let b = t.resolve(OpName::MatchByIndex, 32);
+        assert_eq!(b.budget_pct, 10.0);
+        assert_eq!(b.floor_ms, 0.5);
+        assert_eq!(b.metric, Metric::P50);
+    }
+
+    #[test]
+    fn verdict_faster_or_within_budget_is_ok_beyond_is_regressed() {
+        let b = ResolvedBudget { metric: Metric::P50, budget_pct: 10.0, floor_ms: 0.0 };
+        // faster
+        assert_eq!(b.verdict(2.0, 1.5), Verdict::Ok);
+        // exactly at budget (10% => 2.2) is not "more than" => Ok
+        assert_eq!(b.verdict(2.0, 2.2), Verdict::Ok);
+        // just over budget => Regressed
+        assert_eq!(b.verdict(2.0, 2.21), Verdict::Regressed);
+        // zero/non-finite baseline => N/A
+        assert_eq!(b.verdict(0.0, 1.0), Verdict::NotApplicable);
+        assert_eq!(b.verdict(f64::NAN, 1.0), Verdict::NotApplicable);
+    }
+
+    #[test]
+    fn floor_suppresses_tiny_absolute_slowdowns() {
+        // 50% slower but only +0.15ms absolute; floor 0.5ms suppresses it.
+        let b = ResolvedBudget { metric: Metric::P50, budget_pct: 10.0, floor_ms: 0.5 };
+        assert_eq!(b.verdict(0.30, 0.45), Verdict::Ok);
+        // same relative slowdown but a large absolute delta => Regressed.
+        assert_eq!(b.verdict(3.0, 4.5), Verdict::Regressed);
+    }
+
+    #[test]
+    fn precedence_per_concurrency_over_op_over_default() {
+        let cfg = r#"
+[default]
+budget_pct = 10.0
+floor_ms = 0.5
+
+[op.match_by_index]
+budget_pct = 20.0
+floor_ms = 0.1
+concurrency = { 32 = 40.0 }
+"#;
+        let t = Thresholds::from_toml_str(cfg).unwrap();
+        // default op falls back to [default]
+        assert_eq!(t.resolve(OpName::ReturnConst, 1).budget_pct, 10.0);
+        // per-op override
+        let r16 = t.resolve(OpName::MatchByIndex, 16);
+        assert_eq!(r16.budget_pct, 20.0);
+        assert_eq!(r16.floor_ms, 0.1);
+        // per-op×concurrency override wins for C=32 (floor still from the op level)
+        let r32 = t.resolve(OpName::MatchByIndex, 32);
+        assert_eq!(r32.budget_pct, 40.0);
+        assert_eq!(r32.floor_ms, 0.1);
+    }
+
+    #[test]
+    fn rejects_unknown_op_key() {
+        let err = Thresholds::from_toml_str("[op.not_a_real_op]\nbudget_pct = 5.0\n").unwrap_err();
+        assert!(err.contains("unknown operation 'not_a_real_op'"), "{err}");
+    }
+
+    #[test]
+    fn rejects_invalid_budget_and_floor_and_metric() {
+        assert!(Thresholds::from_toml_str("[default]\nbudget_pct = -1.0\n")
+            .unwrap_err()
+            .contains("non-negative percent"));
+        assert!(Thresholds::from_toml_str("[default]\nfloor_ms = -0.1\n")
+            .unwrap_err()
+            .contains("non-negative number of ms"));
+        assert!(Thresholds::from_toml_str("[default]\nmetric = \"throughput\"\n")
+            .unwrap_err()
+            .contains("reserved for a later iteration"));
+    }
+
+    #[test]
+    fn rejects_non_integer_concurrency_key() {
+        let err = Thresholds::from_toml_str(
+            "[op.match_by_index]\nconcurrency = { fast = 40.0 }\n",
+        )
+        .unwrap_err();
+        assert!(err.contains("non-integer key 'fast'"), "{err}");
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_key() {
+        // deny_unknown_fields guards typos like `budjet_pct`.
+        assert!(Thresholds::from_toml_str("[default]\nbudjet_pct = 10.0\n").is_err());
+    }
+}

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -36,6 +36,7 @@ fn base_config(graph: &str) -> Config {
         cache: CacheSelection::Both,
         out: "synthetic-report.json".to_string(),
         server_image: None,
+        label: None,
         dataset: None,
     }
 }
@@ -958,6 +959,7 @@ fn replay_config(dir: &std::path::Path, graph: &str, out: &str, load: bool) -> R
         client_deadline_ms: 6_000,
         out: out.to_string(),
         server_image: None,
+        label: None,
     }
 }
 
@@ -1088,6 +1090,7 @@ async fn record_and_replay_via_run_command() {
         client_deadline_ms: None,
         out: Some(report_out.clone()),
         server_image: None,
+        label: None,
         generate: false,
         nodes: None,
         edges: None,
@@ -1142,6 +1145,7 @@ async fn replay_concurrency_sweep_verifies_results_and_reports_levels() {
         client_deadline_ms: 6_000,
         out: dir.join("conc.json").to_string_lossy().into_owned(),
         server_image: None,
+        label: None,
     };
     // If any op returned different results at C=4 vs the single-flight reference, run() errors here.
     // The two LIMIT ops (expand_hops_5, aggregate_group) are totally ordered, so their value digests


### PR DESCRIPTION
**Update: the design is approved and Part A (the `FalkorDB/benchmark` tool) is now implemented on this PR.** Part B (the `falkordb-rs-next-gen` CI workflow + config) is a separate PR in that repo, next.

## Design (approved)
Full plan in `docs/design/synthetic-pr-regression-report.md`. Confirmed: non-blocking; add-to (not replace) the label-triggered A/B benchmark, **sequenced not in parallel**; same machine type, own VM, one container at a time; PR-vs-main only until releases exist; verdict = p50; default budget 10% + absolute floor; thresholds TOML in next-gen; divergence = non-fatal 🔴; separate SHA-pinned `SYNTHETIC_BENCHMARK_REF`.

## Part A implemented here (tool)
- **`src/synthetic/thresholds.rs`** — TOML regression budget: `[default]` (metric/`budget_pct`/`floor_ms`) + `[op.<name>]` overrides with an inline `concurrency = { <C> = <pct> }` table; precedence per field `op.<op>.concurrency.<C>` > `op.<op>` > `default`; validated (unknown ops, bad budgets, reserved metrics rejected). `Verdict::{Ok,Regressed,NotApplicable}`.
- **`run --label <name>`** — recorded into the report; used as the diff/regression column header (falls back to A/B).
- **`baseline::regression_guard`** — splits the guard: a **comparability manifest** mismatch (`workload_hash` + samples/warmup + concurrency sweep + `MAX_QUEUED_QUERIES`) → globally *not comparable*; a per-op `result_digest` mismatch → that op only (non-fatal). Strict `report --diff` is unchanged.
- **`report --diff A B --regression [--thresholds t.toml]`** — non-fatal, colored 🟢/🔴/N/A per (op × cache × concurrency) on p50; throughput for context; diverged ops → 🔴 N/A; a regressed-cell count + not-comparable note. Never aborts.
- **`MAX_QUEUED_QUERIES`** recorded in `ServerInfo` (part of the comparability manifest).

## Validation
`just ci` (build + clippy + test, **199 lib + 22 integration** green), `just doc-check`, and `just coverage` (new files: thresholds.rs 99.5%, provenance 98%, diff.rs 97%, baseline.rs 93%). Local `code-review` pass — fixed one finding (escape operator `--label` in table headers).

## Next
Part B PR in `falkordb-rs-next-gen`: `.github/synthetic-thresholds.toml` + `.github/synthetic-workload.toml`; the sequenced synthetic-A/B job (wait-for-rc-by-SHA → pin images to digests → record once → measure PR/main sequentially with `MAX_QUEUED_QUERIES` raised → `report --regression` → arch-marked sticky comment + summary, non-blocking); `SYNTHETIC_BENCHMARK_REF` pinned to this PR's merge SHA. **I'll open it after this PR is reviewed/merged so the ref can be pinned.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added non-blocking, colored `benchmark synthetic report --diff --regression` output with a regression verdict based on p50 latency and configurable budgets.
  * Introduced `--label` support to carry a run name through diff/regression report headers.
  * Added `--thresholds <FILE>` for TOML-configured regression thresholds (with sensible defaults and strict validation).

* **Documentation**
  * Updated the synthetic benchmark record/run/report workflow guide to reflect `--label`, regression behavior, and non-fatal correctness-divergence handling.

* **CI / Automation**
  * Specified a per-PR synthetic A/B pipeline using pinned workloads, sequential measurements, and best-effort (allowed-to-fail) publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->