### PR TITLE
feat(synthetic): show thresholds + compute time in the regression report header

### DIFF
--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -134,6 +134,10 @@ Add a non-fatal, colored mode alongside the strict `--diff` guard. Invocation (t
 - Emits a per-op **verdict line** and an overall count (`🔴 2 of 108 cells over budget: …`) so the
   "suspect calls that got worse" are immediately visible, plus the full per-op × cache × concurrency
   table with a 🟢/🔴/N/A column and the two runs' `--label`s as headers.
+- The report **header echoes the resolved thresholds** — a small table of the `[default]`
+  budget/floor plus any per-op and per-op×concurrency overrides, with a one-line 🟢/🔴 rule (so a
+  reviewer sees *why* a cell passed without opening the TOML) — and, when the caller passes
+  **`--elapsed-secs <n>`**, a **compute-time line** (benchmark + reporting) for the run.
 
 ### A4. Fail-soft is the *job's* responsibility, not the tool's
 

--- a/readme.md
+++ b/readme.md
@@ -467,7 +467,9 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   in a TOML file (`[default]` + `[op.<name>]` with a `concurrency` inline table). Unlike `--diff`,
   it **never aborts**: an op whose `result_digest` differs is shown 🔴 with a `⚠ results differ`
   note and a perf verdict of **N/A** (a mismatched workload/config renders the whole report
-  *not comparable*).
+  *not comparable*). The report **header echoes the resolved thresholds** (the default budget/floor
+  plus any per-op and per-op×concurrency overrides) with a one-line 🟢/🔴 rule, and — when the caller
+  passes **`--elapsed-secs <n>`** — a compute-time line (benchmark + reporting) for the run.
 - **`just synthetic-sanity`** self-checks the tool: it records the same workload twice (asserting an
   identical `workload_hash` — deterministic recording), then `run --recording` at C=1,4 + `report
   --diff` (incl. the C>1 result verification) against a throwaway Docker FalkorDB. Latency is not

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -566,6 +566,13 @@ pub enum SyntheticCommands {
             help = "Markdown output path: the diff (default synthetic-diff.md) with --diff, the regression report (default synthetic-regression.md) with --diff --regression, or the re-rendered report's Markdown when re-rendering a single report"
         )]
         out: Option<String>,
+        #[arg(
+            long = "elapsed-secs",
+            value_name = "SECONDS",
+            requires = "regression",
+            help = "with --diff --regression: total wall-clock seconds the caller spent computing this check (benchmark + reporting), rendered as a compute-time line in the report header"
+        )]
+        elapsed_secs: Option<f64>,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -569,6 +569,7 @@ pub enum SyntheticCommands {
         #[arg(
             long = "elapsed-secs",
             value_name = "SECONDS",
+            value_parser = parse_elapsed_secs,
             requires = "regression",
             help = "with --diff --regression: total wall-clock seconds the caller spent computing this check (benchmark + reporting), rendered as a compute-time line in the report header"
         )]
@@ -584,9 +585,28 @@ fn parse_write_ratio(val: &str) -> Result<f32, String> {
     }
 }
 
+/// Parse `--elapsed-secs`: a finite, non-negative number of seconds (rejects `-1`, `inf`, `NaN`).
+fn parse_elapsed_secs(val: &str) -> Result<f64, String> {
+    match val.parse::<f64>() {
+        Ok(value) if value.is_finite() && value >= 0.0 => Ok(value),
+        Ok(_) => Err(String::from("must be a finite, non-negative number of seconds")),
+        Err(_) => Err(String::from("Invalid float value")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_elapsed_secs_accepts_nonnegative_rejects_bad() {
+        assert_eq!(parse_elapsed_secs("0").unwrap(), 0.0);
+        assert_eq!(parse_elapsed_secs("754.5").unwrap(), 754.5);
+        assert!(parse_elapsed_secs("-1").is_err());
+        assert!(parse_elapsed_secs("inf").is_err());
+        assert!(parse_elapsed_secs("NaN").is_err());
+        assert!(parse_elapsed_secs("abc").is_err());
+    }
 
     #[test]
     fn parse_op_selector_accepts_magic_and_names() {

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -191,6 +191,26 @@ fn pct(
     }
 }
 
+/// Human-readable duration from seconds: `1h 2m 3s`, `4m 5s`, `12s`, or `0.4s` sub-second.
+/// `n/a` for a non-finite or negative input.
+fn fmt_duration_secs(secs: f64) -> String {
+    if !secs.is_finite() || secs < 0.0 {
+        return "n/a".to_string();
+    }
+    if secs < 1.0 {
+        return format!("{secs:.1}s");
+    }
+    let total = secs.round() as u64;
+    let (h, m, s) = (total / 3600, (total % 3600) / 60, total % 60);
+    if h > 0 {
+        format!("{h}h {m}m {s}s")
+    } else if m > 0 {
+        format!("{m}m {s}s")
+    } else {
+        format!("{s}s")
+    }
+}
+
 fn ver(report: &Report) -> String {
     report
         .meta
@@ -235,6 +255,7 @@ pub fn regression_markdown(
     candidate: &Report,
     guard: &RegressionGuard,
     thresholds: &Thresholds,
+    elapsed_secs: Option<f64>,
 ) -> String {
     let la = col_label(baseline, "baseline");
     let lb = col_label(candidate, "candidate");
@@ -244,6 +265,12 @@ pub fn regression_markdown(
         md_cell(&lb),
         md_cell(&la)
     ));
+    if let Some(secs) = elapsed_secs {
+        head.push_str(&format!(
+            "⏱ Computed in {} (benchmark + reporting).\n\n",
+            fmt_duration_secs(secs)
+        ));
+    }
     head.push_str(&format!("| field | {} | {} |\n|---|---|---|\n", md_cell(&la), md_cell(&lb)));
     row2(&mut head, "FalkorDB module", &ver(baseline), &ver(candidate));
     row2(
@@ -259,6 +286,8 @@ pub fn regression_markdown(
         &format!("{} / {}", baseline.meta.samples, baseline.meta.warmup),
         &format!("{} / {}", candidate.meta.samples, candidate.meta.warmup),
     );
+    head.push('\n');
+    head.push_str(&thresholds.settings_markdown());
 
     let (diverged, warnings) = match guard {
         RegressionGuard::NotComparable { reason } => {
@@ -560,13 +589,13 @@ mod tests {
         // within budget: +5% and +0.05 ms (below the 0.5 ms floor) => green
         let b_ok = report(42002, 1.05, 1000.0);
         let g = regression_guard(&a, &b_ok);
-        let md = regression_markdown(&a, &b_ok, &g, &Thresholds::builtin());
+        let md = regression_markdown(&a, &b_ok, &g, &Thresholds::builtin(), None);
         assert!(md.contains("🟢"), "{md}");
         assert!(md.contains("no p50 regression"), "{md}");
         // over budget: +100% and +1 ms => red
         let b_bad = report(42002, 2.0, 500.0);
         let g2 = regression_guard(&a, &b_bad);
-        let md2 = regression_markdown(&a, &b_bad, &g2, &Thresholds::builtin());
+        let md2 = regression_markdown(&a, &b_bad, &g2, &Thresholds::builtin(), None);
         assert!(md2.contains("🔴"), "{md2}");
         assert!(md2.contains("1 of 1 comparable cell(s) over budget"), "{md2}");
     }
@@ -580,7 +609,7 @@ mod tests {
         b.operations.get_mut("match_by_index").unwrap().result_digest =
             Some("sha256:bb".to_string());
         let g = regression_guard(&a, &b);
-        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
         assert!(md.contains("results differ"), "{md}");
         assert!(md.contains("🔴 N/A"), "{md}");
         // The top-line summary must be 🔴 (correctness), not a misleading 🟢.
@@ -596,7 +625,7 @@ mod tests {
         let mut b = report(42002, 1.0, 1000.0);
         b.meta.dataset.as_mut().unwrap().workload_hash = "sha256:zzz".to_string();
         let g = regression_guard(&a, &b);
-        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
         assert!(md.contains("not comparable"), "{md}");
     }
 
@@ -613,7 +642,7 @@ mod tests {
         assert!(md.contains("v1\\|x") && md.contains("v2\\|y"), "diff headers not escaped: {md}");
         // regression headers (field header + per-op header)
         let g = regression_guard(&a, &b);
-        let reg = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        let reg = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
         assert!(reg.contains("v1\\|x") && reg.contains("v2\\|y"), "regression headers not escaped: {reg}");
     }
 
@@ -625,7 +654,38 @@ mod tests {
         let a = report(42001, 0.0, 1000.0);
         let b = report(42002, 1.0, 1000.0);
         let g = regression_guard(&a, &b);
-        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin());
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
         assert!(md.contains("across 0 comparable cell(s)"), "{md}");
+    }
+
+    #[test]
+    fn regression_header_shows_thresholds_and_compute_time() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 1.0, 1000.0);
+        let g = regression_guard(&a, &b);
+        // With an elapsed value the compute-time line renders alongside the thresholds settings.
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), Some(754.0));
+        assert!(md.contains("**Thresholds**"), "settings table missing: {md}");
+        assert!(md.contains("| _default_ | 10.0% | 0.50 ms |"), "{md}");
+        assert!(md.contains("Budget precedence: per-op×concurrency"), "rule missing: {md}");
+        assert!(
+            md.contains("⏱ Computed in 12m 34s (benchmark + reporting)."),
+            "timing missing: {md}"
+        );
+        // Without an elapsed value there is no compute-time line.
+        let md_none = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
+        assert!(!md_none.contains('⏱'), "unexpected timing line: {md_none}");
+    }
+
+    #[test]
+    fn fmt_duration_secs_formats_ranges() {
+        assert_eq!(fmt_duration_secs(0.4), "0.4s");
+        assert_eq!(fmt_duration_secs(12.0), "12s");
+        assert_eq!(fmt_duration_secs(754.0), "12m 34s");
+        assert_eq!(fmt_duration_secs(3723.0), "1h 2m 3s");
+        assert_eq!(fmt_duration_secs(-1.0), "n/a");
+        assert_eq!(fmt_duration_secs(f64::NAN), "n/a");
     }
 }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1235,8 +1235,8 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             );
             Ok(())
         }
-        crate::cli::SyntheticCommands::Report { input, diff, regression, thresholds, out } => {
-            report_command(input, diff, regression, thresholds, out).await
+        crate::cli::SyntheticCommands::Report { input, diff, regression, thresholds, out, elapsed_secs } => {
+            report_command(input, diff, regression, thresholds, out, elapsed_secs).await
         }
     }
 }
@@ -1251,6 +1251,7 @@ async fn report_command(
     regression: bool,
     thresholds: Option<String>,
     out: Option<String>,
+    elapsed_secs: Option<f64>,
 ) -> BenchmarkResult<()> {
     let load = |path: &str| -> BenchmarkResult<crate::synthetic::report::Report> {
         let text = std::fs::read_to_string(path)
@@ -1270,7 +1271,7 @@ async fn report_command(
                 None => crate::synthetic::thresholds::Thresholds::builtin(),
             };
             let guard = baseline::regression_guard(&a, &b);
-            let md = diff::regression_markdown(&a, &b, &guard, &budgets);
+            let md = diff::regression_markdown(&a, &b, &guard, &budgets, elapsed_secs);
             let out_path = out.unwrap_or_else(|| "synthetic-regression.md".to_string());
             tokio::fs::write(&out_path, &md).await?;
             println!("{}", md);
@@ -1655,6 +1656,7 @@ mod tests {
             thresholds: None,
             diff: vec![],
             out: None,
+            elapsed_secs: None,
         })
         .await
         .expect_err("report with no args ⇒ error");
@@ -1701,6 +1703,7 @@ mod tests {
             thresholds: None,
             diff: vec![base.clone(), ok.clone()],
             out: Some(diff_out.clone()),
+            elapsed_secs: None,
         })
         .await
         .is_ok());
@@ -1712,6 +1715,7 @@ mod tests {
             thresholds: None,
             diff: vec![base.clone(), bad.clone()],
             out: Some(diff_out.clone()),
+            elapsed_secs: None,
         })
         .await
         .expect_err("workload_hash mismatch must abort");
@@ -1754,6 +1758,7 @@ mod tests {
             thresholds: None,
             diff: vec![a.clone(), b.clone()],
             out: Some(out.clone()),
+            elapsed_secs: None,
         })
         .await
         .is_ok());

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -37,6 +37,17 @@ pub enum Metric {
     Both,
 }
 
+impl Metric {
+    /// The stable lowercase id used in configs and reports.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Metric::P50 => "p50",
+            Metric::Throughput => "throughput",
+            Metric::Both => "both",
+        }
+    }
+}
+
 /// The per-cell verdict.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verdict {
@@ -241,6 +252,40 @@ impl Thresholds {
             floor_ms,
         }
     }
+
+    /// Render the resolved thresholds (`[default]` plus any per-op / per-op×concurrency overrides)
+    /// and the pass/fail rule as Markdown, for the regression report header.
+    pub fn settings_markdown(&self) -> String {
+        let metric = self.default.metric.as_str();
+        let mut s = String::from("**Thresholds**\n\n");
+        s.push_str("| scope | budget (slower than baseline) | floor (min Δ) |\n");
+        s.push_str("|---|---|---|\n");
+        s.push_str(&format!(
+            "| _default_ | {:.1}% | {:.2} ms |\n",
+            self.default.budget_pct, self.default.floor_ms
+        ));
+        for (op, o) in &self.ops {
+            let base = o.budget_pct.unwrap_or(self.default.budget_pct);
+            let mut budget = format!("{base:.1}%");
+            if !o.per_concurrency_budget_pct.is_empty() {
+                let per: Vec<String> = o
+                    .per_concurrency_budget_pct
+                    .iter()
+                    .map(|(c, p)| format!("c{c} {p:.1}%"))
+                    .collect();
+                budget.push_str(&format!(" ({})", per.join(", ")));
+            }
+            let floor = o.floor_ms.unwrap_or(self.default.floor_ms);
+            s.push_str(&format!("| `{}` | {budget} | {floor:.2} ms |\n", op.as_str()));
+        }
+        s.push_str(&format!(
+            "\n_Metric `{metric}`. A cell is 🔴 only when the candidate is **slower** than the \
+             baseline by **more than** its budget **and** the absolute {metric} increase exceeds \
+             the floor; faster (or slower within either bound) is 🟢 (N/A if the baseline is \
+             missing or ≤ 0). Budget precedence: per-op×concurrency > per-op > default._\n"
+        ));
+        s
+    }
 }
 
 fn check_metric(m: Metric) -> Result<Metric, String> {
@@ -405,5 +450,50 @@ concurrency = { 32 = 40.0 }
         assert_eq!(t.resolve(OpName::MatchByIndex, 1).budget_pct, 7.0);
         let _ = std::fs::remove_file(&p);
         assert!(Thresholds::from_file("/no/such/thresholds-xyz.toml").is_err());
+    }
+
+    #[test]
+    fn metric_as_str_covers_all_variants() {
+        assert_eq!(Metric::P50.as_str(), "p50");
+        assert_eq!(Metric::Throughput.as_str(), "throughput");
+        assert_eq!(Metric::Both.as_str(), "both");
+    }
+
+    #[test]
+    fn settings_markdown_builtin_shows_default_and_rule() {
+        let md = Thresholds::builtin().settings_markdown();
+        assert!(md.contains("**Thresholds**"), "{md}");
+        assert!(md.contains("| _default_ | 10.0% | 0.50 ms |"), "{md}");
+        // No per-op rows for the builtin defaults (an op row's first cell is a `backtick` name).
+        assert!(!md.contains("| `"), "builtin should have no per-op rows: {md}");
+        // The red/green rule references the metric, budget, floor, and precedence.
+        assert!(md.contains("Metric `p50`"), "{md}");
+        assert!(md.contains("🔴") && md.contains("🟢"), "{md}");
+        assert!(md.contains("budget") && md.contains("floor"), "{md}");
+        assert!(md.contains("per-op×concurrency > per-op > default"), "{md}");
+    }
+
+    #[test]
+    fn settings_markdown_renders_op_and_per_concurrency_overrides() {
+        let cfg = r#"
+[default]
+budget_pct = 10.0
+floor_ms = 0.5
+
+[op.match_by_index]
+budget_pct = 15.0
+
+[op.expand_hops_5]
+budget_pct = 12.0
+concurrency = { 16 = 18.0, 32 = 25.0 }
+"#;
+        let md = Thresholds::from_toml_str(cfg).unwrap().settings_markdown();
+        // Per-op override row (falls back to the default floor).
+        assert!(md.contains("| `match_by_index` | 15.0% | 0.50 ms |"), "{md}");
+        // Per-op×concurrency budgets are listed inline next to the op budget.
+        assert!(
+            md.contains("| `expand_hops_5` | 12.0% (c16 18.0%, c32 25.0%) | 0.50 ms |"),
+            "{md}"
+        );
     }
 }


### PR DESCRIPTION
## What it does
Makes the synthetic per-op regression report **self-explanatory** — a reviewer can see *why* a cell passed/failed and how long the check took, without opening the thresholds TOML or the CI logs.

- **Thresholds echoed in the header.** A small table of the resolved budgets: the `[default]` `budget_pct`/`floor_ms` plus any per-op and per-op×concurrency overrides (e.g. `expand_hops_5 → 12.0% (c16 18.0%, c32 25.0%)`).
- **Red/green rule spelled out.** A one-line explanation: a cell is 🔴 only when the candidate is **slower** than the baseline by **more than** its budget **and** the absolute p50 increase exceeds the floor; faster (or slower within either bound) is 🟢; N/A if the baseline is missing/≤0. Includes the precedence (`per-op×concurrency > per-op > default`).
- **Compute-time line.** `report --diff --regression` gains an optional `--elapsed-secs <n>` that renders `⏱ Computed in 12m 34s (benchmark + reporting).` at the top of the report.

## Why
Reviewers kept asking "why is +13.8% on `match_by_index` green?" / "what's the threshold for `aggregate_group`?" — the answer (per-op budget) is now in the report itself. The compute-time line surfaces how long the benchmark+reporting took.

## Changes
- `src/synthetic/thresholds.rs` — `Metric::as_str()`, `Thresholds::settings_markdown()` (+ tests).
- `src/synthetic/diff.rs` — `fmt_duration_secs()`, `regression_markdown()` renders the settings + optional compute-time line (new `elapsed_secs` arg) (+ tests).
- `src/cli.rs` / `src/synthetic/mod.rs` — thread `--elapsed-secs` through `report_command`.
- `readme.md`, `docs/design/synthetic-pr-regression-report.md` — documented.

## Validation
`just clippy`, `just test` (190 synthetic unit tests), `just doc-check` all green locally. Non-blocking, report-only; strict `--diff` untouched.

Follow-up (separate): the falkordb-rs-next-gen synthetic-run.sh will pass `--elapsed-secs` and re-pin `SYNTHETIC_BENCHMARK_REF` to this once merged.