### PR TITLE
feat(synthetic): baseline fixture parity (age index + deterministic bench_capacity) [Phase 3a, #239]

### DIFF
--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -191,7 +191,7 @@ rec/commands: aggregate_count.jsonl aggregate_group.jsonl expand_1_hop.jsonl
 ```json
 {
   "format_version": 1,
-  "generator_version": "synthbench/v3",
+  "generator_version": "synthbench/v4",
   "dataset": { "seed": 7, "nodes": 1000, "edges": 5000 },
   "ops": [ { "name": "return_const", "count": 256 }, { "name": "match_by_index", "count": 256 } ],
   "workload_hash": "sha256:7be5c44c…3058e2"

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -136,7 +136,7 @@ execution + compilation) modes, and derives the per-level **compilation cost** f
 synthetic benchmark — endpoint falkor://127.0.0.1:6381  graph falkor  samples 100  warmup 50  concurrency [1,2,4,8,16,32]  seed 7  connection pool(size=1) per worker
 server — falkordb module ver 4.20.1  redis 8.6.3  CACHE_SIZE 25
 client host — bench-host · macOS · Apple M1 Pro (10c/10t) · 16.0 GiB · arm64
-dataset — seed 7  nodes 1000  edges 5000  workload_hash sha256:7be5c44c…3058e2
+dataset — seed 7  nodes 1000  edges 5000  workload_hash sha256:b74e5a1d…7c1e70
 
 aggregate_count
   [cached — plan reused, execution only]
@@ -179,7 +179,7 @@ seed and the knobs, it is fully offline and reproducible.
 **What you get:**
 
 ```text
-recorded 9 op(s) into rec (workload_hash sha256:7be5c44c…3058e2)
+recorded 9 op(s) into rec (workload_hash sha256:b74e5a1d…7c1e70)
 rec: commands  graph.jsonl  manifest.json
 rec/commands: aggregate_count.jsonl aggregate_group.jsonl expand_1_hop.jsonl
   expand_hops_5.jsonl match_by_index.jsonl match_by_label_scan.jsonl
@@ -194,7 +194,7 @@ rec/commands: aggregate_count.jsonl aggregate_group.jsonl expand_1_hop.jsonl
   "generator_version": "synthbench/v4",
   "dataset": { "seed": 7, "nodes": 1000, "edges": 5000 },
   "ops": [ { "name": "return_const", "count": 256 }, { "name": "match_by_index", "count": 256 } ],
-  "workload_hash": "sha256:7be5c44c…3058e2"
+  "workload_hash": "sha256:b74e5a1d…7c1e70"
 }
 ```
 
@@ -244,7 +244,7 @@ and (b) two runs of the same workload against the same FalkorDB **do not diverge
 # (a) Determinism: record the same workload twice, compare the workload_hash — must be identical.
 benchmark synthetic record --op all --nodes 1000 --edges 5000 --seed 7 --out-dir rec
 benchmark synthetic record --op all --nodes 1000 --edges 5000 --seed 7 --out-dir rec_again
-# → both print the SAME `workload_hash sha256:7be5c44c…3058e2`
+# → both print the SAME `workload_hash sha256:b74e5a1d…7c1e70`
 
 # (b) Non-divergence (the CI gate): record all ops, run twice against ONE FalkorDB across the full
 #     sweep + both cache modes, and fail if any result digest differs. Spins its own throwaway
@@ -265,8 +265,8 @@ Because it compares deterministic result digests (not latency), it is **not** fl
 **What you get:**
 
 ```text
-first : sha256:7be5c44c…3058e2
-again : sha256:7be5c44c…3058e2      ← identical ⇒ deterministic
+first : sha256:b74e5a1d…7c1e70
+again : sha256:b74e5a1d…7c1e70      ← identical ⇒ deterministic
 
 # …and the final line from `just synthetic-verify`:
 synthetic-verify OK — no divergence across all ops × concurrency 1,2,4,8,16,32 × cached/uncached

--- a/docs/synthetic/sample-recording-manifest.json
+++ b/docs/synthetic/sample-recording-manifest.json
@@ -1,6 +1,6 @@
 {
   "format_version": 1,
-  "generator_version": "synthbench/v3",
+  "generator_version": "synthbench/v4",
   "tool_version": "0.1.0",
   "dataset": {
     "seed": 42,
@@ -24,6 +24,6 @@
       "count": 256
     }
   ],
-  "workload_hash": "sha256:57ec47dffa81b5be2d39fba9b634ea93e79020e2a0ba9f578692d72b351c7606",
+  "workload_hash": "sha256:eeaff0294bcda9a9f36b79c910a47163854eba4a075e3954dcc84997e993af45",
   "created_at_epoch_secs": 1784720696
 }

--- a/readme.md
+++ b/readme.md
@@ -215,7 +215,8 @@ sweep never mutates a graph unless you ask. `--tier core` selects a small, cheap
 subset gated on every PR; `--tier full` selects every read op (same as `--all-reads`, run
 nightly/on-demand). `--tier` is mutually exclusive with `--op`/`--all-reads`, and only ever selects
 reads (write ops are `full`-tier but stay opt-in). All read ops except `return_const` target the benchmark's
-`:User {id, age}` / `(:User)-[:Friend]->(:User)` schema (with an index on `:User(id)`). Most draw
+`:User {id, age}` / `(:User)-[:Friend {bench_capacity}]->(:User)` schema (with indexes on both
+`:User(id)` and `:User(age)`, mirroring the A/B baseline fixture). Most draw
 their parameters from `:User` ids sampled out of
 `--graph` (`shortest_path` needs two, `match_by_index`/`expand_*`/`aggregate_*`/`property_projection`
 one); `return_const` and `match_by_label_scan` need no seed ids (they vary a constant / a scan

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -1,13 +1,18 @@
 //! Seeded, reproducible synthetic dataset generator (Part 3).
 //!
-//! Generates a deterministic `:User {id, age}` / `(:User)-[:Friend]->(:User)` graph from a
-//! [`DatasetSpec`] and bulk-loads it via `UNWIND` batches, so operation numbers are controlled and
-//! comparable across runs, machines and FalkorDB versions. All randomness is derived from a
+//! Generates a deterministic `:User {id, age}` / `(:User)-[:Friend {bench_capacity}]->(:User)`
+//! graph from a [`DatasetSpec`] and bulk-loads it via `UNWIND` batches, so operation numbers are
+//! controlled and comparable across runs. To mirror the A/B benchmark's baseline fixture (design
+//! §3.4) it builds **both** the `:User(id)` and `:User(age)` indexes and stamps every `:Friend`
+//! edge with a deterministic [`bench_capacity`](crate::data_prep::bench_capacity), so shapes that
+//! filter on `age` or `r.bench_capacity` exercise the intended plan/predicate rather than a
+//! degenerate empty result. All randomness is derived from a
 //! portable [`splitmix64`] stream keyed by `(seed, domain, index)` — **not** `rand`'s `StdRng`,
 //! whose output isn't guaranteed stable across versions — so "same seed ⇒ same dataset" holds
 //! everywhere. A [`corpus_hash`] over the spec + selected operations + query bodies + sampled pools
 //! is recorded in the report so runs are only compared when the workload truly matches.
 
+use crate::data_prep::bench_capacity;
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::query::Query;
@@ -22,7 +27,7 @@ use std::time::Duration;
 
 /// Bumped whenever the generator algorithm or the operation catalog's query bodies change, so a
 /// [`corpus_hash`] from an older build never compares equal to a newer, differently-generated one.
-pub const GENERATOR_VERSION: &str = "synthbench/v3";
+pub const GENERATOR_VERSION: &str = "synthbench/v4";
 
 /// Max distinct `:User` ids sampled into the [`DatasetHandle`] id pool.
 const POOL_IDS: usize = 4096;
@@ -255,8 +260,13 @@ impl LoadPhase {
     }
 }
 
-/// The `:User(id)` index DDL — created before any data so every insert maintains it.
-const INDEX_STMT: &str = "CREATE INDEX FOR (u:User) ON (u.id)";
+/// The baseline index DDL, created before any data so every insert maintains the indexes. Mirrors
+/// the A/B benchmark's baseline fixture, which builds **both** a `:User(id)` and a `:User(age)`
+/// index (design §3.4); `id` backs point lookups, `age` backs the age-filtered read shapes.
+const INDEX_STMTS: [&str; 2] = [
+    "CREATE INDEX FOR (u:User) ON (u.id)",
+    "CREATE INDEX FOR (u:User) ON (u.age)",
+];
 
 /// One node `UNWIND` batch covering ids `lo..=hi` (inclusive, 1-based).
 fn node_batch(
@@ -274,7 +284,9 @@ fn node_batch(
     format!("UNWIND [{}] AS row CREATE (u:User) SET u = row", maps)
 }
 
-/// One edge `UNWIND` batch covering edge indices `lo..hi` (half-open).
+/// One edge `UNWIND` batch covering edge indices `lo..hi` (half-open). Each `:Friend` edge carries
+/// a deterministic [`bench_capacity`] (same formula as the A/B fixture) so shapes that filter on
+/// `r.bench_capacity` exercise a real predicate instead of always matching zero rows (design §3.4).
 fn edge_batch(
     spec: &DatasetSpec,
     lo: usize,
@@ -286,20 +298,22 @@ fn edge_batch(
             maps.push(',');
         }
         let (src, dst) = spec.edge_at(e);
-        let _ = write!(maps, "{{src:{},dst:{}}}", src, dst);
+        let capacity = bench_capacity(src as u64, dst as u64);
+        let _ = write!(maps, "{{src:{},dst:{},capacity:{}}}", src, dst, capacity);
     }
     format!(
-        "UNWIND [{}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend]->(m)",
+        "UNWIND [{}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend {{bench_capacity: row.capacity}}]->(m)",
         maps
     )
 }
 
-/// The exact ordered sequence of load statements that builds `spec`'s dataset: the index DDL, then
-/// `batch_size`-sized node `UNWIND` batches, then edge batches. **Lazy** — each batch string is
-/// built on demand as the iterator advances, so only one batch is materialized at a time (no
-/// full-script `Vec`). Shared by the live loader ([`generate_and_load`]) and the offline recorder
-/// so a replay loads a byte-identical graph to what a `--generate` run would. Callers must pass a
-/// validated `spec` (`spec.validate()`) and `batch_size >= 1`.
+/// The exact ordered sequence of load statements that builds `spec`'s dataset: the index DDL (both
+/// the `:User(id)` and `:User(age)` indexes), then `batch_size`-sized node `UNWIND` batches, then
+/// edge batches. **Lazy** — each batch string is built on demand as the iterator advances, so only
+/// one batch is materialized at a time (no full-script `Vec`). Shared by the live loader
+/// ([`generate_and_load`]) and the offline recorder so a replay loads a byte-identical graph to
+/// what a `--generate` run would. Callers must pass a validated `spec` (`spec.validate()`) and
+/// `batch_size >= 1`.
 pub(crate) fn load_statements(
     spec: &DatasetSpec,
     batch_size: usize,
@@ -307,7 +321,9 @@ pub(crate) fn load_statements(
     debug_assert!(batch_size >= 1, "batch_size must be >= 1");
     let nodes = spec.nodes as i32;
     let edges = spec.edges;
-    let index = std::iter::once((LoadPhase::Index, INDEX_STMT.to_string()));
+    let index = INDEX_STMTS
+        .iter()
+        .map(|stmt| (LoadPhase::Index, (*stmt).to_string()));
     let node_batches = (1..=nodes).step_by(batch_size).map(move |lo| {
         // Widen to i64 so `lo + batch_size` can't overflow i32 near the id ceiling.
         let hi = ((lo as i64) + (batch_size as i64) - 1).min(nodes as i64) as i32;
@@ -321,9 +337,9 @@ pub(crate) fn load_statements(
 }
 
 /// Generate the dataset described by `spec` and bulk-load it into `graph`, **replacing** whatever
-/// was there (the graph key is dropped first). Creates the `:User(id)` index, loads nodes then
-/// edges in `batch_size` `UNWIND` batches, verifies the final counts, and returns the seeded
-/// [`DatasetHandle`] the operation corpora draw from. `load_deadline` bounds each batch.
+/// was there (the graph key is dropped first). Creates the `:User(id)` and `:User(age)` indexes,
+/// loads nodes then edges in `batch_size` `UNWIND` batches, verifies the final counts, and returns
+/// the seeded [`DatasetHandle`] the operation corpora draw from. `load_deadline` bounds each batch.
 pub(crate) async fn generate_and_load(
     graph: &mut AsyncGraph,
     spec: &DatasetSpec,
@@ -512,13 +528,15 @@ mod tests {
 
     #[test]
     fn load_statements_are_ordered_and_batched() {
-        // 5 nodes, 6 edges, batch 2 → index + ceil(5/2)=3 node batches + ceil(6/2)=3 edge batches.
+        // 5 nodes, 6 edges, batch 2 → 2 index stmts + ceil(5/2)=3 node batches + ceil(6/2)=3 edge
+        // batches.
         let s = spec(3, 5, 6);
         let stmts: Vec<(LoadPhase, String)> = load_statements(&s, 2).collect();
         let phases: Vec<LoadPhase> = stmts.iter().map(|(p, _)| *p).collect();
         assert_eq!(
             phases,
             vec![
+                LoadPhase::Index,
                 LoadPhase::Index,
                 LoadPhase::Nodes,
                 LoadPhase::Nodes,
@@ -528,11 +546,12 @@ mod tests {
                 LoadPhase::Edges,
             ]
         );
-        // The index DDL comes first, verbatim.
-        assert_eq!(stmts[0].1, INDEX_STMT);
+        // Both index DDLs come first, verbatim: `:User(id)` then `:User(age)`.
+        assert_eq!(stmts[0].1, INDEX_STMTS[0]);
+        assert_eq!(stmts[1].1, INDEX_STMTS[1]);
         // First node batch has ids 1,2 with their deterministic ages; last has the lone id 5.
         assert_eq!(
-            stmts[1].1,
+            stmts[2].1,
             format!(
                 "UNWIND [{{id:1,age:{}}},{{id:2,age:{}}}] AS row CREATE (u:User) SET u = row",
                 s.node_age(1),
@@ -540,19 +559,22 @@ mod tests {
             )
         );
         assert_eq!(
-            stmts[3].1,
+            stmts[4].1,
             format!(
                 "UNWIND [{{id:5,age:{}}}] AS row CREATE (u:User) SET u = row",
                 s.node_age(5)
             )
         );
-        // First edge batch covers edge indices 0,1 (the ring backbone start).
+        // First edge batch covers edge indices 0,1 (the ring backbone start), each stamped with its
+        // deterministic bench_capacity.
         let (e0s, e0d) = s.edge_at(0);
         let (e1s, e1d) = s.edge_at(1);
+        let e0c = bench_capacity(e0s as u64, e0d as u64);
+        let e1c = bench_capacity(e1s as u64, e1d as u64);
         assert_eq!(
-            stmts[4].1,
+            stmts[5].1,
             format!(
-                "UNWIND [{{src:{e0s},dst:{e0d}}},{{src:{e1s},dst:{e1d}}}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend]->(m)"
+                "UNWIND [{{src:{e0s},dst:{e0d},capacity:{e0c}}},{{src:{e1s},dst:{e1d},capacity:{e1c}}}] AS row MATCH (n:User {{id: row.src}}), (m:User {{id: row.dst}}) CREATE (n)-[:Friend {{bench_capacity: row.capacity}}]->(m)"
             )
         );
     }
@@ -573,8 +595,8 @@ mod tests {
     fn load_statements_batch_size_one_yields_one_statement_per_row() {
         let s = spec(1, 3, 3);
         let stmts: Vec<_> = load_statements(&s, 1).collect();
-        // index + 3 node batches + 3 edge batches.
-        assert_eq!(stmts.len(), 1 + 3 + 3);
+        // 2 index stmts + 3 node batches + 3 edge batches.
+        assert_eq!(stmts.len(), 2 + 3 + 3);
     }
 
     #[test]
@@ -724,7 +746,7 @@ mod tests {
         )];
         assert_eq!(
             corpus_hash(&s, 0, 256, &bodies, &s.handle()),
-            "sha256:ad6dec1c5dc2f7700383cddecbdb23b0a7b02bead9a12ff64239b3c9aa836ab0"
+            "sha256:9be33d3926a50d91f3ec80d5c0a0abb3256e5700945ab3a1fd202950e8f7e450"
         );
     }
 }

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -501,6 +501,32 @@ async fn generated_dataset_has_exact_counts_index_and_hash() {
     .await;
     assert!(operational >= 1, "expected an OPERATIONAL :User index");
 
+    // ...as does the :User(age) index (fixture parity with the A/B baseline — design §3.4), so age
+    // is indexed alongside id.
+    let age_indexed = scalar_i64(
+        &mut g,
+        "CALL db.indexes() YIELD label, properties, status \
+         WHERE label = 'User' AND status = 'OPERATIONAL' AND 'age' IN properties RETURN count(*)",
+    )
+    .await;
+    assert!(age_indexed >= 1, "expected an OPERATIONAL :User(age) index");
+
+    // Every :Friend edge carries a deterministic bench_capacity in [1, 20] (no NULLs), so
+    // capacity-filtered shapes exercise a real predicate rather than always matching zero rows.
+    let missing_capacity = scalar_i64(
+        &mut g,
+        "MATCH (:User)-[r:Friend]->(:User) WHERE r.bench_capacity IS NULL RETURN count(r)",
+    )
+    .await;
+    assert_eq!(missing_capacity, 0, "every :Friend edge must have bench_capacity");
+    let out_of_range = scalar_i64(
+        &mut g,
+        "MATCH (:User)-[r:Friend]->(:User) WHERE r.bench_capacity < 1 OR r.bench_capacity > 20 \
+         RETURN count(r)",
+    )
+    .await;
+    assert_eq!(out_of_range, 0, "bench_capacity must stay within [1, 20]");
+
     // ...and the point-lookup op uses it (Node By Index Scan in the plan).
     let plan = explain(&mut g, "MATCH (n:User {id: 7}) RETURN n.id").await;
     assert!(


### PR DESCRIPTION
## Phase 3a: baseline fixture parity

Part of #239 (make the synthetic per-op regression check cover the A/B benchmark's query shapes). This is the **first, self-contained step of Phase 3** (design §3.4 / §7): bring the offline synthetic dataset generator to **parity with the A/B benchmark's baseline fixture** so the upcoming ~46 baseline **read** shapes exercise their intended plans/predicates instead of degenerate empty results. No new shapes are wired in yet — this only makes the fixture faithful (and unblocks the reads PR that follows).

### What changed
- **Both baseline indexes.** `INDEX_STMT: &str` → `INDEX_STMTS: [&str; 2]` — the generator now builds **`:User(id)` and `:User(age)`** (was `id` only). `id` backs point lookups; `age` backs the age-filtered read shapes. The load sequence stays lazy/deterministic (2 index stmts → node batches → edge batches).
- **Deterministic edge capacity.** Every `:Friend` edge is stamped with a `bench_capacity` in `[1, 20]` via `data_prep::bench_capacity(src, dst)` — the **same formula and client-side embedding** the A/B loader uses (`CREATE (n)-[:Friend {bench_capacity: row.capacity}]->(m)`), so capacity-filtered shapes hit a real predicate.
- **`GENERATOR_VERSION` `synthbench/v3` → `synthbench/v4`.** The version is folded into `corpus_hash`/`workload_hash`, so this (correctly, by design) invalidates cross-version comparisons and updates the pinned golden-hash test.

### Comparability invariant (record-once → replay-verbatim) preserved
This only changes what the **record**-time load script generates; it's a pure function of `(seed, spec)`. A replay still loads the byte-identical recorded graph, and both replays of a single recorded bundle stay byte-identical — so `workload_hash` remains identical across engines and the **Synthetic non-divergence** gate stays meaningful.

### Tests
- Unit: statement ordering (2 index stmts first, verbatim), batch-size-one count (`2 + 3 + 3`), and the re-pinned golden `corpus_hash`.
- Integration (`#[ignore]`, ran **green against a live FalkorDB**): `generated_dataset_has_exact_counts_index_and_hash` now also asserts an **OPERATIONAL `:User(age)` index** and that **every** `:Friend` edge has a non-null `bench_capacity` within `[1, 20]`.
- Validated locally: `just clippy` (warnings-denied), `just build`, `just test` all green; full `#[ignore]` `synthetic_probe` suite **21/21** against live FalkorDB.

### Docs
Updated the readme schema description and the two illustrative recording-manifest samples (version bump; the sample manifest's `workload_hash` was **regenerated** by running the offline `synthetic record` command so it stays accurate).

### Not in this PR (follow-ups, still Phase 3)
The string-keyed record/run/replay generalization, the `queries_repository` bridge, the ~46 baseline read shapes, and the graph-name-agnostic driver helpers land in the next PR(s) — this fixture-parity step is kept isolated so it's trivially reviewable and safe for the existing ops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Synthetic benchmark datasets now include `:User(age)` indexing.
  * Friend relationships now include deterministic capacity metadata.

* **Documentation**
  * Updated benchmark schema documentation and sample manifests to reflect the new dataset format and generator version.

* **Tests**
  * Added validation for the age index and relationship capacity values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->