### PR TITLE
feat(synthetic): string-keyed op identity foundations (phase 1a)

### DIFF
--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -196,6 +196,86 @@ impl OpName {
     }
 }
 
+/// A stable, name-derived RNG salt for a **string-keyed** synthetic op (design §3.1) — the dynamic
+/// counterpart to [`OpName::salt`]'s hand-assigned constants.
+///
+/// It is a 64-bit FNV-1a hash of the name's bytes: a fixed algorithm with fixed constants, so it is
+/// **process-independent and stable across Rust/`rand` versions** (unlike [`std::hash::DefaultHasher`],
+/// whose output is unspecified). That lets a dynamic op — e.g. a query shape pulled from
+/// `queries_repository` by name, which has no `OpName` variant — derive a reproducible salt from its
+/// name alone, so `seed ^ salt` yields the same corpus every run without a curated constant.
+pub fn salt_from_name(name: &str) -> u64 {
+    // FNV-1a (64-bit): offset basis then, per byte, xor-in and multiply by the FNV prime.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in name.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// A synthetic op's identity, keyed by a **stable string name**.
+///
+/// Built-in ops wrap an [`OpName`] and keep its fixed [`OpName::salt`], so recorded baselines stay
+/// valid. A **dynamic** op — e.g. a query shape pulled from `queries_repository` by name (design
+/// §3.1), which has no `OpName` variant — is identified purely by its stable query name, with a
+/// **name-derived salt** ([`salt_from_name`]) so it needs no hand-assigned constant. Both expose the
+/// same [`name`](Self::name)/[`salt`](Self::salt)/[`kind`](Self::kind), so record/replay/threshold
+/// lookups can key on the string name uniformly (existing `OpName` ops keep working unchanged).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpKey {
+    /// One of the built-in [`OpName`] operations.
+    Named(OpName),
+    /// A dynamic op identified only by its stable string name.
+    Dynamic {
+        /// The op's stable string name (its report / threshold / CLI key).
+        name: String,
+        /// Whether the op reads or writes.
+        kind: QueryType,
+    },
+}
+
+impl OpKey {
+    /// Build a dynamic (string-keyed) op identity from its stable name and kind.
+    pub fn dynamic(name: impl Into<String>, kind: QueryType) -> Self {
+        OpKey::Dynamic {
+            name: name.into(),
+            kind,
+        }
+    }
+
+    /// This op's stable string name — its report / threshold / CLI key.
+    pub fn name(&self) -> &str {
+        match self {
+            OpKey::Named(op) => op.as_str(),
+            OpKey::Dynamic { name, .. } => name,
+        }
+    }
+
+    /// The stable RNG salt mixed into the seed. Built-in ops keep [`OpName::salt`]; dynamic ops
+    /// derive it from their name ([`salt_from_name`]), so an op is reproducible from its name alone.
+    pub fn salt(&self) -> u64 {
+        match self {
+            OpKey::Named(op) => op.salt(),
+            OpKey::Dynamic { name, .. } => salt_from_name(name),
+        }
+    }
+
+    /// Whether this op reads or writes (selects `RO_QUERY` vs `QUERY`).
+    pub fn kind(&self) -> QueryType {
+        match self {
+            OpKey::Named(op) => op.kind(),
+            OpKey::Dynamic { kind, .. } => *kind,
+        }
+    }
+}
+
+impl From<OpName> for OpKey {
+    fn from(op: OpName) -> Self {
+        OpKey::Named(op)
+    }
+}
+
 /// Deserialize an `OpName` from its canonical [`OpName::as_str`] name, so a `synthetic-bench.toml`
 /// `operations = ["expand_1_hop", ...]` list uses the exact same spelling as the CLI (a plain
 /// `rename_all = "snake_case"` derive would produce `expand1_hop`).
@@ -1325,6 +1405,54 @@ mod tests {
         assert_eq!(OpName::ReturnConst.as_str(), "return_const");
         assert_eq!(OpName::ReturnConst.kind(), QueryType::Read);
         assert!(!OpName::ReturnConst.description().is_empty());
+    }
+
+    #[test]
+    fn salt_from_name_is_stable_distinct_and_pinned() {
+        // Deterministic within and across processes (a fixed FNV-1a, not a randomized hasher).
+        assert_eq!(salt_from_name("expand_1_hop"), salt_from_name("expand_1_hop"));
+        // Pinned outputs: changing the hash would silently shift every dynamic op's corpus and
+        // invalidate recorded baselines, so these must fail loudly if the algorithm ever changes.
+        assert_eq!(salt_from_name(""), 0xcbf2_9ce4_8422_2325); // FNV-1a 64-bit offset basis
+        assert_eq!(salt_from_name("expand_1_hop"), 0x306d_432a_b8ba_7b21);
+        assert_eq!(salt_from_name("query_shape_42"), 0xbaf3_f049_7b8e_fed0);
+        // Distinct names get distinct salts, including near-identical ones.
+        assert_ne!(salt_from_name("a"), salt_from_name("b"));
+        assert_ne!(salt_from_name("expand_1_hop"), salt_from_name("expand_hops_5"));
+    }
+
+    #[test]
+    fn op_key_named_matches_its_opname() {
+        let key = OpKey::from(OpName::MatchByIndex);
+        assert_eq!(key, OpKey::Named(OpName::MatchByIndex));
+        assert_eq!(key.name(), OpName::MatchByIndex.as_str());
+        assert_eq!(key.kind(), OpName::MatchByIndex.kind());
+        // A built-in op keeps its curated salt constant — NOT the name-derived one — so existing
+        // recorded baselines stay valid.
+        assert_eq!(key.salt(), OpName::MatchByIndex.salt());
+        assert_ne!(key.salt(), salt_from_name("match_by_index"));
+    }
+
+    #[test]
+    fn op_key_dynamic_uses_name_derived_salt() {
+        let key = OpKey::dynamic("query_shape_42", QueryType::Read);
+        assert_eq!(key.name(), "query_shape_42");
+        assert_eq!(key.kind(), QueryType::Read);
+        assert_eq!(key.salt(), salt_from_name("query_shape_42"));
+        // The kind is carried verbatim (a write shape stays a write).
+        assert_eq!(
+            OpKey::dynamic("w", QueryType::Write).kind(),
+            QueryType::Write
+        );
+        // Two dynamic ops with different names are distinct and draw different salts.
+        assert_ne!(
+            OpKey::dynamic("shape_a", QueryType::Read),
+            OpKey::dynamic("shape_b", QueryType::Read)
+        );
+        assert_ne!(
+            OpKey::dynamic("shape_a", QueryType::Read).salt(),
+            OpKey::dynamic("shape_b", QueryType::Read).salt()
+        );
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -216,63 +216,79 @@ pub fn salt_from_name(name: &str) -> u64 {
 
 /// A synthetic op's identity, keyed by a **stable string name**.
 ///
-/// Built-in ops wrap an [`OpName`] and keep its fixed [`OpName::salt`], so recorded baselines stay
-/// valid. A **dynamic** op — e.g. a query shape pulled from `queries_repository` by name (design
-/// §3.1), which has no `OpName` variant — is identified purely by its stable query name, with a
+/// The representation is **opaque**: an `OpKey` is built only via [`OpKey::from`] (a built-in
+/// [`OpName`]) or [`OpKey::dynamic`] (a string-keyed op), which guarantees a built-in op's name can
+/// never be carried by a dynamic key with a conflicting salt or kind (see [`OpKey::dynamic`]).
+///
+/// Built-in ops keep [`OpName`]'s fixed [`OpName::salt`], so recorded baselines stay valid. A
+/// **dynamic** op — e.g. a query shape pulled from `queries_repository` by name (design §3.1),
+/// which has no `OpName` variant — is identified purely by its stable query name, with a
 /// **name-derived salt** ([`salt_from_name`]) so it needs no hand-assigned constant. Both expose the
 /// same [`name`](Self::name)/[`salt`](Self::salt)/[`kind`](Self::kind), so record/replay/threshold
 /// lookups can key on the string name uniformly (existing `OpName` ops keep working unchanged).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum OpKey {
+pub struct OpKey(OpKeyRepr);
+
+/// Private representation of an [`OpKey`]. Kept private so a dynamic key with a built-in name (which
+/// would carry the wrong salt/kind) is impossible to construct — [`OpKey::dynamic`] canonicalizes
+/// built-in names to [`OpKeyRepr::Named`], and there is no other way in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum OpKeyRepr {
     /// One of the built-in [`OpName`] operations.
     Named(OpName),
     /// A dynamic op identified only by its stable string name.
-    Dynamic {
-        /// The op's stable string name (its report / threshold / CLI key).
-        name: String,
-        /// Whether the op reads or writes.
-        kind: QueryType,
-    },
+    Dynamic { name: String, kind: QueryType },
 }
 
 impl OpKey {
     /// Build a dynamic (string-keyed) op identity from its stable name and kind.
+    ///
+    /// If `name` matches a built-in [`OpName`] tag it **canonicalizes to that `OpName`** (keeping
+    /// the built-in's salt and kind, and ignoring the passed `kind`), so a dynamic key can never
+    /// shadow a built-in op with a conflicting salt/kind — the two would otherwise collide on the
+    /// string name used by reports, thresholds and recordings.
     pub fn dynamic(name: impl Into<String>, kind: QueryType) -> Self {
-        OpKey::Dynamic {
-            name: name.into(),
-            kind,
+        let name = name.into();
+        match OpName::from_tag(&name) {
+            Some(op) => OpKey(OpKeyRepr::Named(op)),
+            None => OpKey(OpKeyRepr::Dynamic { name, kind }),
         }
     }
 
     /// This op's stable string name — its report / threshold / CLI key.
     pub fn name(&self) -> &str {
-        match self {
-            OpKey::Named(op) => op.as_str(),
-            OpKey::Dynamic { name, .. } => name,
+        match &self.0 {
+            OpKeyRepr::Named(op) => op.as_str(),
+            OpKeyRepr::Dynamic { name, .. } => name,
         }
     }
 
     /// The stable RNG salt mixed into the seed. Built-in ops keep [`OpName::salt`]; dynamic ops
     /// derive it from their name ([`salt_from_name`]), so an op is reproducible from its name alone.
     pub fn salt(&self) -> u64 {
-        match self {
-            OpKey::Named(op) => op.salt(),
-            OpKey::Dynamic { name, .. } => salt_from_name(name),
+        match &self.0 {
+            OpKeyRepr::Named(op) => op.salt(),
+            OpKeyRepr::Dynamic { name, .. } => salt_from_name(name),
         }
     }
 
     /// Whether this op reads or writes (selects `RO_QUERY` vs `QUERY`).
     pub fn kind(&self) -> QueryType {
-        match self {
-            OpKey::Named(op) => op.kind(),
-            OpKey::Dynamic { kind, .. } => *kind,
+        match &self.0 {
+            OpKeyRepr::Named(op) => op.kind(),
+            OpKeyRepr::Dynamic { kind, .. } => *kind,
         }
+    }
+
+    /// Whether this key resolves to a built-in [`OpName`] op (vs a dynamic string-keyed op).
+    pub fn is_named(&self) -> bool {
+        matches!(self.0, OpKeyRepr::Named(_))
     }
 }
 
 impl From<OpName> for OpKey {
     fn from(op: OpName) -> Self {
-        OpKey::Named(op)
+        OpKey(OpKeyRepr::Named(op))
     }
 }
 
@@ -1424,7 +1440,8 @@ mod tests {
     #[test]
     fn op_key_named_matches_its_opname() {
         let key = OpKey::from(OpName::MatchByIndex);
-        assert_eq!(key, OpKey::Named(OpName::MatchByIndex));
+        assert!(key.is_named());
+        assert_eq!(key, OpKey::from(OpName::MatchByIndex));
         assert_eq!(key.name(), OpName::MatchByIndex.as_str());
         assert_eq!(key.kind(), OpName::MatchByIndex.kind());
         // A built-in op keeps its curated salt constant — NOT the name-derived one — so existing
@@ -1436,6 +1453,7 @@ mod tests {
     #[test]
     fn op_key_dynamic_uses_name_derived_salt() {
         let key = OpKey::dynamic("query_shape_42", QueryType::Read);
+        assert!(!key.is_named());
         assert_eq!(key.name(), "query_shape_42");
         assert_eq!(key.kind(), QueryType::Read);
         assert_eq!(key.salt(), salt_from_name("query_shape_42"));
@@ -1453,6 +1471,20 @@ mod tests {
             OpKey::dynamic("shape_a", QueryType::Read).salt(),
             OpKey::dynamic("shape_b", QueryType::Read).salt()
         );
+    }
+
+    #[test]
+    fn op_key_dynamic_canonicalizes_builtin_names() {
+        // A dynamic key built from a *built-in* op name must collapse to the `Named` identity, so it
+        // can't shadow the built-in with a conflicting salt/kind on the shared string name (the key
+        // reports, thresholds and recordings all use).
+        let canon = OpKey::dynamic("match_by_index", QueryType::Write);
+        assert!(canon.is_named());
+        assert_eq!(canon, OpKey::from(OpName::MatchByIndex));
+        // The built-in's real salt and kind win; the passed `Write` kind is ignored.
+        assert_eq!(canon.salt(), OpName::MatchByIndex.salt());
+        assert_eq!(canon.kind(), OpName::MatchByIndex.kind());
+        assert_ne!(canon.salt(), salt_from_name("match_by_index"));
     }
 
     #[test]

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -169,7 +169,9 @@ struct OpThresholds {
 #[derive(Debug, Clone)]
 pub struct Thresholds {
     default: ResolvedBudget,
-    ops: BTreeMap<OpName, OpThresholds>,
+    /// Per-op overrides keyed by the op's **stable string name** (`OpName::as_str`, or a dynamic
+    /// op's query name — design §3.1), so a string-keyed op resolves exactly like a built-in one.
+    ops: BTreeMap<String, OpThresholds>,
 }
 
 impl Default for Thresholds {
@@ -212,7 +214,9 @@ impl Thresholds {
 
         let mut ops = BTreeMap::new();
         for (name, raw_op) in raw.op {
-            let op = OpName::from_tag(&name).ok_or_else(|| {
+            // Validate the name maps to a known op, but key the map by the **string name** so a
+            // dynamic (string-keyed) op resolves exactly like a built-in one (design §3.1).
+            OpName::from_tag(&name).ok_or_else(|| {
                 format!("unknown operation '{name}' in [op.{name}] — see `synthetic list-ops`")
             })?;
             if let Some(m) = raw_op.metric {
@@ -240,7 +244,7 @@ impl Thresholds {
                 per_concurrency_budget_pct.insert(c, pct);
             }
             ops.insert(
-                op,
+                name,
                 OpThresholds {
                     metric: raw_op.metric,
                     budget_pct,
@@ -256,7 +260,15 @@ impl Thresholds {
     /// Resolve the budget for one `(op, concurrency)` cell. Precedence per field:
     /// `op.<op>.concurrency.<C>` (budget only) > `op.<op>` > `[default]`.
     pub fn resolve(&self, op: OpName, concurrency: usize) -> ResolvedBudget {
-        let over = self.ops.get(&op);
+        self.resolve_by_name(op.as_str(), concurrency)
+    }
+
+    /// Resolve the budget for one `(op name, concurrency)` cell, keyed by the op's **stable string
+    /// name** so a dynamic (string-keyed) op resolves exactly like a built-in [`OpName`] (design
+    /// §3.1); [`resolve`](Self::resolve) delegates here. Precedence per field:
+    /// `op.<name>.concurrency.<C>` (budget only) > `op.<name>` > `[default]`.
+    pub fn resolve_by_name(&self, name: &str, concurrency: usize) -> ResolvedBudget {
+        let over = self.ops.get(name);
         let budget_pct = over
             .and_then(|o| o.per_concurrency_budget_pct.get(&concurrency).copied())
             .or_else(|| over.and_then(|o| o.budget_pct))
@@ -298,7 +310,7 @@ impl Thresholds {
                 budget.push_str(&format!(" ({})", per.join(", ")));
             }
             let floor = o.floor_ms.unwrap_or(self.default.floor_ms);
-            s.push_str(&format!("| `{}` | {budget} | {} ms |\n", op.as_str(), fmt_threshold(floor)));
+            s.push_str(&format!("| `{op}` | {budget} | {} ms |\n", fmt_threshold(floor)));
         }
         s.push_str(&format!(
             "\n_Metric `{metric}`. A cell is 🔴 only when the candidate is **slower** than the \
@@ -397,6 +409,36 @@ concurrency = { 32 = 40.0 }
         let r32 = t.resolve(OpName::MatchByIndex, 32);
         assert_eq!(r32.budget_pct, 40.0);
         assert_eq!(r32.floor_ms, 0.1);
+    }
+
+    #[test]
+    fn resolve_by_name_keys_on_string_and_matches_opname() {
+        let cfg = r#"
+[default]
+budget_pct = 10.0
+floor_ms = 0.5
+
+[op.match_by_index]
+budget_pct = 20.0
+floor_ms = 0.1
+concurrency = { 32 = 40.0 }
+"#;
+        let t = Thresholds::from_toml_str(cfg).unwrap();
+        // A string-keyed lookup resolves exactly like the OpName-keyed one (`resolve` delegates
+        // here), across the default, per-op and per-op×concurrency precedence tiers.
+        for c in [1usize, 16, 32] {
+            assert_eq!(
+                t.resolve_by_name("match_by_index", c),
+                t.resolve(OpName::MatchByIndex, c),
+            );
+        }
+        assert_eq!(t.resolve_by_name("match_by_index", 32).budget_pct, 40.0);
+        // An unknown / dynamic op name (no override) falls back to `[default]` — the string key
+        // needn't correspond to any `OpName`, which is what lets dynamic ops resolve (design §3.1).
+        let dynamic = t.resolve_by_name("some_dynamic_shape", 8);
+        assert_eq!(dynamic.budget_pct, 10.0);
+        assert_eq!(dynamic.floor_ms, 0.5);
+        assert_eq!(dynamic.metric, Metric::P50);
     }
 
     #[test]


### PR DESCRIPTION
## Phase 1(a): dynamic, string-keyed op identity (foundations)

Implements the **pure-logic foundations** of design phase **1(a)** from #239 — letting a synthetic op be identified by a **stable string name** (with a name-derived RNG salt) **in addition to** the existing static `OpName` enum, which keeps working unchanged. This unblocks later phases that need to cover the A/B benchmark's query shapes (which have no `OpName` variant) without disturbing today's baselines.

### What's in this PR (no live-server paths touched)

- **`salt_from_name(name: &str) -> u64`** (`src/synthetic/mod.rs`) — a 64-bit **FNV-1a** hash of the op name. Fixed algorithm + fixed constants ⇒ **process-independent and stable across Rust/`rand` versions** (unlike `std::hash::DefaultHasher`, whose output is unspecified), so a dynamic op is reproducible from its name alone.
- **`OpKey { Named(OpName), Dynamic { name, kind } }`** (`src/synthetic/mod.rs`) — a uniform op identity exposing `name()` / `salt()` / `kind()`, plus a `dynamic(...)` constructor and `impl From<OpName>`. **Built-in ops keep `OpName`'s fixed salt** (recorded baselines stay valid); dynamic ops derive their salt from the name.
- **String-keyed thresholds** (`src/synthetic/thresholds.rs`) — `Thresholds.ops` is now keyed by the op's **string name**; new `resolve_by_name(name, concurrency)` and the existing `resolve(OpName, concurrency)` delegates to it, so a string-keyed op resolves **exactly** like a built-in. TOML parsing still validates and rejects unknown op names.

### Backward compatibility

- `OpName`-keyed `resolve(...)` is unchanged for callers and returns identical results (it delegates).
- `OpKey::Named` returns `OpName::salt()/kind()/as_str()` verbatim — built-in salts are **not** switched to the name-derived scheme, so existing baselines are unaffected.
- The only observable change is the per-op row order in the thresholds Markdown table (now lexicographic by name); that table is only asserted with order-independent `contains` checks.

### Tests

- `salt_from_name`: determinism, distinctness, and **pinned** outputs (empty ⇒ FNV offset basis, plus two fixed values) so any accidental change to the hash fails loudly.
- `OpKey`: `Named` preserves the `OpName` salt/kind/name (and differs from the name-derived salt); `Dynamic` uses the name-derived salt and carries its kind; distinct names ⇒ distinct keys/salts.
- `resolve_by_name`: parity with `resolve(OpName, _)` across the default / per-op / per-op×concurrency tiers, plus an unknown/dynamic name falling back to `[default]`.

Validated with the CI recipes: `just clippy` (warnings-denied), `just build`, `just test` (220 passed, 0 failed; the `#[ignore]`d integration tests need a live FalkorDB and are not run here).

### Deferred to a later PR (touches live-server measurement paths)

Threading `OpKey` through the **CLI op selector** (`src/cli.rs`), the **record/replay identity lookup** (`src/synthetic/recording.rs`), and **engine seed derivation** is intentionally out of scope here — those run against a live FalkorDB and belong with the runtime work. This PR is the isolated, unit-testable foundation.

Part of #239.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for identifying synthetic operations by stable string names, including dynamically defined operations.
  - Added consistent operation metadata and identifiers for built-in and dynamic operations.
  - Added threshold resolution by operation name, allowing configuration for recognized operations while safely falling back to default thresholds for unknown names.

- **Bug Fixes**
  - Improved consistency between configured thresholds and operation names.
  - Added safeguards ensuring distinct dynamic operation names receive distinct identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->