### PR TITLE
feat(synthetic): recursively canonicalize every FalkorValue for a deterministic result digest

### DIFF
--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -548,10 +548,11 @@ mod tests {
 
     #[test]
     fn canonical_value_distinguishes_structurally_different_shapes() {
-        // A string that happens to look like a compound's rendering can't alias the real compound
-        // (distinct type tags + length framing).
+        // A string that happens to look like a compound's rendering can't alias the real compound:
+        // even when its *content* is byte-identical to the array's canonical rendering, the `s:`
+        // type tag keeps the two apart.
         let arr = FalkorValue::Array(vec![FalkorValue::I64(1)]);
-        let lookalike = FalkorValue::String(canonical_value(&arr).trim_start_matches("arr").into());
+        let lookalike = FalkorValue::String(canonical_value(&arr));
         assert_ne!(canonical_value(&arr), canonical_value(&lookalike));
         // A node and an edge with the same id don't collide.
         let node = FalkorValue::Node(Node {

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -9,9 +9,10 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::synthetic::writes::MutationStats;
-use falkordb::{AsyncGraph, FalkorValue};
+use falkordb::{AsyncGraph, Edge, FalkorValue, Node};
 use futures::StreamExt;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 use tokio::time::error::Elapsed;
@@ -189,8 +190,16 @@ fn canonical_row(values: &[FalkorValue]) -> String {
     s
 }
 
-/// A stable string for one scalar [`FalkorValue`] (the shapes our read ops return). Floats use their
-/// bit pattern so equal values always render identically; other shapes fall back to `Debug`.
+/// A stable, **recursive** canonical string for any [`FalkorValue`] — including the compound shapes
+/// (nodes, edges, paths, maps, arrays, vectors, points, temporals) our read ops can return.
+///
+/// The invariant that makes the result digest deterministic across processes: **`Map` and property
+/// keys are sorted** (a `HashMap`'s iteration order is randomized per process —
+/// `vendor/falkordb-rs/src/value/graph_entities.rs`), while **array and path order is preserved**
+/// (those carry meaningful, server-stable order). Every nested value is length-prefixed
+/// (`<byte-len>:<value>`) and each variant carries a distinct type tag, so no value can alias a
+/// structurally different one. Floats (and `f32` vector lanes / point coordinates) use their bit
+/// pattern so equal values always render identically.
 fn canonical_value(v: &FalkorValue) -> String {
     match v {
         FalkorValue::I64(i) => format!("i:{i}"),
@@ -198,8 +207,103 @@ fn canonical_value(v: &FalkorValue) -> String {
         FalkorValue::Bool(b) => format!("b:{b}"),
         FalkorValue::String(s) => format!("s:{s}"),
         FalkorValue::None => "null".to_string(),
+        FalkorValue::Unparseable(s) => format!("unparseable:{s}"),
+        FalkorValue::Node(n) => canonical_node(n),
+        FalkorValue::Edge(e) => canonical_edge(e),
+        FalkorValue::Path(p) => {
+            // A path's node and relationship sequences are ordered — preserve both.
+            let mut nodes = String::new();
+            for n in &p.nodes {
+                push_field(&mut nodes, &canonical_node(n));
+            }
+            let mut rels = String::new();
+            for r in &p.relationships {
+                push_field(&mut rels, &canonical_edge(r));
+            }
+            let mut s = String::new();
+            push_field(&mut s, &nodes);
+            push_field(&mut s, &rels);
+            format!("path[{s}]")
+        }
+        FalkorValue::Array(items) => {
+            // Array order is meaningful (and server-stable) — preserve it.
+            let mut s = String::new();
+            for item in items {
+                push_field(&mut s, &canonical_value(item));
+            }
+            format!("arr[{s}]")
+        }
+        FalkorValue::Map(m) => format!("map[{}]", canonical_map(m)),
+        FalkorValue::Vec32(v) => {
+            // A search vector's lane order is meaningful — preserve it; bit-pattern each `f32`.
+            let mut s = String::new();
+            for f in &v.values {
+                push_field(&mut s, &format!("{:08x}", f.to_bits()));
+            }
+            format!("vec32[{s}]")
+        }
+        FalkorValue::Point(p) => format!(
+            "point:{:016x},{:016x}",
+            p.latitude.to_bits(),
+            p.longitude.to_bits()
+        ),
+        FalkorValue::DateTime(t) => format!("datetime:{}", t.seconds().get()),
+        FalkorValue::Date(t) => format!("date:{}", t.seconds().get()),
+        FalkorValue::Time(t) => format!("time:{}", t.seconds().get()),
+        FalkorValue::Duration(t) => format!("duration:{}", t.seconds().get()),
+        // `FalkorValue` is `#[non_exhaustive]`; a future variant falls back to `Debug` (tagged `o:`)
+        // so the digest stays defined rather than failing to compile.
         other => format!("o:{other:?}"),
     }
+}
+
+/// Append `content` to `out` length-prefixed as `<byte-len>:<content>`, so concatenated fields can't
+/// shift a boundary and alias a different structure (the same framing [`canonical_row`] uses).
+fn push_field(
+    out: &mut String,
+    content: &str,
+) {
+    out.push_str(&content.len().to_string());
+    out.push(':');
+    out.push_str(content);
+}
+
+/// Canonicalize a property/`Map` bag: entries emitted **key-sorted** (a `HashMap`'s iteration order
+/// is process-unstable) as length-prefixed `key`/`value` pairs.
+fn canonical_map(m: &HashMap<String, FalkorValue>) -> String {
+    let mut entries: Vec<(&String, &FalkorValue)> = m.iter().collect();
+    entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+    let mut s = String::new();
+    for (k, val) in entries {
+        push_field(&mut s, k);
+        push_field(&mut s, &canonical_value(val));
+    }
+    s
+}
+
+/// Canonicalize a [`Node`]: its id, its labels (server order preserved) and its key-sorted
+/// properties.
+fn canonical_node(n: &Node) -> String {
+    let mut labels = String::new();
+    for l in &n.labels {
+        push_field(&mut labels, l);
+    }
+    let mut s = String::new();
+    push_field(&mut s, &format!("id:{}", n.entity_id));
+    push_field(&mut s, &labels);
+    push_field(&mut s, &canonical_map(&n.properties));
+    format!("node[{s}]")
+}
+
+/// Canonicalize an [`Edge`]: its id, relationship type, endpoints and key-sorted properties.
+fn canonical_edge(e: &Edge) -> String {
+    let mut s = String::new();
+    push_field(&mut s, &format!("id:{}", e.entity_id));
+    push_field(&mut s, &format!("type:{}", e.relationship_type));
+    push_field(&mut s, &format!("src:{}", e.src_node_id));
+    push_field(&mut s, &format!("dst:{}", e.dst_node_id));
+    push_field(&mut s, &canonical_map(&e.properties));
+    format!("edge[{s}]")
 }
 
 /// Validate FalkorDB's reported internal execution time: it must be present, finite and
@@ -227,21 +331,247 @@ fn validate_server_ms(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use falkordb::{Date, DateTime, Duration, Path, Point, Time};
+
+    fn map_of(pairs: &[(&str, FalkorValue)]) -> HashMap<String, FalkorValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
 
     #[test]
-    fn canonical_value_covers_every_shape() {
+    fn canonical_value_covers_every_scalar_shape() {
         assert_eq!(canonical_value(&FalkorValue::I64(7)), "i:7");
         assert_eq!(canonical_value(&FalkorValue::Bool(true)), "b:true");
         assert_eq!(canonical_value(&FalkorValue::String("x".into())), "s:x");
         assert_eq!(canonical_value(&FalkorValue::None), "null");
+        assert_eq!(
+            canonical_value(&FalkorValue::Unparseable("boom".into())),
+            "unparseable:boom"
+        );
         // Floats use their bit pattern so equal values render identically.
         assert_eq!(
             canonical_value(&FalkorValue::F64(1.5)),
             canonical_value(&FalkorValue::F64(1.5))
         );
         assert!(canonical_value(&FalkorValue::F64(1.5)).starts_with("f:"));
-        // A non-scalar falls back to Debug (tagged `o:`).
-        assert!(canonical_value(&FalkorValue::Array(vec![FalkorValue::I64(1)])).starts_with("o:"));
+    }
+
+    #[test]
+    fn canonical_value_renders_temporal_and_point() {
+        assert_eq!(
+            canonical_value(&FalkorValue::DateTime(DateTime::new(90))),
+            "datetime:90"
+        );
+        assert_eq!(
+            canonical_value(&FalkorValue::Date(Date::new(-5))),
+            "date:-5"
+        );
+        assert_eq!(canonical_value(&FalkorValue::Time(Time::new(3))), "time:3");
+        assert_eq!(
+            canonical_value(&FalkorValue::Duration(Duration::new(60))),
+            "duration:60"
+        );
+        // A point renders both coordinates by bit pattern; equal points render identically.
+        let p = FalkorValue::Point(Point {
+            latitude: 1.5,
+            longitude: -2.25,
+        });
+        assert!(canonical_value(&p).starts_with("point:"));
+        assert_eq!(
+            canonical_value(&p),
+            canonical_value(&FalkorValue::Point(Point {
+                latitude: 1.5,
+                longitude: -2.25,
+            }))
+        );
+    }
+
+    #[test]
+    fn canonical_map_sorts_keys_regardless_of_insertion_order() {
+        // Two maps with identical entries but built in the opposite insertion order canonicalize
+        // identically — the whole point, since a `HashMap`'s iteration order is process-unstable.
+        let mut a = HashMap::new();
+        a.insert("b".to_string(), FalkorValue::I64(2));
+        a.insert("a".to_string(), FalkorValue::I64(1));
+        let mut b = HashMap::new();
+        b.insert("a".to_string(), FalkorValue::I64(1));
+        b.insert("b".to_string(), FalkorValue::I64(2));
+        assert_eq!(canonical_map(&a), canonical_map(&b));
+        // …and the canonical order is key-sorted ("a" before "b"), length-prefixed.
+        assert_eq!(canonical_map(&a), "1:a3:i:11:b3:i:2");
+        assert_eq!(
+            canonical_value(&FalkorValue::Map(a)),
+            "map[1:a3:i:11:b3:i:2]"
+        );
+    }
+
+    #[test]
+    fn canonical_map_is_value_sensitive() {
+        let a = FalkorValue::Map(map_of(&[("k", FalkorValue::I64(1))]));
+        let b = FalkorValue::Map(map_of(&[("k", FalkorValue::I64(2))]));
+        assert_ne!(canonical_value(&a), canonical_value(&b));
+        // A different key changes it too.
+        let c = FalkorValue::Map(map_of(&[("j", FalkorValue::I64(1))]));
+        assert_ne!(canonical_value(&a), canonical_value(&c));
+    }
+
+    #[test]
+    fn canonical_value_preserves_array_order() {
+        let asc = FalkorValue::Array(vec![FalkorValue::I64(1), FalkorValue::I64(2)]);
+        let desc = FalkorValue::Array(vec![FalkorValue::I64(2), FalkorValue::I64(1)]);
+        assert!(canonical_value(&asc).starts_with("arr["));
+        // Order is meaningful for arrays, so a reordering must change the canonical form.
+        assert_ne!(canonical_value(&asc), canonical_value(&desc));
+    }
+
+    #[test]
+    fn canonical_value_recurses_into_nested_containers() {
+        // A map containing an array containing a node: insertion order of the map still doesn't
+        // matter, but the nested array order and node identity do.
+        let node = FalkorValue::Node(Node {
+            entity_id: 7,
+            labels: vec!["User".into()],
+            properties: map_of(&[("id", FalkorValue::I64(7))]),
+        });
+        let inner = FalkorValue::Array(vec![node, FalkorValue::I64(9)]);
+        let one = FalkorValue::Map(map_of(&[
+            ("z", FalkorValue::Bool(true)),
+            ("items", inner.clone()),
+        ]));
+        let two = FalkorValue::Map(map_of(&[("items", inner), ("z", FalkorValue::Bool(true))]));
+        assert_eq!(canonical_value(&one), canonical_value(&two));
+    }
+
+    #[test]
+    fn canonical_node_sorts_properties_but_not_labels() {
+        let forward = FalkorValue::Node(Node {
+            entity_id: 1,
+            labels: vec!["A".into(), "B".into()],
+            properties: {
+                let mut p = HashMap::new();
+                p.insert("age".into(), FalkorValue::I64(30));
+                p.insert("name".into(), FalkorValue::String("Alice".into()));
+                p
+            },
+        });
+        let props_reversed = FalkorValue::Node(Node {
+            entity_id: 1,
+            labels: vec!["A".into(), "B".into()],
+            properties: {
+                let mut p = HashMap::new();
+                p.insert("name".into(), FalkorValue::String("Alice".into()));
+                p.insert("age".into(), FalkorValue::I64(30));
+                p
+            },
+        });
+        // Property insertion order doesn't matter (keys are sorted).
+        assert_eq!(canonical_value(&forward), canonical_value(&props_reversed));
+        assert!(canonical_value(&forward).starts_with("node["));
+        // Label order *is* preserved, so swapping labels changes the canonical form.
+        let labels_swapped = FalkorValue::Node(Node {
+            entity_id: 1,
+            labels: vec!["B".into(), "A".into()],
+            properties: HashMap::new(),
+        });
+        let labels_forward = FalkorValue::Node(Node {
+            entity_id: 1,
+            labels: vec!["A".into(), "B".into()],
+            properties: HashMap::new(),
+        });
+        assert_ne!(
+            canonical_value(&labels_swapped),
+            canonical_value(&labels_forward)
+        );
+    }
+
+    #[test]
+    fn canonical_edge_sorts_properties_and_captures_endpoints() {
+        let edge = |props: HashMap<String, FalkorValue>| {
+            FalkorValue::Edge(Edge {
+                entity_id: 5,
+                relationship_type: "KNOWS".into(),
+                src_node_id: 1,
+                dst_node_id: 2,
+                properties: props,
+            })
+        };
+        let mut p1 = HashMap::new();
+        p1.insert("since".into(), FalkorValue::I64(2020));
+        p1.insert("weight".into(), FalkorValue::F64(0.5));
+        let mut p2 = HashMap::new();
+        p2.insert("weight".into(), FalkorValue::F64(0.5));
+        p2.insert("since".into(), FalkorValue::I64(2020));
+        assert_eq!(canonical_value(&edge(p1)), canonical_value(&edge(p2)));
+        assert!(canonical_value(&edge(HashMap::new())).starts_with("edge["));
+        // A different endpoint changes the canonical form.
+        let flipped = FalkorValue::Edge(Edge {
+            entity_id: 5,
+            relationship_type: "KNOWS".into(),
+            src_node_id: 2,
+            dst_node_id: 1,
+            properties: HashMap::new(),
+        });
+        assert_ne!(
+            canonical_value(&edge(HashMap::new())),
+            canonical_value(&flipped)
+        );
+    }
+
+    #[test]
+    fn canonical_path_preserves_node_and_edge_order() {
+        let node = |id: i64| Node {
+            entity_id: id,
+            labels: vec!["User".into()],
+            properties: HashMap::new(),
+        };
+        let edge = |id: i64, src: i64, dst: i64| Edge {
+            entity_id: id,
+            relationship_type: "KNOWS".into(),
+            src_node_id: src,
+            dst_node_id: dst,
+            properties: HashMap::new(),
+        };
+        let forward = FalkorValue::Path(Path {
+            nodes: vec![node(1), node(2)],
+            relationships: vec![edge(10, 1, 2)],
+        });
+        assert!(canonical_value(&forward).starts_with("path["));
+        // Reversing the node order along the path changes the canonical form.
+        let reversed = FalkorValue::Path(Path {
+            nodes: vec![node(2), node(1)],
+            relationships: vec![edge(10, 1, 2)],
+        });
+        assert_ne!(canonical_value(&forward), canonical_value(&reversed));
+    }
+
+    #[test]
+    fn canonical_value_distinguishes_structurally_different_shapes() {
+        // A string that happens to look like a compound's rendering can't alias the real compound
+        // (distinct type tags + length framing).
+        let arr = FalkorValue::Array(vec![FalkorValue::I64(1)]);
+        let lookalike = FalkorValue::String(canonical_value(&arr).trim_start_matches("arr").into());
+        assert_ne!(canonical_value(&arr), canonical_value(&lookalike));
+        // A node and an edge with the same id don't collide.
+        let node = FalkorValue::Node(Node {
+            entity_id: 1,
+            labels: vec![],
+            properties: HashMap::new(),
+        });
+        let edge = FalkorValue::Edge(Edge {
+            entity_id: 1,
+            relationship_type: String::new(),
+            src_node_id: 0,
+            dst_node_id: 0,
+            properties: HashMap::new(),
+        });
+        assert_ne!(canonical_value(&node), canonical_value(&edge));
+        // An array and a map don't collide even when "empty".
+        assert_ne!(
+            canonical_value(&FalkorValue::Array(vec![])),
+            canonical_value(&FalkorValue::Map(HashMap::new()))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Implements **Phase 1(b)** of the approved design
`docs/design/synthetic-cover-ab-query-shapes.md` (refs #239): **recursive
`FalkorValue` result canonicalization**.

The synthetic per-op check hashes each read's result set into a per-op
`result_digest` (`op_runner.rs` → `capture_result` → `op_result_digest`).
Today `canonical_value` only renders **scalar** variants and falls back to
Rust `Debug` for nodes/edges/paths/maps/arrays. That fallback is
**process-unstable**: a node/edge's `properties` (and a `Map`) is a
`HashMap` whose iteration order is randomized per process
(`vendor/falkordb-rs/src/value/graph_entities.rs`), so the digest — and
therefore the `synthetic-verify` non-divergence gate — was
non-deterministic (design §3.2).

## Change

`canonical_value` now canonicalizes **every** `FalkorValue` variant
recursively:

- **sorts `Map` keys and Node/Edge property keys** (their `HashMap` order is
  process-unstable), while
- **preserves array order, path node/relationship order, `Vec32` lane order,
  and node label order** (all meaningful and server-stable — labels are built
  positionally from the server's ordered array, not a hash collection).

Every nested field stays **length-prefixed** (`<byte-len>:<content>`, the
same framing `canonical_row` already uses) and each variant carries a
**distinct type tag**, so no value can alias a structurally different one.
Floats, `f32` vector lanes and point coordinates use their bit pattern;
temporal scalars use their `i64` seconds. `FalkorValue` is `#[non_exhaustive]`
so a defensive `Debug` wildcard remains for any future variant.

Pure logic — **no live FalkorDB needed**. No CLI/recipe/behavior change (the
digest simply becomes correct and stable for non-scalar results), so no docs
needed updating.

## Tests

Adds thorough unit tests: map/property **insertion-order independence** (the
key determinism property), array/path **order sensitivity**, value/endpoint
sensitivity, temporal/point rendering, nested-container recursion, and
cross-type non-collision. `Vec32` (vendored `pub(crate)`) and the
`#[non_exhaustive]` wildcard can't be constructed from this crate, so those
two defensive arms are intentionally not unit-tested.

## Validation

`just clippy` (warnings denied), `just build`, `just test` all green
(225 unit/lib tests pass; the `#[ignore]`d integration tests that need a live
FalkorDB were not run).

Part of the multi-PR foundations in #239; independently mergeable.
