### PR TITLE
feat(synthetic): record the ExtendedCore temporal_spatial_roundtrip read (Phase 4)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -450,9 +450,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   over the graph *and* the commands (so any later edit is detected on load). It is **offline** — a
   pure function of the seed + knobs — and reads `synthetic-bench.toml` for defaults. Select ops with
   `--op <names>`, or **`--op all`** (or `--op '*'`) for every read operation. Alternatively,
-  **`--repo-reads <core|full>`** records the A/B benchmark's baseline non-algorithm **read shapes**
-  straight from `queries_repository` (auto-discovered, then annotated with a coverage tier +
-  result policy): `core` is the small per-PR subset, `full` is all ~46 reads. Each shape's corpus is
+  **`--repo-reads <core|full>`** records the A/B benchmark's non-algorithm **read shapes**
+  straight from `queries_repository` (auto-discovered, then annotated with a coverage profile + tier +
+  result policy): `core` is the small per-PR subset, `full` is all 47 reads — the 46 baseline reads
+  plus the ExtendedCore `temporal_spatial_roundtrip` (which round-trips deterministic temporal/spatial
+  values). Each shape's corpus is
   rendered **once** here from the seed and recorded verbatim (record-once → replay-verbatim), so the
   bundle stays byte-identical across runs; shapes whose result set isn't byte-stable (e.g. a `LIMIT`
   without `ORDER BY`) are still recorded + timed but marked **result-N/A** so replay never gates

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -537,7 +537,7 @@ pub enum SyntheticCommands {
             long = "repo-reads",
             value_enum,
             conflicts_with_all = ["ops", "all_reads", "tier"],
-            help = "record the A/B benchmark's baseline NON-ALGORITHM READ shapes from queries_repository at a coverage tier: `core` (small per-PR subset) or `full` (all ~46 reads). Auto-discovered + annotated; deterministic (record-once/replay-verbatim). Mutually exclusive with --op/--all-reads/--tier."
+            help = "record the A/B benchmark's NON-ALGORITHM READ shapes from queries_repository at a coverage tier: `core` (small per-PR subset) or `full` (all 47 reads — 46 baseline + the ExtendedCore temporal/spatial roundtrip). Auto-discovered + annotated; deterministic (record-once/replay-verbatim). Mutually exclusive with --op/--all-reads/--tier."
         )]
         repo_reads: Option<Tier>,
         #[arg(

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1437,7 +1437,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let ops = crate::cli::expand_op_selectors(&ops);
             // Reuse the run-config resolution (with generate=true) to validate + resolve the
             // dataset knobs, graph and read-op selection, then record OFFLINE (no server).
-            // `--repo-reads` selects the baseline read SHAPES implicitly (not catalog ops), so it
+            // `--repo-reads` selects the repo read SHAPES implicitly (not catalog ops), so it
             // forces `all_reads` only to satisfy op resolution; the resolved ops are ignored below.
             let overrides = config::CliOverrides {
                 endpoint: None,

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1466,10 +1466,11 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 OtherError("record requires --nodes/--edges (or a config) to generate a dataset".to_string())
             })?;
             let manifest = if let Some(tier) = repo_reads {
-                // Phase 3 B2: record the queries_repository baseline read shapes. Each shape's
-                // corpus is rendered ONCE here from `resolved.seed ^ salt` (record-once →
-                // replay-verbatim), then `record_rendered` writes the identical bundle format the
-                // catalog path produces (so `workload_hash` stays byte-identical across engines).
+                // Phase 3/4: record the queries_repository read shapes (Baseline reads +
+                // ExtendedCore `temporal_spatial_roundtrip`). Each shape's corpus is rendered ONCE
+                // here from `resolved.seed ^ salt` (record-once → replay-verbatim), then
+                // `record_rendered` writes the identical bundle format the catalog path produces (so
+                // `workload_hash` stays byte-identical across engines).
                 let recorded = crate::synthetic::shapes::record_repo_reads(
                     tier,
                     spec.nodes as i32,
@@ -2161,9 +2162,10 @@ mod tests {
     #[tokio::test]
     async fn run_command_record_offline_records_repo_read_shapes() {
         // `synthetic record --repo-reads core` runs OFFLINE (no server): it writes a bundle
-        // containing exactly the CORE baseline read SHAPES from queries_repository (Phase 3 B2),
-        // and a full-only shape is absent. Exercises the Record handler's `repo_reads` plumbing
-        // end-to-end (shapes::record_repo_reads → record_rendered).
+        // containing exactly the CORE read SHAPES from queries_repository (Phase 3 baseline reads +
+        // the Phase 4 ExtendedCore `temporal_spatial_roundtrip`), and a full-only shape is absent.
+        // Exercises the Record handler's `repo_reads` plumbing end-to-end (shapes::record_repo_reads
+        // → record_rendered).
         use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let out_dir = std::env::temp_dir().join(format!(
@@ -2188,12 +2190,16 @@ mod tests {
             .expect("offline repo-reads record succeeds without a server");
         assert!(out_dir.join("manifest.json").exists());
         let commands = out_dir.join("commands");
-        // Every core baseline read shape is recorded…
-        let core: Vec<_> = crate::synthetic::shapes::baseline_read_shapes()
+        // Every core read shape is recorded (incl. the ExtendedCore temporal_spatial_roundtrip)…
+        let core: Vec<_> = crate::synthetic::shapes::repo_read_shapes()
             .into_iter()
             .filter(|s| s.tier == Tier::Core)
             .collect();
         assert!(!core.is_empty(), "core tier must select at least one shape");
+        assert!(
+            core.iter().any(|s| s.name == "temporal_spatial_roundtrip"),
+            "the ExtendedCore shape is Core-tier and must be recorded"
+        );
         for shape in &core {
             assert!(
                 commands.join(format!("{}.jsonl", shape.name)).exists(),

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -1,11 +1,12 @@
-//! Bridge the A/B benchmark's `queries_repository` **baseline read shapes** into the synthetic
-//! record/replay pipeline (design §3.4 / Phase 3).
+//! Bridge the A/B benchmark's `queries_repository` **read shapes** into the synthetic
+//! record/replay pipeline (design §3.4 / Phases 3–4).
 //!
 //! The synthetic check historically probes a small, hand-curated catalog ([`catalog`]). This module
-//! lets it also record the **baseline non-algorithm read shapes** the A/B benchmark measures — the
-//! op *set* is **auto-discovered** from [`queries_repository`] (proven by the drift-guard test), and
-//! this module adds the explicit synthetic metadata each shape carries (coverage tier + result
-//! policy — the *derive-with-annotation* model, Decision 3).
+//! lets it also record the A/B benchmark's **non-algorithm read shapes** — the `Baseline` reads
+//! (Phase 3) plus the `ExtendedCore` `temporal_spatial_roundtrip` (Phase 4). The op *set* is
+//! **auto-discovered** from [`queries_repository`] (proven by the drift-guard tests), and this module
+//! adds the explicit synthetic metadata each shape carries (coverage profile + tier + result policy —
+//! the *derive-with-annotation* model, Decision 3).
 //!
 //! ## Determinism (record-once → replay-verbatim)
 //! Each shape's corpus is rendered **once at record time** from a fixed per-shape seed
@@ -54,18 +55,22 @@ impl ResultPolicy {
     }
 }
 
-/// One baseline read shape's synthetic metadata: its stable [`queries_repository`] name, coverage
-/// tier (Decision 1), and result policy (Decision 4).
+/// One repo read shape's synthetic metadata: its stable [`queries_repository`] name, coverage
+/// **profile** (Baseline / ExtendedCore), coverage **tier** (Decision 1), and result policy
+/// (Decision 4).
 ///
-/// Kind is always `Read` and profile always `Baseline` for this table; **capability** (fulltext/
-/// vector) and per-op **budget** are deferred to their phases (Phase 5 / Phase 6) — see the module
-/// docs.
+/// Kind is always `Read` for this table; **capability** (fulltext/vector) and per-op **budget** are
+/// deferred to their phases (Phase 5 / Phase 6). Temporal/spatial (the sole ExtendedCore read) is
+/// engine-supported on the FalkorDB record path, so it needs no capability gate — see the module docs.
 ///
 /// [`queries_repository`]: crate::queries_repository
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ShapeSpec {
     /// The shape's stable `queries_repository` read name (also the recorded op's key).
     pub name: &'static str,
+    /// Coverage profile the shape belongs to: [`QueryCoverageProfile::Baseline`] (Phase 3) or
+    /// [`QueryCoverageProfile::ExtendedCore`] (Phase 4).
+    pub profile: QueryCoverageProfile,
     /// Coverage tier: [`Tier::Core`] gates every PR; [`Tier::Full`] runs nightly/on-demand.
     pub tier: Tier,
     /// Whether replay gates this shape's result digest ([`ResultPolicy`]).
@@ -87,7 +92,7 @@ pub struct ShapeSpec {
 pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
     use ResultPolicy::{Gated, NotApplicable};
     use Tier::{Core, Full};
-    // `s(name, tier, policy)` keeps the table dense and readable.
+    // `s(name, tier, policy)` keeps the table dense and readable — every row is a `Baseline` read.
     fn s(
         name: &'static str,
         tier: Tier,
@@ -95,6 +100,7 @@ pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
     ) -> ShapeSpec {
         ShapeSpec {
             name,
+            profile: QueryCoverageProfile::Baseline,
             tier,
             result_policy,
         }
@@ -153,6 +159,37 @@ pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
     ]
 }
 
+/// The curated annotation for the **ExtendedCore** read shapes (design §3.4 / Phase 4): today just
+/// `temporal_spatial_roundtrip`, which round-trips deterministic temporal (`date`/`localtime`/
+/// `duration`) and spatial (`point`/`distance`) values.
+///
+/// It binds **no random params**, so every render is byte-identical; its result canonicalizes stably
+/// ([`op_runner`] handles `Date`/`Time`/`Duration`/`Point` and bit-patterns floats), so it is
+/// result-**gated**. The `ExtendedCore` profile is unavailable on Memgraph, but the synthetic record
+/// path is FalkorDB-only, so the shape is always present there (no capability gate needed).
+///
+/// Auto-discovered like the baseline set: the drift-guard test asserts these names are **exactly** the
+/// reads the `ExtendedCore` profile adds over `Baseline`.
+///
+/// [`op_runner`]: crate::synthetic::op_runner
+pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
+    vec![ShapeSpec {
+        name: "temporal_spatial_roundtrip",
+        profile: QueryCoverageProfile::ExtendedCore,
+        tier: Tier::Core,
+        result_policy: ResultPolicy::Gated,
+    }]
+}
+
+/// Every repo read shape the synthetic check records: the [`baseline_read_shapes`] (Phase 3) followed
+/// by the [`extended_core_read_shapes`] (Phase 4), in `queries_repository` definition order (the
+/// record order that feeds `workload_hash`).
+pub fn repo_read_shapes() -> Vec<ShapeSpec> {
+    let mut shapes = baseline_read_shapes();
+    shapes.extend(extended_core_read_shapes());
+    shapes
+}
+
 /// The algorithm selection the baseline-read source uses: **none**. Algorithm reads are opt-in and
 /// capability-gated (Phase 6), so they're excluded from the auto-discovered baseline read set.
 fn no_algorithms() -> AlgorithmQuerySelection {
@@ -164,37 +201,34 @@ fn no_algorithms() -> AlgorithmQuerySelection {
     }
 }
 
-/// Build the `queries_repository` handle the baseline read shapes render from: `FalkorDB` flavour,
-/// no algorithms, `Baseline` coverage profile. `vertices` must match the recorded graph's `:User`
-/// count (ids `1..=vertices`) so each shape's random params address real nodes.
-fn baseline_repository(
+/// Build the `queries_repository` handle the read shapes render from: `FalkorDB` flavour, no
+/// algorithms, at the given coverage `profile`. `vertices` must match the recorded graph's `:User`
+/// count (ids `1..=vertices`) so each shape's random params address real nodes. `ExtendedCore` is a
+/// superset of `Baseline` for non-algorithm reads (the baseline shapes render identically under it),
+/// so the record path builds one `ExtendedCore` repository to render both phases' shapes.
+fn read_shapes_repository(
+    profile: QueryCoverageProfile,
     vertices: i32,
     edges: i32,
 ) -> UsersQueriesRepository {
-    UsersQueriesRepository::new(
-        vertices,
-        edges,
-        Flavour::FalkorDB,
-        no_algorithms(),
-        QueryCoverageProfile::Baseline,
-    )
+    UsersQueriesRepository::new(vertices, edges, Flavour::FalkorDB, no_algorithms(), profile)
 }
 
-/// Render the selected `tier`'s baseline read shapes into [`RecordedOp`]s, ready for
+/// Render the selected `tier`'s repo read shapes into [`RecordedOp`]s, ready for
 /// [`record_rendered`](crate::synthetic::recording::record_rendered) — **offline**, no server.
 ///
 /// Each shape's corpus is [`CORPUS_SIZE`] renders drawn from a fixed per-shape seed
 /// (`corpus_seed ^ salt`, the op's [`OpKey::salt`]), so a given seed yields a byte-identical corpus
-/// (record-once → replay-verbatim). [`Tier::Full`] selects every baseline read; [`Tier::Core`]
-/// selects only the core subset. Returns an error if the annotation table names a shape that isn't
-/// an auto-discovered `queries_repository` baseline read (annotation drift).
+/// (record-once → replay-verbatim). [`Tier::Full`] selects every repo read; [`Tier::Core`] selects
+/// only the core subset. Returns an error if the annotation table names a shape that isn't an
+/// auto-discovered `queries_repository` read (annotation drift).
 pub fn record_repo_reads(
     tier: Tier,
     vertices: i32,
     edges: i32,
     corpus_seed: u64,
 ) -> BenchmarkResult<Vec<RecordedOp>> {
-    let selected: Vec<ShapeSpec> = baseline_read_shapes()
+    let selected: Vec<ShapeSpec> = repo_read_shapes()
         .into_iter()
         // `Tier::Full` records everything; `Tier::Core` records only the core subset.
         .filter(|shape| tier.includes(shape.tier))
@@ -202,7 +236,7 @@ pub fn record_repo_reads(
     record_selected_shapes(&selected, vertices, edges, corpus_seed)
 }
 
-/// Render the given `shapes` into [`RecordedOp`]s against a fresh baseline repository. Split out of
+/// Render the given `shapes` into [`RecordedOp`]s against a fresh repository. Split out of
 /// [`record_repo_reads`] so the annotation-drift guard is unit-testable with a bogus shape.
 fn record_selected_shapes(
     shapes: &[ShapeSpec],
@@ -210,7 +244,9 @@ fn record_selected_shapes(
     edges: i32,
     corpus_seed: u64,
 ) -> BenchmarkResult<Vec<RecordedOp>> {
-    let repo = baseline_repository(vertices, edges);
+    // `ExtendedCore` covers every recordable read (Baseline shapes render identically under it), so a
+    // single repository renders both phases' shapes.
+    let repo = read_shapes_repository(QueryCoverageProfile::ExtendedCore, vertices, edges);
     let available: BTreeSet<&str> = repo
         .non_algorithm_read_names()
         .iter()
@@ -221,7 +257,7 @@ fn record_selected_shapes(
     for shape in shapes {
         if !available.contains(shape.name) {
             return Err(OtherError(format!(
-                "baseline read shape '{}' is annotated but not a queries_repository baseline read \
+                "repo read shape '{}' is annotated but not a queries_repository read \
                  (annotation drift — update src/synthetic/shapes.rs)",
                 shape.name
             )));
@@ -231,7 +267,7 @@ fn record_selected_shapes(
         let mut commands = Vec::with_capacity(CORPUS_SIZE);
         for _ in 0..CORPUS_SIZE {
             let prepared = repo.render_read_with_rng(shape.name, &mut rng).ok_or_else(|| {
-                OtherError(format!("baseline read shape '{}' failed to render", shape.name))
+                OtherError(format!("repo read shape '{}' failed to render", shape.name))
             })?;
             commands.push(prepared.cypher);
         }
@@ -260,7 +296,7 @@ mod tests {
         // no fewer, no reordering. Order matters: it's the record order, which feeds `workload_hash`
         // (recording.rs). If `queries_repository` gains, drops, or reorders a baseline read, this
         // fails until `baseline_read_shapes()` is realigned.
-        let repo = baseline_repository(1000, 5000);
+        let repo = read_shapes_repository(QueryCoverageProfile::Baseline, 1000, 5000);
         let discovered: Vec<&str> =
             repo.non_algorithm_read_names().iter().map(String::as_str).collect();
         let annotated: Vec<&str> = baseline_read_shapes().iter().map(|s| s.name).collect();
@@ -278,6 +314,39 @@ mod tests {
     }
 
     #[test]
+    fn extended_core_adds_exactly_temporal_spatial_roundtrip_over_baseline() {
+        // Derive-with-annotation for Phase 4: the reads the `ExtendedCore` profile adds over
+        // `Baseline` must be EXACTLY the annotated extended-core shapes (today just
+        // `temporal_spatial_roundtrip`). If `queries_repository` adds another ExtendedCore read, this
+        // fails until `extended_core_read_shapes()` is updated.
+        let baseline_repo = read_shapes_repository(QueryCoverageProfile::Baseline, 1000, 5000);
+        let extended_repo = read_shapes_repository(QueryCoverageProfile::ExtendedCore, 1000, 5000);
+        let baseline: BTreeSet<&str> =
+            baseline_repo.non_algorithm_read_names().iter().map(String::as_str).collect();
+        let extended: BTreeSet<&str> =
+            extended_repo.non_algorithm_read_names().iter().map(String::as_str).collect();
+        let added: BTreeSet<&str> = extended.difference(&baseline).copied().collect();
+        let annotated: BTreeSet<&str> =
+            extended_core_read_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(added, annotated, "ExtendedCore adds exactly the annotated extended-core reads");
+        assert!(added.contains("temporal_spatial_roundtrip"));
+        for shape in extended_core_read_shapes() {
+            assert_eq!(shape.profile, QueryCoverageProfile::ExtendedCore);
+        }
+    }
+
+    #[test]
+    fn repo_read_shapes_match_the_extended_core_discovery_in_order() {
+        // The combined annotation (baseline ++ extended-core) must equal the ExtendedCore-profile
+        // discovery, in definition order — the record order that feeds `workload_hash`.
+        let repo = read_shapes_repository(QueryCoverageProfile::ExtendedCore, 1000, 5000);
+        let discovered: Vec<&str> =
+            repo.non_algorithm_read_names().iter().map(String::as_str).collect();
+        let annotated: Vec<&str> = repo_read_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(annotated, discovered, "repo read shapes drifted from ExtendedCore discovery");
+    }
+
+    #[test]
     fn there_are_forty_six_baseline_reads_with_a_nonempty_core_subset() {
         let shapes = baseline_read_shapes();
         assert_eq!(shapes.len(), 46, "expected the 46 baseline reads (design §3.4)");
@@ -288,10 +357,30 @@ mod tests {
     }
 
     #[test]
+    fn repo_read_shapes_are_forty_seven_including_one_extended_core() {
+        // Baseline (46) + ExtendedCore (1) = 47 unique reads across profiles.
+        let shapes = repo_read_shapes();
+        assert_eq!(shapes.len(), 47, "46 baseline + 1 extended-core read");
+        let names: BTreeSet<&str> = shapes.iter().map(|s| s.name).collect();
+        assert_eq!(names.len(), 47, "shape names must be unique across profiles");
+        assert_eq!(
+            shapes.iter().filter(|s| s.profile == QueryCoverageProfile::ExtendedCore).count(),
+            1,
+            "exactly one extended-core read"
+        );
+        // `temporal_spatial_roundtrip` is ExtendedCore, Core-tier, and result-gated.
+        let ts = shapes.iter().find(|s| s.name == "temporal_spatial_roundtrip").unwrap();
+        assert_eq!(ts.profile, QueryCoverageProfile::ExtendedCore);
+        assert_eq!(ts.tier, Tier::Core);
+        assert!(ts.result_policy.is_gated());
+    }
+
+    #[test]
     fn exactly_the_limit_without_order_shape_is_result_na() {
-        // Only `entity_path_introspection` (LIMIT 1 without ORDER BY) is result-N/A among the
-        // baseline reads; every other baseline read is result-gated (Decision 4).
-        for shape in baseline_read_shapes() {
+        // Only `entity_path_introspection` (LIMIT 1 without ORDER BY) is result-N/A among all repo
+        // reads; every other read — including `temporal_spatial_roundtrip` — is result-gated
+        // (Decision 4).
+        for shape in repo_read_shapes() {
             let expected_gated = shape.name != "entity_path_introspection";
             assert_eq!(
                 shape.result_policy.is_gated(),
@@ -303,10 +392,11 @@ mod tests {
     }
 
     #[test]
-    fn record_repo_reads_full_covers_every_baseline_read() {
+    fn record_repo_reads_full_covers_every_repo_read() {
         let ops = record_repo_reads(Tier::Full, 1000, 5000, 42).unwrap();
         let names: BTreeSet<&str> = ops.iter().map(|o| o.key.name()).collect();
-        assert_eq!(names, annotated_names(), "Full must record every baseline read");
+        let expected: BTreeSet<&str> = repo_read_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(names, expected, "Full must record every repo read");
         // Every op renders a full corpus and is keyed by the shape name as a read.
         for op in &ops {
             assert_eq!(op.commands.len(), CORPUS_SIZE, "op '{}' short corpus", op.key.name());
@@ -314,7 +404,7 @@ mod tests {
         }
         // `shortest_path` shares its name with a built-in `OpName`, so `OpKey::dynamic`
         // canonicalizes it to that built-in (by design — same name/kind/salt across every run);
-        // every other baseline read is a genuinely dynamic string-keyed op.
+        // every other repo read (incl. `temporal_spatial_roundtrip`) is a genuinely dynamic op.
         for op in &ops {
             if op.key.name() == "shortest_path" {
                 assert!(op.key.is_named(), "shortest_path canonicalizes to the built-in OpName");
@@ -322,12 +412,15 @@ mod tests {
                 assert!(!op.key.is_named(), "'{}' should be a dynamic read", op.key.name());
             }
         }
-        // The result-N/A shape is recorded but not gated; the rest are gated.
+        // The ExtendedCore shape is recorded and result-gated…
+        let ts = ops.iter().find(|o| o.key.name() == "temporal_spatial_roundtrip").unwrap();
+        assert!(ts.result_gated, "temporal_spatial_roundtrip is result-gated");
+        // …and the result-N/A shape is recorded but not gated; it's the only one.
         let na = ops.iter().find(|o| o.key.name() == "entity_path_introspection").unwrap();
         assert!(!na.result_gated, "the LIMIT-without-ORDER shape is result-N/A");
         assert!(
             ops.iter().filter(|o| !o.result_gated).count() == 1,
-            "exactly one baseline read is result-N/A"
+            "exactly one repo read is result-N/A"
         );
     }
 
@@ -378,6 +471,7 @@ mod tests {
         // safety net behind the derive-with-annotation model.
         let bogus = [ShapeSpec {
             name: "__not_a_repo_read__",
+            profile: QueryCoverageProfile::Baseline,
             tier: Tier::Full,
             result_policy: ResultPolicy::Gated,
         }];

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -221,7 +221,7 @@ fn read_shapes_repository(
 /// (`corpus_seed ^ salt`, the op's [`OpKey::salt`]), so a given seed yields a byte-identical corpus
 /// (record-once → replay-verbatim). [`Tier::Full`] selects every repo read; [`Tier::Core`] selects
 /// only the core subset. Returns an error if the annotation table names a shape that isn't an
-/// auto-discovered `queries_repository` read (annotation drift).
+/// auto-discovered `queries_repository` non-algorithm read (annotation drift).
 pub fn record_repo_reads(
     tier: Tier,
     vertices: i32,
@@ -257,7 +257,7 @@ fn record_selected_shapes(
     for shape in shapes {
         if !available.contains(shape.name) {
             return Err(OtherError(format!(
-                "repo read shape '{}' is annotated but not a queries_repository read \
+                "repo read shape '{}' is annotated but not a queries_repository non-algorithm read \
                  (annotation drift — update src/synthetic/shapes.rs)",
                 shape.name
             )));

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1061,10 +1061,10 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
         nodes: 500,
         edges: 1500,
     };
-    // Render every baseline read shape's corpus ONCE from the fixed seed, then record verbatim.
+    // Render every repo read shape's corpus ONCE from the fixed seed, then record verbatim.
     let recorded = shapes::record_repo_reads(Tier::Full, spec.nodes as i32, spec.edges as i32, spec.seed)
         .expect("render repo reads");
-    assert_eq!(recorded.len(), 46, "Full records every baseline read shape");
+    assert_eq!(recorded.len(), 47, "Full records every repo read shape (46 baseline + 1 ExtendedCore)");
     recording::record_rendered(&spec, graph, &recorded, spec.seed, 256, &dir).expect("record");
 
     // Replay #1 loads the recorded graph; #2 reuses it (no-load), count-verifying first.
@@ -1081,7 +1081,7 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
     let ha = a.meta.dataset.as_ref().expect("dataset a").workload_hash.clone();
     let hb = b.meta.dataset.as_ref().expect("dataset b").workload_hash.clone();
     assert_eq!(ha, hb, "workload_hash must match across replays");
-    assert_eq!(a.operations.len(), 46);
+    assert_eq!(a.operations.len(), 47);
 
     // Every result-gated shape has a digest that matches across the two replays; the
     // LIMIT-without-ORDER shape is result-N/A (digest absent) in both.
@@ -1096,6 +1096,10 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
             assert_eq!(da, db, "result digest for {name} must match across replays");
         }
     }
+    // The Phase 4 ExtendedCore shape round-trips a byte-stable, gated digest (temporal + spatial +
+    // float distance canonicalize deterministically).
+    let ts = a.operations.get("temporal_spatial_roundtrip").expect("temporal_spatial_roundtrip present");
+    assert!(ts.result_digest.is_some(), "temporal_spatial_roundtrip must be result-gated (digest present)");
 
     // The guard proceeds (same workload + matching gated digests).
     match guard(&BaselineKey::from_report(&a), &BaselineKey::from_report(&b)) {


### PR DESCRIPTION
## Phase 4 — record the ExtendedCore `temporal_spatial_roundtrip` read

Implements **Phase 4** of #239 (design §3.4). Wires the A/B benchmark's
`ExtendedCore` read shape **`temporal_spatial_roundtrip`** (from
`queries_repository`) into the synthetic per-op record/replay pipeline, taking
the repo-read coverage from **46 → 47** shapes.

**Reads only** — no writes (Phase 7) or algorithms (Phase 6).

### What it does
- Discovers the shape from `queries_repository` (auto-discovered, then annotated —
  the *derive-with-annotation* model) and records it through the same
  `render_read_with_rng` → `record_rendered` path Phase 3 introduced.
- Annotated **profile** `ExtendedCore`, **tier** `Core` (cheap + deterministic;
  the per-PR FalkorDB-vs-FalkorDB A/B path supports temporal/spatial), **result
  policy** `Gated`.

### Comparability invariant preserved (record-once → replay-verbatim)
Each shape's corpus is rendered **once** at record time from a fixed per-shape
seed (`corpus_seed ^ salt`); the concrete Cypher is stored and replayed verbatim
(no replay-time RNG, no per-engine regeneration), so **`workload_hash` stays
byte-identical** across engines/runs.

`ExtendedCore` is a **strict superset** of `Baseline` for non-algorithm reads
(the baseline shapes are registered unconditionally; the profile only *adds*
`temporal_spatial_roundtrip`), so the record path builds one `ExtendedCore`
repository and the 46 baseline shapes render byte-identically under it. Drift
guards assert `ExtendedCore` adds **exactly** `temporal_spatial_roundtrip` over
`Baseline`, and that the combined 47-shape annotation matches discovery **in
definition order** (the order that feeds `workload_hash`).

### Why `Gated` (not result-N/A)
The shape returns deterministic temporal (`date`/`localtime`/`duration`) and
spatial (`point`/`distance`) constants with **no random params**, so every render
is byte-identical and the result canonicalizes stably (`op_runner` handles
`Date`/`Time`/`Duration`/`Point` and bit-patterns floats). The single result-N/A
shape remains `entity_path_introspection` (LIMIT without ORDER BY).

### Validation (all green locally)
- `just clippy` (warnings-denied), `just build`, `just test` — green (288 unit tests).
- `just doc-check` — green (readme touched).
- All 22 `#[ignore]` `synthetic_probe` integration tests against a live FalkorDB — green
  (the roundtrip test now asserts 47 ops and that `temporal_spatial_roundtrip`
  round-trips a **present, byte-identical** gated digest across two replays).
- `just synthetic-verify` (Synthetic non-divergence gate) — **OK, no divergence**
  (unaffected: it records the `--op all` catalog path, not `--repo-reads`).
- **Patch coverage ≈ 98.5%** on added executable lines (well above the 90% gate);
  the one uncovered line is a pre-existing defensive `ok_or_else` error branch
  (guarded unreachable) whose only change here is message text.

Design phase: **Phase 4 (ExtendedCore `temporal_spatial_roundtrip`)** of #239.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full repository-read recording now includes 47 read shapes, including the temporal/spatial roundtrip.
  * Replay coverage includes the additional shape with result validation and byte-identical verification.

* **Documentation**
  * Updated CLI help and documentation to describe the 47-read full tier and the recording/replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->