### PR TITLE
feat(synthetic): cover the ~46 baseline read shapes via --repo-reads (Phase 3 B2)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -449,7 +449,14 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   `graph.jsonl` (load statements) + `commands/<op>.jsonl`, plus a length-framed **`workload_hash`**
   over the graph *and* the commands (so any later edit is detected on load). It is **offline** — a
   pure function of the seed + knobs — and reads `synthetic-bench.toml` for defaults. Select ops with
-  `--op <names>`, or **`--op all`** (or `--op '*'`) for every read operation.
+  `--op <names>`, or **`--op all`** (or `--op '*'`) for every read operation. Alternatively,
+  **`--repo-reads <core|full>`** records the A/B benchmark's baseline non-algorithm **read shapes**
+  straight from `queries_repository` (auto-discovered, then annotated with a coverage tier +
+  result policy): `core` is the small per-PR subset, `full` is all ~46 reads. Each shape's corpus is
+  rendered **once** here from the seed and recorded verbatim (record-once → replay-verbatim), so the
+  bundle stays byte-identical across runs; shapes whose result set isn't byte-stable (e.g. a `LIMIT`
+  without `ORDER BY`) are still recorded + timed but marked **result-N/A** so replay never gates
+  their digest. `--repo-reads` is mutually exclusive with `--op`/`--all-reads`/`--tier`.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -534,6 +534,13 @@ pub enum SyntheticCommands {
         )]
         tier: Option<Tier>,
         #[arg(
+            long = "repo-reads",
+            value_enum,
+            conflicts_with_all = ["ops", "all_reads", "tier"],
+            help = "record the A/B benchmark's baseline NON-ALGORITHM READ shapes from queries_repository at a coverage tier: `core` (small per-PR subset) or `full` (all ~46 reads). Auto-discovered + annotated; deterministic (record-once/replay-verbatim). Mutually exclusive with --op/--all-reads/--tier."
+        )]
+        repo_reads: Option<Tier>,
+        #[arg(
             long,
             help = "seed for the dataset and the per-operation corpora (same seed + same tool build ⇒ identical bundle; default 0)"
         )]
@@ -778,6 +785,45 @@ mod tests {
         .is_err());
         assert!(Cli::try_parse_from([
             "benchmark", "synthetic", "run", "--tier", "core", "--all-reads",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn cli_repo_reads_flag_parses_and_conflicts_with_op_selection() {
+        use clap::Parser;
+        // `--repo-reads core|full` parses on `record`.
+        assert!(Cli::try_parse_from([
+            "benchmark", "synthetic", "record", "--repo-reads", "core", "--out-dir", "rec-out",
+        ])
+        .is_ok());
+        assert!(Cli::try_parse_from([
+            "benchmark", "synthetic", "record", "--repo-reads", "full", "--out-dir", "rec-out",
+        ])
+        .is_ok());
+        // An unknown tier is rejected.
+        assert!(Cli::try_parse_from([
+            "benchmark", "synthetic", "record", "--repo-reads", "nope", "--out-dir", "rec-out",
+        ])
+        .is_err());
+        // `--repo-reads` is mutually exclusive with `--op`, `--all-reads` and `--tier`.
+        for conflicting in [
+            vec!["--op", "match_by_index"],
+            vec!["--all-reads"],
+            vec!["--tier", "core"],
+        ] {
+            let mut argv = vec![
+                "benchmark", "synthetic", "record", "--repo-reads", "core", "--out-dir", "rec-out",
+            ];
+            argv.extend(conflicting);
+            assert!(
+                Cli::try_parse_from(argv.clone()).is_err(),
+                "expected conflict for {argv:?}"
+            );
+        }
+        // `--repo-reads` is record-only (not a `run` flag).
+        assert!(Cli::try_parse_from([
+            "benchmark", "synthetic", "run", "--repo-reads", "core",
         ])
         .is_err());
     }

--- a/src/queries_repository.rs
+++ b/src/queries_repository.rs
@@ -271,6 +271,32 @@ impl QueriesRepository {
         self.catalog.clone()
     }
 
+    /// The non-algorithm read shape names, in definition order — the baseline read shapes the
+    /// synthetic check records (design §3.4). Excludes algorithm reads (opt-in, capability-gated)
+    /// and writes.
+    pub fn non_algorithm_read_names(&self) -> &[String] {
+        &self.non_algorithm_read_query_names
+    }
+
+    /// Render the read shape `name` from a caller-supplied RNG, so a fixed seed yields a
+    /// byte-identical Cypher+params corpus (design §4.1 — the seedable entry the record-once /
+    /// replay-verbatim synthetic path renders each shape's corpus with). Returns `None` if `name`
+    /// is not a known read shape.
+    pub fn render_read_with_rng(
+        &self,
+        name: &str,
+        rng: &mut dyn Rng,
+    ) -> Option<PreparedQuery> {
+        let generator = self.read_queries.get(name)?;
+        let q_id = *self.name_to_id.get(name).unwrap_or(&0);
+        Some(PreparedQuery::new(
+            q_id,
+            name.to_string(),
+            generator.query_type,
+            generator.generate_with_rng(rng),
+        ))
+    }
+
     fn random_query_from_pool(
         &self,
         queries: &HashMap<String, QueryGenerator>,
@@ -341,6 +367,22 @@ pub struct UsersQueriesRepository {
 impl UsersQueriesRepository {
     pub fn catalog(&self) -> Vec<QueryCatalogEntry> {
         self.queries_repository.catalog()
+    }
+
+    /// The baseline read shape names (non-algorithm reads), in definition order — the shapes the
+    /// synthetic check records via [`Self::render_read_with_rng`] (design §3.4).
+    pub fn non_algorithm_read_names(&self) -> &[String] {
+        self.queries_repository.non_algorithm_read_names()
+    }
+
+    /// Render the read shape `name` from a caller-supplied RNG (record-once determinism, §4.1).
+    /// Returns `None` if `name` is not a known read shape.
+    pub fn render_read_with_rng(
+        &self,
+        name: &str,
+        rng: &mut dyn Rng,
+    ) -> Option<PreparedQuery> {
+        self.queries_repository.render_read_with_rng(name, rng)
     }
 
     pub fn random_queries(
@@ -1325,5 +1367,83 @@ mod tests {
             repository.queries_repository.algorithm_read_query_count(),
             1
         );
+    }
+
+    #[test]
+    fn non_algorithm_read_names_are_the_baseline_reads() {
+        let repo = UsersQueriesRepository::new(
+            100,
+            1000,
+            Flavour::FalkorDB,
+            AlgorithmQuerySelection::default(),
+            QueryCoverageProfile::Baseline,
+        );
+        let names: Vec<&str> = repo.non_algorithm_read_names().iter().map(String::as_str).collect();
+
+        // Representative baseline reads are present…
+        for expected in ["single_vertex_read", "id_range_scan", "entity_path_introspection"] {
+            assert!(names.contains(&expected), "expected baseline read '{expected}'");
+        }
+        // …algorithms, writes, and out-of-profile shapes are excluded.
+        for excluded in [
+            "algo_pagerank_summary",         // algorithm read (opt-in)
+            "single_vertex_write",           // write
+            "temporal_spatial_roundtrip",    // ExtendedCore (not in Baseline)
+            "vector_query_nodes_smoke",      // FixtureDependent (not in Baseline)
+        ] {
+            assert!(!names.contains(&excluded), "'{excluded}' must not be a baseline read");
+        }
+        // Every name resolves to a Read shape.
+        for name in &names {
+            assert!(
+                repo.render_read_with_rng(name, &mut rand::rng()).is_some(),
+                "baseline read '{name}' must be renderable"
+            );
+        }
+    }
+
+    #[test]
+    fn render_read_with_rng_is_byte_identical_for_a_fixed_seed() {
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+
+        let repo = UsersQueriesRepository::new(
+            1_000_000,
+            1_000_000,
+            Flavour::FalkorDB,
+            AlgorithmQuerySelection::default(),
+            QueryCoverageProfile::Baseline,
+        );
+
+        // Render a whole corpus (many draws) for a randomised shape from a fixed seed, twice: the
+        // rendered Cypher+params stream must be byte-identical — the record-once / replay-verbatim
+        // determinism the A/B non-divergence gate depends on.
+        let corpus = |seed: u64| -> Vec<String> {
+            let mut rng = StdRng::seed_from_u64(seed);
+            (0..64)
+                .map(|_| {
+                    repo.render_read_with_rng("shortest_path", &mut rng)
+                        .expect("shape present")
+                        .cypher
+                })
+                .collect()
+        };
+        assert_eq!(corpus(0xA11CE), corpus(0xA11CE));
+        // A different seed yields a different stream (the shape is genuinely seed-sensitive).
+        assert_ne!(corpus(0xA11CE), corpus(0xB0B));
+    }
+
+    #[test]
+    fn render_read_with_rng_rejects_unknown_and_non_read_shapes() {
+        let repo = UsersQueriesRepository::new(
+            100,
+            1000,
+            Flavour::FalkorDB,
+            AlgorithmQuerySelection::default(),
+            QueryCoverageProfile::Baseline,
+        );
+        assert!(repo.render_read_with_rng("no_such_shape", &mut rand::rng()).is_none());
+        // A write shape is not a read and must not render through the read seam.
+        assert!(repo.render_read_with_rng("single_vertex_write", &mut rand::rng()).is_none());
     }
 }

--- a/src/queries_repository.rs
+++ b/src/queries_repository.rs
@@ -288,7 +288,7 @@ impl QueriesRepository {
         rng: &mut dyn Rng,
     ) -> Option<PreparedQuery> {
         let generator = self.read_queries.get(name)?;
-        let q_id = *self.name_to_id.get(name).unwrap_or(&0);
+        let q_id = *self.name_to_id.get(name)?;
         Some(PreparedQuery::new(
             q_id,
             name.to_string(),

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -27,6 +27,7 @@ pub mod provenance;
 pub mod recording;
 pub mod replay;
 pub mod report;
+pub mod shapes;
 pub mod stats;
 pub mod thresholds;
 pub mod writes;
@@ -1426,6 +1427,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             ops,
             all_reads,
             tier,
+            repo_reads,
             seed,
             nodes,
             edges,
@@ -1435,11 +1437,13 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let ops = crate::cli::expand_op_selectors(&ops);
             // Reuse the run-config resolution (with generate=true) to validate + resolve the
             // dataset knobs, graph and read-op selection, then record OFFLINE (no server).
+            // `--repo-reads` selects the baseline read SHAPES implicitly (not catalog ops), so it
+            // forces `all_reads` only to satisfy op resolution; the resolved ops are ignored below.
             let overrides = config::CliOverrides {
                 endpoint: None,
                 graph,
                 ops,
-                all_reads,
+                all_reads: all_reads || repo_reads.is_some(),
                 tier,
                 samples: None,
                 warmup: None,
@@ -1461,14 +1465,35 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let spec = resolved.dataset.ok_or_else(|| {
                 OtherError("record requires --nodes/--edges (or a config) to generate a dataset".to_string())
             })?;
-            let manifest = recording::record(
-                &spec,
-                &resolved.graph,
-                &resolved.ops,
-                resolved.seed,
-                DATASET_LOAD_BATCH,
-                std::path::Path::new(&out_dir),
-            )?;
+            let manifest = if let Some(tier) = repo_reads {
+                // Phase 3 B2: record the queries_repository baseline read shapes. Each shape's
+                // corpus is rendered ONCE here from `resolved.seed ^ salt` (record-once →
+                // replay-verbatim), then `record_rendered` writes the identical bundle format the
+                // catalog path produces (so `workload_hash` stays byte-identical across engines).
+                let recorded = crate::synthetic::shapes::record_repo_reads(
+                    tier,
+                    spec.nodes as i32,
+                    spec.edges as i32,
+                    resolved.seed,
+                )?;
+                recording::record_rendered(
+                    &spec,
+                    &resolved.graph,
+                    &recorded,
+                    resolved.seed,
+                    DATASET_LOAD_BATCH,
+                    std::path::Path::new(&out_dir),
+                )?
+            } else {
+                recording::record(
+                    &spec,
+                    &resolved.graph,
+                    &resolved.ops,
+                    resolved.seed,
+                    DATASET_LOAD_BATCH,
+                    std::path::Path::new(&out_dir),
+                )?
+            };
             println!(
                 "recorded {} op(s) into {} (workload_hash {})",
                 manifest.ops.len(),
@@ -2115,6 +2140,7 @@ mod tests {
             ops: vec![],
             all_reads: false,
             tier: Some(Tier::Core),
+            repo_reads: None,
             seed: Some(3),
             nodes: Some(200),
             edges: Some(600),
@@ -2129,6 +2155,54 @@ mod tests {
         }
         // …and a full-only op (shortest_path) is not.
         assert!(!commands.join("shortest_path.jsonl").exists());
+        std::fs::remove_dir_all(&out_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_command_record_offline_records_repo_read_shapes() {
+        // `synthetic record --repo-reads core` runs OFFLINE (no server): it writes a bundle
+        // containing exactly the CORE baseline read SHAPES from queries_repository (Phase 3 B2),
+        // and a full-only shape is absent. Exercises the Record handler's `repo_reads` plumbing
+        // end-to-end (shapes::record_repo_reads → record_rendered).
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let out_dir = std::env::temp_dir().join(format!(
+            "syn-rec-reporeads-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let command = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: Some("greporeads".to_string()),
+            ops: vec![],
+            all_reads: false,
+            tier: None,
+            repo_reads: Some(Tier::Core),
+            seed: Some(5),
+            nodes: Some(300),
+            edges: Some(900),
+            out_dir: out_dir.to_string_lossy().into_owned(),
+        };
+        run_command(command)
+            .await
+            .expect("offline repo-reads record succeeds without a server");
+        assert!(out_dir.join("manifest.json").exists());
+        let commands = out_dir.join("commands");
+        // Every core baseline read shape is recorded…
+        let core: Vec<_> = crate::synthetic::shapes::baseline_read_shapes()
+            .into_iter()
+            .filter(|s| s.tier == Tier::Core)
+            .collect();
+        assert!(!core.is_empty(), "core tier must select at least one shape");
+        for shape in &core {
+            assert!(
+                commands.join(format!("{}.jsonl", shape.name)).exists(),
+                "missing core shape {}",
+                shape.name
+            );
+        }
+        // …and a full-only shape (aggregate_expansion_2) is not.
+        assert!(!commands.join("aggregate_expansion_2.jsonl").exists());
         std::fs::remove_dir_all(&out_dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -66,12 +66,27 @@ pub struct OpEntry {
     /// (v1 records reads only), and is **not** folded into the [`Manifest::workload_hash`].
     #[serde(default = "default_op_kind")]
     pub kind: QueryType,
+    /// Whether this op's result is compared across the A/B (record-once / replay-verbatim) gate.
+    /// `true` (the default, and the value for every built-in catalog op) means replay computes and
+    /// gates a `result_digest`; `false` marks the op **result-N/A** — still recorded and timed, but
+    /// its result is *not* gated, for shapes whose result set isn't byte-stable (LIMIT-without-
+    /// ORDER, top-k, float scores — design §3.2 / Decision 4). Like [`Self::kind`] it is **not**
+    /// folded into the [`Manifest::workload_hash`] (it's replay-gating policy, not workload content)
+    /// and defaults to `true` for bundles written before this field existed.
+    #[serde(default = "default_result_gated")]
+    pub result_gated: bool,
     pub count: usize,
 }
 
 /// The read/write kind an [`OpEntry`] without an explicit `kind` deserializes to (v1 read bundles).
 fn default_op_kind() -> QueryType {
     QueryType::Read
+}
+
+/// The result-gating an [`OpEntry`] without an explicit `result_gated` deserializes to: gated
+/// (every op recorded before the field existed had its result digest compared).
+fn default_result_gated() -> bool {
+    true
 }
 
 /// Reject an op name that isn't a safe single-path-component slug.
@@ -224,6 +239,9 @@ impl WorkloadHasher {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecordedOp {
     pub key: OpKey,
+    /// Whether replay gates this op's result digest — see [`OpEntry::result_gated`]. `true` for
+    /// every built-in catalog op and byte-stable shape; `false` marks a result-N/A shape.
+    pub result_gated: bool,
     pub commands: Vec<String>,
 }
 
@@ -274,6 +292,8 @@ pub fn record(
     for &op in ops {
         recorded.push(RecordedOp {
             key: OpKey::from(op),
+            // Every built-in catalog op projects byte-stable scalars, so its result is gated.
+            result_gated: true,
             commands: render_commands(op, dataset, corpus_seed)?,
         });
     }
@@ -376,6 +396,7 @@ pub fn record_rendered(
         op_entries.push(OpEntry {
             name: name.to_string(),
             kind: op.key.kind(),
+            result_gated: op.result_gated,
             count: cyphers.len(),
         });
     }
@@ -714,6 +735,7 @@ mod tests {
         };
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("single_vertex_read", QueryType::Read),
+            result_gated: true,
             commands: vec![
                 "CYPHER id=1 MATCH (n:User {id:$id}) RETURN n".to_string(),
                 "CYPHER id=2 MATCH (n:User {id:$id}) RETURN n".to_string(),
@@ -756,6 +778,7 @@ mod tests {
         };
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("bulk_insert", QueryType::Write),
+            result_gated: true,
             commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -773,6 +796,7 @@ mod tests {
         };
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("empty_shape", QueryType::Read),
+            result_gated: true,
             commands: vec![],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -791,10 +815,12 @@ mod tests {
         let ops = vec![
             RecordedOp {
                 key: OpKey::dynamic("a_read", QueryType::Read),
+                result_gated: true,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("a_read", QueryType::Read),
+                result_gated: true,
                 commands: vec!["CYPHER  RETURN 2".to_string()],
             },
         ];
@@ -825,6 +851,7 @@ mod tests {
         };
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("../escape", QueryType::Read),
+            result_gated: true,
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -845,10 +872,12 @@ mod tests {
         let ops = vec![
             RecordedOp {
                 key: OpKey::dynamic("dup", QueryType::Read),
+                result_gated: true,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("dup", QueryType::Write),
+                result_gated: true,
                 commands: vec!["CYPHER  CREATE (n)".to_string()],
             },
         ];
@@ -869,6 +898,7 @@ mod tests {
         };
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("safe_read", QueryType::Read),
+            result_gated: true,
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -894,6 +924,7 @@ mod tests {
         };
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("safe_read", QueryType::Read),
+            result_gated: true,
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -906,6 +937,71 @@ mod tests {
         let err = load(&dir).unwrap_err();
         assert!(format!("{err}").contains("duplicate op name"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_persists_result_gated_and_load_round_trips_it() {
+        // A bundle can mix a gated op and a result-N/A op; `load` round-trips each op's
+        // `result_gated` so replay knows which results to gate (design §3.2 / Decision 4).
+        let dir = temp_bundle_dir("synthrec-gated");
+        let spec = DatasetSpec {
+            seed: 4,
+            nodes: 20,
+            edges: 60,
+        };
+        let ops = vec![
+            RecordedOp {
+                key: OpKey::dynamic("gated_read", QueryType::Read),
+                result_gated: true,
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            },
+            RecordedOp {
+                key: OpKey::dynamic("na_read", QueryType::Read),
+                result_gated: false,
+                commands: vec!["CYPHER  MATCH (n) RETURN n LIMIT 1".to_string()],
+            },
+        ];
+        let manifest = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        assert!(manifest.ops[0].result_gated, "first op stays gated");
+        assert!(!manifest.ops[1].result_gated, "second op is result-N/A");
+
+        let bundle = load(&dir).unwrap();
+        assert!(bundle.manifest.ops[0].result_gated);
+        assert!(!bundle.manifest.ops[1].result_gated);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn result_gated_is_not_folded_into_the_workload_hash() {
+        // `result_gated` is replay-gating policy, not workload content: two bundles that differ
+        // ONLY in it must share a `workload_hash` (so it never perturbs the A/B comparability gate).
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 20,
+            edges: 60,
+        };
+        let make = |gated: bool| {
+            let dir = temp_bundle_dir(if gated { "synthrec-hg" } else { "synthrec-hn" });
+            let ops = vec![RecordedOp {
+                key: OpKey::dynamic("shape", QueryType::Read),
+                result_gated: gated,
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            }];
+            let m = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+            std::fs::remove_dir_all(&dir).ok();
+            m.workload_hash
+        };
+        assert_eq!(make(true), make(false));
+    }
+
+    #[test]
+    fn op_entry_defaults_result_gated_true_for_pre_field_bundles() {
+        // An `OpEntry` serialized before `result_gated` existed (no such key) deserializes to
+        // gated — preserving the pre-field behaviour where every op's result was compared.
+        let entry: OpEntry =
+            serde_json::from_str(r#"{"name":"legacy_op","count":3}"#).unwrap();
+        assert_eq!(entry.kind, QueryType::Read);
+        assert!(entry.result_gated, "a pre-field op defaults to gated");
     }
 
     #[test]

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -178,11 +178,25 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     let uid_alloc = AtomicU64::new(0);
     let max_c = concurrency.iter().copied().max().unwrap_or(1);
 
+    // Per-op result-gating policy from the recorded manifest (keyed by the op's unique name). A
+    // result-N/A op — a shape whose result set isn't byte-stable (LIMIT-without-ORDER, top-k,
+    // float scores — design §3.2 / Decision 4) — is still loaded, replayed, and timed, but its
+    // result is neither cross-concurrency-verified nor digested, so a benign result difference
+    // never fails the A/B non-divergence gate. Unknown names default to gated (the safe default).
+    let result_gated: std::collections::HashMap<&str, bool> = bundle
+        .manifest
+        .ops
+        .iter()
+        .map(|e| (e.name.as_str(), e.result_gated))
+        .collect();
+
     let mut operations = BTreeMap::new();
     for (op, corpus, shapes) in &reference {
+        let is_gated = result_gated.get(op.name()).copied().unwrap_or(true);
         // Verify results are IDENTICAL at the highest concurrency (untimed) before trusting the
-        // measured latencies — a concurrent path that returns different/wrong results is a hard fail.
-        if max_c > 1 {
+        // measured latencies — a concurrent path that returns different/wrong results is a hard
+        // fail. Skipped for result-N/A ops, whose results aren't required to be stable.
+        if max_c > 1 && is_gated {
             verify_concurrent(
                 &config.endpoint,
                 &graph_name,
@@ -212,7 +226,10 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             client_deadline,
         )
         .await?;
-        op_report.result_digest = Some(op_result_digest(op.name(), shapes));
+        // Gate the result only for byte-stable shapes; a result-N/A op reports `None` so the diff
+        // guard renders it N/A instead of comparing a non-deterministic digest.
+        op_report.result_digest =
+            is_gated.then(|| op_result_digest(op.name(), shapes));
         operations.insert(op.name().to_string(), op_report);
     }
 

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -1,0 +1,383 @@
+//! Bridge the A/B benchmark's `queries_repository` **baseline read shapes** into the synthetic
+//! record/replay pipeline (design §3.4 / Phase 3).
+//!
+//! The synthetic check historically probes a small, hand-curated catalog ([`catalog`]). This module
+//! lets it also record the **baseline non-algorithm read shapes** the A/B benchmark measures — the
+//! op *set* is **auto-discovered** from [`queries_repository`] (proven by the drift-guard test), and
+//! this module adds the explicit synthetic metadata each shape carries (coverage tier + result
+//! policy — the *derive-with-annotation* model, Decision 3).
+//!
+//! ## Determinism (record-once → replay-verbatim)
+//! Each shape's corpus is rendered **once at record time** from a fixed per-shape seed
+//! (`corpus_seed ^ salt`, mirroring how [`catalog`] ops seed) via the seedable
+//! [`UsersQueriesRepository::render_read_with_rng`] entry (design §4.1), and the concrete Cypher is
+//! recorded verbatim. Replay never touches the RNG — it replays the recorded strings — so the
+//! `workload_hash` is byte-identical across engines and the A/B non-divergence gate stays meaningful.
+//!
+//! ## Result policy (Decision 4)
+//! Most baseline reads project byte-stable results and are result-**gated**. A few shapes whose
+//! result set isn't byte-stable (e.g. `LIMIT` without `ORDER BY`) are recorded and timed but marked
+//! result-**N/A** ([`ResultPolicy::NotApplicable`]) so a benign result difference never fails the
+//! gate — we do **not** add `ORDER BY` to the shared repo queries (that would change the shape).
+//!
+//! [`catalog`]: crate::synthetic::catalog
+//! [`queries_repository`]: crate::queries_repository
+//! [`UsersQueriesRepository::render_read_with_rng`]: crate::queries_repository::UsersQueriesRepository::render_read_with_rng
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::queries_repository::{
+    AlgorithmQuerySelection, Flavour, QueryCoverageProfile, QueryType, UsersQueriesRepository,
+};
+use crate::synthetic::catalog::CORPUS_SIZE;
+use crate::synthetic::recording::RecordedOp;
+use crate::synthetic::{OpKey, Tier};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use std::collections::BTreeSet;
+
+/// Whether a shape's result set is byte-stable across runs/engines, and so whether replay gates its
+/// result digest (design §3.2 / Decision 4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResultPolicy {
+    /// Byte-stable result: replay computes and compares a `result_digest`.
+    Gated,
+    /// Result excluded from strict gating (still recorded + timed) — the shape's result set isn't
+    /// byte-stable (e.g. `LIMIT` without `ORDER BY`). Carries a human-readable reason.
+    NotApplicable(&'static str),
+}
+
+impl ResultPolicy {
+    /// Whether replay should gate (compute + compare) this shape's result digest.
+    pub fn is_gated(self) -> bool {
+        matches!(self, ResultPolicy::Gated)
+    }
+}
+
+/// One baseline read shape's synthetic metadata: its stable [`queries_repository`] name, coverage
+/// tier (Decision 1), and result policy (Decision 4).
+///
+/// Kind is always `Read` and profile always `Baseline` for this table; **capability** (fulltext/
+/// vector) and per-op **budget** are deferred to their phases (Phase 5 / Phase 6) — see the module
+/// docs.
+///
+/// [`queries_repository`]: crate::queries_repository
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShapeSpec {
+    /// The shape's stable `queries_repository` read name (also the recorded op's key).
+    pub name: &'static str,
+    /// Coverage tier: [`Tier::Core`] gates every PR; [`Tier::Full`] runs nightly/on-demand.
+    pub tier: Tier,
+    /// Whether replay gates this shape's result digest ([`ResultPolicy`]).
+    pub result_policy: ResultPolicy,
+}
+
+/// The curated annotation for the **46 baseline non-algorithm read shapes** (design §3.4).
+///
+/// The op *set* is auto-discovered from [`queries_repository`] — the drift-guard test asserts this
+/// table's names are **exactly** [`UsersQueriesRepository::non_algorithm_read_names`] for the
+/// `Baseline` profile, so adding/removing a baseline read there fails the build until this table is
+/// updated. Order mirrors the `queries_repository` definition order.
+///
+/// A small [`Tier::Core`] subset gates every PR (cheap, deterministic, representative of distinct
+/// plan shapes — point lookup, label scan, 1–2-hop expansion, aggregation, index filter, hash
+/// join); everything else is [`Tier::Full`] (nightly/on-demand).
+///
+/// [`queries_repository`]: crate::queries_repository
+pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
+    use ResultPolicy::{Gated, NotApplicable};
+    use Tier::{Core, Full};
+    // `s(name, tier, policy)` keeps the table dense and readable.
+    fn s(
+        name: &'static str,
+        tier: Tier,
+        result_policy: ResultPolicy,
+    ) -> ShapeSpec {
+        ShapeSpec {
+            name,
+            tier,
+            result_policy,
+        }
+    }
+    vec![
+        s("single_vertex_read", Core, Gated),
+        s("aggregate_expansion_1", Core, Gated),
+        s("aggregate_expansion_1_with_filter", Core, Gated),
+        s("aggregate_expansion_2", Full, Gated),
+        s("aggregate_expansion_2_with_filter", Full, Gated),
+        s("aggregate_expansion_3", Full, Gated),
+        s("aggregate_expansion_3_with_filter", Full, Gated),
+        s("aggregate_expansion_4", Full, Gated),
+        s("aggregate_expansion_4_with_filter", Full, Gated),
+        s("aggregate_age", Core, Gated),
+        s("aggregate_age_distinct", Full, Gated),
+        s("aggregate_age_filtered", Full, Gated),
+        s("aggregate_count_users", Core, Gated),
+        s("aggregate_age_min_max_avg", Full, Gated),
+        s("neighbours_2", Core, Gated),
+        s("neighbours_2_with_filter", Full, Gated),
+        s("neighbours_2_with_data", Full, Gated),
+        s("neighbours_2_with_data_and_filter", Full, Gated),
+        s("shortest_path", Full, Gated),
+        s("shortest_path_with_filter", Full, Gated),
+        s("pattern_cycle", Full, Gated),
+        s("pattern_long", Full, Gated),
+        s("pattern_short", Full, Gated),
+        s("vertex_on_label_property", Full, Gated),
+        s("vertex_on_label_property_index", Core, Gated),
+        s("vertex_on_property", Core, Gated),
+        s("value_join", Full, Gated),
+        s("value_join_cnt", Core, Gated),
+        s("order_by_age", Full, Gated),
+        s("unwind_rows", Full, Gated),
+        s("var_len_friends", Full, Gated),
+        s("optional_friend", Full, Gated),
+        s("call_subquery", Full, Gated),
+        s("id_seek", Core, Gated),
+        s("id_range_scan", Full, Gated),
+        s("union_all_ids", Full, Gated),
+        s("union_distinct_ids", Full, Gated),
+        s("all_shortest_paths_len", Full, Gated),
+        s("var_len_with_edge_where_filter", Full, Gated),
+        s("exact_5_hop_traverse_count", Full, Gated),
+        s("exact_6_hop_traverse_count", Full, Gated),
+        s("count_users_plain", Core, Gated),
+        s("count_friend_edges_plain", Core, Gated),
+        s("indexed_or_predicate", Full, Gated),
+        s("indexed_in_list_predicate", Full, Gated),
+        s(
+            "entity_path_introspection",
+            Full,
+            NotApplicable("LIMIT without ORDER BY returns an unordered subset"),
+        ),
+    ]
+}
+
+/// The algorithm selection the baseline-read source uses: **none**. Algorithm reads are opt-in and
+/// capability-gated (Phase 6), so they're excluded from the auto-discovered baseline read set.
+fn no_algorithms() -> AlgorithmQuerySelection {
+    AlgorithmQuerySelection {
+        pagerank: false,
+        max_flow: false,
+        msf: false,
+        harmonic: false,
+    }
+}
+
+/// Build the `queries_repository` handle the baseline read shapes render from: `FalkorDB` flavour,
+/// no algorithms, `Baseline` coverage profile. `vertices` must match the recorded graph's `:User`
+/// count (ids `1..=vertices`) so each shape's random params address real nodes.
+fn baseline_repository(
+    vertices: i32,
+    edges: i32,
+) -> UsersQueriesRepository {
+    UsersQueriesRepository::new(
+        vertices,
+        edges,
+        Flavour::FalkorDB,
+        no_algorithms(),
+        QueryCoverageProfile::Baseline,
+    )
+}
+
+/// Render the selected `tier`'s baseline read shapes into [`RecordedOp`]s, ready for
+/// [`record_rendered`](crate::synthetic::recording::record_rendered) — **offline**, no server.
+///
+/// Each shape's corpus is [`CORPUS_SIZE`] renders drawn from a fixed per-shape seed
+/// (`corpus_seed ^ salt`, the op's [`OpKey::salt`]), so a given seed yields a byte-identical corpus
+/// (record-once → replay-verbatim). [`Tier::Full`] selects every baseline read; [`Tier::Core`]
+/// selects only the core subset. Returns an error if the annotation table names a shape that isn't
+/// an auto-discovered `queries_repository` baseline read (annotation drift).
+pub fn record_repo_reads(
+    tier: Tier,
+    vertices: i32,
+    edges: i32,
+    corpus_seed: u64,
+) -> BenchmarkResult<Vec<RecordedOp>> {
+    let selected: Vec<ShapeSpec> = baseline_read_shapes()
+        .into_iter()
+        // `Tier::Full` records everything; `Tier::Core` records only the core subset.
+        .filter(|shape| tier == Tier::Full || shape.tier == Tier::Core)
+        .collect();
+    record_selected_shapes(&selected, vertices, edges, corpus_seed)
+}
+
+/// Render the given `shapes` into [`RecordedOp`]s against a fresh baseline repository. Split out of
+/// [`record_repo_reads`] so the annotation-drift guard is unit-testable with a bogus shape.
+fn record_selected_shapes(
+    shapes: &[ShapeSpec],
+    vertices: i32,
+    edges: i32,
+    corpus_seed: u64,
+) -> BenchmarkResult<Vec<RecordedOp>> {
+    let repo = baseline_repository(vertices, edges);
+    let available: BTreeSet<&str> = repo
+        .non_algorithm_read_names()
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    let mut ops = Vec::with_capacity(shapes.len());
+    for shape in shapes {
+        if !available.contains(shape.name) {
+            return Err(OtherError(format!(
+                "baseline read shape '{}' is annotated but not a queries_repository baseline read \
+                 (annotation drift — update src/synthetic/shapes.rs)",
+                shape.name
+            )));
+        }
+        let key = OpKey::dynamic(shape.name.to_string(), QueryType::Read);
+        let mut rng = StdRng::seed_from_u64(corpus_seed ^ key.salt());
+        let mut commands = Vec::with_capacity(CORPUS_SIZE);
+        for _ in 0..CORPUS_SIZE {
+            let prepared = repo.render_read_with_rng(shape.name, &mut rng).ok_or_else(|| {
+                OtherError(format!("baseline read shape '{}' failed to render", shape.name))
+            })?;
+            commands.push(prepared.cypher);
+        }
+        ops.push(RecordedOp {
+            key,
+            result_gated: shape.result_policy.is_gated(),
+            commands,
+        });
+    }
+    Ok(ops)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The set of names in the annotation table.
+    fn annotated_names() -> BTreeSet<&'static str> {
+        baseline_read_shapes().iter().map(|s| s.name).collect()
+    }
+
+    #[test]
+    fn baseline_shapes_match_the_auto_discovered_repository_reads() {
+        // Derive-with-annotation (Decision 3): the annotation table must name EXACTLY the
+        // auto-discovered baseline (non-algorithm) reads — no more, no fewer. If `queries_repository`
+        // gains or drops a baseline read, this fails until `baseline_read_shapes()` is updated.
+        let repo = baseline_repository(1000, 5000);
+        let discovered: BTreeSet<&str> =
+            repo.non_algorithm_read_names().iter().map(String::as_str).collect();
+        let annotated = annotated_names();
+        assert_eq!(
+            annotated, discovered,
+            "annotation drift — annotated-only: {:?}; discovered-only: {:?}",
+            annotated.difference(&discovered).collect::<Vec<_>>(),
+            discovered.difference(&annotated).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn there_are_forty_six_baseline_reads_with_a_nonempty_core_subset() {
+        let shapes = baseline_read_shapes();
+        assert_eq!(shapes.len(), 46, "expected the 46 baseline reads (design §3.4)");
+        // Names are unique.
+        assert_eq!(annotated_names().len(), 46, "shape names must be unique");
+        let core = shapes.iter().filter(|s| s.tier == Tier::Core).count();
+        assert!(core > 0 && core < shapes.len(), "core is a small non-empty subset, got {core}");
+    }
+
+    #[test]
+    fn exactly_the_limit_without_order_shape_is_result_na() {
+        // Only `entity_path_introspection` (LIMIT 1 without ORDER BY) is result-N/A among the
+        // baseline reads; every other baseline read is result-gated (Decision 4).
+        for shape in baseline_read_shapes() {
+            let expected_gated = shape.name != "entity_path_introspection";
+            assert_eq!(
+                shape.result_policy.is_gated(),
+                expected_gated,
+                "unexpected result policy for '{}'",
+                shape.name
+            );
+        }
+    }
+
+    #[test]
+    fn record_repo_reads_full_covers_every_baseline_read() {
+        let ops = record_repo_reads(Tier::Full, 1000, 5000, 42).unwrap();
+        let names: BTreeSet<&str> = ops.iter().map(|o| o.key.name()).collect();
+        assert_eq!(names, annotated_names(), "Full must record every baseline read");
+        // Every op renders a full corpus and is keyed by the shape name as a read.
+        for op in &ops {
+            assert_eq!(op.commands.len(), CORPUS_SIZE, "op '{}' short corpus", op.key.name());
+            assert_eq!(op.key.kind(), QueryType::Read);
+        }
+        // `shortest_path` shares its name with a built-in `OpName`, so `OpKey::dynamic`
+        // canonicalizes it to that built-in (by design — same name/kind/salt across every run);
+        // every other baseline read is a genuinely dynamic string-keyed op.
+        for op in &ops {
+            if op.key.name() == "shortest_path" {
+                assert!(op.key.is_named(), "shortest_path canonicalizes to the built-in OpName");
+            } else {
+                assert!(!op.key.is_named(), "'{}' should be a dynamic read", op.key.name());
+            }
+        }
+        // The result-N/A shape is recorded but not gated; the rest are gated.
+        let na = ops.iter().find(|o| o.key.name() == "entity_path_introspection").unwrap();
+        assert!(!na.result_gated, "the LIMIT-without-ORDER shape is result-N/A");
+        assert!(
+            ops.iter().filter(|o| !o.result_gated).count() == 1,
+            "exactly one baseline read is result-N/A"
+        );
+    }
+
+    #[test]
+    fn record_repo_reads_core_is_a_subset_of_full() {
+        let core_ops = record_repo_reads(Tier::Core, 1000, 5000, 7).unwrap();
+        let full_ops = record_repo_reads(Tier::Full, 1000, 5000, 7).unwrap();
+        let core: BTreeSet<&str> = core_ops.iter().map(|o| o.key.name()).collect();
+        let full: BTreeSet<&str> = full_ops.iter().map(|o| o.key.name()).collect();
+        assert!(!core.is_empty() && core.len() < full.len());
+        assert!(core.is_subset(&full), "core must be a subset of full");
+    }
+
+    #[test]
+    fn record_repo_reads_is_byte_identical_for_a_fixed_seed() {
+        // Record-once determinism: a fixed seed renders a byte-identical corpus for every shape, so
+        // two records produce identical `RecordedOp`s — the comparability the A/B gate relies on.
+        let a = record_repo_reads(Tier::Full, 2000, 8000, 12345).unwrap();
+        let b = record_repo_reads(Tier::Full, 2000, 8000, 12345).unwrap();
+        assert_eq!(a, b, "a fixed seed must render an identical corpus");
+        // A different seed shifts the rendered params (the corpus is genuinely seed-sensitive).
+        let c = record_repo_reads(Tier::Full, 2000, 8000, 9).unwrap();
+        assert_ne!(a, c, "a different seed must render a different corpus");
+    }
+
+    #[test]
+    fn baseline_reads_render_valid_in_range_params() {
+        // Every rendered command binds `:User` ids within `[1, vertices]` (so it addresses real
+        // recorded nodes) — a spot check that the seam wires `vertices` through correctly.
+        let vertices = 500;
+        let ops = record_repo_reads(Tier::Full, vertices, 2000, 3).unwrap();
+        let single = ops.iter().find(|o| o.key.name() == "single_vertex_read").unwrap();
+        for cmd in &single.commands {
+            // `single_vertex_read` renders `CYPHER id = <n> MATCH (n:User {id : $id}) RETURN n`.
+            let id: i32 = cmd
+                .split("= ")
+                .nth(1)
+                .and_then(|s| s.split_whitespace().next())
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| panic!("no id param in {cmd:?}"));
+            assert!((1..=vertices).contains(&id), "id {id} out of range in {cmd:?}");
+        }
+    }
+
+    #[test]
+    fn record_selected_shapes_rejects_annotation_drift() {
+        // A shape annotated but absent from the auto-discovered repository reads is rejected — the
+        // safety net behind the derive-with-annotation model.
+        let bogus = [ShapeSpec {
+            name: "__not_a_repo_read__",
+            tier: Tier::Full,
+            result_policy: ResultPolicy::Gated,
+        }];
+        let err = record_selected_shapes(&bogus, 1000, 5000, 1).unwrap_err();
+        assert!(
+            format!("{err}").contains("annotation drift"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -197,7 +197,7 @@ pub fn record_repo_reads(
     let selected: Vec<ShapeSpec> = baseline_read_shapes()
         .into_iter()
         // `Tier::Full` records everything; `Tier::Core` records only the core subset.
-        .filter(|shape| tier == Tier::Full || shape.tier == Tier::Core)
+        .filter(|shape| tier.includes(shape.tier))
         .collect();
     record_selected_shapes(&selected, vertices, edges, corpus_seed)
 }
@@ -256,18 +256,25 @@ mod tests {
     #[test]
     fn baseline_shapes_match_the_auto_discovered_repository_reads() {
         // Derive-with-annotation (Decision 3): the annotation table must name EXACTLY the
-        // auto-discovered baseline (non-algorithm) reads — no more, no fewer. If `queries_repository`
-        // gains or drops a baseline read, this fails until `baseline_read_shapes()` is updated.
+        // auto-discovered baseline (non-algorithm) reads, IN THE SAME definition order — no more,
+        // no fewer, no reordering. Order matters: it's the record order, which feeds `workload_hash`
+        // (recording.rs). If `queries_repository` gains, drops, or reorders a baseline read, this
+        // fails until `baseline_read_shapes()` is realigned.
         let repo = baseline_repository(1000, 5000);
-        let discovered: BTreeSet<&str> =
+        let discovered: Vec<&str> =
             repo.non_algorithm_read_names().iter().map(String::as_str).collect();
-        let annotated = annotated_names();
+        let annotated: Vec<&str> = baseline_read_shapes().iter().map(|s| s.name).collect();
+        // Set diff first for the common "added/removed a shape" case (clearer than a raw seq diff)…
+        let annotated_set: BTreeSet<&str> = annotated.iter().copied().collect();
+        let discovered_set: BTreeSet<&str> = discovered.iter().copied().collect();
         assert_eq!(
-            annotated, discovered,
+            annotated_set, discovered_set,
             "annotation drift — annotated-only: {:?}; discovered-only: {:?}",
-            annotated.difference(&discovered).collect::<Vec<_>>(),
-            discovered.difference(&annotated).collect::<Vec<_>>()
+            annotated_set.difference(&discovered_set).collect::<Vec<_>>(),
+            discovered_set.difference(&annotated_set).collect::<Vec<_>>()
         );
+        // …then exact definition-order equality (the record order that determines `workload_hash`).
+        assert_eq!(annotated, discovered, "baseline read shapes are out of definition order");
     }
 
     #[test]

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1041,6 +1041,72 @@ async fn record_then_replay_roundtrips_and_guard_proceeds() {
     drop_graph(graph).await;
 }
 
+/// Phase 3 B2: record the queries_repository baseline READ shapes (`--repo-reads full`) OFFLINE,
+/// then replay --load → --no-load. The workload identity (workload_hash) is byte-identical across
+/// replays, every result-gated shape yields matching digests, and the one LIMIT-without-ORDER shape
+/// (`entity_path_introspection`) is recorded + timed but result-N/A (digest `None`) in both replays.
+///
+/// Uses a multi-thread runtime: the baseline reads return nodes/relations/paths, and the FalkorDB
+/// client decodes those via `block_in_place` (as the production `#[tokio::main]` runtime does).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
+    use benchmark::synthetic::{shapes, Tier};
+
+    let graph = "syn_it_repo_reads";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-repo-reads");
+    let spec = DatasetSpec {
+        seed: 9,
+        nodes: 500,
+        edges: 1500,
+    };
+    // Render every baseline read shape's corpus ONCE from the fixed seed, then record verbatim.
+    let recorded = shapes::record_repo_reads(Tier::Full, spec.nodes as i32, spec.edges as i32, spec.seed)
+        .expect("render repo reads");
+    assert_eq!(recorded.len(), 46, "Full records every baseline read shape");
+    recording::record_rendered(&spec, graph, &recorded, spec.seed, 256, &dir).expect("record");
+
+    // Replay #1 loads the recorded graph; #2 reuses it (no-load), count-verifying first.
+    let ref_out = dir.join("ref.json").to_string_lossy().into_owned();
+    let cand_out = dir.join("cand.json").to_string_lossy().into_owned();
+    let a = replay::run(&replay_config(&dir, graph, &ref_out, true))
+        .await
+        .expect("replay --load");
+    let b = replay::run(&replay_config(&dir, graph, &cand_out, false))
+        .await
+        .expect("replay --no-load");
+
+    // Same workload identity across replays (record-once → replay-verbatim).
+    let ha = a.meta.dataset.as_ref().expect("dataset a").workload_hash.clone();
+    let hb = b.meta.dataset.as_ref().expect("dataset b").workload_hash.clone();
+    assert_eq!(ha, hb, "workload_hash must match across replays");
+    assert_eq!(a.operations.len(), 46);
+
+    // Every result-gated shape has a digest that matches across the two replays; the
+    // LIMIT-without-ORDER shape is result-N/A (digest absent) in both.
+    for (name, op_a) in &a.operations {
+        let op_b = b.operations.get(name).expect("op present in both replays");
+        if name == "entity_path_introspection" {
+            assert!(op_a.result_digest.is_none(), "{name} must be result-N/A");
+            assert!(op_b.result_digest.is_none(), "{name} must be result-N/A");
+        } else {
+            let da = op_a.result_digest.as_ref().unwrap_or_else(|| panic!("digest a for {name}"));
+            let db = op_b.result_digest.as_ref().unwrap_or_else(|| panic!("digest b for {name}"));
+            assert_eq!(da, db, "result digest for {name} must match across replays");
+        }
+    }
+
+    // The guard proceeds (same workload + matching gated digests).
+    match guard(&BaselineKey::from_report(&a), &BaselineKey::from_report(&b)) {
+        GuardOutcome::Proceed { .. } => {}
+        GuardOutcome::Abort { reason } => panic!("guard aborted unexpectedly: {reason}"),
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
 /// replay --no-load against a graph that doesn't hold the recorded dataset fails closed (the
 /// count-verify rejects it) rather than silently measuring the wrong graph.
 #[tokio::test]
@@ -1091,6 +1157,7 @@ async fn record_and_replay_via_run_command() {
         ],
         all_reads: false,
         tier: None,
+        repo_reads: None,
         seed: Some(11),
         nodes: Some(400),
         edges: Some(1200),


### PR DESCRIPTION
## Phase 3 B2 — cover the ~46 baseline read shapes (design #239)

Wires the A/B benchmark's **baseline NON-ALGORITHM READ shapes** from `queries_repository` into the synthetic record/replay pipeline, so the synthetic per-op regression check covers the same read shapes the A/B benchmark measures. Implements **Phase 3 B2** of #239.

### What's covered
- **46 baseline reads** recorded via a new `synthetic record --repo-reads <core|full>` selector.
  - **45 are result-gated** (byte-stable → replay computes + compares a `result_digest`).
  - **1 is result-N/A**: `entity_path_introspection` (uses `LIMIT` without `ORDER BY` → an unordered subset). It is still **recorded + timed**, but replay reports `result_digest = N/A` so a benign result difference never fails the gate. No `ORDER BY` was added to the shared repo queries (per decision 4).
- **Coverage tiers**: `core` (a small, cheap, representative per-PR subset) ⊆ `full` (all 46, nightly/on-demand).
- **Derive-with-annotation**: the op *set* is auto-discovered from `queries_repository`; a curated table annotates each shape with `Tier` + `ResultPolicy`. A drift-guard unit test asserts the table equals `non_algorithm_read_names()` exactly, so the build fails if the two drift.
- **Reads only** — writes (Phase 7) and algorithms (Phase 6) remain out of scope.

### Record-once → replay-verbatim comparability (preserved)
Each shape's corpus is rendered **once at record time** from a fixed per-shape seed (`corpus_seed ^ salt`) via the Phase 2 `render_read_with_rng` seam, and recorded verbatim. Replay never calls the RNG. The new `result_gated` flag is **not** folded into `workload_hash`, so the hash stays byte-identical across engines/runs.

Empirically verified against a live FalkorDB:
- record `--repo-reads full` → replay ×2 (load, then no-load): **`workload_hash` byte-identical**, all **45 gated digests match** (0 mismatches), `entity_path_introspection` digest `None`.
- two independent records from the same seed produce **byte-identical** `commands/` + `graph.jsonl` + `workload_hash` (the PR-image vs main-image comparability basis).

### Changes
- `queries_repository`: public `non_algorithm_read_names()` + `render_read_with_rng(name, rng)`.
- New `src/synthetic/shapes.rs`: `baseline_read_shapes()` table + `record_repo_reads(tier, …)`.
- `recording`: self-describing `result_gated` flag on `OpEntry`/`RecordedOp` (serde default `true`, excluded from `workload_hash`; pre-field bundles still load + gate).
- `replay`: for a result-N/A op, skip the concurrent verify and report `result_digest = None`.
- `cli`/`mod`: `--repo-reads <core|full>` on `synthetic record` (mutually exclusive with `--op`/`--all-reads`/`--tier`).
- `readme`: documents `--repo-reads`.

### Validation
- `just clippy` (warnings denied), `just build`, `just test` — green (285 unit tests).
- `#[ignore]` `synthetic_probe` integration suite (incl. the new B2 record→replay test) — **22 passed** against a live FalkorDB.
- `just synthetic-verify` (catalog non-divergence gate) — **green** (no divergence across all ops × concurrency 1–32 × cached/uncached).
- Patch coverage measured via `cargo-llvm-cov --include-ignored` ≈ **97%** (≥ 90% gate).

### Remaining phases (need the user and/or a live server / next-gen CI)
- **Phase 4** — ExtendedCore `temporal_spatial_roundtrip`.
- **Phase 5** — fulltext/vector READ shapes (capability-gated; results N/A).
- **Phase 6** — algorithm reads. **Phase 7** — writes.
- The per-PR measurement matrix (`--concurrency`/`--cache`) and publishing the full report to GitHub Pages + the PR summary comment are owned by the next-gen CI, not this tool PR.

🤖 Generated with GitHub Copilot CLI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--repo-reads <core|full>` to record baseline repository read workloads.
  * Recorded workloads now preserve deterministic query rendering for reproducible bundles.
  * Replay reports distinguish stable results from operations that cannot be strictly result-validated.
* **Documentation**
  * Expanded workflow documentation with recording behavior, tier selection, replay handling, and option compatibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->