### PR TITLE
feat(synthetic): per-line p50 guard + folded non-gated p90/p99 + collapsed sections

### DIFF
--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -71,6 +71,11 @@ Why this meets both goals:
   verdict."* Absolute throughput is folded into the same context line (also not gated).
 - **Auditable floor** — the primary line adds the absolute `Δms` next to `Δp50` so the reader can
   check the ms floor directly (the % alone can't be checked against a ms floor).
+- **Collapsed per-op sections** — each op's cache-mode tables are wrapped in a **`<details>` collapsed
+  by default**, with the op's worst verdict (🔴 if any cell regressed or results diverged, else 🟢) on
+  the `<summary>` row. The overview (title, compute time, thresholds, summary verdict, legend) stays
+  visible; only the verbose tables collapse, so the PR sticky comment is compact and you expand just
+  the ops you care about.
 
 ## 4. Alternatives (so we choose deliberately)
 

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -122,7 +122,8 @@ Pure formatting change in the renderer; measurement/recording/JSON untouched.
   ms`) so the header *policy* and the per-line *guard* can never disagree on the same number.
 - **Missing / partial data:** `LevelMetrics` is optional per side. If one side is absent, still render
   the present side and show the absent side's tails **and** throughput as `—` (e.g.
-  `context: p90 — · p99 — · — op/s`). A zero/None baseline p50 stays **N/A** (unchanged). For an
+  `context: p90 — · p99 — · — op/s`). A zero/None/non-finite p50 on **either** side (baseline or
+  candidate) stays **N/A**, matching `ResolvedBudget::verdict` (unchanged). For an
   **unknown op** (`OpName::from_tag` → `None`) there is no resolvable guard → print `—`. For a
   **diverged** op **whose name is known**, show the context tails and the resolved `guard` value with
   the verdict already `🔴 N/A` ("shown, not evaluated"); an **unknown** diverged op stays `—` in the

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -93,7 +93,7 @@ most strongly. This is **open question §8.1**.
 | --- | --- | --- |
 | **p50** (`total_ms.median`) | **Gated** — unchanged `ResolvedBudget::verdict` | primary line |
 | p90, p99 (`total_ms.p90/.p99`) | Context only | `context:` line (or §4-A block) |
-| throughput (`op/s`, Δ) | Context only | `context:` line |
+| throughput (per-side `op/s`) | Context only | `context:` line |
 | budget_pct / floor_ms | The threshold **applied to p50** | new `guard` column |
 | absolute Δms | Audit aid for the ms floor | primary line, next to Δp50 |
 
@@ -117,13 +117,16 @@ Pure formatting change in the renderer; measurement/recording/JSON untouched.
   signed absolute delta; print the `guard` from the reused `ResolvedBudget`.
 - **Threshold formatting must be lossless-enough:** print `budget_pct` and `floor_ms` with trailing
   zeros trimmed and enough precision to round-trip the configured value (e.g. `15%`, `12.5%`,
-  `0.5 ms`, `0.05 ms`) — never round `10.04%`→`10.0%`. Guard against implying false precision.
-- **Missing / partial data:** `LevelMetrics` is optional per side. If one side is absent, still show
-  the other's context (`… · —` / `— · …`) and throughput direction (`5550→—`). A zero/None baseline p50
-  stays **N/A** (unchanged). For an **unknown op** (`OpName::from_tag` → `None`) there is no resolvable
-  guard → print `—`. For a **diverged** op, show the context tails but the `guard` cell prints the
-  configured value with the verdict already `🔴 N/A` ("shown, not evaluated"); it must **not** count
-  toward comparable cells.
+  `0.5 ms`, `0.05 ms`) — never round `10.04%`→`10.0%`. Guard against implying false precision. Apply
+  the **same** formatter to the header `Thresholds::settings_markdown` (today fixed `{:.1}%` / `{:.2}
+  ms`) so the header *policy* and the per-line *guard* can never disagree on the same number.
+- **Missing / partial data:** `LevelMetrics` is optional per side. If one side is absent, still render
+  the present side and show the absent side's tails **and** throughput as `—` (e.g.
+  `context: p90 — · p99 — · — op/s`). A zero/None baseline p50 stays **N/A** (unchanged). For an
+  **unknown op** (`OpName::from_tag` → `None`) there is no resolvable guard → print `—`. For a
+  **diverged** op **whose name is known**, show the context tails and the resolved `guard` value with
+  the verdict already `🔴 N/A` ("shown, not evaluated"); an **unknown** diverged op stays `—` in the
+  guard (no `resolve` input). Neither counts toward comparable cells.
 - Header `Thresholds` table (`settings_markdown`): **keep** as the policy-at-a-glance summary (defaults
   + overrides); per-line `guard` is the *effective* value, the header is the *policy* (drop only if
   §8.1 says so).

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -1,6 +1,7 @@
 # Design — per-line budget/floor + non-gated tail latencies (p90/p99) in the synthetic regression report
 
-**Status:** proposal for review — **not implemented**. Shared for approval before any code lands.
+**Status:** **implemented** in this PR (design retained as the record). Shared as a design first, then
+built after sign-off.
 **Scope:** presentation only, in `benchmark synthetic report --diff … --regression`
 (`regression_markdown` / `render_regression_mode`, `src/synthetic/diff.rs`). **No change** to the
 gate (still **p50-only**, `ResolvedBudget::verdict`), the comparable-cell counts, the report JSON, or

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -126,9 +126,10 @@ Pure formatting change in the renderer; measurement/recording/JSON untouched.
   `0.5 ms`, `0.05 ms`) — never round `10.04%`→`10.0%`. Guard against implying false precision. Apply
   the **same** formatter to the header `Thresholds::settings_markdown` (today fixed `{:.1}%` / `{:.2}
   ms`) so the header *policy* and the per-line *guard* can never disagree on the same number.
-- **Missing / partial data:** `LevelMetrics` is optional per side. If one side is absent, still render
-  the present side and show the absent side's tails **and** throughput as `—` (e.g.
-  `context: p90 — · p99 — · — op/s`). A zero/None/non-finite p50 on **either** side (baseline or
+- **Missing / partial data:** `LevelMetrics` is optional per side. If one side is absent, that side's
+  whole cell is `—` — a `LevelMetrics` is all-or-nothing (its percentiles come as one `Summary`), so
+  there is no partial-within-a-side data to preserve; the present side still renders its p50 +
+  `context:` line. A zero/None/non-finite p50 on **either** side (baseline or
   candidate) stays **N/A**, matching `ResolvedBudget::verdict` (unchanged). For an
   **unknown op** (`OpName::from_tag` → `None`) there is no resolvable guard → print `—`. For a
   **diverged** op **whose name is known**, show the context tails and the resolved `guard` value with

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -19,7 +19,7 @@ the CLI. This doc was rubber-duck reviewed; §7/§8/§9 fold in that feedback.
 
 Per `op × cache-mode`, one table, one row per concurrency `C` (8 columns):
 
-```
+```markdown
 _cached_
 
 | C | main p50 (ms) | pr p50 (ms) | Δp50 | main tput | pr tput | Δtput | verdict |
@@ -42,7 +42,7 @@ verified against GitHub's Markdown renderer). One row per `C`; each row reads as
 
 Raw Markdown:
 
-```
+```markdown
 _cached_ — **only p50 is gated.** The `context:` line (p90/p99, throughput) is informational and never affects the verdict.
 
 | C | main p50 (ms) | pr p50 (ms) | Δp50 (Δms) | p50 guard (>% AND >ms) | verdict |
@@ -53,7 +53,7 @@ _cached_ — **only p50 is gated.** The `context:` line (p90/p99, throughput) is
 
 Rendered, each row is two lines — the gate on top, the tucked-under context beneath each value:
 
-```
+```text
  C | main p50 (ms)          | pr p50 (ms)           | Δp50 (Δms)      | p50 guard (>% AND >ms) | verdict
  2 | 0.190                  | 0.202                 | +6.4% (+0.012)  | 15% AND 0.5 ms         | 🟢
      context: p90 0.36 …       context: p90 0.38 …
@@ -89,9 +89,9 @@ Why this meets both goals:
 - **C. Extra plain columns** (`main p90`, `pr p90`, `main p99`, `pr p99`). Clearest alignment, but ~13
   columns — wide horizontal scroll and the largest comment.
 
-**Recommendation:** ship **§3** (your folded-line steer) with the §7 guardrails, *or* **§4-A** if we
-want the leanest comment. §3 keeps every number on-screen; §4-A is smaller and separates gate/context
-most strongly. This is **open question §8.1**.
+**Selected (shipped): §3** (the folded-line layout) with the §7 guardrails **plus collapsed per-op
+`<details>` sections**. §4-A/B/C are retained as historical alternatives. (This closes former open
+question §8.1.)
 
 ## 5. Gated vs. context (the gate does not change)
 
@@ -103,7 +103,7 @@ most strongly. This is **open question §8.1**.
 | budget_pct / floor_ms | The threshold **applied to p50** | new `guard` column |
 | absolute Δms | Audit aid for the ms floor | primary line, next to Δp50 |
 
-`p95` is also computed but **left out initially** (§8.2). Tail **Δ**s are left out initially (§8.3).
+`p95` is also computed but **left out** (§8.2). Tail **Δ**s are left out (§8.3).
 
 ## 6. Data availability (no new collection)
 
@@ -136,8 +136,7 @@ Pure formatting change in the renderer; measurement/recording/JSON untouched.
   the verdict already `🔴 N/A` ("shown, not evaluated"); an **unknown** diverged op stays `—` in the
   guard (no `resolve` input). Neither counts toward comparable cells.
 - Header `Thresholds` table (`settings_markdown`): **keep** as the policy-at-a-glance summary (defaults
-  + overrides); per-line `guard` is the *effective* value, the header is the *policy* (drop only if
-  §8.1 says so).
+  + overrides); per-line `guard` is the *effective* value, the header is the *policy* (kept — §8.4).
 - **Tests (must prove tail isolation, not just presence):**
   - unchanged p50 + a *catastrophic* p90/p99 regression → **same** 🟢 verdict and same comparable count;
   - 🔴 p50 + *improved* tails → still 🔴;
@@ -148,16 +147,17 @@ Pure formatting change in the renderer; measurement/recording/JSON untouched.
     `context:` substrings render.
 - Docs: `readme.md` `--regression` section + this doc.
 
-## 8. Open questions (for you)
+## 8. Decisions (resolved — this shipped)
 
-1. **Layout:** §3 (folded context line — your steer) **or** §4-A (collapsed context table, leanest +
-   clearest separation)?
-2. **p95:** include it (`p90 · p95 · p99`) or keep just `p90 · p99`?
-3. **Tail Δ:** show only raw p90/p99 (compact) or also `Δp90`/`Δp99` to quantify tail moves?
-4. **Header Thresholds table:** keep it as the policy summary, or drop it now that each line shows the
-   effective guard?
-5. **`<br>` dependency:** the report targets GitHub Markdown (PR comments + job summaries) where `<br>`
-   renders; it degrades in a plain terminal. OK to depend on that? (§4-A/B/C avoid multi-line cells.)
+1. **Layout:** **§3** (folded context line) **+ collapsed per-op `<details>`**. §4-A/B/C kept as
+   historical alternatives.
+2. **p95:** **not** shown — just `p90 · p99` (keeps the context line compact). p95 stays available in
+   the report JSON if we want it later.
+3. **Tail Δ:** **raw p90/p99 only** (no `Δp90`/`Δp99`) — compact, and they are context, not gated.
+4. **Header Thresholds table:** **kept** as the policy-at-a-glance summary; per-line `guard` is the
+   *effective* value.
+5. **`<br>` dependency:** **yes** — the report targets GitHub Markdown (PR comments + job summaries)
+   where `<br>`/`<sub>`/`<details>` render; it degrades gracefully to plain text elsewhere.
 
 ## 9. Comment-size budget (important, from review)
 

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -1,0 +1,169 @@
+# Design — per-line budget/floor + non-gated tail latencies (p90/p99) in the synthetic regression report
+
+**Status:** proposal for review — **not implemented**. Shared for approval before any code lands.
+**Scope:** presentation only, in `benchmark synthetic report --diff … --regression`
+(`regression_markdown` / `render_regression_mode`, `src/synthetic/diff.rs`). **No change** to the
+gate (still **p50-only**, `ResolvedBudget::verdict`), the comparable-cell counts, the report JSON, or
+the CLI. This doc was rubber-duck reviewed; §7/§8/§9 fold in that feedback.
+
+## 1. Goals
+
+1. **Show the effective budget + floor on every cell row** — the exact threshold that applied to that
+   `op × cache-mode × concurrency` cell (including per-op×concurrency overrides), so a reviewer never
+   has to cross-reference the header **Thresholds** table.
+2. **Show p90 + p99 tail latencies** for context, **without gating on them**, in a way that is
+   **compact** yet **unmistakably not part of the gate**.
+
+## 2. Current format (reference)
+
+Per `op × cache-mode`, one table, one row per concurrency `C` (8 columns):
+
+```
+_cached_
+
+| C | main p50 (ms) | pr p50 (ms) | Δp50 | main tput | pr tput | Δtput | verdict |
+|--:|--:|--:|--:|--:|--:|--:|:--:|
+| 1 | 0.180 | 0.205 | +13.8% | 5550 | 4880 | -12.1% | 🟢 |
+| 2 | 0.190 | 0.202 |  +6.4% | 10200 | 9600 |  -5.9% | 🟢 |
+```
+
+Since #235 the **header** already renders a `Thresholds` summary table (`Thresholds::settings_markdown`,
+default + per-op/per-op×C overrides) and the 🟢/🔴 rule. The per-cell `budget_pct`/`floor_ms` already
+exist — `render_regression_mode` calls `thresholds.resolve(op, C)` for the verdict; today that resolved
+value is not printed on the row.
+
+## 3. Recommended layout — lean gated line + a folded context line (your steer)
+
+Keep the **primary line** on the gate (**p50** value, `Δp50`, absolute `Δms`, **guard**, verdict) and
+**fold the non-gated data** (p90/p99; absolute throughput) into a smaller second line **under each
+cell**, via `<br>` + a `context:` label (both render in GitHub PR comments and Actions job summaries —
+verified against GitHub's Markdown renderer). One row per `C`; each row reads as two visual lines.
+
+Raw Markdown:
+
+```
+_cached_ — **only p50 is gated.** The `context:` line (p90/p99, throughput) is informational and never affects the verdict.
+
+| C | main p50 (ms) | pr p50 (ms) | Δp50 (Δms) | p50 guard (>% AND >ms) | verdict |
+|--:|--:|--:|--:|:--:|:--:|
+| 1 | 0.180<br><sub>context: p90 0.34 · p99 0.51 · 5550 op/s</sub> | 0.205<br><sub>context: p90 0.39 · p99 0.60 · 4880 op/s</sub> | +13.8% (+0.025) | 15% AND 0.5 ms | 🟢 |
+| 2 | 0.190<br><sub>context: p90 0.36 · p99 0.55 · 10200 op/s</sub> | 0.202<br><sub>context: p90 0.38 · p99 0.58 · 9600 op/s</sub> |  +6.4% (+0.012) | 15% AND 0.5 ms | 🟢 |
+```
+
+Rendered, each row is two lines — the gate on top, the tucked-under context beneath each value:
+
+```
+ C | main p50 (ms)          | pr p50 (ms)           | Δp50 (Δms)      | p50 guard (>% AND >ms) | verdict
+ 2 | 0.190                  | 0.202                 | +6.4% (+0.012)  | 15% AND 0.5 ms         | 🟢
+     context: p90 0.36 …       context: p90 0.38 …
+```
+
+Why this meets both goals:
+
+- **Budget/floor per line** — the `p50 guard (>% AND >ms)` column prints the **same** `ResolvedBudget`
+  object used for the verdict, e.g. `15% AND 0.5 ms`; a per-C override (e.g. `expand_hops_5` at C=16 →
+  `18% AND 0.5 ms`) is visible in context. The `AND` header makes explicit that a 🔴 needs **both**
+  the % **and** the ms floor exceeded (`verdict` in `thresholds.rs`).
+- **p90/p99 shown, clearly not gated** — the tails live only on the smaller `context:` line, the
+  header keeps `main p50 (ms)`/`pr p50 (ms)` (p50 named, not implied), the `Δp50`/`guard`/`verdict`
+  columns are all p50, and the caption states *"only p50 is gated; the context line never affects the
+  verdict."* Absolute throughput is folded into the same context line (also not gated).
+- **Auditable floor** — the primary line adds the absolute `Δms` next to `Δp50` so the reader can
+  check the ms floor directly (the % alone can't be checked against a ms floor).
+
+## 4. Alternatives (so we choose deliberately)
+
+- **A. Collapsed context table (rubber-duck's pick; most size- and clarity-safe).** Keep a lean 6-col
+  gated table (`C | main p50 | pr p50 | Δp50 (Δms) | guard | verdict`), then **one collapsed block per
+  mode**: `<details><summary>tail latencies + throughput (context — not gated)</summary>` wrapping a
+  small table `C | main p90/p99 | pr p90/p99 | main→pr op/s (Δ)`. Strongest gate/context separation and
+  the **smallest** rendered comment; the tails are one click away.
+- **B. Packed single-line cell.** `0.190 · 0.36 · 0.55` (p50·p90·p99 in one cell, no second line).
+  Most vertically compact, but tails share the p50 line, so "not gated" rests on the caption alone.
+- **C. Extra plain columns** (`main p90`, `pr p90`, `main p99`, `pr p99`). Clearest alignment, but ~13
+  columns — wide horizontal scroll and the largest comment.
+
+**Recommendation:** ship **§3** (your folded-line steer) with the §7 guardrails, *or* **§4-A** if we
+want the leanest comment. §3 keeps every number on-screen; §4-A is smaller and separates gate/context
+most strongly. This is **open question §8.1**.
+
+## 5. Gated vs. context (the gate does not change)
+
+| Value | Role | Where |
+| --- | --- | --- |
+| **p50** (`total_ms.median`) | **Gated** — unchanged `ResolvedBudget::verdict` | primary line |
+| p90, p99 (`total_ms.p90/.p99`) | Context only | `context:` line (or §4-A block) |
+| throughput (`op/s`, Δ) | Context only | `context:` line |
+| budget_pct / floor_ms | The threshold **applied to p50** | new `guard` column |
+| absolute Δms | Audit aid for the ms floor | primary line, next to Δp50 |
+
+`p95` is also computed but **left out initially** (§8.2). Tail **Δ**s are left out initially (§8.3).
+
+## 6. Data availability (no new collection)
+
+- `Summary` already carries `median`/`p90`/`p95`/`p99` (`src/synthetic/stats.rs`); percentiles are a
+  monotonic non-decreasing sequence over the same sorted samples, so `p90 ≥ p50` always holds — a
+  `p90 < p50` would mean malformed external JSON; the renderer prints values verbatim (no reordering).
+- `thresholds.resolve(op, C) -> ResolvedBudget { budget_pct, floor_ms }` already exists and is already
+  called for the verdict. **Resolve once per (op, C) and reuse the same object for both the verdict and
+  the `guard` cell**, so the printed threshold can never disagree with the one that was applied.
+
+Pure formatting change in the renderer; measurement/recording/JSON untouched.
+
+## 7. Implementation plan + guardrails (from review)
+
+- `render_regression_mode` (`src/synthetic/diff.rs`): new column set; build each p50 cell as
+  `{p50:.3}<br><sub>context: p90 {..:.3} · p99 {..:.3} · {tput:.0} op/s</sub>`; print `Δms` as the
+  signed absolute delta; print the `guard` from the reused `ResolvedBudget`.
+- **Threshold formatting must be lossless-enough:** print `budget_pct` and `floor_ms` with trailing
+  zeros trimmed and enough precision to round-trip the configured value (e.g. `15%`, `12.5%`,
+  `0.5 ms`, `0.05 ms`) — never round `10.04%`→`10.0%`. Guard against implying false precision.
+- **Missing / partial data:** `LevelMetrics` is optional per side. If one side is absent, still show
+  the other's context (`… · —` / `— · …`) and throughput direction (`5550→—`). A zero/None baseline p50
+  stays **N/A** (unchanged). For an **unknown op** (`OpName::from_tag` → `None`) there is no resolvable
+  guard → print `—`. For a **diverged** op, show the context tails but the `guard` cell prints the
+  configured value with the verdict already `🔴 N/A` ("shown, not evaluated"); it must **not** count
+  toward comparable cells.
+- Header `Thresholds` table (`settings_markdown`): **keep** as the policy-at-a-glance summary (defaults
+  + overrides); per-line `guard` is the *effective* value, the header is the *policy* (drop only if
+  §8.1 says so).
+- **Tests (must prove tail isolation, not just presence):**
+  - unchanged p50 + a *catastrophic* p90/p99 regression → **same** 🟢 verdict and same comparable count;
+  - 🔴 p50 + *improved* tails → still 🔴;
+  - zero/missing p50 with valid tails → N/A, **0** comparable;
+  - diverged op → tails rendered but excluded from counts;
+  - per-C override renders its budget **with the inherited per-op floor**;
+  - assert the **summary line + verdict sequence** (not the whole Markdown), plus that the `guard` and
+    `context:` substrings render.
+- Docs: `readme.md` `--regression` section + this doc.
+
+## 8. Open questions (for you)
+
+1. **Layout:** §3 (folded context line — your steer) **or** §4-A (collapsed context table, leanest +
+   clearest separation)?
+2. **p95:** include it (`p90 · p95 · p99`) or keep just `p90 · p99`?
+3. **Tail Δ:** show only raw p90/p99 (compact) or also `Δp90`/`Δp99` to quantify tail moves?
+4. **Header Thresholds table:** keep it as the policy summary, or drop it now that each line shows the
+   effective guard?
+5. **`<br>` dependency:** the report targets GitHub Markdown (PR comments + job summaries) where `<br>`
+   renders; it degrades in a plain terminal. OK to depend on that? (§4-A/B/C avoid multi-line cells.)
+
+## 9. Comment-size budget (important, from review)
+
+The `falkordb-rs-next-gen` sticky comment embeds this report (up to ~108 cells: ~9 read ops × 6
+concurrencies × 2 cache modes). Folding adds `<br><sub>context: …</sub>` per side per row, which can
+**roughly double** the rendered size and push a large run toward GitHub's **65,536-char** comment cap.
+Mitigation, to decide alongside the layout:
+
+- Prefer **§4-A** (collapsed `<details>`) if size is a concern — it adds little to the primary table.
+- Add a **rendered-size assertion** in the tool tests (fail if a full 108-cell report exceeds a safe
+  budget, e.g. ~45 KB), and have the **Part-B job** post a **lean comment** (gate table only) while
+  uploading the **full report** to the job summary + artifact if the budget is exceeded. `<details>`
+  hides visual bulk but **not** body length, so the byte budget is what matters.
+
+## 10. Rollout
+
+Land in `FalkorDB/benchmark` (renderer + tests + readme); `falkordb-rs-next-gen` picks it up on the
+next `SYNTHETIC_BENCHMARK_REF` bump (same mechanism as the settings/compute-time change). Non-blocking,
+report-only; the `synthetic-verify` determinism gate is unaffected (it compares result digests, not the
+Markdown).

--- a/readme.md
+++ b/readme.md
@@ -469,7 +469,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   note and a perf verdict of **N/A** (a mismatched workload/config renders the whole report
   *not comparable*). The report **header echoes the resolved thresholds** (the default budget/floor
   plus any per-op and per-op×concurrency overrides) with a one-line 🟢/🔴 rule, and — when the caller
-  passes **`--elapsed-secs <n>`** — a compute-time line (benchmark + reporting) for the run.
+  passes **`--elapsed-secs <n>`** — a compute-time line (benchmark + reporting) for the run. Each cell
+  row also prints the **effective `p50 guard`** applied to it (e.g. `15% AND 0.5 ms`, per-op×C
+  overrides included) and the absolute `Δms`, and folds **p90/p99 + throughput** onto a smaller,
+  clearly non-gated `context:` line — the verdict stays **p50-only**.
 - **`just synthetic-sanity`** self-checks the tool: it records the same workload twice (asserting an
   identical `workload_hash` — deterministic recording), then `run --recording` at C=1,4 + `report
   --diff` (incl. the C>1 result verification) against a throwaway Docker FalkorDB. Latency is not

--- a/readme.md
+++ b/readme.md
@@ -472,7 +472,9 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   passes **`--elapsed-secs <n>`** — a compute-time line (benchmark + reporting) for the run. Each cell
   row also prints the **effective `p50 guard`** applied to it (e.g. `15% AND 0.5 ms`, per-op×C
   overrides included) and the absolute `Δms`, and folds **p90/p99 + throughput** onto a smaller,
-  clearly non-gated `context:` line — the verdict stays **p50-only**.
+  clearly non-gated `context:` line — the verdict stays **p50-only**. Each op's tables are wrapped in
+  a **collapsed `<details>`** (with the op's 🟢/🔴 verdict on the summary row) so the PR sticky
+  comment stays compact — the reader expands only the ops they care about.
 - **`just synthetic-sanity`** self-checks the tool: it records the same workload twice (asserting an
   identical `workload_hash` — deterministic recording), then `run --recording` at C=1,4 + `report
   --diff` (incl. the C>1 result verification) against a throwaway Docker FalkorDB. Latency is not

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -179,6 +179,23 @@ fn percentiles(m: &LevelMetrics) -> String {
     format!("{:.3} / {:.3} / {:.3} / {:.3}", s.median, s.p90, s.p95, s.p99)
 }
 
+/// A regression-table latency cell: the gated **p50** on the primary line, with p90/p99 and
+/// throughput folded onto a smaller `context:` line (informational, never gated). `—` when the
+/// side is absent. Values are fixed-precision measurements, so no operator-supplied text is
+/// interpolated (no `md_cell` escaping needed).
+fn latency_cell(m: Option<&LevelMetrics>) -> String {
+    match m {
+        None => "—".to_string(),
+        Some(m) => {
+            let s = &m.metrics.total_ms;
+            format!(
+                "{:.3}<br><sub>context: p90 {:.3} · p99 {:.3} · {:.0} op/s</sub>",
+                s.median, s.p90, s.p99, m.throughput_ops_per_sec
+            )
+        }
+    }
+}
+
 /// `100·(b−a)/a`, formatted with a sign; `n/a` when `a == 0`.
 fn pct(
     a: f64,
@@ -351,7 +368,8 @@ pub fn regression_markdown(
     }
     out.push_str(
         "\n🟢 = faster or within budget · 🔴 = slower than budget **or** results differ · \
-         N/A = no perf verdict. Non-blocking.\n",
+         N/A = no perf verdict. Only **p50** is gated — the `context:` line (p90/p99 · throughput) \
+         and `Δms` are informational, never part of the verdict. Non-blocking.\n",
     );
     out.push_str(&body);
     out
@@ -389,10 +407,8 @@ fn render_regression_mode(
     }
     out.push_str(&format!("\n_{}_\n\n", mode.label()));
     out.push_str(&format!(
-        "| C | {} p50 (ms) | {} p50 (ms) | Δp50 | {} tput | {} tput | Δtput | verdict |\n\
-         |---:|---:|---:|---:|---:|---:|---:|:--:|\n",
-        md_cell(la),
-        md_cell(lb),
+        "| C | {} p50 (ms) | {} p50 (ms) | Δp50 (Δms) | p50 guard (>% AND >ms) | verdict |\n\
+         |---:|---:|---:|---:|:--:|:--:|\n",
         md_cell(la),
         md_cell(lb),
     ));
@@ -401,28 +417,25 @@ fn render_regression_mode(
         let bm = level_metrics(b, op, c, mode);
         let ap = am.map(|m| m.metrics.total_ms.median);
         let bp = bm.map(|m| m.metrics.total_ms.median);
-        let a_s = ap.map(|v| format!("{v:.3}")).unwrap_or_else(|| "—".to_string());
-        let b_s = bp.map(|v| format!("{v:.3}")).unwrap_or_else(|| "—".to_string());
+        // Resolve the budget ONCE per (op, C) and reuse it for both the printed guard and the
+        // verdict, so the shown threshold can never disagree with the one that was applied.
+        let resolved = opname.map(|name| thresholds.resolve(name, c));
+
+        let a_cell = latency_cell(am);
+        let b_cell = latency_cell(bm);
+        // Gated delta: p50 % change, plus the signed absolute ms change (so the ms floor is auditable).
         let dp50 = match (ap, bp) {
-            (Some(x), Some(y)) => pct(x, y),
+            (Some(x), Some(y)) => format!("{} ({:+.3})", pct(x, y), y - x),
             _ => "—".to_string(),
         };
-        let a_tp = am
-            .map(|m| format!("{:.0}", m.throughput_ops_per_sec))
-            .unwrap_or_else(|| "—".to_string());
-        let b_tp = bm
-            .map(|m| format!("{:.0}", m.throughput_ops_per_sec))
-            .unwrap_or_else(|| "—".to_string());
-        let dtp = match (am, bm) {
-            (Some(x), Some(y)) => pct(x.throughput_ops_per_sec, y.throughput_ops_per_sec),
-            _ => "—".to_string(),
-        };
+        // The configured guard for this exact cell — only resolvable for a known op.
+        let guard = resolved.map(|r| r.guard_cell()).unwrap_or_else(|| "—".to_string());
         let verdict = if op_diverged {
             "🔴 N/A".to_string()
         } else {
-            match (ap, bp, opname) {
-                (Some(x), Some(y), Some(name)) => {
-                    let v = thresholds.resolve(name, c).verdict(x, y);
+            match (ap, bp, resolved) {
+                (Some(x), Some(y), Some(r)) => {
+                    let v = r.verdict(x, y);
                     match v {
                         Verdict::Regressed => {
                             *regressed += 1;
@@ -430,7 +443,7 @@ fn render_regression_mode(
                         }
                         // A real (comparable) 🟢 cell.
                         Verdict::Ok => *comparable_cells += 1,
-                        // Zero/non-finite baseline ⇒ no verdict; not a comparable cell.
+                        // Zero/non-finite p50 on either side ⇒ no verdict; not a comparable cell.
                         Verdict::NotApplicable => {}
                     }
                     v.emoji().to_string()
@@ -438,9 +451,7 @@ fn render_regression_mode(
                 _ => "N/A".to_string(),
             }
         };
-        out.push_str(&format!(
-            "| {c} | {a_s} | {b_s} | {dp50} | {a_tp} | {b_tp} | {dtp} | {verdict} |\n"
-        ));
+        out.push_str(&format!("| {c} | {a_cell} | {b_cell} | {dp50} | {guard} | {verdict} |\n"));
     }
 }
 
@@ -668,7 +679,7 @@ mod tests {
         // With an elapsed value the compute-time line renders alongside the thresholds settings.
         let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), Some(754.0));
         assert!(md.contains("**Thresholds**"), "settings table missing: {md}");
-        assert!(md.contains("| _default_ | 10.0% | 0.50 ms |"), "{md}");
+        assert!(md.contains("| _default_ | 10% | 0.5 ms |"), "{md}");
         assert!(md.contains("Budget precedence: per-op×concurrency"), "rule missing: {md}");
         assert!(
             md.contains("⏱ Computed in 12m 34s (benchmark + reporting)."),
@@ -687,5 +698,136 @@ mod tests {
         assert_eq!(fmt_duration_secs(3723.0), "1h 2m 3s");
         assert_eq!(fmt_duration_secs(-1.0), "n/a");
         assert_eq!(fmt_duration_secs(f64::NAN), "n/a");
+    }
+
+    // --- folded layout: per-line guard + non-gated p90/p99 context -----------------------------
+
+    /// Mutate the candidate's cached `total_ms` percentiles in place (keeping p50) so tests can
+    /// isolate tail behaviour from the gated p50.
+    fn set_tails(r: &mut Report, p90: f64, p99: f64) {
+        let m = r
+            .operations
+            .get_mut("match_by_index")
+            .unwrap()
+            .levels[0]
+            .cached
+            .as_mut()
+            .unwrap();
+        m.metrics.total_ms.p90 = p90;
+        m.metrics.total_ms.p99 = p99;
+    }
+
+    #[test]
+    fn regression_row_folds_context_and_shows_per_line_guard() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 1.1, 900.0); // +10% p50 (+0.100 ms), −10% tput
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
+        // Header keeps p50 named and adds the guard column.
+        assert!(md.contains("p50 (ms)") && md.contains("p50 guard (>% AND >ms)"), "{md}");
+        // Δp50 carries the signed absolute ms delta so the floor is auditable.
+        assert!(md.contains("(+0.100)"), "Δms missing: {md}");
+        // p90/p99 + throughput are folded onto the context line (not their own columns).
+        assert!(md.contains("<br><sub>context: p90 ") && md.contains("op/s</sub>"), "{md}");
+        // The per-line guard shows the resolved default (10%) + floor.
+        assert!(md.contains("10% AND 0.5 ms"), "guard cell: {md}");
+        // Legend states the gate is p50-only.
+        assert!(md.contains("Only **p50** is gated"), "{md}");
+    }
+
+    #[test]
+    fn catastrophic_tail_regression_does_not_change_the_p50_verdict() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        // Identical p50 on both sides ⇒ green. Baseline unchanged, candidate tails blown up.
+        let a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        set_tails(&mut b, 50.0, 500.0);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
+        // Verdict + comparable count are exactly what they'd be without the tail blow-up.
+        assert!(
+            md.contains("🟢 no p50 regression beyond budget across 1 comparable cell(s)"),
+            "tails must not gate: {md}"
+        );
+        // …and the blown-up tail is still shown, as context.
+        assert!(md.contains("context: p90 50.000 · p99 500.000"), "{md}");
+    }
+
+    #[test]
+    fn red_p50_stays_red_even_with_improved_tails() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 2.0, 500.0); // +100% p50 ⇒ red
+        set_tails(&mut b, 0.10, 0.20); // tails *better* than baseline — must not rescue the verdict
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
+        assert!(md.contains("🔴 1 of 1 comparable cell(s) over budget"), "{md}");
+    }
+
+    #[test]
+    fn per_line_guard_reflects_op_override_with_inherited_floor() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        // Op override changes the budget; the floor is inherited from [default].
+        let t = Thresholds::from_toml_str("[op.match_by_index]\nbudget_pct = 20.0\n").unwrap();
+        let a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 1.0, 1000.0);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &t, None);
+        assert!(md.contains("20% AND 0.5 ms"), "resolved override guard: {md}");
+    }
+
+    /// A full-size report: every read op × the whole concurrency sweep × both cache modes.
+    fn big_report(ver: u64) -> Report {
+        let ops = [
+            "return_const",
+            "match_by_index",
+            "match_by_label_scan",
+            "expand_1_hop",
+            "expand_hops_5",
+            "aggregate_count",
+            "aggregate_group",
+            "shortest_path",
+            "property_projection",
+        ];
+        let sweep = [1usize, 2, 4, 8, 16, 32];
+        let mut operations = BTreeMap::new();
+        for op in ops {
+            let levels = sweep
+                .iter()
+                .map(|&c| LevelReport {
+                    concurrency: c,
+                    cached: Some(metrics(0.512, 5000.0)),
+                    uncached: Some(metrics(0.987, 3000.0)),
+                    compilation_ms_median: None,
+                })
+                .collect();
+            operations.insert(
+                op.to_string(),
+                OperationReport { levels, result_digest: Some("sha256:aa".to_string()) },
+            );
+        }
+        let mut r = report(ver, 1.0, 1000.0);
+        r.operations = operations;
+        r
+    }
+
+    #[test]
+    fn full_report_stays_under_comment_budget() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = big_report(1);
+        let b = big_report(2);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), Some(300.0));
+        // 9 ops × 6 concurrencies × 2 cache modes = 108 cells. Keep the rendered report well under
+        // GitHub's 65_536-char comment cap so the Part-B sticky comment keeps headroom for its
+        // wrappers/warnings (see the design's comment-size budget).
+        assert!(md.len() < 45_000, "regression report too large: {} bytes", md.len());
+        assert!(md.contains("`shortest_path`") && md.contains("`return_const`"), "missing ops");
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -337,6 +337,7 @@ pub fn regression_markdown(
         let op_diverged = diverged.contains(op);
         let opname = OpName::from_tag(op);
         let regressed_before = regressed;
+        let comparable_before = comparable_cells;
         // Render this op's cache-mode tables into a temp buffer so the whole op section can be
         // wrapped in a **collapsed** <details> — keeps the PR sticky comment compact by default.
         let mut op_body = String::new();
@@ -349,8 +350,16 @@ pub fn regression_markdown(
         if op_body.trim().is_empty() {
             continue;
         }
-        // Per-op headline shown on the collapsed row: 🔴 if any cell regressed OR results diverged.
-        let op_emoji = if op_diverged || regressed > regressed_before { "🔴" } else { "🟢" };
+        // Per-op headline on the collapsed row: 🔴 if any cell regressed OR results diverged; 🟢 if
+        // it had ≥1 comparable cell and none regressed; N/A when no cell was evaluable (all rows
+        // N/A) so it never reads like a pass.
+        let op_emoji = if op_diverged || regressed > regressed_before {
+            "🔴"
+        } else if comparable_cells > comparable_before {
+            "🟢"
+        } else {
+            "N/A"
+        };
         let diverged_note =
             if op_diverged { " — ⚠ results differ (perf verdict N/A)" } else { "" };
         body.push_str(&format!(
@@ -441,9 +450,13 @@ fn render_regression_mode(
 
         let a_cell = latency_cell(am);
         let b_cell = latency_cell(bm);
-        // Gated delta: p50 % change, plus the signed absolute ms change (so the ms floor is auditable).
+        // Gated delta: p50 % change + signed absolute ms change (so the ms floor is auditable).
+        // Only shown when both p50s are valid (finite, > 0) — i.e. exactly when a verdict exists;
+        // otherwise the cell is N/A and an absolute Δ would be misleading.
         let dp50 = match (ap, bp) {
-            (Some(x), Some(y)) => format!("{} ({:+.3})", pct(x, y), y - x),
+            (Some(x), Some(y)) if x.is_finite() && x > 0.0 && y.is_finite() && y > 0.0 => {
+                format!("{} ({:+.3})", pct(x, y), y - x)
+            }
             _ => "—".to_string(),
         };
         // The configured guard for this exact cell — only resolvable for a known op.
@@ -685,6 +698,11 @@ mod tests {
         let g = regression_guard(&a, &b);
         let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
         assert!(md.contains("across 0 comparable cell(s)"), "{md}");
+        // An all-N/A op reads as N/A on its collapsed summary, never a green pass.
+        assert!(md.contains("N/A <code>match_by_index</code></summary>"), "{md}");
+        assert!(!md.contains("🟢 <code>match_by_index</code>"), "{md}");
+        // A zero/invalid p50 ⇒ the Δp50 (Δms) cell is `—`, not a misleading `n/a (+…)`.
+        assert!(!md.contains("n/a (+"), "no absolute Δ for N/A cells: {md}");
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -196,6 +196,13 @@ fn latency_cell(m: Option<&LevelMetrics>) -> String {
     }
 }
 
+/// Escape a string for safe embedding as **HTML text** (e.g. inside a `<code>`/`<summary>`): a
+/// crafted report could carry an op key with `<`, `>` or `&` that would otherwise break the
+/// `<details>` markup or inject HTML into the PR comment. Order matters — `&` first.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+}
+
 /// `100·(b−a)/a`, formatted with a sign; `n/a` when `a == 0`.
 fn pct(
     a: f64,
@@ -347,7 +354,8 @@ pub fn regression_markdown(
         let diverged_note =
             if op_diverged { " — ⚠ results differ (perf verdict N/A)" } else { "" };
         body.push_str(&format!(
-            "\n<details><summary>{op_emoji} <code>{op}</code>{diverged_note}</summary>\n{op_body}\n</details>\n"
+            "\n<details><summary>{op_emoji} <code>{}</code>{diverged_note}</summary>\n{op_body}\n</details>\n",
+            html_escape(op)
         ));
     }
 
@@ -862,5 +870,23 @@ mod tests {
             "per-op verdict in the collapsed summary: {md}"
         );
         assert!(!md.contains("#### `match_by_index`"), "old heading should be gone: {md}");
+    }
+
+    #[test]
+    fn op_name_is_html_escaped_in_the_collapsed_summary() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        // A crafted report could carry an op key with HTML-special chars; it must not break markup.
+        let evil = "x<b>&y";
+        let mut a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        let va = a.operations.remove("match_by_index").unwrap();
+        a.operations.insert(evil.to_string(), va);
+        let vb = b.operations.remove("match_by_index").unwrap();
+        b.operations.insert(evil.to_string(), vb);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
+        assert!(md.contains("<code>x&lt;b&gt;&amp;y</code>"), "op not HTML-escaped: {md}");
+        assert!(!md.contains("<code>x<b>&y"), "raw HTML leaked: {md}");
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -328,17 +328,27 @@ pub fn regression_markdown(
         .collect();
     for op in ops {
         let op_diverged = diverged.contains(op);
-        body.push_str(&format!(
-            "\n#### `{op}`{}\n",
-            if op_diverged { "  —  ⚠ results differ (perf verdict N/A)" } else { "" }
-        ));
         let opname = OpName::from_tag(op);
+        let regressed_before = regressed;
+        // Render this op's cache-mode tables into a temp buffer so the whole op section can be
+        // wrapped in a **collapsed** <details> — keeps the PR sticky comment compact by default.
+        let mut op_body = String::new();
         for mode in [Mode::Cached, Mode::Uncached] {
             render_regression_mode(
-                &mut body, baseline, candidate, op, opname, mode, op_diverged, thresholds, &la,
+                &mut op_body, baseline, candidate, op, opname, mode, op_diverged, thresholds, &la,
                 &lb, &mut regressed, &mut comparable_cells,
             );
         }
+        if op_body.trim().is_empty() {
+            continue;
+        }
+        // Per-op headline shown on the collapsed row: 🔴 if any cell regressed OR results diverged.
+        let op_emoji = if op_diverged || regressed > regressed_before { "🔴" } else { "🟢" };
+        let diverged_note =
+            if op_diverged { " — ⚠ results differ (perf verdict N/A)" } else { "" };
+        body.push_str(&format!(
+            "\n<details><summary>{op_emoji} <code>{op}</code>{diverged_note}</summary>\n{op_body}\n</details>\n"
+        ));
     }
 
     // Assemble: header + summary + warnings + legend + body. The top-line is 🟢 only when there
@@ -752,6 +762,8 @@ mod tests {
             md.contains("🟢 no p50 regression beyond budget across 1 comparable cell(s)"),
             "tails must not gate: {md}"
         );
+        // …the op's collapsed summary is 🟢 (its p50 didn't regress)…
+        assert!(md.contains("🟢 <code>match_by_index</code></summary>"), "{md}");
         // …and the blown-up tail is still shown, as context.
         assert!(md.contains("context: p90 50.000 · p99 500.000"), "{md}");
     }
@@ -828,6 +840,27 @@ mod tests {
         // GitHub's 65_536-char comment cap so the Part-B sticky comment keeps headroom for its
         // wrappers/warnings (see the design's comment-size budget).
         assert!(md.len() < 45_000, "regression report too large: {} bytes", md.len());
-        assert!(md.contains("`shortest_path`") && md.contains("`return_const`"), "missing ops");
+        assert!(
+            md.contains("<code>shortest_path</code>") && md.contains("<code>return_const</code>"),
+            "missing ops"
+        );
+    }
+
+    #[test]
+    fn per_op_sections_are_collapsed_with_verdict_in_summary() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        // A regressed op shows 🔴 on its collapsed summary row; the `####` heading is gone.
+        let a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 2.0, 500.0); // +100% p50 ⇒ regressed
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &Thresholds::builtin(), None);
+        assert!(md.contains("<details><summary>"), "sections must be collapsible: {md}");
+        assert!(md.contains("</details>"), "{md}");
+        assert!(
+            md.contains("🔴 <code>match_by_index</code></summary>"),
+            "per-op verdict in the collapsed summary: {md}"
+        );
+        assert!(!md.contains("#### `match_by_index`"), "old heading should be gone: {md}");
     }
 }

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -99,6 +99,24 @@ impl ResolvedBudget {
             Verdict::Ok
         }
     }
+
+    /// The per-cell guard as printed in the report: `<budget>% AND <floor> ms`. Named "AND" because
+    /// a cell is 🔴 only when the candidate p50 is slower by MORE than the budget **and** the
+    /// absolute increase exceeds the floor — both must hold (see [`Self::verdict`]).
+    pub fn guard_cell(&self) -> String {
+        format!(
+            "{}% AND {} ms",
+            fmt_threshold(self.budget_pct),
+            fmt_threshold(self.floor_ms)
+        )
+    }
+}
+
+/// Lossless-enough rendering of a threshold number: trailing zeros trimmed, round-tripping the
+/// configured value (Rust's `f64` `Display` gives the shortest exact form — `10`, `12.5`, `0.5`,
+/// `0.05`). Shared by the header settings table and the per-line guard so they never disagree.
+fn fmt_threshold(v: f64) -> String {
+    format!("{v}")
 }
 
 // ---- On-disk (raw) TOML shape ------------------------------------------------------------------
@@ -261,22 +279,23 @@ impl Thresholds {
         s.push_str("| scope | budget (slower than baseline) | floor (min Δ) |\n");
         s.push_str("|---|---|---|\n");
         s.push_str(&format!(
-            "| _default_ | {:.1}% | {:.2} ms |\n",
-            self.default.budget_pct, self.default.floor_ms
+            "| _default_ | {}% | {} ms |\n",
+            fmt_threshold(self.default.budget_pct),
+            fmt_threshold(self.default.floor_ms)
         ));
         for (op, o) in &self.ops {
             let base = o.budget_pct.unwrap_or(self.default.budget_pct);
-            let mut budget = format!("{base:.1}%");
+            let mut budget = format!("{}%", fmt_threshold(base));
             if !o.per_concurrency_budget_pct.is_empty() {
                 let per: Vec<String> = o
                     .per_concurrency_budget_pct
                     .iter()
-                    .map(|(c, p)| format!("c{c} {p:.1}%"))
+                    .map(|(c, p)| format!("c{c} {}%", fmt_threshold(*p)))
                     .collect();
                 budget.push_str(&format!(" ({})", per.join(", ")));
             }
             let floor = o.floor_ms.unwrap_or(self.default.floor_ms);
-            s.push_str(&format!("| `{}` | {budget} | {floor:.2} ms |\n", op.as_str()));
+            s.push_str(&format!("| `{}` | {budget} | {} ms |\n", op.as_str(), fmt_threshold(floor)));
         }
         s.push_str(&format!(
             "\n_Metric `{metric}`. A cell is 🔴 only when the candidate is **slower** than the \
@@ -463,7 +482,7 @@ concurrency = { 32 = 40.0 }
     fn settings_markdown_builtin_shows_default_and_rule() {
         let md = Thresholds::builtin().settings_markdown();
         assert!(md.contains("**Thresholds**"), "{md}");
-        assert!(md.contains("| _default_ | 10.0% | 0.50 ms |"), "{md}");
+        assert!(md.contains("| _default_ | 10% | 0.5 ms |"), "{md}");
         // No per-op rows for the builtin defaults (an op row's first cell is a `backtick` name).
         assert!(!md.contains("| `"), "builtin should have no per-op rows: {md}");
         // The red/green rule references the metric, budget, floor, and precedence.
@@ -489,11 +508,24 @@ concurrency = { 16 = 18.0, 32 = 25.0 }
 "#;
         let md = Thresholds::from_toml_str(cfg).unwrap().settings_markdown();
         // Per-op override row (falls back to the default floor).
-        assert!(md.contains("| `match_by_index` | 15.0% | 0.50 ms |"), "{md}");
+        assert!(md.contains("| `match_by_index` | 15% | 0.5 ms |"), "{md}");
         // Per-op×concurrency budgets are listed inline next to the op budget.
         assert!(
-            md.contains("| `expand_hops_5` | 12.0% (c16 18.0%, c32 25.0%) | 0.50 ms |"),
+            md.contains("| `expand_hops_5` | 12% (c16 18%, c32 25%) | 0.5 ms |"),
             "{md}"
         );
+    }
+
+    #[test]
+    fn guard_cell_and_fmt_threshold_are_lossless() {
+        assert_eq!(fmt_threshold(10.0), "10");
+        assert_eq!(fmt_threshold(12.5), "12.5");
+        assert_eq!(fmt_threshold(0.5), "0.5");
+        assert_eq!(fmt_threshold(0.05), "0.05");
+        let b = ResolvedBudget { metric: Metric::P50, budget_pct: 12.0, floor_ms: 0.5 };
+        assert_eq!(b.guard_cell(), "12% AND 0.5 ms");
+        // A non-round budget must not be rounded away.
+        let b2 = ResolvedBudget { metric: Metric::P50, budget_pct: 10.04, floor_ms: 0.05 };
+        assert_eq!(b2.guard_cell(), "10.04% AND 0.05 ms");
     }
 }

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -116,6 +116,9 @@ impl ResolvedBudget {
 /// configured value (Rust's `f64` `Display` gives the shortest exact form — `10`, `12.5`, `0.5`,
 /// `0.05`). Shared by the header settings table and the per-line guard so they never disagree.
 fn fmt_threshold(v: f64) -> String {
+    // Normalize `-0.0` (accepted by check_budget/check_floor, since it isn't `< 0.0`) so it never
+    // renders as a spurious "-0".
+    let v = if v == 0.0 { 0.0 } else { v };
     format!("{v}")
 }
 
@@ -522,6 +525,7 @@ concurrency = { 16 = 18.0, 32 = 25.0 }
         assert_eq!(fmt_threshold(12.5), "12.5");
         assert_eq!(fmt_threshold(0.5), "0.5");
         assert_eq!(fmt_threshold(0.05), "0.05");
+        assert_eq!(fmt_threshold(-0.0), "0"); // normalized, never "-0"
         let b = ResolvedBudget { metric: Metric::P50, budget_pct: 12.0, floor_ms: 0.5 };
         assert_eq!(b.guard_cell(), "12% AND 0.5 ms");
         // A non-round budget must not be rounded away.


### PR DESCRIPTION
**Implemented** (started as a design draft; the design doc is retained in `docs/design/` as the record).

Report-only change to the synthetic per-op regression report (`benchmark synthetic report --diff … --regression`); the **gate stays p50-only**:

1. show the **effective budget + floor on each cell row** — a `p50 guard` column (e.g. `15% AND 0.5 ms`, per-op×concurrency overrides included), resolved once per (op, C) and reused for both the printed guard and the verdict; plus the absolute `Δms` next to `Δp50`;
2. show **p90/p99** (and throughput) as a **folded, clearly non-gated `context:` line** under each p50 cell;
3. **collapse each per-op section** by default (`<details>` with the op's 🟢/🔴 verdict on the summary row) so the PR sticky comment stays compact;
4. **lossless threshold formatting** shared by the header Thresholds table and the per-line guard (no `10.04% → 10.0%`, no `-0`).

Guardrails from the rubber-duck review + two local code-reviews: mutation tests prove a catastrophic tail regression keeps the same verdict/count and a red p50 stays red with improved tails; a size test keeps a full 108-cell report ~24 KB (< 65 KB comment cap). `just clippy` / `just test` (215) / `just doc-check` all green.

Once merged, `falkordb-rs-next-gen` picks it up on the next `SYNTHETIC_BENCHMARK_REF` bump.
