### PR TITLE
feat(synthetic): record the FixtureDependent fulltext/vector reads (Phase 5)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -452,13 +452,16 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   `--op <names>`, or **`--op all`** (or `--op '*'`) for every read operation. Alternatively,
   **`--repo-reads <core|full>`** records the A/B benchmark's non-algorithm **read shapes**
   straight from `queries_repository` (auto-discovered, then annotated with a coverage profile + tier +
-  result policy): `core` is the small per-PR subset, `full` is all 47 reads — the 46 baseline reads
-  plus the ExtendedCore `temporal_spatial_roundtrip` (which round-trips deterministic temporal/spatial
-  values). Each shape's corpus is
+  result policy + capability): `core` is the small per-PR subset, `full` is all 50 reads — the 46
+  baseline reads, the ExtendedCore `temporal_spatial_roundtrip` (which round-trips deterministic
+  temporal/spatial values), and the 3 FixtureDependent fulltext/vector reads. Each shape's corpus is
   rendered **once** here from the seed and recorded verbatim (record-once → replay-verbatim), so the
-  bundle stays byte-identical across runs; shapes whose result set isn't byte-stable (e.g. a `LIMIT`
-  without `ORDER BY`) are still recorded + timed but marked **result-N/A** so replay never gates
-  their digest. `--repo-reads` is mutually exclusive with `--op`/`--all-reads`/`--tier`.
+  bundle stays byte-identical across runs; shapes whose result set isn't byte-stable (a `LIMIT`
+  without `ORDER BY`, or the fulltext/vector **top-k** reads) are still recorded + timed but marked
+  **result-N/A** so replay never gates their digest. The FixtureDependent reads additionally need a
+  fulltext/vector **fixture** (index DDL + seed data); when a `full` selection includes them the tool
+  bakes that fixture into the recorded graph **once**, so every engine replays the identical fixture.
+  `--repo-reads` is mutually exclusive with `--op`/`--all-reads`/`--tier`.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result

--- a/readme.md
+++ b/readme.md
@@ -460,7 +460,9 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   without `ORDER BY`, or the fulltext/vector **top-k** reads) are still recorded + timed but marked
   **result-N/A** so replay never gates their digest. The FixtureDependent reads additionally need a
   fulltext/vector **fixture** (index DDL + seed data); when a `full` selection includes them the tool
-  bakes that fixture into the recorded graph **once**, so every engine replays the identical fixture.
+  bakes that fixture into the recorded graph **once**, so every replay endpoint gets the identical
+  fixture. (That fixture uses FalkorDB-specific DDL/procedures, so these shapes are for the
+  FalkorDB-vs-FalkorDB A/B — two FalkorDB versions — not cross-database runs.)
   `--repo-reads` is mutually exclusive with `--op`/`--all-reads`/`--tier`.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -537,7 +537,7 @@ pub enum SyntheticCommands {
             long = "repo-reads",
             value_enum,
             conflicts_with_all = ["ops", "all_reads", "tier"],
-            help = "record the A/B benchmark's NON-ALGORITHM READ shapes from queries_repository at a coverage tier: `core` (small per-PR subset) or `full` (all 47 reads — 46 baseline + the ExtendedCore temporal/spatial roundtrip). Auto-discovered + annotated; deterministic (record-once/replay-verbatim). Mutually exclusive with --op/--all-reads/--tier."
+            help = "record the A/B benchmark's NON-ALGORITHM READ shapes from queries_repository at a coverage tier: `core` (small per-PR subset) or `full` (all 50 reads — 46 baseline + the ExtendedCore temporal/spatial roundtrip + 3 FixtureDependent fulltext/vector reads, whose top-k results are N/A). Auto-discovered + annotated; deterministic (record-once/replay-verbatim). Mutually exclusive with --op/--all-reads/--tier."
         )]
         repo_reads: Option<Tier>,
         #[arg(

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -280,7 +280,8 @@ const INDEX_STMTS: [&str; 2] = [
 /// (`FalkorDriver::ensure_post_phase1_fixtures_ready`, design §3.4): two fulltext indexes and one
 /// vector index, then two idempotent `SET`s that seed the `ft_text` / `embedding` properties on a
 /// deterministic id slice (`id % 97 == 0`). Every statement is **constant** — no `spec`-derived
-/// values — so it records and replays byte-identically; `SET` is idempotent so a re-run is a no-op.
+/// values — so it records and replays byte-identically. The `SET`s are inherently idempotent; the
+/// index DDL assumes a **fresh load** (which replay guarantees by dropping + reloading the graph).
 /// A graph with fewer than 97 users seeds no rows (the queries still run, just over empty results),
 /// which is fine because these shapes are result-N/A (top-k is non-deterministic).
 const FIXTURE_STMTS: [&str; 5] = [

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -230,13 +230,18 @@ pub fn corpus_hash(
 }
 
 /// The phase a load statement belongs to, so a recorded bundle can label statements and a loader
-/// can report which phase failed. All three run identically (execute + drain), but the ordering
-/// (index first, then nodes, then edges) matters and is preserved by [`load_statements`].
+/// can report which phase failed. All phases run identically (execute + drain), but the ordering
+/// (index first, then nodes, then edges, then the optional fixture) matters and is preserved by
+/// [`load_statements`] / [`fixture_statements`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoadPhase {
     Index,
     Nodes,
     Edges,
+    /// The optional post-load fixture (fulltext + vector indexes and their seed data) required by
+    /// the FixtureDependent read shapes. Emitted only when a recording includes those shapes; see
+    /// [`fixture_statements`].
+    Fixture,
 }
 
 impl LoadPhase {
@@ -246,6 +251,7 @@ impl LoadPhase {
             LoadPhase::Index => "index",
             LoadPhase::Nodes => "nodes",
             LoadPhase::Edges => "edges",
+            LoadPhase::Fixture => "fixture",
         }
     }
 
@@ -255,6 +261,7 @@ impl LoadPhase {
             "index" => Some(LoadPhase::Index),
             "nodes" => Some(LoadPhase::Nodes),
             "edges" => Some(LoadPhase::Edges),
+            "fixture" => Some(LoadPhase::Fixture),
             _ => None,
         }
     }
@@ -266,6 +273,22 @@ impl LoadPhase {
 const INDEX_STMTS: [&str; 2] = [
     "CREATE INDEX FOR (u:User) ON (u.id)",
     "CREATE INDEX FOR (u:User) ON (u.age)",
+];
+
+/// The optional post-load fixture DDL + seed data required by the FixtureDependent read shapes
+/// (the fulltext/vector smoke queries). Mirrors the A/B benchmark's post-phase-1 fixture
+/// (`FalkorDriver::ensure_post_phase1_fixtures_ready`, design §3.4): two fulltext indexes and one
+/// vector index, then two idempotent `SET`s that seed the `ft_text` / `embedding` properties on a
+/// deterministic id slice (`id % 97 == 0`). Every statement is **constant** — no `spec`-derived
+/// values — so it records and replays byte-identically; `SET` is idempotent so a re-run is a no-op.
+/// A graph with fewer than 97 users seeds no rows (the queries still run, just over empty results),
+/// which is fine because these shapes are result-N/A (top-k is non-deterministic).
+const FIXTURE_STMTS: [&str; 5] = [
+    "CREATE FULLTEXT INDEX FOR (l:User) ON (l.ft_text)",
+    "CREATE FULLTEXT INDEX FOR ()-[l:Friend]->() ON (l.ft_text)",
+    "CREATE VECTOR INDEX FOR (l:User) ON (l.embedding) OPTIONS { dimension: 3, similarityFunction: 'cosine' }",
+    "MATCH (u:User) WHERE u.id % 97 = 0 SET u.ft_text = 'fixture_alice user_' + toString(u.id), u.embedding = vecf32([toFloat((u.id % 10) + 1) / 10.0, toFloat(((u.id + 3) % 10) + 1) / 10.0, toFloat(((u.id + 6) % 10) + 1) / 10.0])",
+    "MATCH (s:User)-[r:Friend]->(d:User) WHERE s.id % 97 = 0 SET r.ft_text = 'fixture_blue edge_' + toString(s.id) + '_' + toString(d.id)",
 ];
 
 /// One node `UNWIND` batch covering ids `lo..=hi` (inclusive, 1-based).
@@ -334,6 +357,18 @@ pub(crate) fn load_statements(
         (LoadPhase::Edges, edge_batch(spec, lo, hi))
     });
     index.chain(node_batches).chain(edge_batches)
+}
+
+/// The optional post-load fixture statements ([`FIXTURE_STMTS`]) tagged as [`LoadPhase::Fixture`],
+/// appended **after** [`load_statements`] when a recording includes the FixtureDependent read
+/// shapes. Kept separate from `load_statements` so the live loader and every existing recording
+/// stay byte-identical: only recordings that opt in (via `record_rendered_with_fixture`) carry
+/// these statements. The nodes/edges the seed `SET`s `MATCH` are created by `load_statements`, so
+/// this must run last.
+pub(crate) fn fixture_statements() -> impl Iterator<Item = (LoadPhase, String)> {
+    FIXTURE_STMTS
+        .iter()
+        .map(|stmt| (LoadPhase::Fixture, (*stmt).to_string()))
 }
 
 /// Generate the dataset described by `spec` and bulk-load it into `graph`, **replacing** whatever
@@ -597,6 +632,47 @@ mod tests {
         let stmts: Vec<_> = load_statements(&s, 1).collect();
         // 2 index stmts + 3 node batches + 3 edge batches.
         assert_eq!(stmts.len(), 2 + 3 + 3);
+    }
+
+    #[test]
+    fn load_phase_tag_round_trips_for_every_variant() {
+        for phase in [
+            LoadPhase::Index,
+            LoadPhase::Nodes,
+            LoadPhase::Edges,
+            LoadPhase::Fixture,
+        ] {
+            assert_eq!(LoadPhase::from_tag(phase.tag()), Some(phase));
+        }
+        assert_eq!(LoadPhase::from_tag("nope"), None);
+    }
+
+    #[test]
+    fn fixture_statements_are_constant_deterministic_and_tagged() {
+        let a: Vec<(LoadPhase, String)> = fixture_statements().collect();
+        let b: Vec<(LoadPhase, String)> = fixture_statements().collect();
+        // Byte-identical across calls (constant, no spec/seed input) — the record-once/replay
+        // guarantee for the fixture.
+        assert_eq!(a, b);
+        // Three index DDLs then two seed `SET`s, all under the Fixture phase.
+        assert_eq!(a.len(), 5);
+        assert!(a.iter().all(|(p, _)| *p == LoadPhase::Fixture));
+        assert!(a[0].1.starts_with("CREATE FULLTEXT INDEX FOR (l:User)"));
+        assert!(a[1].1.starts_with("CREATE FULLTEXT INDEX FOR ()-[l:Friend]->()"));
+        assert!(a[2].1.starts_with("CREATE VECTOR INDEX FOR (l:User)"));
+        assert!(a[3].1.starts_with("MATCH (u:User) WHERE u.id % 97 = 0 SET"));
+        assert!(a[3].1.contains("fixture_alice"));
+        assert!(a[3].1.contains("vecf32("));
+        assert!(a[4].1.starts_with("MATCH (s:User)-[r:Friend]->(d:User) WHERE s.id % 97 = 0 SET"));
+        assert!(a[4].1.contains("fixture_blue"));
+    }
+
+    #[test]
+    fn fixture_statements_do_not_leak_into_load_statements() {
+        // `load_statements` must stay byte-identical to pre-fixture recordings: no Fixture phase.
+        let s = spec(7, 200, 400);
+        let phases: Vec<LoadPhase> = load_statements(&s, 32).map(|(p, _)| p).collect();
+        assert!(!phases.contains(&LoadPhase::Fixture));
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1471,9 +1471,11 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 // reads). Each shape's corpus is rendered ONCE here from `resolved.seed ^ salt`
                 // (record-once → replay-verbatim), then `record_rendered[_with_fixture]` writes the
                 // identical bundle format the catalog path produces (so `workload_hash` stays
-                // byte-identical across engines). When the selected tier includes any
-                // FixtureDependent shape, the fulltext/vector fixture is baked into the recorded
-                // graph (once), so every engine replays the identical fixture.
+                // byte-identical across replay endpoints — the A/B compares two FalkorDB versions).
+                // When the selected tier includes any FixtureDependent shape, the fulltext/vector
+                // fixture is baked into the recorded graph (once), so every replay gets the identical
+                // fixture (that fixture DDL is FalkorDB-specific — FalkorDB-vs-FalkorDB, not
+                // cross-database).
                 let recorded = crate::synthetic::shapes::record_repo_reads(
                     tier,
                     spec.nodes as i32,

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1466,25 +1466,39 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 OtherError("record requires --nodes/--edges (or a config) to generate a dataset".to_string())
             })?;
             let manifest = if let Some(tier) = repo_reads {
-                // Phase 3/4: record the queries_repository read shapes (Baseline reads +
-                // ExtendedCore `temporal_spatial_roundtrip`). Each shape's corpus is rendered ONCE
-                // here from `resolved.seed ^ salt` (record-once → replay-verbatim), then
-                // `record_rendered` writes the identical bundle format the catalog path produces (so
-                // `workload_hash` stays byte-identical across engines).
+                // Phase 3/4/5: record the queries_repository read shapes (Baseline reads +
+                // ExtendedCore `temporal_spatial_roundtrip` + the FixtureDependent fulltext/vector
+                // reads). Each shape's corpus is rendered ONCE here from `resolved.seed ^ salt`
+                // (record-once → replay-verbatim), then `record_rendered[_with_fixture]` writes the
+                // identical bundle format the catalog path produces (so `workload_hash` stays
+                // byte-identical across engines). When the selected tier includes any
+                // FixtureDependent shape, the fulltext/vector fixture is baked into the recorded
+                // graph (once), so every engine replays the identical fixture.
                 let recorded = crate::synthetic::shapes::record_repo_reads(
                     tier,
                     spec.nodes as i32,
                     spec.edges as i32,
                     resolved.seed,
                 )?;
-                recording::record_rendered(
-                    &spec,
-                    &resolved.graph,
-                    &recorded,
-                    resolved.seed,
-                    DATASET_LOAD_BATCH,
-                    std::path::Path::new(&out_dir),
-                )?
+                if crate::synthetic::shapes::repo_reads_need_fixture(tier) {
+                    recording::record_rendered_with_fixture(
+                        &spec,
+                        &resolved.graph,
+                        &recorded,
+                        resolved.seed,
+                        DATASET_LOAD_BATCH,
+                        std::path::Path::new(&out_dir),
+                    )?
+                } else {
+                    recording::record_rendered(
+                        &spec,
+                        &resolved.graph,
+                        &recorded,
+                        resolved.seed,
+                        DATASET_LOAD_BATCH,
+                        std::path::Path::new(&out_dir),
+                    )?
+                }
             } else {
                 recording::record(
                     &spec,
@@ -2209,6 +2223,81 @@ mod tests {
         }
         // …and a full-only shape (aggregate_expansion_2) is not.
         assert!(!commands.join("aggregate_expansion_2.jsonl").exists());
+        // Core selects no FixtureDependent shape, so the bundle bakes NO fixture into its graph.
+        let bundle = recording::load(&out_dir).expect("core bundle loads");
+        assert!(
+            !bundle
+                .graph_statements
+                .iter()
+                .any(|(phase, _)| *phase == crate::synthetic::dataset::LoadPhase::Fixture),
+            "core bundle must not contain the fulltext/vector fixture"
+        );
+        assert!(
+            !commands.join("vector_query_nodes_smoke.jsonl").exists(),
+            "the FixtureDependent reads are Full-only"
+        );
+        std::fs::remove_dir_all(&out_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_command_record_offline_repo_reads_full_bakes_the_fixture() {
+        // `synthetic record --repo-reads full` runs OFFLINE: it records the FixtureDependent
+        // fulltext/vector reads (Phase 5) as non-gated (result-N/A) ops AND bakes the fulltext/vector
+        // fixture into the recorded graph exactly once (record-once → replay-verbatim). Exercises the
+        // Record handler's `repo_reads_need_fixture` → `record_rendered_with_fixture` plumbing.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let out_dir = std::env::temp_dir().join(format!(
+            "syn-rec-reporeads-full-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let command = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: Some("greporeadsfull".to_string()),
+            ops: vec![],
+            all_reads: false,
+            tier: None,
+            repo_reads: Some(Tier::Full),
+            seed: Some(5),
+            nodes: Some(300),
+            edges: Some(900),
+            out_dir: out_dir.to_string_lossy().into_owned(),
+        };
+        run_command(command)
+            .await
+            .expect("offline full repo-reads record succeeds without a server");
+        let commands = out_dir.join("commands");
+        // The three FixtureDependent reads are recorded…
+        for name in [
+            "vector_query_nodes_smoke",
+            "fulltext_query_nodes_smoke",
+            "fulltext_query_relationships_smoke",
+        ] {
+            assert!(commands.join(format!("{name}.jsonl")).exists(), "missing fixture read {name}");
+        }
+        // …the fixture (5 statements) is baked into the graph, in the Fixture phase, after the base
+        // load statements…
+        let bundle = recording::load(&out_dir).expect("full bundle loads + passes the integrity gate");
+        let fixture_stmts: Vec<&str> = bundle
+            .graph_statements
+            .iter()
+            .filter(|(phase, _)| *phase == crate::synthetic::dataset::LoadPhase::Fixture)
+            .map(|(_, s)| s.as_str())
+            .collect();
+        assert_eq!(fixture_stmts.len(), 5, "the fixture is 3 index DDL + 2 seed SETs");
+        assert!(fixture_stmts.iter().any(|s| s.contains("VECTOR INDEX")));
+        assert!(fixture_stmts.iter().any(|s| s.contains("FULLTEXT INDEX")));
+        assert!(fixture_stmts.iter().any(|s| s.contains("fixture_alice")));
+        // …and the fixture reads are recorded as non-gated (result-N/A) ops.
+        for name in [
+            "vector_query_nodes_smoke",
+            "fulltext_query_nodes_smoke",
+            "fulltext_query_relationships_smoke",
+        ] {
+            let entry = bundle.manifest.ops.iter().find(|o| o.name == name).unwrap();
+            assert!(!entry.result_gated, "{name} must be result-N/A (top-k)");
+        }
         std::fs::remove_dir_all(&out_dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -323,11 +323,12 @@ pub fn record_rendered(
 /// Like [`record_rendered`], but also appends the post-load [`fixture_statements`] (the fulltext +
 /// vector index DDL and their deterministic seed data) to `graph.jsonl`, folded into the
 /// [`Manifest::workload_hash`]. Used when a recording includes the FixtureDependent read shapes so
-/// every engine replays the identical fulltext/vector fixture (record-once → replay-verbatim). A
-/// bundle written this way stays byte-identical across engines; the fixture statements are constant
+/// every replay endpoint gets the identical fulltext/vector fixture (record-once → replay-verbatim).
+/// A bundle written this way stays byte-identical across replays; the fixture statements are constant
 /// (no `spec`/seed-derived values). The seed `SET`s are inherently idempotent; the index DDL
 /// (`CREATE FULLTEXT/VECTOR INDEX …`) assumes a **fresh load** — which replay guarantees by dropping
-/// and reloading the graph before executing `graph.jsonl` (design §3.4).
+/// and reloading the graph before executing `graph.jsonl` (design §3.4). The fixture DDL is
+/// FalkorDB-specific, so these shapes are for FalkorDB-vs-FalkorDB A/B, not cross-database runs.
 pub fn record_rendered_with_fixture(
     dataset: &DatasetSpec,
     graph: &str,

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -26,7 +26,9 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::synthetic::catalog::spec;
-use crate::synthetic::dataset::{load_statements, DatasetSpec, LoadPhase, GENERATOR_VERSION};
+use crate::synthetic::dataset::{
+    fixture_statements, load_statements, DatasetSpec, LoadPhase, GENERATOR_VERSION,
+};
 use crate::synthetic::{OpKey, OpName};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -315,6 +317,38 @@ pub fn record_rendered(
     batch_size: usize,
     out_dir: &Path,
 ) -> BenchmarkResult<Manifest> {
+    record_rendered_impl(dataset, graph, ops, corpus_seed, batch_size, out_dir, false)
+}
+
+/// Like [`record_rendered`], but also appends the post-load [`fixture_statements`] (the fulltext +
+/// vector index DDL and their deterministic seed data) to `graph.jsonl`, folded into the
+/// [`Manifest::workload_hash`]. Used when a recording includes the FixtureDependent read shapes so
+/// every engine replays the identical fulltext/vector fixture (record-once → replay-verbatim). A
+/// bundle written this way stays byte-identical across engines; the fixture statements are constant
+/// and idempotent (design §3.4).
+pub fn record_rendered_with_fixture(
+    dataset: &DatasetSpec,
+    graph: &str,
+    ops: &[RecordedOp],
+    corpus_seed: u64,
+    batch_size: usize,
+    out_dir: &Path,
+) -> BenchmarkResult<Manifest> {
+    record_rendered_impl(dataset, graph, ops, corpus_seed, batch_size, out_dir, true)
+}
+
+/// Shared body of [`record_rendered`] / [`record_rendered_with_fixture`]. When `include_fixture` is
+/// set, the fixture statements are streamed into `graph.jsonl` after the base load statements and
+/// hashed in the same order, so the two entry points differ only by whether the fixture is present.
+fn record_rendered_impl(
+    dataset: &DatasetSpec,
+    graph: &str,
+    ops: &[RecordedOp],
+    corpus_seed: u64,
+    batch_size: usize,
+    out_dir: &Path,
+    include_fixture: bool,
+) -> BenchmarkResult<Manifest> {
     dataset.validate()?;
     if batch_size == 0 {
         return Err(OtherError("record batch_size must be greater than 0".to_string()));
@@ -354,11 +388,15 @@ pub fn record_rendered(
         corpus_seed,
     );
 
-    // graph.jsonl — streamed straight from the lazy statement iterator (one batch in memory).
+    // graph.jsonl — streamed straight from the lazy statement iterator (one batch in memory). When
+    // a fixture is requested, its statements follow the base load statements in the same stream, so
+    // they are written and hashed in that exact order (index → nodes → edges → fixture).
     let graph_path = out_dir.join("graph.jsonl");
     {
         let mut w = BufWriter::new(create_file(&graph_path)?);
-        for (seq, (phase, stmt)) in load_statements(dataset, batch_size).enumerate() {
+        let fixture = fixture_statements().take(if include_fixture { usize::MAX } else { 0 });
+        let stmts = load_statements(dataset, batch_size).chain(fixture);
+        for (seq, (phase, stmt)) in stmts.enumerate() {
             hasher.graph_record(phase.tag(), &stmt);
             let rec = GraphRecord {
                 seq,
@@ -756,6 +794,51 @@ mod tests {
         assert_eq!(key.kind(), QueryType::Read);
         assert_eq!(cmds, &ops[0].commands);
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_with_fixture_appends_fixture_and_changes_hash() {
+        // Recording the FixtureDependent shapes bakes the fulltext/vector fixture into `graph.jsonl`
+        // (record-once → replay-verbatim) and folds it into the workload_hash.
+        let dir = temp_bundle_dir("synthrec-fixture");
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 200,
+            edges: 400,
+        };
+        let ops = vec![RecordedOp {
+            // Mirrors a fixture-dependent shape: a non-gated (result-N/A) read.
+            key: OpKey::dynamic("vector_query_nodes_smoke", QueryType::Read),
+            result_gated: false,
+            commands: vec![
+                "CALL db.idx.vector.queryNodes('User', 'embedding', 10, vecf32([0.1, 0.2, 0.3])) \
+                 YIELD node, score RETURN id(node), score LIMIT 10"
+                    .to_string(),
+            ],
+        }];
+        let with = record_rendered_with_fixture(&spec, "gfix", &ops, 9, 32, &dir).unwrap();
+
+        // The bundle survives the integrity gate and its graph is base load stmts + the fixture.
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.manifest, with);
+        let base: Vec<(LoadPhase, String)> = load_statements(&spec, 32).collect();
+        let fixture: Vec<(LoadPhase, String)> = fixture_statements().collect();
+        let want: Vec<(LoadPhase, String)> = base.iter().chain(fixture.iter()).cloned().collect();
+        assert_eq!(bundle.graph_statements, want);
+        // The trailing statements are exactly the fixture phase, in order.
+        let tail = &bundle.graph_statements[bundle.graph_statements.len() - fixture.len()..];
+        assert_eq!(tail, fixture.as_slice());
+        // The recorded op stays non-gated (result-N/A) through the round-trip.
+        assert!(!bundle.manifest.ops[0].result_gated);
+
+        // Recording the same spec/ops *without* the fixture yields a different workload_hash, proving
+        // the fixture is folded into the hash (so it can't be silently dropped on replay).
+        let dir2 = temp_bundle_dir("synthrec-nofixture");
+        let without = record_rendered(&spec, "gfix", &ops, 9, 32, &dir2).unwrap();
+        assert_ne!(with.workload_hash, without.workload_hash);
+
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::remove_dir_all(&dir2).ok();
     }
 
     #[test]

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -396,7 +396,11 @@ fn record_rendered_impl(
     let graph_path = out_dir.join("graph.jsonl");
     {
         let mut w = BufWriter::new(create_file(&graph_path)?);
-        let fixture = fixture_statements().take(if include_fixture { usize::MAX } else { 0 });
+        // Append the fixture statements only when requested; `None` contributes nothing to the stream.
+        let fixture = include_fixture
+            .then(fixture_statements)
+            .into_iter()
+            .flatten();
         let stmts = load_statements(dataset, batch_size).chain(fixture);
         for (seq, (phase, stmt)) in stmts.enumerate() {
             hasher.graph_record(phase.tag(), &stmt);

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -325,7 +325,9 @@ pub fn record_rendered(
 /// [`Manifest::workload_hash`]. Used when a recording includes the FixtureDependent read shapes so
 /// every engine replays the identical fulltext/vector fixture (record-once → replay-verbatim). A
 /// bundle written this way stays byte-identical across engines; the fixture statements are constant
-/// and idempotent (design §3.4).
+/// (no `spec`/seed-derived values). The seed `SET`s are inherently idempotent; the index DDL
+/// (`CREATE FULLTEXT/VECTOR INDEX …`) assumes a **fresh load** — which replay guarantees by dropping
+/// and reloading the graph before executing `graph.jsonl` (design §3.4).
 pub fn record_rendered_with_fixture(
     dataset: &DatasetSpec,
     graph: &str,

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -45,7 +45,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::collections::BTreeSet;
 
-/// Whether a shape's result set is byte-stable across runs/engines, and so whether replay gates its
+/// Whether a shape's result set is byte-stable across runs/replays, and so whether replay gates its
 /// result digest (design §3.2 / Decision 4).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResultPolicy {
@@ -218,7 +218,7 @@ pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
 /// Each requires the post-load fixture ([`fixture_statements`](crate::synthetic::dataset::fixture_statements))
 /// — the fulltext/vector index DDL and seed data — baked into the recorded graph, so the record path
 /// records them via [`record_rendered_with_fixture`](crate::synthetic::recording::record_rendered_with_fixture)
-/// (record-once → replay-verbatim: every engine replays the identical fixture). They bind **no random
+/// (record-once → replay-verbatim: every replay endpoint gets the identical fixture). They bind **no random
 /// params** (byte-identical renders), but their result set is **top-k** (ties/ordering are
 /// non-deterministic), so all three are result-**N/A** ([`ResultPolicy::NotApplicable`], Decision 4) —
 /// we do not add `ORDER BY` to force determinism. Each is annotated with the [`ShapeCapability`] it

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -62,8 +62,12 @@ impl ResultPolicy {
 }
 
 /// The engine capability a fixture-dependent read requires beyond plain Cypher (design §3.4). The
-/// fulltext/vector smoke reads name the specific index procedure they exercise so the runtime can
-/// gate them (record-and-skip-as-N/A on an engine lacking the capability); non-fixture reads need
+/// fulltext/vector smoke reads name the specific index procedure they exercise.
+///
+/// Today this is **annotation only** — a stable, machine-readable label carried on the [`ShapeSpec`]
+/// so a future capability-gating pass (record-and-skip-as-N/A on an engine that lacks the capability)
+/// can key off it without a bundle-format change. It is not yet consulted at record or replay time
+/// (the per-PR A/B images are modern FalkorDB with all three capabilities). Non-fixture reads need
 /// nothing (`capability = None`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShapeCapability {
@@ -215,9 +219,9 @@ pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
 /// (record-once → replay-verbatim: every engine replays the identical fixture). They bind **no random
 /// params** (byte-identical renders), but their result set is **top-k** (ties/ordering are
 /// non-deterministic), so all three are result-**N/A** ([`ResultPolicy::NotApplicable`], Decision 4) —
-/// we do not add `ORDER BY` to force determinism. Each carries the [`ShapeCapability`] it exercises so
-/// an engine that lacks it can record-and-skip-as-N/A. All are [`Tier::Full`]: capability-gated shapes
-/// stay out of the always-on core subset.
+/// we do not add `ORDER BY` to force determinism. Each is annotated with the [`ShapeCapability`] it
+/// exercises (metadata for a future capability-gating pass — see [`ShapeCapability`]). All are
+/// [`Tier::Full`]: capability-gated shapes stay out of the always-on core subset.
 ///
 /// Auto-discovered like the other sets: the drift-guard test asserts these names are **exactly** the
 /// reads the `FixtureDependent` profile adds over `ExtendedCore`.

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -14,11 +14,13 @@
 //! (`corpus_seed ^ salt`, mirroring how [`catalog`] ops seed) via the seedable
 //! [`UsersQueriesRepository::render_read_with_rng`] entry (design §4.1), and the concrete Cypher is
 //! recorded verbatim. Replay never touches the RNG — it replays the recorded strings — so the
-//! `workload_hash` is byte-identical across engines and the A/B non-divergence gate stays meaningful.
+//! `workload_hash` is byte-identical across replay endpoints (the A/B compares two FalkorDB
+//! versions/images, not different databases) and the non-divergence gate stays meaningful.
 //! The FixtureDependent reads additionally need a fulltext/vector **fixture** (index DDL + seed data)
 //! in the graph; it is baked into the recorded bundle **once** (design §3.4 /
 //! [`fixture_statements`](crate::synthetic::dataset::fixture_statements)) and replayed verbatim into
-//! every engine, so the fixture never diverges either.
+//! every endpoint, so the fixture never diverges either. (The fixture DDL/queries are
+//! FalkorDB-specific, so these shapes are for FalkorDB-vs-FalkorDB A/B, not cross-database runs.)
 //!
 //! ## Result policy (Decision 4)
 //! Most baseline reads project byte-stable results and are result-**gated**. Shapes whose result set

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -1,12 +1,13 @@
 //! Bridge the A/B benchmark's `queries_repository` **read shapes** into the synthetic
-//! record/replay pipeline (design §3.4 / Phases 3–4).
+//! record/replay pipeline (design §3.4 / Phases 3–5).
 //!
 //! The synthetic check historically probes a small, hand-curated catalog ([`catalog`]). This module
 //! lets it also record the A/B benchmark's **non-algorithm read shapes** — the `Baseline` reads
-//! (Phase 3) plus the `ExtendedCore` `temporal_spatial_roundtrip` (Phase 4). The op *set* is
-//! **auto-discovered** from [`queries_repository`] (proven by the drift-guard tests), and this module
-//! adds the explicit synthetic metadata each shape carries (coverage profile + tier + result policy —
-//! the *derive-with-annotation* model, Decision 3).
+//! (Phase 3), the `ExtendedCore` `temporal_spatial_roundtrip` (Phase 4), and the `FixtureDependent`
+//! fulltext/vector reads (Phase 5). The op *set* is **auto-discovered** from [`queries_repository`]
+//! (proven by the drift-guard tests), and this module adds the explicit synthetic metadata each shape
+//! carries (coverage profile + tier + result policy + capability — the *derive-with-annotation*
+//! model, Decision 3).
 //!
 //! ## Determinism (record-once → replay-verbatim)
 //! Each shape's corpus is rendered **once at record time** from a fixed per-shape seed
@@ -14,12 +15,17 @@
 //! [`UsersQueriesRepository::render_read_with_rng`] entry (design §4.1), and the concrete Cypher is
 //! recorded verbatim. Replay never touches the RNG — it replays the recorded strings — so the
 //! `workload_hash` is byte-identical across engines and the A/B non-divergence gate stays meaningful.
+//! The FixtureDependent reads additionally need a fulltext/vector **fixture** (index DDL + seed data)
+//! in the graph; it is baked into the recorded bundle **once** (design §3.4 /
+//! [`fixture_statements`](crate::synthetic::dataset::fixture_statements)) and replayed verbatim into
+//! every engine, so the fixture never diverges either.
 //!
 //! ## Result policy (Decision 4)
-//! Most baseline reads project byte-stable results and are result-**gated**. A few shapes whose
-//! result set isn't byte-stable (e.g. `LIMIT` without `ORDER BY`) are recorded and timed but marked
-//! result-**N/A** ([`ResultPolicy::NotApplicable`]) so a benign result difference never fails the
-//! gate — we do **not** add `ORDER BY` to the shared repo queries (that would change the shape).
+//! Most baseline reads project byte-stable results and are result-**gated**. Shapes whose result set
+//! isn't byte-stable — `LIMIT` without `ORDER BY`, or the fulltext/vector **top-k** reads (ties and
+//! ordering are non-deterministic) — are recorded and timed but marked result-**N/A**
+//! ([`ResultPolicy::NotApplicable`]) so a benign result difference never fails the gate. We do **not**
+//! add `ORDER BY` to the shared repo queries (that would change the shape).
 //!
 //! [`catalog`]: crate::synthetic::catalog
 //! [`queries_repository`]: crate::queries_repository
@@ -55,26 +61,43 @@ impl ResultPolicy {
     }
 }
 
+/// The engine capability a fixture-dependent read requires beyond plain Cypher (design §3.4). The
+/// fulltext/vector smoke reads name the specific index procedure they exercise so the runtime can
+/// gate them (record-and-skip-as-N/A on an engine lacking the capability); non-fixture reads need
+/// nothing (`capability = None`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShapeCapability {
+    /// `db.idx.vector.queryNodes` — a vector index over `:User(embedding)`.
+    VectorQueryNodes,
+    /// `db.idx.fulltext.queryNodes` — a fulltext index over `:User(ft_text)`.
+    FulltextQueryNodes,
+    /// `db.idx.fulltext.queryRelationships` — a fulltext index over `:Friend(ft_text)`.
+    FulltextQueryRelationships,
+}
+
 /// One repo read shape's synthetic metadata: its stable [`queries_repository`] name, coverage
-/// **profile** (Baseline / ExtendedCore), coverage **tier** (Decision 1), and result policy
-/// (Decision 4).
+/// **profile** (Baseline / ExtendedCore / FixtureDependent), coverage **tier** (Decision 1), result
+/// policy (Decision 4), and optional **capability** (Phase 5 fulltext/vector).
 ///
-/// Kind is always `Read` for this table; **capability** (fulltext/vector) and per-op **budget** are
-/// deferred to their phases (Phase 5 / Phase 6). Temporal/spatial (the sole ExtendedCore read) is
-/// engine-supported on the FalkorDB record path, so it needs no capability gate — see the module docs.
+/// Kind is always `Read` for this table; per-op **budget** is deferred to its phase. The Baseline and
+/// ExtendedCore reads need no capability (`capability = None`); the FixtureDependent fulltext/vector
+/// reads carry the [`ShapeCapability`] they exercise — see the module docs.
 ///
 /// [`queries_repository`]: crate::queries_repository
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ShapeSpec {
     /// The shape's stable `queries_repository` read name (also the recorded op's key).
     pub name: &'static str,
-    /// Coverage profile the shape belongs to: [`QueryCoverageProfile::Baseline`] (Phase 3) or
-    /// [`QueryCoverageProfile::ExtendedCore`] (Phase 4).
+    /// Coverage profile the shape belongs to: [`QueryCoverageProfile::Baseline`] (Phase 3),
+    /// [`QueryCoverageProfile::ExtendedCore`] (Phase 4), or [`QueryCoverageProfile::FixtureDependent`]
+    /// (Phase 5).
     pub profile: QueryCoverageProfile,
     /// Coverage tier: [`Tier::Core`] gates every PR; [`Tier::Full`] runs nightly/on-demand.
     pub tier: Tier,
     /// Whether replay gates this shape's result digest ([`ResultPolicy`]).
     pub result_policy: ResultPolicy,
+    /// The engine capability this shape requires, or `None` for plain-Cypher reads ([`ShapeCapability`]).
+    pub capability: Option<ShapeCapability>,
 }
 
 /// The curated annotation for the **46 baseline non-algorithm read shapes** (design §3.4).
@@ -103,6 +126,7 @@ pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
             profile: QueryCoverageProfile::Baseline,
             tier,
             result_policy,
+            capability: None,
         }
     }
     vec![
@@ -178,16 +202,78 @@ pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
         profile: QueryCoverageProfile::ExtendedCore,
         tier: Tier::Core,
         result_policy: ResultPolicy::Gated,
+        capability: None,
     }]
 }
 
-/// Every repo read shape the synthetic check records: the [`baseline_read_shapes`] (Phase 3) followed
-/// by the [`extended_core_read_shapes`] (Phase 4), in `queries_repository` definition order (the
-/// record order that feeds `workload_hash`).
+/// The curated annotation for the **FixtureDependent** fulltext/vector read shapes (design §3.4 /
+/// Phase 5): the vector smoke read plus the two fulltext (node + relationship) smoke reads.
+///
+/// Each requires the post-load fixture ([`fixture_statements`](crate::synthetic::dataset::fixture_statements))
+/// — the fulltext/vector index DDL and seed data — baked into the recorded graph, so the record path
+/// records them via [`record_rendered_with_fixture`](crate::synthetic::recording::record_rendered_with_fixture)
+/// (record-once → replay-verbatim: every engine replays the identical fixture). They bind **no random
+/// params** (byte-identical renders), but their result set is **top-k** (ties/ordering are
+/// non-deterministic), so all three are result-**N/A** ([`ResultPolicy::NotApplicable`], Decision 4) —
+/// we do not add `ORDER BY` to force determinism. Each carries the [`ShapeCapability`] it exercises so
+/// an engine that lacks it can record-and-skip-as-N/A. All are [`Tier::Full`]: capability-gated shapes
+/// stay out of the always-on core subset.
+///
+/// Auto-discovered like the other sets: the drift-guard test asserts these names are **exactly** the
+/// reads the `FixtureDependent` profile adds over `ExtendedCore`.
+pub fn fixture_dependent_read_shapes() -> Vec<ShapeSpec> {
+    use ShapeCapability::{FulltextQueryNodes, FulltextQueryRelationships, VectorQueryNodes};
+    // Every row is a FixtureDependent, Full-tier, result-N/A read; only the name + capability differ.
+    fn s(
+        name: &'static str,
+        capability: ShapeCapability,
+    ) -> ShapeSpec {
+        ShapeSpec {
+            name,
+            profile: QueryCoverageProfile::FixtureDependent,
+            tier: Tier::Full,
+            result_policy: ResultPolicy::NotApplicable(
+                "vector/fulltext top-k ordering is non-deterministic",
+            ),
+            capability: Some(capability),
+        }
+    }
+    vec![
+        s("vector_query_nodes_smoke", VectorQueryNodes),
+        s("fulltext_query_nodes_smoke", FulltextQueryNodes),
+        s("fulltext_query_relationships_smoke", FulltextQueryRelationships),
+    ]
+}
+
+/// Every repo read shape the synthetic check records: the [`baseline_read_shapes`] (Phase 3), then
+/// the [`extended_core_read_shapes`] (Phase 4), then the [`fixture_dependent_read_shapes`] (Phase 5),
+/// in `queries_repository` definition order (the record order that feeds `workload_hash`).
 pub fn repo_read_shapes() -> Vec<ShapeSpec> {
     let mut shapes = baseline_read_shapes();
     shapes.extend(extended_core_read_shapes());
+    shapes.extend(fixture_dependent_read_shapes());
     shapes
+}
+
+/// The repo read shapes the given `tier` selects, in record order: [`Tier::Full`] selects every repo
+/// read; [`Tier::Core`] selects only the core subset. Shared by [`record_repo_reads`] and
+/// [`repo_reads_need_fixture`] so the two agree on what a tier records.
+fn selected_shapes(tier: Tier) -> Vec<ShapeSpec> {
+    repo_read_shapes()
+        .into_iter()
+        .filter(|shape| tier.includes(shape.tier))
+        .collect()
+}
+
+/// Whether the `tier`'s selection includes any [`QueryCoverageProfile::FixtureDependent`] shape, so
+/// the record path must bake the fulltext/vector fixture into the recorded graph
+/// ([`record_rendered_with_fixture`](crate::synthetic::recording::record_rendered_with_fixture))
+/// instead of the plain [`record_rendered`](crate::synthetic::recording::record_rendered). The
+/// fixture shapes are all [`Tier::Full`], so `Tier::Core` never needs the fixture.
+pub fn repo_reads_need_fixture(tier: Tier) -> bool {
+    selected_shapes(tier)
+        .iter()
+        .any(|shape| shape.profile == QueryCoverageProfile::FixtureDependent)
 }
 
 /// The algorithm selection the baseline-read source uses: **none**. Algorithm reads are opt-in and
@@ -203,9 +289,10 @@ fn no_algorithms() -> AlgorithmQuerySelection {
 
 /// Build the `queries_repository` handle the read shapes render from: `FalkorDB` flavour, no
 /// algorithms, at the given coverage `profile`. `vertices` must match the recorded graph's `:User`
-/// count (ids `1..=vertices`) so each shape's random params address real nodes. `ExtendedCore` is a
-/// superset of `Baseline` for non-algorithm reads (the baseline shapes render identically under it),
-/// so the record path builds one `ExtendedCore` repository to render both phases' shapes.
+/// count (ids `1..=vertices`) so each shape's random params address real nodes. `FixtureDependent`
+/// is a superset of `ExtendedCore` (itself a superset of `Baseline`) for non-algorithm reads — the
+/// lower-profile shapes render identically under it — so the record path builds one
+/// `FixtureDependent` repository to render every phase's shapes.
 fn read_shapes_repository(
     profile: QueryCoverageProfile,
     vertices: i32,
@@ -228,12 +315,7 @@ pub fn record_repo_reads(
     edges: i32,
     corpus_seed: u64,
 ) -> BenchmarkResult<Vec<RecordedOp>> {
-    let selected: Vec<ShapeSpec> = repo_read_shapes()
-        .into_iter()
-        // `Tier::Full` records everything; `Tier::Core` records only the core subset.
-        .filter(|shape| tier.includes(shape.tier))
-        .collect();
-    record_selected_shapes(&selected, vertices, edges, corpus_seed)
+    record_selected_shapes(&selected_shapes(tier), vertices, edges, corpus_seed)
 }
 
 /// Render the given `shapes` into [`RecordedOp`]s against a fresh repository. Split out of
@@ -244,9 +326,9 @@ fn record_selected_shapes(
     edges: i32,
     corpus_seed: u64,
 ) -> BenchmarkResult<Vec<RecordedOp>> {
-    // `ExtendedCore` covers every recordable read (Baseline shapes render identically under it), so a
-    // single repository renders both phases' shapes.
-    let repo = read_shapes_repository(QueryCoverageProfile::ExtendedCore, vertices, edges);
+    // `FixtureDependent` covers every recordable read (the Baseline/ExtendedCore shapes render
+    // identically under it), so a single repository renders every phase's shapes.
+    let repo = read_shapes_repository(QueryCoverageProfile::FixtureDependent, vertices, edges);
     let available: BTreeSet<&str> = repo
         .non_algorithm_read_names()
         .iter()
@@ -336,14 +418,59 @@ mod tests {
     }
 
     #[test]
-    fn repo_read_shapes_match_the_extended_core_discovery_in_order() {
-        // The combined annotation (baseline ++ extended-core) must equal the ExtendedCore-profile
-        // discovery, in definition order — the record order that feeds `workload_hash`.
-        let repo = read_shapes_repository(QueryCoverageProfile::ExtendedCore, 1000, 5000);
+    fn fixture_dependent_adds_exactly_the_three_reads_over_extended_core() {
+        // Derive-with-annotation for Phase 5: the reads the `FixtureDependent` profile adds over
+        // `ExtendedCore` must be EXACTLY the annotated fixture-dependent shapes (the vector +
+        // two fulltext smoke reads). If `queries_repository` adds another FixtureDependent read, this
+        // fails until `fixture_dependent_read_shapes()` is updated.
+        let extended_repo = read_shapes_repository(QueryCoverageProfile::ExtendedCore, 1000, 5000);
+        let fixture_repo = read_shapes_repository(QueryCoverageProfile::FixtureDependent, 1000, 5000);
+        let extended: BTreeSet<&str> =
+            extended_repo.non_algorithm_read_names().iter().map(String::as_str).collect();
+        let fixture: BTreeSet<&str> =
+            fixture_repo.non_algorithm_read_names().iter().map(String::as_str).collect();
+        let added: BTreeSet<&str> = fixture.difference(&extended).copied().collect();
+        let annotated: BTreeSet<&str> =
+            fixture_dependent_read_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(added, annotated, "FixtureDependent adds exactly the annotated fixture reads");
+        assert_eq!(
+            added,
+            BTreeSet::from([
+                "vector_query_nodes_smoke",
+                "fulltext_query_nodes_smoke",
+                "fulltext_query_relationships_smoke",
+            ])
+        );
+        // Every fixture shape is FixtureDependent, Full-tier, result-N/A, and carries a capability.
+        for shape in fixture_dependent_read_shapes() {
+            assert_eq!(shape.profile, QueryCoverageProfile::FixtureDependent);
+            assert_eq!(shape.tier, Tier::Full);
+            assert!(!shape.result_policy.is_gated(), "top-k reads are result-N/A");
+            assert!(shape.capability.is_some(), "fixture reads carry a capability");
+        }
+        // The capabilities map 1:1 to the three index procedures.
+        let caps: Vec<Option<ShapeCapability>> =
+            fixture_dependent_read_shapes().iter().map(|s| s.capability).collect();
+        assert_eq!(
+            caps,
+            vec![
+                Some(ShapeCapability::VectorQueryNodes),
+                Some(ShapeCapability::FulltextQueryNodes),
+                Some(ShapeCapability::FulltextQueryRelationships),
+            ]
+        );
+    }
+
+    #[test]
+    fn repo_read_shapes_match_the_fixture_dependent_discovery_in_order() {
+        // The combined annotation (baseline ++ extended-core ++ fixture-dependent) must equal the
+        // FixtureDependent-profile discovery, in definition order — the record order that feeds
+        // `workload_hash`.
+        let repo = read_shapes_repository(QueryCoverageProfile::FixtureDependent, 1000, 5000);
         let discovered: Vec<&str> =
             repo.non_algorithm_read_names().iter().map(String::as_str).collect();
         let annotated: Vec<&str> = repo_read_shapes().iter().map(|s| s.name).collect();
-        assert_eq!(annotated, discovered, "repo read shapes drifted from ExtendedCore discovery");
+        assert_eq!(annotated, discovered, "repo read shapes drifted from FixtureDependent discovery");
     }
 
     #[test]
@@ -357,38 +484,61 @@ mod tests {
     }
 
     #[test]
-    fn repo_read_shapes_are_forty_seven_including_one_extended_core() {
-        // Baseline (46) + ExtendedCore (1) = 47 unique reads across profiles.
+    fn repo_read_shapes_are_fifty_across_the_three_profiles() {
+        // Baseline (46) + ExtendedCore (1) + FixtureDependent (3) = 50 unique reads across profiles.
         let shapes = repo_read_shapes();
-        assert_eq!(shapes.len(), 47, "46 baseline + 1 extended-core read");
+        assert_eq!(shapes.len(), 50, "46 baseline + 1 extended-core + 3 fixture-dependent reads");
         let names: BTreeSet<&str> = shapes.iter().map(|s| s.name).collect();
-        assert_eq!(names.len(), 47, "shape names must be unique across profiles");
+        assert_eq!(names.len(), 50, "shape names must be unique across profiles");
         assert_eq!(
             shapes.iter().filter(|s| s.profile == QueryCoverageProfile::ExtendedCore).count(),
             1,
             "exactly one extended-core read"
+        );
+        assert_eq!(
+            shapes.iter().filter(|s| s.profile == QueryCoverageProfile::FixtureDependent).count(),
+            3,
+            "exactly three fixture-dependent reads"
         );
         // `temporal_spatial_roundtrip` is ExtendedCore, Core-tier, and result-gated.
         let ts = shapes.iter().find(|s| s.name == "temporal_spatial_roundtrip").unwrap();
         assert_eq!(ts.profile, QueryCoverageProfile::ExtendedCore);
         assert_eq!(ts.tier, Tier::Core);
         assert!(ts.result_policy.is_gated());
+        assert_eq!(ts.capability, None);
+        // The fixture reads are FixtureDependent, Full-tier, result-N/A, with a capability.
+        for name in [
+            "vector_query_nodes_smoke",
+            "fulltext_query_nodes_smoke",
+            "fulltext_query_relationships_smoke",
+        ] {
+            let s = shapes.iter().find(|s| s.name == name).unwrap();
+            assert_eq!(s.profile, QueryCoverageProfile::FixtureDependent);
+            assert_eq!(s.tier, Tier::Full);
+            assert!(!s.result_policy.is_gated());
+            assert!(s.capability.is_some());
+        }
     }
 
     #[test]
-    fn exactly_the_limit_without_order_shape_is_result_na() {
-        // Only `entity_path_introspection` (LIMIT 1 without ORDER BY) is result-N/A among all repo
-        // reads; every other read — including `temporal_spatial_roundtrip` — is result-gated
-        // (Decision 4).
-        for shape in repo_read_shapes() {
-            let expected_gated = shape.name != "entity_path_introspection";
-            assert_eq!(
-                shape.result_policy.is_gated(),
-                expected_gated,
-                "unexpected result policy for '{}'",
-                shape.name
-            );
-        }
+    fn only_the_top_k_and_limit_shapes_are_result_na() {
+        // The result-N/A reads are exactly `entity_path_introspection` (LIMIT without ORDER BY) and
+        // the three fulltext/vector top-k reads; every other read is result-gated (Decision 4).
+        let na: BTreeSet<&str> = repo_read_shapes()
+            .iter()
+            .filter(|s| !s.result_policy.is_gated())
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(
+            na,
+            BTreeSet::from([
+                "entity_path_introspection",
+                "vector_query_nodes_smoke",
+                "fulltext_query_nodes_smoke",
+                "fulltext_query_relationships_smoke",
+            ]),
+            "unexpected result-N/A set"
+        );
     }
 
     #[test]
@@ -415,13 +565,53 @@ mod tests {
         // The ExtendedCore shape is recorded and result-gated…
         let ts = ops.iter().find(|o| o.key.name() == "temporal_spatial_roundtrip").unwrap();
         assert!(ts.result_gated, "temporal_spatial_roundtrip is result-gated");
-        // …and the result-N/A shape is recorded but not gated; it's the only one.
-        let na = ops.iter().find(|o| o.key.name() == "entity_path_introspection").unwrap();
-        assert!(!na.result_gated, "the LIMIT-without-ORDER shape is result-N/A");
-        assert!(
-            ops.iter().filter(|o| !o.result_gated).count() == 1,
-            "exactly one repo read is result-N/A"
+        // …and the result-N/A reads are recorded but not gated: the LIMIT-without-ORDER shape plus
+        // the three fulltext/vector top-k reads.
+        let na: BTreeSet<&str> =
+            ops.iter().filter(|o| !o.result_gated).map(|o| o.key.name()).collect();
+        assert_eq!(
+            na,
+            BTreeSet::from([
+                "entity_path_introspection",
+                "vector_query_nodes_smoke",
+                "fulltext_query_nodes_smoke",
+                "fulltext_query_relationships_smoke",
+            ]),
+            "exactly the LIMIT-without-ORDER and top-k reads are result-N/A"
         );
+    }
+
+    #[test]
+    fn full_records_the_fixture_dependent_reads_and_needs_the_fixture() {
+        // The three fulltext/vector reads are recorded under Full as dynamic, result-N/A reads, and
+        // the selection reports it needs the baked-in fixture (so the record path uses
+        // `record_rendered_with_fixture`). Core omits them and needs no fixture.
+        let full = record_repo_reads(Tier::Full, 1000, 5000, 42).unwrap();
+        let full_names: BTreeSet<&str> = full.iter().map(|o| o.key.name()).collect();
+        for name in [
+            "vector_query_nodes_smoke",
+            "fulltext_query_nodes_smoke",
+            "fulltext_query_relationships_smoke",
+        ] {
+            assert!(full_names.contains(name), "Full must record '{name}'");
+            let op = full.iter().find(|o| o.key.name() == name).unwrap();
+            assert!(!op.key.is_named(), "'{name}' is a dynamic read");
+            assert_eq!(op.key.kind(), QueryType::Read);
+            assert!(!op.result_gated, "'{name}' is result-N/A (top-k)");
+            assert_eq!(op.commands.len(), CORPUS_SIZE, "'{name}' short corpus");
+        }
+        assert!(repo_reads_need_fixture(Tier::Full), "Full selects fixture-dependent reads");
+
+        let core = record_repo_reads(Tier::Core, 1000, 5000, 42).unwrap();
+        let core_names: BTreeSet<&str> = core.iter().map(|o| o.key.name()).collect();
+        for name in [
+            "vector_query_nodes_smoke",
+            "fulltext_query_nodes_smoke",
+            "fulltext_query_relationships_smoke",
+        ] {
+            assert!(!core_names.contains(name), "Core must omit '{name}'");
+        }
+        assert!(!repo_reads_need_fixture(Tier::Core), "Core needs no fixture");
     }
 
     #[test]
@@ -474,6 +664,7 @@ mod tests {
             profile: QueryCoverageProfile::Baseline,
             tier: Tier::Full,
             result_policy: ResultPolicy::Gated,
+            capability: None,
         }];
         let err = record_selected_shapes(&bogus, 1000, 5000, 1).unwrap_err();
         assert!(

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1041,10 +1041,16 @@ async fn record_then_replay_roundtrips_and_guard_proceeds() {
     drop_graph(graph).await;
 }
 
-/// Phase 3 B2: record the queries_repository baseline READ shapes (`--repo-reads full`) OFFLINE,
-/// then replay --load → --no-load. The workload identity (workload_hash) is byte-identical across
-/// replays, every result-gated shape yields matching digests, and the one LIMIT-without-ORDER shape
-/// (`entity_path_introspection`) is recorded + timed but result-N/A (digest `None`) in both replays.
+/// Phase 3 B2 / Phase 4 / Phase 5: record the queries_repository READ shapes (`--repo-reads full`)
+/// OFFLINE, then replay --load → --no-load. The workload identity (workload_hash) is byte-identical
+/// across replays, every result-gated shape yields matching digests, and the result-N/A shapes (the
+/// LIMIT-without-ORDER `entity_path_introspection` and the three fulltext/vector top-k reads) are
+/// recorded + timed but carry no digest (`None`) in both replays.
+///
+/// Full includes the FixtureDependent fulltext/vector reads, so the bundle is recorded with
+/// [`recording::record_rendered_with_fixture`] — the fulltext/vector fixture (index DDL + seed data)
+/// is baked into the recorded graph ONCE and replayed verbatim, so both replays load the identical
+/// fixture and the three smoke queries run against real indexes.
 ///
 /// Uses a multi-thread runtime: the baseline reads return nodes/relations/paths, and the FalkorDB
 /// client decodes those via `block_in_place` (as the production `#[tokio::main]` runtime does).
@@ -1052,6 +1058,7 @@ async fn record_then_replay_roundtrips_and_guard_proceeds() {
 #[ignore = "requires a running FalkorDB server"]
 async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
     use benchmark::synthetic::{shapes, Tier};
+    use std::collections::BTreeSet;
 
     let graph = "syn_it_repo_reads";
     drop_graph(graph).await;
@@ -1061,13 +1068,24 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
         nodes: 500,
         edges: 1500,
     };
-    // Render every repo read shape's corpus ONCE from the fixed seed, then record verbatim.
+    // Render every repo read shape's corpus ONCE from the fixed seed, then record verbatim. Full
+    // selects the FixtureDependent reads, so the bundle bakes in the fulltext/vector fixture.
     let recorded = shapes::record_repo_reads(Tier::Full, spec.nodes as i32, spec.edges as i32, spec.seed)
         .expect("render repo reads");
-    assert_eq!(recorded.len(), 47, "Full records every repo read shape (46 baseline + 1 ExtendedCore)");
-    recording::record_rendered(&spec, graph, &recorded, spec.seed, 256, &dir).expect("record");
+    assert_eq!(
+        recorded.len(),
+        50,
+        "Full records every repo read shape (46 baseline + 1 ExtendedCore + 3 FixtureDependent)"
+    );
+    assert!(
+        shapes::repo_reads_need_fixture(Tier::Full),
+        "Full needs the fulltext/vector fixture"
+    );
+    recording::record_rendered_with_fixture(&spec, graph, &recorded, spec.seed, 256, &dir)
+        .expect("record");
 
-    // Replay #1 loads the recorded graph; #2 reuses it (no-load), count-verifying first.
+    // Replay #1 loads the recorded graph (incl. the fixture); #2 reuses it (no-load), count-verifying
+    // first.
     let ref_out = dir.join("ref.json").to_string_lossy().into_owned();
     let cand_out = dir.join("cand.json").to_string_lossy().into_owned();
     let a = replay::run(&replay_config(&dir, graph, &ref_out, true))
@@ -1081,13 +1099,23 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
     let ha = a.meta.dataset.as_ref().expect("dataset a").workload_hash.clone();
     let hb = b.meta.dataset.as_ref().expect("dataset b").workload_hash.clone();
     assert_eq!(ha, hb, "workload_hash must match across replays");
-    assert_eq!(a.operations.len(), 47);
+    assert_eq!(a.operations.len(), 50);
 
-    // Every result-gated shape has a digest that matches across the two replays; the
-    // LIMIT-without-ORDER shape is result-N/A (digest absent) in both.
+    // The result-N/A shapes: the LIMIT-without-ORDER read plus the three fulltext/vector top-k reads.
+    let result_na: BTreeSet<&str> = [
+        "entity_path_introspection",
+        "vector_query_nodes_smoke",
+        "fulltext_query_nodes_smoke",
+        "fulltext_query_relationships_smoke",
+    ]
+    .into_iter()
+    .collect();
+
+    // Every result-gated shape has a digest that matches across the two replays; each result-N/A
+    // shape is timed but carries no digest in both replays.
     for (name, op_a) in &a.operations {
         let op_b = b.operations.get(name).expect("op present in both replays");
-        if name == "entity_path_introspection" {
+        if result_na.contains(name.as_str()) {
             assert!(op_a.result_digest.is_none(), "{name} must be result-N/A");
             assert!(op_b.result_digest.is_none(), "{name} must be result-N/A");
         } else {
@@ -1100,6 +1128,16 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
     // float distance canonicalize deterministically).
     let ts = a.operations.get("temporal_spatial_roundtrip").expect("temporal_spatial_roundtrip present");
     assert!(ts.result_digest.is_some(), "temporal_spatial_roundtrip must be result-gated (digest present)");
+    // The Phase 5 FixtureDependent shapes are recorded, timed, and present in both replays (their
+    // fulltext/vector fixture loaded and the smoke queries ran against real indexes).
+    for name in [
+        "vector_query_nodes_smoke",
+        "fulltext_query_nodes_smoke",
+        "fulltext_query_relationships_smoke",
+    ] {
+        let op = a.operations.get(name).unwrap_or_else(|| panic!("{name} present"));
+        assert!(op.result_digest.is_none(), "{name} is result-N/A (top-k)");
+    }
 
     // The guard proceeds (same workload + matching gated digests).
     match guard(&BaselineKey::from_report(&a), &BaselineKey::from_report(&b)) {

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1135,7 +1135,7 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
         "fulltext_query_nodes_smoke",
         "fulltext_query_relationships_smoke",
     ] {
-        let op = a.operations.get(name).unwrap_or_else(|| panic!("{name} present"));
+        let op = a.operations.get(name).unwrap_or_else(|| panic!("{name} missing from report"));
         assert!(op.result_digest.is_none(), "{name} is result-N/A (top-k)");
     }
 


### PR DESCRIPTION
## Phase 5 — FixtureDependent fulltext/vector READ shapes

Implements **Phase 5** of the synthetic A/B query-shape coverage effort (#239): wires the three `queries_repository` **FixtureDependent** read shapes into the synthetic record/replay pipeline, taking the recorded repo reads from **47 → 50** (46 baseline + 1 ExtendedCore + **3 FixtureDependent**).

| Shape | Capability | Result |
| --- | --- | --- |
| `vector_query_nodes_smoke` | `db.idx.vector.queryNodes` | **N/A** (top-k) |
| `fulltext_query_nodes_smoke` | `db.idx.fulltext.queryNodes` | **N/A** (top-k) |
| `fulltext_query_relationships_smoke` | `db.idx.fulltext.queryRelationships` | **N/A** (top-k) |

### Comparability preserved (record-once → replay-verbatim)
These reads need a fulltext/vector **fixture** (index DDL + seed data) in the graph. It is baked into the recorded bundle **once** and replayed **verbatim** into every replay endpoint — never regenerated per-replay, never seeded per-run, no RNG at replay — so `workload_hash` stays byte-identical (the A/B compares two FalkorDB versions/images; the fixture DDL is FalkorDB-specific, so these shapes are FalkorDB-vs-FalkorDB, not cross-database) and the **Synthetic non-divergence** gate stays meaningful.

- **`dataset.rs`** — new `LoadPhase::Fixture` + `fixture_statements()`: two fulltext indexes (`:User(ft_text)`, `:Friend(ft_text)`), one vector index (`:User(embedding)`, dim 3 cosine), and two idempotent seed `SET`s on the deterministic `id % 97 == 0` slice — all **constant strings** (byte-identical), mirroring the A/B benchmark's `ensure_post_phase1_fixtures_ready`.
- **`recording.rs`** — new `record_rendered_with_fixture()` appends the fixture to `graph.jsonl` and folds it into `workload_hash` (verified on `load()` too, so a bundle can't silently drop it); `record_rendered()` is now a thin no-fixture wrapper, so the catalog path and every existing bundle stay **byte-identical**.
- **`shapes.rs`** — new `ShapeCapability` enum + `capability` field on `ShapeSpec`; `fixture_dependent_read_shapes()` (Tier::Full, result-N/A, capability-annotated); discovery now uses the FixtureDependent profile (a superset that renders lower-profile shapes identically); new `repo_reads_need_fixture()`. Drift-guard tests assert the annotation matches the auto-discovered names in definition order.
- **`mod.rs`** — the record handler bakes the fixture **only** when the selected tier includes a FixtureDependent shape (Full); Core is unchanged and needs no fixture.

### Decisions honored
- **Results = N/A** for all 3 (fulltext/vector top-k ordering is non-deterministic, Decision 4) — recorded + timed but not digest-gated. **No `ORDER BY`** added to shared repo queries.
- **Reads only** — no writes/algorithms.
- **Derive-with-annotation** — op set auto-discovered; each shape annotated (kind/profile/capability/tier/result).
- **Tier::Full** — capability-gated shapes stay out of the always-on core subset.

### Capability gating — what's here vs. deferred
Each fixture shape carries its `ShapeCapability` (annotation foundation for gating). On the real per-PR A/B scenario **both images are modern FalkorDB with these capabilities**, so the happy path (fixture loads, queries run, results N/A) is fully implemented, tested, and green. The **capability-absent runtime tolerance** (best-effort DDL + reference-pass query-skip so an engine *lacking* fulltext/vector never fails the run) is **deferred to a focused follow-up**: it is measurement-path surgery that needs a **capability-lacking FalkorDB** to validate end-to-end, which isn't available here. Flagging explicitly.

### Validation
- `just clippy` (warnings-denied) + `just build` + `just test` green.
- The `#[ignore]` `synthetic_probe` integration suite (**22/22**, incl. the updated fixture roundtrip) green against a live FalkorDB — record → replay --load → replay --no-load **byte-identical** (`workload_hash` matches; the 4 result-N/A shapes carry no digest; the guard proceeds).
- `just synthetic-verify` still reports **no divergence** on the catalog path (the `record_rendered` refactor is behavior-preserving).
- **Patch coverage ≈ 99%** (cargo-llvm-cov incl. `--include-ignored`).

Refs #239.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the full synthetic benchmark tier to 50 repository-read operations, including fulltext and vector search scenarios.
  * Added deterministic fixture setup so fixture-dependent reads replay consistently across runs.
  * Clearly identifies non-byte-stable results as `result-N/A`.

* **Documentation**
  * Updated CLI help and README guidance with the new read coverage, fixture behavior, replay details, and tier restrictions.

* **Tests**
  * Expanded coverage to verify recording and replay of all 50 operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->