### PR TITLE
feat(synthetic): add per-op runtime budget metadata and resolver

### DIFF
--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -13,7 +13,7 @@ use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::query::{Query, QueryBuilder};
 use crate::synthetic::writes::{ExpectedMutation, WritePlan, WriteScratch};
-use crate::synthetic::{OpName, Tier};
+use crate::synthetic::{CacheSelection, OpName, Tier};
 use rand::{Rng, RngExt};
 
 /// Number of distinct parameterizations pre-generated per operation. The measured loop cycles
@@ -88,6 +88,42 @@ impl DatasetRequirement {
 pub type CorpusFn =
     fn(&mut dyn Rng, &DatasetHandle, usize, usize) -> BenchmarkResult<Vec<Query>>;
 
+/// Per-operation runtime budget: optional overrides layered on the global
+/// [`Config`](crate::synthetic::Config) (design §3.5). Each `None` field inherits the corresponding
+/// global knob; a `Some` value overrides it for this operation only. Every operation in the catalog
+/// currently uses [`OpBudget::INHERIT`] (no overrides), so today's behaviour — and the record-once /
+/// replay-verbatim A/B comparability — is unchanged. The machinery lets heavier future shapes (e.g.
+/// algorithms) dial their own samples/timeout/concurrency/cache down without perturbing the rest of
+/// the catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct OpBudget {
+    /// Override the measured sample count for this op.
+    pub samples: Option<usize>,
+    /// Override the warm-up (discarded) sample count for this op.
+    pub warmup: Option<usize>,
+    /// Replace the concurrency sweep for this op (closed-loop worker counts).
+    pub concurrency: Option<&'static [usize]>,
+    /// Override which plan-cache condition(s) to measure this op under.
+    pub cache: Option<CacheSelection>,
+    /// Override the per-query server timeout (ms) for this op.
+    pub server_timeout_ms: Option<i64>,
+    /// Override the per-query client deadline (ms) for this op.
+    pub client_deadline_ms: Option<u64>,
+}
+
+impl OpBudget {
+    /// Inherit every knob from the global [`Config`](crate::synthetic::Config) — no per-op override.
+    /// The default for every current operation.
+    pub const INHERIT: OpBudget = OpBudget {
+        samples: None,
+        warmup: None,
+        concurrency: None,
+        cache: None,
+        server_timeout_ms: None,
+        client_deadline_ms: None,
+    };
+}
+
 /// One catalog entry: an operation's identity, its read/write kind, a one-line description, the
 /// seed data it needs, and its corpus builder. `OpName` stays the single source of truth; this
 /// spec is what the runner and `--help`/completion all agree on.
@@ -100,6 +136,9 @@ pub struct OperationSpec {
     /// Coverage tier: `Core` gates every PR, `Full` runs nightly/on-demand (design §3.5). Reads
     /// are split across tiers; write ops always carry [`Tier::Full`] (opt-in, reads-only scope).
     pub tier: Tier,
+    /// Per-op runtime budget overriding global [`Config`](crate::synthetic::Config) knobs. Defaults
+    /// to [`OpBudget::INHERIT`] (no override) for every current op — see [`OpBudget`].
+    pub budget: OpBudget,
     pub corpus: CorpusFn,
     /// Present for write operations (Part 5): the lifecycle hooks, mutation to verify, and timed
     /// query builder. `None` for reads, which use `corpus` instead.
@@ -144,6 +183,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "RETURN $i — pure round-trip baseline (no dataset required)",
             requirement: DatasetRequirement::None,
             tier: Tier::Core,
+            budget: OpBudget::INHERIT,
             corpus: corpus_return_const,
             write: None,
         },
@@ -153,6 +193,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "point lookup on the :User(id) index",
             requirement: DatasetRequirement::OneId,
             tier: Tier::Core,
+            budget: OpBudget::INHERIT,
             corpus: corpus_match_by_index,
             write: None,
         },
@@ -162,6 +203,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "full :User label scan with a non-indexable predicate",
             requirement: DatasetRequirement::None,
             tier: Tier::Core,
+            budget: OpBudget::INHERIT,
             corpus: corpus_match_by_label_scan,
             write: None,
         },
@@ -171,6 +213,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "1-hop :Friend expansion from a seed node",
             requirement: DatasetRequirement::OneId,
             tier: Tier::Core,
+            budget: OpBudget::INHERIT,
             corpus: corpus_expand_1_hop,
             write: None,
         },
@@ -180,6 +223,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "fixed 5-hop :Friend expansion from a seed node",
             requirement: DatasetRequirement::OneId,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: corpus_expand_hops_5,
             write: None,
         },
@@ -189,6 +233,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "count a seed node's 1-hop :Friend neighbours",
             requirement: DatasetRequirement::OneId,
             tier: Tier::Core,
+            budget: OpBudget::INHERIT,
             corpus: corpus_aggregate_count,
             write: None,
         },
@@ -198,6 +243,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "group a seed node's neighbours by age with counts",
             requirement: DatasetRequirement::OneId,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: corpus_aggregate_group,
             write: None,
         },
@@ -207,6 +253,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "bounded shortest :Friend path between two seed nodes",
             requirement: DatasetRequirement::TwoIds,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: corpus_shortest_path,
             write: None,
         },
@@ -216,6 +263,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "project scalar properties of an indexed node",
             requirement: DatasetRequirement::OneId,
             tier: Tier::Core,
+            budget: OpBudget::INHERIT,
             corpus: corpus_property_projection,
             write: None,
         },
@@ -225,6 +273,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "create a fresh scratch node each invocation",
             requirement: DatasetRequirement::None,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
                 expected: ExpectedMutation::NodeCreated,
@@ -242,6 +291,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "MERGE a fresh scratch node each invocation (always misses → creates)",
             requirement: DatasetRequirement::None,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
                 expected: ExpectedMutation::NodeCreated,
@@ -259,6 +309,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "create a fresh edge between two of this worker's scratch nodes",
             requirement: DatasetRequirement::None,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
                 expected: ExpectedMutation::RelationshipCreated,
@@ -276,6 +327,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "set a property on a pre-created scratch node each invocation",
             requirement: DatasetRequirement::None,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
                 expected: ExpectedMutation::PropertySet,
@@ -293,6 +345,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "delete a pre-created scratch node each invocation",
             requirement: DatasetRequirement::None,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
                 expected: ExpectedMutation::NodeDeleted,
@@ -310,6 +363,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             description: "MERGE an existing scratch node each invocation (always hits)",
             requirement: DatasetRequirement::None,
             tier: Tier::Full,
+            budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
                 expected: ExpectedMutation::NodeMatched,

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -37,7 +37,7 @@ use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
 use crate::query::Query;
 use crate::synthetic::catalog::{
-    spec, DatasetHandle, DatasetRequirement, OperationSpec, CORPUS_SIZE,
+    spec, DatasetHandle, DatasetRequirement, OpBudget, OperationSpec, CORPUS_SIZE,
 };
 use crate::synthetic::dataset::DatasetSpec;
 use crate::synthetic::engine::{run_closed_loop, OpInvoker};
@@ -467,6 +467,36 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    /// A per-operation view of this config with `budget`'s overrides applied (design §3.5). Each
+    /// `None` field in the [`OpBudget`] inherits the corresponding global knob, so
+    /// [`OpBudget::INHERIT`] yields a config equal to `self` — preserving today's behaviour and the
+    /// record-once / replay-verbatim A/B comparability for every current op. Used per op by [`run`]
+    /// to derive that op's effective knobs before measuring it.
+    pub fn with_budget(&self, budget: &OpBudget) -> Config {
+        let mut cfg = self.clone();
+        if let Some(samples) = budget.samples {
+            cfg.samples = samples;
+        }
+        if let Some(warmup) = budget.warmup {
+            cfg.warmup = warmup;
+        }
+        if let Some(concurrency) = budget.concurrency {
+            cfg.concurrency = concurrency.to_vec();
+        }
+        if let Some(cache) = budget.cache {
+            cfg.cache = cache;
+        }
+        if let Some(server_timeout_ms) = budget.server_timeout_ms {
+            cfg.server_timeout_ms = server_timeout_ms;
+        }
+        if let Some(client_deadline_ms) = budget.client_deadline_ms {
+            cfg.client_deadline_ms = client_deadline_ms;
+        }
+        cfg
+    }
+}
+
 /// Print the available operations (for `synthetic list-ops`).
 pub fn list_ops() -> String {
     let mut out = String::from("Available operations:\n");
@@ -639,6 +669,14 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     let mut op_fingerprints: Vec<(OpName, String)> = Vec::with_capacity(ops.len());
     for op in ops {
         let op_spec = spec(op);
+        // Per-op runtime budget (design §3.5): overlay this op's `OpBudget` on the global config.
+        // Every current op is `INHERIT`, so `op_config`/`op_concurrency`/`op_client_deadline` equal
+        // the global values and behaviour — and the record-once/replay-verbatim A/B comparability —
+        // is unchanged. The corpus is still seeded from the global `config.seed` (never budgeted),
+        // so the recorded query strings stay identical regardless of any budget.
+        let op_config = config.with_budget(&op_spec.budget);
+        let op_concurrency = normalize_concurrency(&op_config.concurrency)?;
+        let op_client_deadline = Duration::from_millis(op_config.client_deadline_ms);
         // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
         let mut rng = StdRng::seed_from_u64(config.seed ^ op.salt());
         let corpus = Arc::new(op_spec.build_corpus(&mut rng, &dataset, 0, 1)?);
@@ -654,13 +692,13 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         // bundle stores, so a generated run and a `--recording` run measure identically.
         let rendered: Arc<Vec<String>> = Arc::new(corpus.iter().map(|q| q.to_cypher()).collect());
         let op_report = measure_op(
-            config,
-            &concurrency,
+            &op_config,
+            &op_concurrency,
             &op_spec,
             rendered,
             run_token,
             &uid_alloc,
-            client_deadline,
+            op_client_deadline,
         )
         .await?;
         operations.insert(op.as_str().to_string(), op_report);
@@ -1779,6 +1817,100 @@ mod tests {
         // Empty and zero-containing sweeps are rejected.
         assert!(normalize_concurrency(&[]).is_err());
         assert!(normalize_concurrency(&[1, 0, 4]).is_err());
+    }
+
+    #[test]
+    fn with_budget_inherit_preserves_every_knob() {
+        // `OpBudget::INHERIT` (no overrides) must yield a config equal to the original, so the
+        // existing ops measure exactly as before and the A/B comparability is preserved.
+        let base = Config {
+            samples: 123,
+            warmup: 45,
+            concurrency: vec![1, 4, 16],
+            cache: CacheSelection::Cached,
+            server_timeout_ms: 999,
+            client_deadline_ms: 1234,
+            seed: 77,
+            reset_every: 5,
+            ..Config::default()
+        };
+        let got = base.with_budget(&OpBudget::INHERIT);
+        assert_eq!(got.samples, base.samples);
+        assert_eq!(got.warmup, base.warmup);
+        assert_eq!(got.concurrency, base.concurrency);
+        assert_eq!(got.cache, base.cache);
+        assert_eq!(got.server_timeout_ms, base.server_timeout_ms);
+        assert_eq!(got.client_deadline_ms, base.client_deadline_ms);
+        // Un-budgeted knobs are always inherited.
+        assert_eq!(got.seed, base.seed);
+        assert_eq!(got.reset_every, base.reset_every);
+    }
+
+    #[test]
+    fn with_budget_overrides_every_knob_independently() {
+        // Each `Some` field overrides exactly its own knob; everything else is inherited. Setting
+        // all six exercises every override branch.
+        let base = Config::default();
+        let budget = OpBudget {
+            samples: Some(7),
+            warmup: Some(3),
+            concurrency: Some(&[9, 2]),
+            cache: Some(CacheSelection::Uncached),
+            server_timeout_ms: Some(111),
+            client_deadline_ms: Some(222),
+        };
+        let got = base.with_budget(&budget);
+        assert_eq!(got.samples, 7);
+        assert_eq!(got.warmup, 3);
+        // The static override slice is copied verbatim (normalization happens later, per op).
+        assert_eq!(got.concurrency, vec![9, 2]);
+        assert_eq!(got.cache, CacheSelection::Uncached);
+        assert_eq!(got.server_timeout_ms, 111);
+        assert_eq!(got.client_deadline_ms, 222);
+        // Never-budgeted knobs (seed/reset_every) stay put — critical for record/replay determinism.
+        assert_eq!(got.seed, base.seed);
+        assert_eq!(got.reset_every, base.reset_every);
+    }
+
+    #[test]
+    fn with_budget_partial_override_leaves_other_knobs_inherited() {
+        let base = Config {
+            samples: 100,
+            warmup: 20,
+            concurrency: vec![1, 8],
+            cache: CacheSelection::Both,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            ..Config::default()
+        };
+        // Override only samples + concurrency.
+        let budget = OpBudget {
+            samples: Some(10),
+            concurrency: Some(&[2, 4]),
+            ..OpBudget::INHERIT
+        };
+        let got = base.with_budget(&budget);
+        assert_eq!(got.samples, 10);
+        assert_eq!(got.concurrency, vec![2, 4]);
+        // The rest inherit the global config.
+        assert_eq!(got.warmup, base.warmup);
+        assert_eq!(got.cache, base.cache);
+        assert_eq!(got.server_timeout_ms, base.server_timeout_ms);
+        assert_eq!(got.client_deadline_ms, base.client_deadline_ms);
+    }
+
+    #[test]
+    fn inherit_is_the_default_budget_and_every_catalog_op_uses_it() {
+        // The reads-only scope carries no per-op budgets yet: every op inherits the global knobs, so
+        // enabling budgets later is purely additive. This tripwire flags any op that gains one.
+        assert_eq!(OpBudget::default(), OpBudget::INHERIT);
+        for op in OpName::all() {
+            assert_eq!(
+                spec(*op).budget,
+                OpBudget::INHERIT,
+                "op should inherit its budget until a phase deliberately sets one"
+            );
+        }
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -675,6 +675,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         // is unchanged. The corpus is still seeded from the global `config.seed` (never budgeted),
         // so the recorded query strings stay identical regardless of any budget.
         let op_config = config.with_budget(&op_spec.budget);
+        validate_op_config(op, &op_config)?;
         let op_concurrency = normalize_concurrency(&op_config.concurrency)?;
         let op_client_deadline = Duration::from_millis(op_config.client_deadline_ms);
         // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
@@ -760,6 +761,19 @@ pub(crate) fn normalize_concurrency(concurrency: &[usize]) -> BenchmarkResult<Ve
     levels.sort_unstable();
     levels.dedup();
     Ok(levels)
+}
+
+/// Validate a per-op resolved [`Config`]: the global `run()` guard only checks the global
+/// `samples`, so a per-op [`OpBudget`] that zeroed `samples` would slip past it and fail later
+/// deep inside sampling with a less actionable error. Reject it up front, naming the op.
+pub(crate) fn validate_op_config(op: OpName, cfg: &Config) -> BenchmarkResult<()> {
+    if cfg.samples == 0 {
+        return Err(OtherError(format!(
+            "operation '{}' resolved to a per-op budget with samples = 0; samples must be greater than 0",
+            op.as_str()
+        )));
+    }
+    Ok(())
 }
 
 /// Deduplicate the selected ops, preserving first-occurrence order (so a repeated `--op` or an
@@ -1897,6 +1911,26 @@ mod tests {
         assert_eq!(got.cache, base.cache);
         assert_eq!(got.server_timeout_ms, base.server_timeout_ms);
         assert_eq!(got.client_deadline_ms, base.client_deadline_ms);
+    }
+
+    #[test]
+    fn validate_op_config_rejects_a_zero_samples_budget() {
+        // The global `run()` guard only checks the global samples; a per-op budget that zeroed
+        // samples must still fail fast with a message that names the offending op.
+        let base = Config {
+            samples: 100,
+            ..Config::default()
+        };
+        let zeroed = base.with_budget(&OpBudget {
+            samples: Some(0),
+            ..OpBudget::INHERIT
+        });
+        let err = validate_op_config(OpName::ReturnConst, &zeroed).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("samples must be greater than 0"), "{msg}");
+        assert!(msg.contains("return_const"), "{msg}");
+        // A non-zero (inherited) config passes.
+        validate_op_config(OpName::ReturnConst, &base).unwrap();
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -763,15 +763,24 @@ pub(crate) fn normalize_concurrency(concurrency: &[usize]) -> BenchmarkResult<Ve
     Ok(levels)
 }
 
-/// Validate a per-op resolved [`Config`]: the global `run()` guard only checks the global
-/// `samples`, so a per-op [`OpBudget`] that zeroed `samples` would slip past it and fail later
-/// deep inside sampling with a less actionable error. Reject it up front, naming the op.
+/// Validate a per-op resolved [`Config`]: the global `run()` guard only checks the global knobs, so
+/// a per-op [`OpBudget`] that zeroed `samples` or set an invalid concurrency sweep would slip past
+/// it and fail later with a less actionable error. Reject it up front, naming the op. Concurrency
+/// reuses [`normalize_concurrency`]'s rules (kept the single source of truth) with the op prefixed.
 pub(crate) fn validate_op_config(op: OpName, cfg: &Config) -> BenchmarkResult<()> {
     if cfg.samples == 0 {
         return Err(OtherError(format!(
             "operation '{}' resolved to a per-op budget with samples = 0; samples must be greater than 0",
             op.as_str()
         )));
+    }
+    if let Err(e) = normalize_concurrency(&cfg.concurrency) {
+        // Unwrap the inner message so the op-prefixed error isn't double-wrapped with "Other error:".
+        let detail = match e {
+            OtherError(m) => m,
+            other => other.to_string(),
+        };
+        return Err(OtherError(format!("operation '{}': {detail}", op.as_str())));
     }
     Ok(())
 }
@@ -1914,22 +1923,45 @@ mod tests {
     }
 
     #[test]
-    fn validate_op_config_rejects_a_zero_samples_budget() {
-        // The global `run()` guard only checks the global samples; a per-op budget that zeroed
-        // samples must still fail fast with a message that names the offending op.
+    fn validate_op_config_rejects_invalid_per_op_budgets() {
+        // The global `run()` guard only checks the global knobs; a per-op budget that zeroed
+        // samples or produced an invalid concurrency sweep must fail fast, naming the offending op.
         let base = Config {
             samples: 100,
+            concurrency: vec![1, 4],
             ..Config::default()
         };
+        // samples = 0.
         let zeroed = base.with_budget(&OpBudget {
             samples: Some(0),
             ..OpBudget::INHERIT
         });
-        let err = validate_op_config(OpName::ReturnConst, &zeroed).unwrap_err();
-        let msg = err.to_string();
+        let msg = validate_op_config(OpName::ReturnConst, &zeroed)
+            .unwrap_err()
+            .to_string();
         assert!(msg.contains("samples must be greater than 0"), "{msg}");
         assert!(msg.contains("return_const"), "{msg}");
-        // A non-zero (inherited) config passes.
+        // Empty concurrency sweep — reuses normalize_concurrency's rule, op-named.
+        let empty = Config {
+            concurrency: vec![],
+            ..base.clone()
+        };
+        let msg = validate_op_config(OpName::MatchByIndex, &empty)
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("match_by_index"), "{msg}");
+        assert!(msg.contains("at least one level"), "{msg}");
+        // A concurrency level of 0 — op-named.
+        let zero_level = Config {
+            concurrency: vec![0],
+            ..base.clone()
+        };
+        let msg = validate_op_config(OpName::MatchByIndex, &zero_level)
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("match_by_index"), "{msg}");
+        assert!(msg.contains(">= 1"), "{msg}");
+        // A fully valid (inherited) config passes.
         validate_op_config(OpName::ReturnConst, &base).unwrap();
     }
 


### PR DESCRIPTION
## What & why

Part of #239. This is **Phase 1c / §3.5: per-operation runtime budget metadata** — the second tool-side runtime/report-policy PR (after #243 tier metadata). Pure logic, no live server.

Per §3.5, runtime is the dominant cost and there's **no per-op sample/timeout/concurrency/cache budget** today, so heavier shapes (e.g. algorithms) can't run "smaller" than the rest. This PR adds that machinery — additively and behavior-preserving.

## Changes

- **`OpBudget`** (`src/synthetic/catalog.rs`): all-`Option` overrides — `samples`, `warmup`, `concurrency` (`Option<&'static [usize]>`), `cache`, `server_timeout_ms`, `client_deadline_ms` — plus `const INHERIT` (all `None`, equal to the derived `Default`).
- **`OperationSpec.budget`**: a new field, set to `OpBudget::INHERIT` on all 15 catalog arms.
- **`Config::with_budget(&OpBudget) -> Config`** (`src/synthetic/mod.rs`): a pure resolver that clones the global config and applies each `Some` override (`None` inherits).
- **Wiring**: the per-op loop in `run()` now measures each op under `config.with_budget(&op_spec.budget)`, with that op's own normalized concurrency and client deadline.

## Behavior-preserving & comparability-safe

Every current op is `INHERIT`, so the effective per-op knobs equal today's globals (unit-tested identity) — nothing measurable changes for the existing catalog. Crucially for the **record-once → replay-verbatim** A/B model:
- the per-op corpus is still seeded from the **global** `config.seed` (never budgeted), and
- the write fingerprint still uses global `reset_every`,

so recorded query strings stay byte-identical regardless of any budget. `OpBudget` has no `seed` field by design.

## Tests (offline, no server)

INHERIT identity (all knobs preserved), full override (all six knobs), partial override (only specified knobs change, rest inherit), `Default == INHERIT`, and an all-catalog-`INHERIT` tripwire that flags any op that gains a budget. The 6 server-path wiring lines in `run()` are exercised by the `#[ignore]`d integration tests under CI coverage (live FalkorDB).

Validated locally with the CI recipes: `just fmt`, `just clippy` (warnings-denied), `just build`, `just test`.

## Relationship to #243 & follow-ups

Branched off `master` per the workflow. It's **independent of #243** (tier) in logic, but both add a field to `OperationSpec`/its 15 arms, so whichever merges second needs a trivial mechanical rebase.

Deferred: the **lean SUMMARY output + result-stability metadata** (Decision 4/5) come in the next Phase 1c PR (which also consumes #243's per-tier metadata). A forward-looking note: the up-front write-scratch key-band validation uses the global concurrency sweep, not a per-op budgeted one — harmless today (writes are deferred and all `INHERIT`; still guarded fail-later in `measure_level`) — to be revisited when the writes phase introduces the first real per-op budget.
