### PR TITLE
chore(deps): bump @types/react-dom to 19.2.3 (completes #229)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -4017,13 +4017,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.2.tgz",
-      "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-gtm-module": {


### PR DESCRIPTION
Follow-up to #236: the npm-minor-patch group (#229) intended to bump `@types/react-dom` 19.0.2 → 19.2.3, but the combined PR's `npm install` kept 19.0.2 (the `^19` range was already satisfied), so the lockfile-only bump was missed. Applied surgically with `npm update @types/react-dom`.

Type-definitions-only, in-range; `just ui-lint` + `just ui-build` green. Flagged by Copilot on #236.