### PR TITLE
refactor(synthetic): key record/replay pipeline on string OpKey (Phase 3b plumbing, #239)

### DIFF
--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -695,7 +695,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         let op_report = measure_op(
             &op_config,
             &op_concurrency,
-            &op_spec,
+            MeasureTarget::from_spec(&op_spec),
             rendered,
             run_token,
             &uid_alloc,
@@ -992,13 +992,41 @@ impl OpInvoker for GraphWorker {
     }
 }
 
+/// The minimal per-operation facts the measurement engine needs, decoupled from the catalog's
+/// [`OperationSpec`] so a recorded **string-keyed** op — which has no `OperationSpec` (see
+/// [`OpKey`]) — can be measured the same way: its read/write [`QueryType`] (selects `RO_QUERY` vs
+/// `QUERY`) and, for writes, the [`WritePlan`] whose setup/reset/cleanup hooks frame the measured
+/// window. Reads carry `write: None`.
+#[derive(Clone, Copy)]
+pub(crate) struct MeasureTarget {
+    pub kind: QueryType,
+    pub write: Option<WritePlan>,
+}
+
+impl MeasureTarget {
+    /// The measurement target for a built-in catalog operation.
+    pub(crate) fn from_spec(op_spec: &OperationSpec) -> Self {
+        Self {
+            kind: op_spec.kind,
+            write: op_spec.write,
+        }
+    }
+
+    /// A read-only measurement target (no write hooks) — used by the reads-only replay path.
+    pub(crate) fn read() -> Self {
+        Self {
+            kind: QueryType::Read,
+            write: None,
+        }
+    }
+}
+
 /// Measure one operation across the concurrency sweep, under every requested cache mode, and derive
 /// its per-level compilation cost.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn measure_op(
     config: &Config,
     concurrency: &[usize],
-    op_spec: &OperationSpec,
+    target: MeasureTarget,
     corpus: Arc<Vec<String>>,
     run_token: u64,
     uid_alloc: &AtomicU64,
@@ -1012,7 +1040,7 @@ pub(crate) async fn measure_op(
             let metrics = measure_level(
                 config,
                 c,
-                op_spec,
+                target,
                 &corpus,
                 mode,
                 run_token,
@@ -1091,7 +1119,7 @@ async fn run_scratch_cleanup(
 async fn measure_level(
     config: &Config,
     concurrency: usize,
-    op_spec: &OperationSpec,
+    target: MeasureTarget,
     corpus: &Arc<Vec<String>>,
     mode: CacheMode,
     run_token: u64,
@@ -1121,7 +1149,7 @@ async fn measure_level(
     // For a write op, capture the cleanup handle up-front — *before* any worker's setup mutates the
     // graph — so a mid-loop connection/setup failure still drops whatever scratch earlier workers
     // created. The run label is shared, so worker 0's scratch cleans the whole run.
-    let write_cleanup: Option<(WritePlan, WriteScratch)> = match &op_spec.write {
+    let write_cleanup: Option<(WritePlan, WriteScratch)> = match &target.write {
         Some(plan) => Some((*plan, WriteScratch::new(run_token, 0, config.reset_every)?)),
         None => None,
     };
@@ -1134,7 +1162,7 @@ async fn measure_level(
         for w in 0..concurrency {
             let mut graph = open_graph(&config.endpoint, &config.graph).await?;
             let uid_base = uid_alloc.fetch_add(block, Ordering::Relaxed);
-            let source = match &op_spec.write {
+            let source = match &target.write {
                 Some(plan) => {
                     let scratch = WriteScratch::new(run_token, w, config.reset_every)?;
                     // Untimed setup on this worker's own connection before the measurement window.
@@ -1157,7 +1185,7 @@ async fn measure_level(
             };
             workers.push(GraphWorker {
                 graph,
-                kind: op_spec.kind,
+                kind: target.kind,
                 mode,
                 run_token,
                 uid_base,

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -74,6 +74,24 @@ fn default_op_kind() -> QueryType {
     QueryType::Read
 }
 
+/// Reject an op name that isn't a safe single-path-component slug.
+///
+/// A recorded op's name becomes a file stem (`commands/<name>.jsonl`), so a string-keyed name
+/// containing a path separator or `..` could otherwise escape the bundle directory on record **or**
+/// on [`load`] (from a crafted manifest). Names are restricted to `[A-Za-z0-9_-]+`, which every
+/// built-in [`OpName`] already satisfies, so this only constrains dynamic string-keyed ops.
+fn validate_op_name(name: &str) -> BenchmarkResult<()> {
+    if !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    {
+        Ok(())
+    } else {
+        Err(OtherError(format!(
+            "unsafe operation name {name:?}: names must be non-empty and contain only \
+             ASCII letters, digits, '_' or '-'"
+        )))
+    }
+}
+
 /// The bundle manifest (`manifest.json`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Manifest {
@@ -281,17 +299,22 @@ pub fn record_rendered(
     if batch_size == 0 {
         return Err(OtherError("record batch_size must be greater than 0".to_string()));
     }
+    // Reject writes on the *original* ops (before dedup) so a duplicate-name write can't be dropped
+    // by dedup and slip through, and validate every name up-front (a name becomes a file stem).
+    for op in ops {
+        validate_op_name(op.key.name())?;
+        if op.key.kind() == QueryType::Write {
+            return Err(OtherError(format!(
+                "recording write op '{}' is not supported yet (v1 records read ops only)",
+                op.key.name()
+            )));
+        }
+    }
     let ops = dedup_recorded(ops);
     if ops.is_empty() {
         return Err(OtherError(
             "no operations to record — pass at least one read --op".to_string(),
         ));
-    }
-    if let Some(op) = ops.iter().find(|op| op.key.kind() == QueryType::Write) {
-        return Err(OtherError(format!(
-            "recording write op '{}' is not supported yet (v1 records read ops only)",
-            op.key.name()
-        )));
     }
 
     let knobs = DatasetKnobs {
@@ -417,6 +440,9 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
     // commands/<op>.jsonl for each op named in the manifest, in order.
     let mut commands = Vec::with_capacity(manifest.ops.len());
     for entry in &manifest.ops {
+        // Reject an unsafe name before it becomes a file path — a crafted manifest name with a path
+        // separator or `..` must not read outside the bundle's `commands/` directory.
+        validate_op_name(&entry.name)?;
         // Rebuild the op identity from its name + kind. `OpKey::dynamic` canonicalizes a built-in
         // name back to its `OpName` (keeping the built-in salt/kind); a name with no `OpName`
         // becomes a string-keyed dynamic op. Either way the bundle round-trips by name.
@@ -766,6 +792,83 @@ mod tests {
         assert_eq!(manifest.ops.len(), 1);
         let bundle = load(&dir).unwrap();
         assert_eq!(bundle.commands[0].1, vec!["CYPHER  RETURN 1".to_string()]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn validate_op_name_accepts_slugs_and_rejects_traversal() {
+        for ok in ["match_by_index", "expand_1hop", "shape-42", "A_b-9"] {
+            assert!(validate_op_name(ok).is_ok(), "{ok} should be accepted");
+        }
+        for bad in ["", "../evil", "a/b", "a\\b", "a.b", "..", "with space", "emoji_🚀"] {
+            assert!(validate_op_name(bad).is_err(), "{bad:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn record_rendered_rejects_unsafe_names() {
+        let dir = temp_bundle_dir("synthrec-unsafe");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("../escape", QueryType::Read),
+            commands: vec!["CYPHER  RETURN 1".to_string()],
+        }];
+        let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
+        assert!(format!("{err}").contains("unsafe operation name"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_rejects_a_write_hidden_behind_a_duplicate_read() {
+        // The write check runs on the original ops (before dedup), so a later same-named write is
+        // caught rather than dropped by first-occurrence dedup.
+        let dir = temp_bundle_dir("synthrec-dupwrite");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![
+            RecordedOp {
+                key: OpKey::dynamic("dup", QueryType::Read),
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            },
+            RecordedOp {
+                key: OpKey::dynamic("dup", QueryType::Write),
+                commands: vec!["CYPHER  CREATE (n)".to_string()],
+            },
+        ];
+        let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
+        assert!(format!("{err}").contains("write op"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_unsafe_manifest_names() {
+        // A crafted manifest whose op name contains a path separator must be rejected on load,
+        // before the name is turned into a `commands/<name>.jsonl` path.
+        let dir = temp_bundle_dir("synthrec-loadunsafe");
+        let spec = DatasetSpec {
+            seed: 2,
+            nodes: 20,
+            edges: 60,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("safe_read", QueryType::Read),
+            commands: vec!["CYPHER  RETURN 1".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        let manifest_path = dir.join("manifest.json");
+        let doctored = std::fs::read_to_string(&manifest_path)
+            .unwrap()
+            .replace("safe_read", "../evil");
+        std::fs::write(&manifest_path, doctored).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{err}").contains("unsafe operation name"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -439,10 +439,20 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
 
     // commands/<op>.jsonl for each op named in the manifest, in order.
     let mut commands = Vec::with_capacity(manifest.ops.len());
+    let mut seen_names = std::collections::BTreeSet::new();
     for entry in &manifest.ops {
         // Reject an unsafe name before it becomes a file path — a crafted manifest name with a path
         // separator or `..` must not read outside the bundle's `commands/` directory.
         validate_op_name(&entry.name)?;
+        // Reject duplicate op names: op names key `commands/<name>.jsonl` and the replay report's
+        // per-op map, so a duplicate would double-run or silently overwrite a result. A recorded
+        // bundle is deduped at record time, so a duplicate here means a crafted/corrupt manifest.
+        if !seen_names.insert(entry.name.as_str()) {
+            return Err(OtherError(format!(
+                "manifest lists duplicate op name '{}'",
+                entry.name
+            )));
+        }
         // Rebuild the op identity from its name + kind. `OpKey::dynamic` canonicalizes a built-in
         // name back to its `OpName` (keeping the built-in salt/kind); a name with no `OpName`
         // becomes a string-keyed dynamic op. Either way the bundle round-trips by name.
@@ -869,6 +879,32 @@ mod tests {
         std::fs::write(&manifest_path, doctored).unwrap();
         let err = load(&dir).unwrap_err();
         assert!(format!("{err}").contains("unsafe operation name"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_duplicate_manifest_op_names() {
+        // A recorded bundle is deduped at record time; a manifest with two entries sharing a name
+        // is crafted/corrupt and must be rejected so replay can't double-run or overwrite by name.
+        let dir = temp_bundle_dir("synthrec-dupload");
+        let spec = DatasetSpec {
+            seed: 2,
+            nodes: 20,
+            edges: 60,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("safe_read", QueryType::Read),
+            commands: vec!["CYPHER  RETURN 1".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        let manifest_path = dir.join("manifest.json");
+        let mut v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        let dup = v["ops"][0].clone();
+        v["ops"].as_array_mut().unwrap().push(dup);
+        std::fs::write(&manifest_path, serde_json::to_string_pretty(&v).unwrap()).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{err}").contains("duplicate op name"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -27,7 +27,7 @@ use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::synthetic::catalog::spec;
 use crate::synthetic::dataset::{load_statements, DatasetSpec, LoadPhase, GENERATOR_VERSION};
-use crate::synthetic::OpName;
+use crate::synthetic::{OpKey, OpName};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
@@ -61,7 +61,17 @@ impl DatasetKnobs {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpEntry {
     pub name: String,
+    /// The op's read/write kind, so [`load`] can rebuild its [`OpKey`] — a built-in [`OpName`] or a
+    /// string-keyed dynamic op. Defaults to `Read` for bundles written before this field existed
+    /// (v1 records reads only), and is **not** folded into the [`Manifest::workload_hash`].
+    #[serde(default = "default_op_kind")]
+    pub kind: QueryType,
     pub count: usize,
+}
+
+/// The read/write kind an [`OpEntry`] without an explicit `kind` deserializes to (v1 read bundles).
+fn default_op_kind() -> QueryType {
+    QueryType::Read
 }
 
 /// The bundle manifest (`manifest.json`).
@@ -112,8 +122,9 @@ pub struct Bundle {
     pub manifest: Manifest,
     /// The ordered load statements (`graph.jsonl`).
     pub graph_statements: Vec<(LoadPhase, String)>,
-    /// Each recorded op's ordered commands, in the manifest's op order.
-    pub commands: Vec<(OpName, Vec<String>)>,
+    /// Each recorded op's ordered commands, in the manifest's op order. The [`OpKey`] carries the
+    /// op's stable name + kind (a built-in [`OpName`] or a string-keyed dynamic op).
+    pub commands: Vec<(OpKey, Vec<String>)>,
 }
 
 /// Length-framed workload hasher. Every part is prefixed with its byte length (u64 LE) before the
@@ -188,12 +199,23 @@ impl WorkloadHasher {
     }
 }
 
-/// De-duplicate ops preserving first-occurrence order (matching how a run executes them).
-fn dedup_ops(ops: &[OpName]) -> Vec<OpName> {
+/// One operation to record, with its already-rendered measured command corpus. Lets callers record
+/// ops that have **no catalog `OperationSpec`** — string-keyed `queries_repository` shapes — by
+/// supplying the rendered commands directly, while built-in ops are rendered by [`record`] via
+/// [`render_commands`]. `key` carries the op's stable name and read/write kind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedOp {
+    pub key: OpKey,
+    pub commands: Vec<String>,
+}
+
+/// De-duplicate recorded ops preserving first-occurrence order (matching how a run executes them),
+/// keyed on the stable op name.
+fn dedup_recorded(ops: &[RecordedOp]) -> Vec<RecordedOp> {
     let mut seen = std::collections::BTreeSet::new();
     ops.iter()
-        .copied()
-        .filter(|op| seen.insert(op.as_str()))
+        .filter(|op| seen.insert(op.key.name().to_string()))
+        .cloned()
         .collect()
 }
 
@@ -211,11 +233,9 @@ pub fn render_commands(
     Ok(corpus.iter().map(|q| q.to_cypher()).collect())
 }
 
-/// Record a workload bundle to `out_dir` (created if absent). **Offline** — no server is contacted.
-///
-/// Writes `graph.jsonl` (the [`load_statements`] for `dataset`), `commands/<op>.jsonl` for each op,
-/// and `manifest.json` with the [`Manifest::workload_hash`]. `ops` are de-duplicated (first
-/// occurrence wins); **write ops are rejected** (v1 records read ops only). Returns the manifest.
+/// Record a workload bundle to `out_dir` (created if absent) for the given built-in catalog read
+/// `ops`. **Offline** — no server is contacted. Renders each op's corpus via [`render_commands`]
+/// then delegates to [`record_rendered`]; **write ops are rejected** (v1 records read ops only).
 pub fn record(
     dataset: &DatasetSpec,
     graph: &str,
@@ -224,20 +244,53 @@ pub fn record(
     batch_size: usize,
     out_dir: &Path,
 ) -> BenchmarkResult<Manifest> {
+    // Reject writes up-front — before rendering — so we never build a write op's corpus (v1 records
+    // reads only). [`record_rendered`] re-checks by kind for string-keyed callers.
+    if let Some(op) = ops.iter().find(|op| spec(**op).kind == QueryType::Write) {
+        return Err(OtherError(format!(
+            "recording write op '{}' is not supported yet (v1 records read ops only)",
+            op.as_str()
+        )));
+    }
+    let mut recorded = Vec::with_capacity(ops.len());
+    for &op in ops {
+        recorded.push(RecordedOp {
+            key: OpKey::from(op),
+            commands: render_commands(op, dataset, corpus_seed)?,
+        });
+    }
+    record_rendered(dataset, graph, &recorded, corpus_seed, batch_size, out_dir)
+}
+
+/// Record a workload bundle from **already-rendered** ops — the general form behind [`record`], used
+/// for string-keyed shapes that have no catalog `OperationSpec`. **Offline** — no server is
+/// contacted.
+///
+/// Writes `graph.jsonl` (the [`load_statements`] for `dataset`), `commands/<op>.jsonl` for each op,
+/// and `manifest.json` with the [`Manifest::workload_hash`]. `ops` are de-duplicated by name (first
+/// occurrence wins); **write ops are rejected** (v1 records read ops only). Returns the manifest.
+pub fn record_rendered(
+    dataset: &DatasetSpec,
+    graph: &str,
+    ops: &[RecordedOp],
+    corpus_seed: u64,
+    batch_size: usize,
+    out_dir: &Path,
+) -> BenchmarkResult<Manifest> {
     dataset.validate()?;
     if batch_size == 0 {
         return Err(OtherError("record batch_size must be greater than 0".to_string()));
     }
-    let ops = dedup_ops(ops);
+    let ops = dedup_recorded(ops);
     if ops.is_empty() {
         return Err(OtherError(
             "no operations to record — pass at least one read --op".to_string(),
         ));
     }
-    if let Some(op) = ops.iter().find(|op| spec(**op).kind == QueryType::Write) {
+    if let Some(op) = ops.iter().find(|op| op.key.kind() == QueryType::Write) {
         return Err(OtherError(format!(
             "recording write op '{}' is not supported yet (v1 records read ops only)",
-            op.as_str()
+            op.key.name()
         )));
     }
 
@@ -278,9 +331,13 @@ pub fn record(
     // commands/<op>.jsonl.
     let mut op_entries = Vec::with_capacity(ops.len());
     for op in &ops {
-        let cyphers = render_commands(*op, dataset, corpus_seed)?;
-        hasher.op_header(op.as_str(), cyphers.len());
-        let path = commands_dir.join(format!("{}.jsonl", op.as_str()));
+        let name = op.key.name();
+        let cyphers = &op.commands;
+        if cyphers.is_empty() {
+            return Err(OtherError(format!("operation '{}' produced an empty corpus", name)));
+        }
+        hasher.op_header(name, cyphers.len());
+        let path = commands_dir.join(format!("{}.jsonl", name));
         let mut w = BufWriter::new(create_file(&path)?);
         for (seq, cypher) in cyphers.iter().enumerate() {
             hasher.command(cypher);
@@ -294,7 +351,8 @@ pub fn record(
         w.flush()
             .map_err(|e| OtherError(format!("flushing {}: {}", path.display(), e)))?;
         op_entries.push(OpEntry {
-            name: op.as_str().to_string(),
+            name: name.to_string(),
+            kind: op.key.kind(),
             count: cyphers.len(),
         });
     }
@@ -359,8 +417,10 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
     // commands/<op>.jsonl for each op named in the manifest, in order.
     let mut commands = Vec::with_capacity(manifest.ops.len());
     for entry in &manifest.ops {
-        let op = OpName::from_tag(&entry.name)
-            .ok_or_else(|| OtherError(format!("manifest names unknown op '{}'", entry.name)))?;
+        // Rebuild the op identity from its name + kind. `OpKey::dynamic` canonicalizes a built-in
+        // name back to its `OpName` (keeping the built-in salt/kind); a name with no `OpName`
+        // becomes a string-keyed dynamic op. Either way the bundle round-trips by name.
+        let op = OpKey::dynamic(entry.name.clone(), entry.kind);
         let path = dir.join("commands").join(format!("{}.jsonl", entry.name));
         let recs: Vec<CommandRecord> = read_jsonl(&path)?;
         if recs.len() != entry.count {
@@ -492,7 +552,8 @@ mod tests {
         assert_eq!(bundle.graph_statements, want);
         // commands equal what a run would derive for each op.
         for (op, cyphers) in &bundle.commands {
-            assert_eq!(*cyphers, render_commands(*op, &spec, manifest.corpus_seed).unwrap());
+            let name = OpName::from_tag(op.name()).expect("built-in op name");
+            assert_eq!(*cyphers, render_commands(name, &spec, manifest.corpus_seed).unwrap());
             assert!(!cyphers.is_empty());
         }
         std::fs::remove_dir_all(&dir).ok();
@@ -591,6 +652,121 @@ mod tests {
 
         let dir2 = temp_bundle_dir("synthrec-empty");
         assert!(record(&spec, "g", &[], 1, 8, &dir2).is_err());
+    }
+
+    #[test]
+    fn op_entry_kind_defaults_to_read_when_absent() {
+        // A v1 bundle (written before `kind` existed) recorded reads only — a kind-less entry must
+        // deserialize to `Read` via `default_op_kind`, and an explicit kind round-trips.
+        let legacy: OpEntry = serde_json::from_str(r#"{"name":"match_by_index","count":3}"#).unwrap();
+        assert_eq!(legacy.kind, QueryType::Read);
+        assert_eq!(legacy.count, 3);
+        let explicit: OpEntry =
+            serde_json::from_str(r#"{"name":"w","kind":"Write","count":1}"#).unwrap();
+        assert_eq!(explicit.kind, QueryType::Write);
+    }
+
+    #[test]
+    fn record_rendered_round_trips_a_dynamic_op() {
+        // A string-keyed op with no built-in `OpName`, recorded from hand-supplied commands (the
+        // path a `queries_repository` shape will use), survives `load` with the integrity gate.
+        let dir = temp_bundle_dir("synthrec-dyn");
+        let spec = DatasetSpec {
+            seed: 3,
+            nodes: 50,
+            edges: 150,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("single_vertex_read", QueryType::Read),
+            commands: vec![
+                "CYPHER id=1 MATCH (n:User {id:$id}) RETURN n".to_string(),
+                "CYPHER id=2 MATCH (n:User {id:$id}) RETURN n".to_string(),
+            ],
+        }];
+        let manifest = record_rendered(&spec, "gdyn", &ops, 9, 32, &dir).unwrap();
+        assert_eq!(manifest.ops.len(), 1);
+        assert_eq!(manifest.ops[0].name, "single_vertex_read");
+        assert_eq!(manifest.ops[0].kind, QueryType::Read);
+        assert_eq!(manifest.ops[0].count, 2);
+
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.manifest, manifest);
+        assert_eq!(bundle.commands.len(), 1);
+        let (key, cmds) = &bundle.commands[0];
+        assert_eq!(key.name(), "single_vertex_read");
+        assert!(!key.is_named(), "an unknown name loads back as a dynamic op");
+        assert_eq!(key.kind(), QueryType::Read);
+        assert_eq!(cmds, &ops[0].commands);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_canonicalizes_builtin_names_to_named_ops() {
+        // Built-in read ops recorded via `record` load back as `Named` keys (canonicalized by name),
+        // so the built-in salt/kind is preserved across a record→load round-trip.
+        let (dir, _man) = record_to_temp(11);
+        let bundle = load(&dir).unwrap();
+        assert!(bundle.commands.iter().all(|(k, _)| k.is_named()));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_rejects_write_kind_ops() {
+        let dir = temp_bundle_dir("synthrec-dynwrite");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("bulk_insert", QueryType::Write),
+            commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
+        }];
+        let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
+        assert!(format!("{}", err).contains("write op"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_rejects_an_empty_corpus() {
+        let dir = temp_bundle_dir("synthrec-dynempty");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("empty_shape", QueryType::Read),
+            commands: vec![],
+        }];
+        let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
+        assert!(format!("{}", err).contains("empty corpus"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_dedups_by_name_keeping_first() {
+        let dir = temp_bundle_dir("synthrec-dyndedup");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![
+            RecordedOp {
+                key: OpKey::dynamic("a_read", QueryType::Read),
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            },
+            RecordedOp {
+                key: OpKey::dynamic("a_read", QueryType::Read),
+                commands: vec!["CYPHER  RETURN 2".to_string()],
+            },
+        ];
+        let manifest = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        assert_eq!(manifest.ops.len(), 1);
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.commands[0].1, vec!["CYPHER  RETURN 1".to_string()]);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -18,14 +18,14 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
-use crate::synthetic::catalog::{spec, DEFAULT_RESET_EVERY};
+use crate::synthetic::catalog::DEFAULT_RESET_EVERY;
 use crate::synthetic::dataset::{self, DatasetSpec};
 use crate::synthetic::op_runner::{capture_result, ResultShape};
 use crate::synthetic::recording::{self, Bundle};
 use crate::synthetic::report::{DatasetInfo, Meta, Report, ServerInfo, SCHEMA_VERSION};
 use crate::synthetic::{
     measure_op, normalize_concurrency, open_graph, provenance, redact_endpoint, write_report,
-    CacheSelection, Config, OpName,
+    CacheSelection, Config, MeasureTarget, OpKey,
 };
 use falkordb::AsyncGraph;
 use sha2::{Digest, Sha256};
@@ -81,12 +81,12 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     if let Some((op, _)) = bundle
         .commands
         .iter()
-        .find(|(op, _)| spec(*op).kind == QueryType::Write)
+        .find(|(op, _)| op.kind() == QueryType::Write)
     {
         return Err(OtherError(format!(
             "recorded op '{}' is a write op — replaying writes is not supported (v1 records reads \
              only)",
-            op.as_str()
+            op.name()
         )));
     }
     let dataset_spec = bundle.spec();
@@ -134,21 +134,21 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // shape (cardinality + order-independent value digest). This is the correctness oracle and also
     // primes the plan cache. Reads return scalars, so a single connection is safe.
     let st = config.server_timeout_ms;
-    let mut reference: Vec<(OpName, Arc<Vec<String>>, Vec<ResultShape>)> =
+    let mut reference: Vec<(OpKey, Arc<Vec<String>>, Vec<ResultShape>)> =
         Vec::with_capacity(bundle.commands.len());
     for (op, cyphers) in &bundle.commands {
         if cyphers.is_empty() {
-            return Err(OtherError(format!("op '{}' has no recorded commands", op.as_str())));
+            return Err(OtherError(format!("op '{}' has no recorded commands", op.name())));
         }
         let mut shapes = Vec::with_capacity(cyphers.len());
         for c in cyphers {
             shapes.push(
                 capture_result(&mut graph, c, st, client_deadline)
                     .await
-                    .map_err(|e| OtherError(format!("capturing '{}': {}", op.as_str(), e)))?,
+                    .map_err(|e| OtherError(format!("capturing '{}': {}", op.name(), e)))?,
             );
         }
-        reference.push((*op, Arc::new(cyphers.clone()), shapes));
+        reference.push((op.clone(), Arc::new(cyphers.clone()), shapes));
     }
     // Setup connection done; drop it so it isn't an idle extra connection during the sweep.
     drop(graph);
@@ -157,7 +157,10 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     let engine_config = Config {
         endpoint: config.endpoint.clone(),
         graph: graph_name.clone(),
-        ops: reference.iter().map(|(op, _, _)| *op).collect(),
+        // `ops` is unused by the measurement path (`measure_op` replays the passed-in corpus, not
+        // the config's op list) — leave it empty rather than lossily mapping string-keyed `OpKey`s
+        // back to the `OpName` enum this field holds.
+        ops: Vec::new(),
         samples: config.samples,
         warmup: config.warmup,
         concurrency: concurrency.clone(),
@@ -193,7 +196,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             .map_err(|e| {
                 OtherError(format!(
                     "op '{}' returned different results at concurrency {}: {}",
-                    op.as_str(),
+                    op.name(),
                     max_c,
                     e
                 ))
@@ -202,15 +205,15 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         let mut op_report = measure_op(
             &engine_config,
             &concurrency,
-            &spec(*op),
+            MeasureTarget::read(),
             Arc::clone(corpus),
             run_token,
             &uid_alloc,
             client_deadline,
         )
         .await?;
-        op_report.result_digest = Some(op_result_digest(*op, shapes));
-        operations.insert(op.as_str().to_string(), op_report);
+        op_report.result_digest = Some(op_result_digest(op.name(), shapes));
+        operations.insert(op.name().to_string(), op_report);
     }
 
     // The corpus size is what the bundle actually recorded per op (not the compile-time constant).
@@ -338,11 +341,11 @@ async fn verify_concurrent(
 /// length-framed so it can't alias a different op's digest. Two versions returning different results
 /// for the same recorded command produce different digests.
 fn op_result_digest(
-    op: OpName,
+    name: &str,
     shapes: &[ResultShape],
 ) -> String {
     let mut h = Sha256::new();
-    let name = op.as_str().as_bytes();
+    let name = name.as_bytes();
     h.update((name.len() as u64).to_le_bytes());
     h.update(name);
     h.update((shapes.len() as u64).to_le_bytes());
@@ -369,14 +372,14 @@ mod tests {
     #[test]
     fn op_result_digest_is_deterministic_and_sensitive() {
         let base = vec![shape(1, "aa"), shape(3, "bb")];
-        let a = op_result_digest(OpName::MatchByIndex, &base);
-        assert_eq!(a, op_result_digest(OpName::MatchByIndex, &base));
+        let a = op_result_digest("match_by_index", &base);
+        assert_eq!(a, op_result_digest("match_by_index", &base));
         // A different value digest changes it (even at the same cardinality).
-        assert_ne!(a, op_result_digest(OpName::MatchByIndex, &[shape(1, "aa"), shape(3, "cc")]));
+        assert_ne!(a, op_result_digest("match_by_index", &[shape(1, "aa"), shape(3, "cc")]));
         // A different cardinality changes it.
-        assert_ne!(a, op_result_digest(OpName::MatchByIndex, &[shape(2, "aa"), shape(3, "bb")]));
+        assert_ne!(a, op_result_digest("match_by_index", &[shape(2, "aa"), shape(3, "bb")]));
         // The op name is part of the digest.
-        assert_ne!(a, op_result_digest(OpName::Expand1Hop, &base));
+        assert_ne!(a, op_result_digest("expand_1hop", &base));
         assert!(a.starts_with("sha256:"));
     }
 


### PR DESCRIPTION
## Phase 3b (pipeline generalization) — prerequisite plumbing for #239

Part of the effort to make the **synthetic per-op regression check cover the A/B benchmark's query shapes** (#239). This is the isolated, **behavior-preserving** refactor that lets the record→replay pipeline carry query shapes that have **no catalog `OperationSpec`** — a prerequisite for the next PR, which wires `queries_repository` read shapes into the synthetic path.

### What changes
Generalize the pipeline's op identity from the static `OpName` enum to the string-keyed **`OpKey`** (already introduced in Phase 1a — either a built-in `OpName` or a dynamic string-named op):

- **`recording.rs`**: split `record()` into a thin built-in wrapper over a new general **`record_rendered(&[RecordedOp])`** path that records already-rendered command corpora. `load()` rebuilds each op via `OpKey::dynamic(name, kind)` (built-in names canonicalize back to `Named`; unknown names become dynamic). `OpEntry` gains a `kind` field (defaulted to `Read` for v1 bundles) so `load()` can reconstruct the key.
- **`mod.rs`**: replace the `&OperationSpec` argument to `measure_op`/`measure_level` with a small `Copy` **`MeasureTarget { kind, write }`**, so a string-keyed op (which has no spec) is measured identically to a built-in one.
- **`replay.rs`**: thread `OpKey` through the reference/measurement pass; guard writes by `op.kind()`; digest results by op name.

### Comparability invariant preserved
The **record-once → replay-verbatim** model is untouched: recording stays offline, and the new `OpEntry.kind` is persisted **but is NOT folded into `workload_hash`**. I verified empirically that recording the same bundle on `master` and on this branch yields a **byte-identical `workload_hash`**, and that a `master`-recorded (kind-less) bundle still passes the integrity/hash gate under this build. So cross-engine comparability and the live **Synthetic non-divergence** gate are unaffected.

### On driver helpers
The design mentions graph-name-agnostic driver helpers, but no refactor was needed: `Falkor::client()`'s hardcoded `"falkor"` graph is on the **A/B path** (`src/falkor/`), which the synthetic path never touches — the synthetic path already opens graphs by name via `open_graph(endpoint, graph_name)`. Touching `Falkor::client` would risk the live A/B path, so it was deliberately left alone.

### Tests / validation
- New unit tests: dynamic-op `record_rendered`→`load` round-trip (survives the hash gate as a `Dynamic` key), built-in-name canonicalization to `Named`, write/empty/dedup rejection, and the kind-less (v1) manifest default.
- `just clippy` (warnings denied), `just build`, `just test` all green (264 lib tests).
- All 21 `#[ignore]` `synthetic_probe` integration tests pass against a live FalkorDB, including the record→replay non-divergence roundtrip and the concurrency-sweep result verification.
- No new op shapes and no behavior change; this is pure plumbing.

Refs #239.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for measuring and replaying dynamically recorded operations while preserving each operation’s identity and type.
  * Recording bundles now retain operation kinds and support older bundle formats.
* **Bug Fixes**
  * Improved validation prevents unsafe operation names and invalid recording data.
  * Corrected handling of duplicate operations, built-in operation names, and dynamic-operation round trips.
  * Write operations are rejected earlier during recording and replay.
* **Compatibility**
  * Existing recording bundles remain readable through backward-compatible format handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->