### PR TITLE
design: cover the A/B benchmark's algorithm shapes in the synthetic check (Phase 6)

### DIFF
--- a/docs/design/synthetic-cover-ab-query-shapes.md
+++ b/docs/design/synthetic-cover-ab-query-shapes.md
@@ -1,8 +1,7 @@
 # Design — cover the A/B benchmark's query shapes in the synthetic per-op check
 
-**Status:** the **reads-scope implementation has already landed on `master`** via separate merged PRs
-(#240–#250); the per-PR non-divergence gate is being hardened to mirror the CI matrix (#251, in
-flight). **This PR carries the design-of-record + status doc itself** (doc-only) — the symbols it
+**Status:** the reads-scope implementation has already landed on `master` via separate merged PRs
+(#240–#250); the per-PR non-divergence gate now mirrors the CI matrix (#251, merged). **This PR carries the design-of-record + status doc itself** (doc-only) — the symbols it
 references (`OpKey`, `--tier`, `generate_with_rng`, `--repo-reads`, …) live in `master`, not in this
 one-file diff, so the doc intentionally lags the code it describes. **Writes (Phase 7)**
 and **algorithms (Phase 6)** are **deferred** by the reads-first decision. This is now a **living
@@ -37,8 +36,8 @@ the design-of-record and intentionally lags the code it describes.
 | 3 | Baseline fixture parity (age index + deterministic `bench_capacity`) + string-`OpKey` record/replay plumbing + the ~46 Baseline reads via `--repo-reads` | ✅ #246 (3a), #247 (3b), #248 (B2) |
 | 4 | ExtendedCore `temporal_spatial_roundtrip` read | ✅ #249 |
 | 5 | Fulltext/vector fixture + fixture-dependent reads | ✅ #250 |
-| — | Per-PR non-divergence gate mirrors the CI matrix (uncached, C=1 & C=8) | 🚧 #251 |
-| 6 | Algorithms (capability-gated, per-op budgets, determinism exclusions) | ⛔ deferred |
+| — | Per-PR non-divergence gate mirrors the CI matrix (uncached, C=1 & C=8) | ✅ #251 |
+| 6 | Algorithms (capability-gated, per-op budgets, determinism exclusions) | 🚧 design ([phase 6](./synthetic-cover-algorithms-phase6.md)) |
 | 7 | Writes (base-fixture mutation + non-determinism; needs a state-isolation design) | ⛔ deferred (own design) |
 
 **Decisions (locked):** **reads-first** (writes/algorithms deferred to their own designs);
@@ -222,7 +221,7 @@ Land the phases in `FalkorDB/benchmark`; `falkordb-rs-next-gen` picks each up on
 `SYNTHETIC_BENCHMARK_REF` bump. The per-PR synthetic job stays non-blocking; `synthetic-verify` guards
 every phase.
 > **Status:** Phases 1–5 landed (#240–#250); the `synthetic-verify` non-divergence gate now mirrors the
-> per-PR matrix (`--repo-reads full` × C=1,8 × uncached) — #251, in flight.
+> per-PR matrix (`--repo-reads full` × C=1,8 × uncached) — #251, merged.
 
 ## 11. What the rubber-duck corrected (so reviewers can trust this revision)
 1. **No "automatic flow"** — synthetic is `OpName`-static; needs a string-keyed dynamic op (§3.1).

--- a/docs/design/synthetic-cover-ab-query-shapes.md
+++ b/docs/design/synthetic-cover-ab-query-shapes.md
@@ -2,8 +2,8 @@
 
 **Status:** the reads-scope implementation has already landed on `master` via separate merged PRs
 (#240–#250); the per-PR non-divergence gate now mirrors the CI matrix (#251, merged). **This PR carries the design-of-record + status doc itself** (doc-only) — the symbols it
-references (`OpKey`, `--tier`, `generate_with_rng`, `--repo-reads`, …) live in `master`, not in this
-one-file diff, so the doc intentionally lags the code it describes. **Writes (Phase 7)**
+references (`OpKey`, `--tier`, `generate_with_rng`, `--repo-reads`, …) live in `master`, not in
+this docs-only diff, so the doc intentionally lags the code it describes. **Writes (Phase 7)**
 and **algorithms (Phase 6)** are **deferred** by the reads-first decision. This is now a **living
 design + status record**, kept in sync as work lands — see the status table (§0) and the per-phase
 markers in §3/§7. §2/§3 describe the **pre-implementation baseline** that motivated the work; the

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -1,0 +1,184 @@
+# Design — cover the A/B benchmark's algorithm shapes in the synthetic check (Phase 6)
+
+**Status:** proposal for review — **not implemented**. Draft for maintainer review before any code
+(per the workflow). **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+first draft understated the work (see §11). Follows the reads-scope work (design
+[`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5, merged in
+PRs #240–#250): the per-op non-divergence gate now covers the **50 A/B read shapes** but deliberately
+**excludes the 4 capability-gated algorithm reads**. This is Phase 6 — cover those 4, **opt-in and
+nightly**, so the algorithm latency the A/B
+[per-query trend](https://falkordb.github.io/falkordb-rs-next-gen/benchmark/trend/) tracks is probed
+per-op, and the deterministic ones gate a `result_digest`.
+
+**Legend:** ✅ implemented & merged · 🚧 in progress · ⛔ deferred.
+
+## 1. Scope: the 4 algorithm shapes
+
+`queries_repository` defines exactly four, listed in `ALGORITHM_QUERY_NAMES`
+(`src/queries_repository.rs:23-28`) and **each independently gated** by `AlgorithmQuerySelection`
+(`:31-46`, all four enabled by default):
+
+| Shape | FalkorDB Cypher (`src/queries_repository.rs`) | Returns | Whole-graph? |
+| --- | --- | --- | --- |
+| `algo_pagerank_summary` | `CALL algo.pageRank('User', null) YIELD node, score RETURN score LIMIT 1` (`:748`) | one `score` (float) | yes |
+| `algo_max_flow_single_pair` | `CALL algo.maxFlow({… capacityProperty:'bench_capacity'}) YIELD maxFlow` (`:784`) | one `max_flow` (float) for a seeded `(s,t)` pair | no (single pair) |
+| `algo_msf_summary` | `CALL algo.MSF({weightAttribute:'bench_capacity'}) YIELD edges RETURN size(edges), reduce(… total_weight)` (`:827`) | `edge_count` (int) + `total_weight` (float) | yes |
+| `algo_harmonic_summary` | `CALL algo.HarmonicCentrality() YIELD node, score RETURN count, avg, max` (`:869`) | `node_count` (int) + `avg_score`/`max_score` (float) | yes |
+
+Synthetic records the **FalkorDB flavour only** (`read_shapes_repository` builds `Flavour::FalkorDB`,
+`src/synthetic/shapes.rs`), so the Neo4j `gds.*`/projected-`benchmark_algo_graph` and Memgraph
+variants are out of scope — only FalkorDB's `algo.*` procedures matter.
+
+## 2. What is already in place (built by Phases 1–5)
+
+- **String-keyed ops** (`OpKey`, #241) and the **`result_policy`** mechanism
+  (`ResultPolicy::{Gated, NotApplicable(reason)}`, #240) — the gate/N-A machinery an algorithm op
+  needs already exists (Decision 4). Canonicalization hashes floats via `f64::to_bits()`
+  (`src/synthetic/op_runner.rs:193-206`), so a **gated** algorithm's float digest is exact — the only
+  question is run-to-run *value* stability (§6), not formatting.
+- **Coverage tiers** (`Tier::{Core, Full}`, #243) — algorithms must never enter the always-on Core
+  per-PR subset. **But `Tier::Full` alone is not enough to keep them out of the per-PR gate** (§3.2).
+- **Capability annotation** (`ShapeCapability`, Phase 5) — an extensible, machine-readable label; a
+  per-procedure algorithm capability slots in (§3.5).
+- **`bench_capacity`** is written deterministically on **every** generated `:Friend` edge
+  (`src/synthetic/dataset.rs:311-330`), exactly what `algo.maxFlow` (`capacityProperty`) and
+  `algo.MSF` (`weightAttribute`) read — so **pageRank / Harmonic / MSF need no new fixture**. `maxFlow`
+  is the exception (§3.3).
+
+## 3. The gap (five blockers, verified)
+
+### 3.1 `algo.maxFlow` needs a **simple** graph; the synthetic generator does not guarantee one
+The generator forbids self-loops but **not parallel edges** — `edges_are_deterministic_and_never_self_loops`
+(`src/synthetic/dataset.rs:680-684`) asserts only `a != b`, and `edge_at` (`:119-150`) can emit
+duplicate `(src,dst)` pairs. On a multigraph FalkorDB's `algo.maxFlow` errors
+(`relationship type must not contain multi-edges (tensors)`), and the exact CI oracle fixture
+(`seed=7`, 1000/5000, `Justfile:322-324`) contains duplicate endpoint pairs. So "no new fixture" is
+**false for maxFlow**. **Fix:** a deterministic **simple-graph guarantee** for the algorithm fixture
+(dedupe `(src,dst)` at generation, keeping the count/`bench_capacity` deterministic) or an
+algorithm-specific simple fixture; add a "no parallel `:Friend` edges" test + a live maxFlow smoke
+test. *(Empirically confirm the dup-pair count and the tensors error first.)*
+
+### 3.2 `Tier::Full` cannot double as "algorithm opt-in"
+`--repo-reads` is `Option<Tier>` (`src/cli.rs:542`); selection filters **only** by tier
+(`shapes.rs:selected_shapes`); `Tier::Full` is the *complete read set* and `Core ⊆ Full`
+(`mod.rs:340-352`); and CI already runs **`--repo-reads full`** (`Justfile:323-324`). So adding
+Full-tier algorithms to `repo_read_shapes()` would **silently pull them into every PR**, while keeping
+them separate makes them unreachable by tier. **Fix:** an **orthogonal** selection dimension — a
+`--repo-algorithms` flag (or `RepoShapeSelection::{Reads(Tier), Algorithms}`) — leaving
+`repo_read_shapes()` and `--repo-reads full` as **exactly** today's 50 reads.
+
+### 3.3 The record path hard-excludes algorithms, and the profile enum is shared with the A/B CLI
+`read_shapes_repository()` always builds with **`no_algorithms()`** and `record_selected_shapes()`
+always builds a `FixtureDependent` repo and validates only **`non_algorithm_read_names()`**
+(`src/synthetic/shapes.rs`); `ShapeSpec.profile` is never consulted for repo construction. Worse,
+`QueryCoverageProfile` is the **global A/B `--query-profile` enum** (`queries_repository.rs:64`, used
+at `cli.rs:205-208,264-271`) — so a `QueryCoverageProfile::Algorithm` would expose a misleading
+`--query-profile algorithm` on the A/B benchmark **and still wouldn't enable algorithms** (that's
+`AlgorithmQuerySelection`). **Fix:** a **synthetic-only** shape family (not `QueryCoverageProfile`), a
+separate `record_algorithm_reads()` that builds an **all-algorithms-enabled** repository with its
+**own** drift-guard, and a new `algorithm_read_names()` accessor on both the inner repo
+(`queries_repository.rs:274-279`) and the wrapper (`:372-376`).
+
+### 3.4 Per-op budget + corpus size are not wired for **recorded** (dynamic) shapes
+`OpBudget` is applied only to catalog `OpName`s (`src/synthetic/mod.rs:671-705`); `ShapeSpec`,
+`RecordedOp`, and `OpEntry` carry **no** budget (`shapes.rs`, `recording.rs`), and replay applies one
+global config and **captures all `CORPUS_SIZE` (256) commands before checking `result_policy`**
+(`replay.rs:133-151`). Whole-graph algorithms are ~40–80 ms/call locally, so a 256-command reference
+pass is ~11–20 s **per op** — untenable. **Fix (prerequisite):** wire a per-shape **budget + corpus
+size** into the recorded-shape path (1 command for the parameterless pageRank/Harmonic/MSF; a small
+seeded pair set for maxFlow) and **skip the full reference capture for result-N/A shapes**.
+
+### 3.5 One coarse capability is wrong, and N/A does not skip execution
+FalkorDB capabilities are detected **per procedure** (`src/falkor/falkor_driver.rs:520-550`), and
+Harmonic is independently optional (`src/main.rs:1171-1183`) — a single `GraphAlgorithms` label can't
+represent a partially-supported engine. And `ResultPolicy::NotApplicable` only disables *digest
+comparison*; it does **not** skip execution, so an engine lacking a procedure still runs (and fails)
+the query. **Fix:** **per-procedure** capability variants (`PageRank`/`MaxFlow`/`Msf`/`Harmonic`),
+**probe-before-capture**, and a defined representation for a **skipped** op in the report/diff.
+
+## 4. Approach — a synthetic-only algorithm family, opt-in, behind prerequisites
+
+Mirror the reads' **derive-with-annotation** coupling (one source of truth in `queries_repository`,
+curated metadata in `shapes.rs`), but on a **separate axis** from reads:
+
+1. **Prerequisites first:** the simple-graph algorithm fixture (§3.1) and the recorded-shape
+   budget/corpus plumbing (§3.4).
+2. A **synthetic-only** `CoverageFamily` (or decouple `ShapeSpec.profile` from the A/B enum) with an
+   `Algorithm` member — no change to the A/B `--query-profile`.
+3. `algorithm_read_shapes() -> Vec<ShapeSpec>` (4 shapes, per-procedure `capability`, `result_policy`
+   per §6, per-op budget/corpus) + `algorithm_read_names()` accessor + a drift-guard asserting the
+   table equals the repo's algorithm names.
+4. `record_algorithm_reads()` rendering from an **all-algorithms-enabled** repository (not
+   `no_algorithms()`), against the **simple-graph** fixture.
+5. An **orthogonal** opt-in selector (`--repo-algorithms`); algorithms never in `--repo-reads full`
+   nor the per-PR gate; documented in cookbook + readme.
+
+## 5. Scope: in / out
+- **In:** the 4 FalkorDB `algo.*` shapes; the simple-graph fixture, recorded-shape budget/corpus
+  plumbing, per-procedure capability labels, per-shape result policy; opt-in (nightly / on-demand)
+  record + replay.
+- **Out:** Neo4j `gds.*` + projected `benchmark_algo_graph`, Memgraph variants; writes (Phase 7); any
+  change to the default per-PR read gate or the A/B `--query-profile`.
+
+## 6. Determinism per shape
+Floats are digested by `f64::to_bits()` (exact), so the question is **value** stability run-to-run on
+the same image:
+
+| Shape | Proposed `result_policy` | Why |
+| --- | --- | --- |
+| `algo_pagerank_summary` | **N/A** | `RETURN score LIMIT 1` (no `ORDER BY`) — arbitrary single float. |
+| `algo_harmonic_summary` | **N/A** (pending) | `avg`/`max` over all nodes; iterative/aggregation value stability unproven. |
+| `algo_max_flow_single_pair` | **Gated (candidate)** | Max-flow of a fixed simple graph + capacities + seeded pair is a unique integral value coerced to exact `f64`. |
+| `algo_msf_summary` | **Gated (candidate)** | `edge_count` and MSF `total_weight` are unique (tie-breaking cannot change the minimum total). |
+
+Default **all four to N/A**; promote `max_flow`/`msf` to `Gated` **only after** confirming byte-stable
+digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synthetic-only `ORDER BY`.
+
+## 7. Phasing (prerequisites first, each its own PR)
+1. **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
+2. **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the dynamic
+   path; N/A shapes skip full reference capture.
+3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
+   `algorithm_read_names()` + drift-guard, `record_algorithm_reads()`, `--repo-algorithms`. Record +
+   replay the 4 shapes end-to-end, opt-in.
+4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
+5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
+6. **Docs:** cookbook + readme.
+
+## 8. Risks & open questions
+1. **maxFlow topology (§3.1)** — biggest: confirm the dup-pair count + tensors error, and that a
+   deduped simple graph keeps `workload_hash`/digests deterministic.
+2. **Float/iteration value stability (§6)** — whether `max_flow`/`msf` digests are byte-stable
+   run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`.
+3. **Value of N/A-only coverage** — N/A shapes add latency/trend coverage + exercise the `algo.*`
+   paths but nothing to the divergence gate; acceptable because algorithms are opt-in, not per-PR.
+4. **Budget/corpus plumbing is real work (§3.4)**, not annotation — it is a prerequisite, and it also
+   benefits any future heavy read.
+5. **Skipped-op semantics (§3.5)** — how a capability-absent op appears in `report --diff` needs
+   defining so it neither reads as a pass nor a divergence.
+
+## 9. Acceptance
+Opt-in record + replay of the 4 algorithm shapes end-to-end on the FalkorDB per-PR image against the
+simple-graph fixture, off the per-PR read gate and the A/B `--query-profile`; `pagerank`/`harmonic`
+result-N/A, `max_flow`/`msf` gated **iff** verified byte-stable; a drift-guard binds the table to
+`queries_repository`'s algorithm names. "Algorithms every PR" is explicitly **not** the target.
+
+## 10. Rollout
+Land the phases behind `--repo-algorithms` in `FalkorDB/benchmark`; `falkordb-rs-next-gen` picks each
+up on the next `SYNTHETIC_BENCHMARK_REF` bump. The per-PR `synthetic-verify` gate stays reads-only; a
+nightly/on-demand job exercises the algorithm shapes.
+
+## 11. What the rubber-duck corrected (so reviewers can trust this revision)
+1. **maxFlow needs a simple graph** — the generator only forbids self-loops, so the oracle fixture has
+   parallel edges and `algo.maxFlow` errors on tensors; "no new fixture" was wrong (§3.1).
+2. **`Tier::Full` ≠ opt-in** — `--repo-reads full` already means "all reads" and runs every PR; a
+   separate selection axis is required so algorithms don't leak into the gate (§3.2).
+3. **The record path hard-excludes algorithms and the profile enum is the A/B CLI's** — needs a
+   synthetic-only family + `record_algorithm_reads()` + `algorithm_read_names()`, not
+   `QueryCoverageProfile::Algorithm` (§3.3).
+4. **Per-op budget/corpus is unwired for recorded shapes** and replay captures all 256 commands before
+   checking policy — a real prerequisite, not annotation (§3.4).
+5. **Capability must be per-procedure**, and result-N/A does **not** skip execution — needs
+   probe-before-capture + skipped-op reporting (§3.5).
+6. **Floats are fine to gate** once deterministic — canonicalization hashes `f64::to_bits()`, so
+   `max_flow`/`msf` are sound `Gated` candidates after the topology fix (§6).

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -43,7 +43,7 @@ variants are out of scope — only FalkorDB's `algo.*` procedures matter.
 - **`bench_capacity`** is written deterministically on **every** generated `:Friend` edge
   (`src/synthetic/dataset.rs:311-330`), exactly what `algo.maxFlow` (`capacityProperty`) and
   `algo.MSF` (`weightAttribute`) read — so **pageRank / Harmonic / MSF need no new fixture**. `maxFlow`
-  is the exception (§3.3).
+  is the exception (§3.1).
 
 ## 3. The gap (five blockers, verified)
 

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -76,13 +76,15 @@ at `cli.rs:205-208,264-271`) — so a `QueryCoverageProfile::Algorithm` would ex
 `--query-profile algorithm` on the A/B benchmark **and still wouldn't enable algorithms** (that's
 `AlgorithmQuerySelection`). **Fix:** a **synthetic-only** shape family (not `QueryCoverageProfile`), a
 separate `record_algorithm_reads()` that builds an **all-algorithms-enabled** repository with its
-**own** drift-guard, and a new `algorithm_read_names()` accessor on both the inner repo
-(`queries_repository.rs:274-279`) and the wrapper (`:372-376`).
+**own** drift-guard, and a new `algorithm_read_names()` accessor added alongside
+`non_algorithm_read_names()` on both the inner repo (`queries_repository.rs:274-279`) and the
+wrapper (`:372-376`).
 
 ### 3.4 Per-op budget + corpus size are not wired for **recorded** (dynamic) shapes
 `OpBudget` is applied only to catalog `OpName`s (`src/synthetic/mod.rs:671-705`); `ShapeSpec`,
 `RecordedOp`, and `OpEntry` carry **no** budget (`shapes.rs`, `recording.rs`), and replay applies one
-global config and **captures all `CORPUS_SIZE` (256) commands before checking `result_policy`**
+global config and **captures all `CORPUS_SIZE` (256) commands — `result_policy` is never
+consulted**
 (`replay.rs:133-151`). Whole-graph algorithms are ~40–80 ms/call locally, so a 256-command reference
 pass is ~11–20 s **per op** — untenable. **Fix (prerequisite):** wire a per-shape **budget + corpus
 size** into the recorded-shape path (1 command for the parameterless pageRank/Harmonic/MSF; a small

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -49,7 +49,7 @@ variants are out of scope — only FalkorDB's `algo.*` procedures matter.
 
 ### 3.1 `algo.maxFlow` needs a **simple** graph; the synthetic generator does not guarantee one
 The generator forbids self-loops but **not parallel edges** — `edges_are_deterministic_and_never_self_loops`
-(`src/synthetic/dataset.rs:680-684`) asserts only `a != b`, and `edge_at` (`:119-150`) can emit
+(`src/synthetic/dataset.rs:680-684`) asserts only `a != b`, and `edge_at` (`:120-135`) can emit
 duplicate `(src,dst)` pairs. On a multigraph FalkorDB's `algo.maxFlow` errors
 (`relationship type must not contain multi-edges (tensors)`), and the exact CI oracle fixture
 (`seed=7`, 1000/5000, `Justfile:322-324`) contains duplicate endpoint pairs. So "no new fixture" is


### PR DESCRIPTION
Design proposal only — **no code**, opened as a **draft** for your review before implementation (per our workflow). Follows the reads-scope work (Phases 1–5, #240–#250, and the parent design #239).

**Goal:** cover the **4 capability-gated algorithm shapes** the reads coverage deliberately excluded — `algo_pagerank_summary`, `algo_max_flow_single_pair`, `algo_msf_summary`, `algo_harmonic_summary` — **opt-in and nightly**, off the per-PR read gate, so the algorithm latency the A/B per-query trend tracks is probed per-op and the deterministic ones gate a `result_digest`.

**Rubber-duck reviewed** — the first draft was corrected on five points (see §11 in the doc). Headlines the review surfaced:

1. **`algo.maxFlow` needs a simple graph.** The synthetic generator only forbids self-loops, so the oracle fixture has parallel `:Friend` edges and FalkorDB's maxFlow errors on tensors (multi-edges). Needs a deterministic simple-graph fixture — *not* "no new fixture" as the first draft claimed. pageRank/Harmonic/MSF are fine on today's fixture (`bench_capacity` is already deterministic per edge).
2. **`Tier::Full` is not opt-in.** `--repo-reads full` already means "all reads" and runs every PR, so algorithms need an **orthogonal** selector (`--repo-algorithms`), never folded into `repo_read_shapes()`.
3. **The record path hard-excludes algorithms and `QueryCoverageProfile` is the shared A/B `--query-profile` enum** — so this needs a synthetic-only shape family + a separate `record_algorithm_reads()`, not `QueryCoverageProfile::Algorithm`.
4. **Per-op budget/corpus is unwired for recorded shapes** (catalog-`OpName`-only today), and replay captures all 256 commands before checking result policy — a real prerequisite for whole-graph algos (~40–80 ms/call).
5. **Capability must be per-procedure** (FalkorDB detects each `algo.*` separately; Harmonic is independently optional), and `ResultPolicy::NotApplicable` does not skip execution — needs probe-before-capture + skipped-op reporting.

**Determinism:** floats are digested by `f64::to_bits()`, so `max_flow`/`msf` are sound gated candidates once the topology is fixed; `pagerank` (LIMIT 1) and `harmonic` (float aggregation) stay result-N/A. Default all four N/A, promote after verifying byte-stability.

**Phasing** (prereqs first): simple-graph fixture → recorded-shape budget/corpus plumbing → annotation+selection (all N/A) → per-procedure capability → promote gated → docs.

Please review the scope/phasing — especially whether the **`--repo-algorithms` opt-in axis** and the **simple-graph fixture** are the right calls — before I turn Phase 6.1 into an implementation PR. Parent status table updated (#251 merged, Phase 6 in design).


---

# Full design document (verbatim)

# Design — cover the A/B benchmark's algorithm shapes in the synthetic check (Phase 6)

**Status:** proposal for review — **not implemented**. Draft for maintainer review before any code
(per the workflow). **Rubber-duck reviewed**; this revision folds in the review's corrections — the
first draft understated the work (see §11). Follows the reads-scope work (design
[`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5, merged in
PRs #240–#250): the per-op non-divergence gate now covers the **50 A/B read shapes** but deliberately
**excludes the 4 capability-gated algorithm reads**. This is Phase 6 — cover those 4, **opt-in and
nightly**, so the algorithm latency the A/B
[per-query trend](https://falkordb.github.io/falkordb-rs-next-gen/benchmark/trend/) tracks is probed
per-op, and the deterministic ones gate a `result_digest`.

**Legend:** ✅ implemented & merged · 🚧 in progress · ⛔ deferred.

## 1. Scope: the 4 algorithm shapes

`queries_repository` defines exactly four, listed in `ALGORITHM_QUERY_NAMES`
(`src/queries_repository.rs:23-28`) and **each independently gated** by `AlgorithmQuerySelection`
(`:31-46`, all four enabled by default):

| Shape | FalkorDB Cypher (`src/queries_repository.rs`) | Returns | Whole-graph? |
| --- | --- | --- | --- |
| `algo_pagerank_summary` | `CALL algo.pageRank('User', null) YIELD node, score RETURN score LIMIT 1` (`:748`) | one `score` (float) | yes |
| `algo_max_flow_single_pair` | `CALL algo.maxFlow({… capacityProperty:'bench_capacity'}) YIELD maxFlow` (`:784`) | one `max_flow` (float) for a seeded `(s,t)` pair | no (single pair) |
| `algo_msf_summary` | `CALL algo.MSF({weightAttribute:'bench_capacity'}) YIELD edges RETURN size(edges), reduce(… total_weight)` (`:827`) | `edge_count` (int) + `total_weight` (float) | yes |
| `algo_harmonic_summary` | `CALL algo.HarmonicCentrality() YIELD node, score RETURN count, avg, max` (`:869`) | `node_count` (int) + `avg_score`/`max_score` (float) | yes |

Synthetic records the **FalkorDB flavour only** (`read_shapes_repository` builds `Flavour::FalkorDB`,
`src/synthetic/shapes.rs`), so the Neo4j `gds.*`/projected-`benchmark_algo_graph` and Memgraph
variants are out of scope — only FalkorDB's `algo.*` procedures matter.

## 2. What is already in place (built by Phases 1–5)

- **String-keyed ops** (`OpKey`, #241) and the **`result_policy`** mechanism
  (`ResultPolicy::{Gated, NotApplicable(reason)}`, #240) — the gate/N-A machinery an algorithm op
  needs already exists (Decision 4). Canonicalization hashes floats via `f64::to_bits()`
  (`src/synthetic/op_runner.rs:193-206`), so a **gated** algorithm's float digest is exact — the only
  question is run-to-run *value* stability (§6), not formatting.
- **Coverage tiers** (`Tier::{Core, Full}`, #243) — algorithms must never enter the always-on Core
  per-PR subset. **But `Tier::Full` alone is not enough to keep them out of the per-PR gate** (§3.2).
- **Capability annotation** (`ShapeCapability`, Phase 5) — an extensible, machine-readable label; a
  per-procedure algorithm capability slots in (§3.5).
- **`bench_capacity`** is written deterministically on **every** generated `:Friend` edge
  (`src/synthetic/dataset.rs:311-330`), exactly what `algo.maxFlow` (`capacityProperty`) and
  `algo.MSF` (`weightAttribute`) read — so **pageRank / Harmonic / MSF need no new fixture**. `maxFlow`
  is the exception (§3.1).

## 3. The gap (five blockers, verified)

### 3.1 `algo.maxFlow` needs a **simple** graph; the synthetic generator does not guarantee one
The generator forbids self-loops but **not parallel edges** — `edges_are_deterministic_and_never_self_loops`
(`src/synthetic/dataset.rs:680-684`) asserts only `a != b`, and `edge_at` (`:120-135`) can emit
duplicate `(src,dst)` pairs. On a multigraph FalkorDB's `algo.maxFlow` errors
(`relationship type must not contain multi-edges (tensors)`), and the exact CI oracle fixture
(`seed=7`, 1000/5000, `Justfile:322-324`) contains duplicate endpoint pairs. So "no new fixture" is
**false for maxFlow**. **Fix:** a deterministic **simple-graph guarantee** for the algorithm fixture
(dedupe `(src,dst)` at generation, keeping the count/`bench_capacity` deterministic) or an
algorithm-specific simple fixture; add a "no parallel `:Friend` edges" test + a live maxFlow smoke
test. *(Empirically confirm the dup-pair count and the tensors error first.)*

### 3.2 `Tier::Full` cannot double as "algorithm opt-in"
`--repo-reads` is `Option<Tier>` (`src/cli.rs:542`); selection filters **only** by tier
(`shapes.rs:selected_shapes`); `Tier::Full` is the *complete read set* and `Core ⊆ Full`
(`mod.rs:340-352`); and CI already runs **`--repo-reads full`** (`Justfile:323-324`). So adding
Full-tier algorithms to `repo_read_shapes()` would **silently pull them into every PR**, while keeping
them separate makes them unreachable by tier. **Fix:** an **orthogonal** selection dimension — a
`--repo-algorithms` flag (or `RepoShapeSelection::{Reads(Tier), Algorithms}`) — leaving
`repo_read_shapes()` and `--repo-reads full` as **exactly** today's 50 reads.

### 3.3 The record path hard-excludes algorithms, and the profile enum is shared with the A/B CLI
`read_shapes_repository()` always builds with **`no_algorithms()`** and `record_selected_shapes()`
always builds a `FixtureDependent` repo and validates only **`non_algorithm_read_names()`**
(`src/synthetic/shapes.rs`); `ShapeSpec.profile` is never consulted for repo construction. Worse,
`QueryCoverageProfile` is the **global A/B `--query-profile` enum** (`queries_repository.rs:64`, used
at `cli.rs:205-208,264-271`) — so a `QueryCoverageProfile::Algorithm` would expose a misleading
`--query-profile algorithm` on the A/B benchmark **and still wouldn't enable algorithms** (that's
`AlgorithmQuerySelection`). **Fix:** a **synthetic-only** shape family (not `QueryCoverageProfile`), a
separate `record_algorithm_reads()` that builds an **all-algorithms-enabled** repository with its
**own** drift-guard, and a new `algorithm_read_names()` accessor added alongside
`non_algorithm_read_names()` on both the inner repo (`queries_repository.rs:274-279`) and the
wrapper (`:372-376`).

### 3.4 Per-op budget + corpus size are not wired for **recorded** (dynamic) shapes
`OpBudget` is applied only to catalog `OpName`s (`src/synthetic/mod.rs:671-705`); `ShapeSpec`,
`RecordedOp`, and `OpEntry` carry **no** budget (`shapes.rs`, `recording.rs`), and replay applies one
global config and **captures all `CORPUS_SIZE` (256) commands — `result_policy` is never
consulted**
(`replay.rs:133-151`). Whole-graph algorithms are ~40–80 ms/call locally, so a 256-command reference
pass is ~11–20 s **per op** — untenable. **Fix (prerequisite):** wire a per-shape **budget + corpus
size** into the recorded-shape path (1 command for the parameterless pageRank/Harmonic/MSF; a small
seeded pair set for maxFlow) and **skip the full reference capture for result-N/A shapes**.

### 3.5 One coarse capability is wrong, and N/A does not skip execution
FalkorDB capabilities are detected **per procedure** (`src/falkor/falkor_driver.rs:520-550`), and
Harmonic is independently optional (`src/main.rs:1171-1183`) — a single `GraphAlgorithms` label can't
represent a partially-supported engine. And `ResultPolicy::NotApplicable` only disables *digest
comparison*; it does **not** skip execution, so an engine lacking a procedure still runs (and fails)
the query. **Fix:** **per-procedure** capability variants (`PageRank`/`MaxFlow`/`Msf`/`Harmonic`),
**probe-before-capture**, and a defined representation for a **skipped** op in the report/diff.

## 4. Approach — a synthetic-only algorithm family, opt-in, behind prerequisites

Mirror the reads' **derive-with-annotation** coupling (one source of truth in `queries_repository`,
curated metadata in `shapes.rs`), but on a **separate axis** from reads:

1. **Prerequisites first:** the simple-graph algorithm fixture (§3.1) and the recorded-shape
   budget/corpus plumbing (§3.4).
2. A **synthetic-only** `CoverageFamily` (or decouple `ShapeSpec.profile` from the A/B enum) with an
   `Algorithm` member — no change to the A/B `--query-profile`.
3. `algorithm_read_shapes() -> Vec<ShapeSpec>` (4 shapes, per-procedure `capability`, `result_policy`
   per §6, per-op budget/corpus) + `algorithm_read_names()` accessor + a drift-guard asserting the
   table equals the repo's algorithm names.
4. `record_algorithm_reads()` rendering from an **all-algorithms-enabled** repository (not
   `no_algorithms()`), against the **simple-graph** fixture.
5. An **orthogonal** opt-in selector (`--repo-algorithms`); algorithms never in `--repo-reads full`
   nor the per-PR gate; documented in cookbook + readme.

## 5. Scope: in / out
- **In:** the 4 FalkorDB `algo.*` shapes; the simple-graph fixture, recorded-shape budget/corpus
  plumbing, per-procedure capability labels, per-shape result policy; opt-in (nightly / on-demand)
  record + replay.
- **Out:** Neo4j `gds.*` + projected `benchmark_algo_graph`, Memgraph variants; writes (Phase 7); any
  change to the default per-PR read gate or the A/B `--query-profile`.

## 6. Determinism per shape
Floats are digested by `f64::to_bits()` (exact), so the question is **value** stability run-to-run on
the same image:

| Shape | Proposed `result_policy` | Why |
| --- | --- | --- |
| `algo_pagerank_summary` | **N/A** | `RETURN score LIMIT 1` (no `ORDER BY`) — arbitrary single float. |
| `algo_harmonic_summary` | **N/A** (pending) | `avg`/`max` over all nodes; iterative/aggregation value stability unproven. |
| `algo_max_flow_single_pair` | **Gated (candidate)** | Max-flow of a fixed simple graph + capacities + seeded pair is a unique integral value coerced to exact `f64`. |
| `algo_msf_summary` | **Gated (candidate)** | `edge_count` and MSF `total_weight` are unique (tie-breaking cannot change the minimum total). |

Default **all four to N/A**; promote `max_flow`/`msf` to `Gated` **only after** confirming byte-stable
digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synthetic-only `ORDER BY`.

## 7. Phasing (prerequisites first, each its own PR)
1. **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
2. **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the dynamic
   path; N/A shapes skip full reference capture.
3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
   `algorithm_read_names()` + drift-guard, `record_algorithm_reads()`, `--repo-algorithms`. Record +
   replay the 4 shapes end-to-end, opt-in.
4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
6. **Docs:** cookbook + readme.

## 8. Risks & open questions
1. **maxFlow topology (§3.1)** — biggest: confirm the dup-pair count + tensors error, and that a
   deduped simple graph keeps `workload_hash`/digests deterministic.
2. **Float/iteration value stability (§6)** — whether `max_flow`/`msf` digests are byte-stable
   run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`.
3. **Value of N/A-only coverage** — N/A shapes add latency/trend coverage + exercise the `algo.*`
   paths but nothing to the divergence gate; acceptable because algorithms are opt-in, not per-PR.
4. **Budget/corpus plumbing is real work (§3.4)**, not annotation — it is a prerequisite, and it also
   benefits any future heavy read.
5. **Skipped-op semantics (§3.5)** — how a capability-absent op appears in `report --diff` needs
   defining so it neither reads as a pass nor a divergence.

## 9. Acceptance
Opt-in record + replay of the 4 algorithm shapes end-to-end on the FalkorDB per-PR image against the
simple-graph fixture, off the per-PR read gate and the A/B `--query-profile`; `pagerank`/`harmonic`
result-N/A, `max_flow`/`msf` gated **iff** verified byte-stable; a drift-guard binds the table to
`queries_repository`'s algorithm names. "Algorithms every PR" is explicitly **not** the target.

## 10. Rollout
Land the phases behind `--repo-algorithms` in `FalkorDB/benchmark`; `falkordb-rs-next-gen` picks each
up on the next `SYNTHETIC_BENCHMARK_REF` bump. The per-PR `synthetic-verify` gate stays reads-only; a
nightly/on-demand job exercises the algorithm shapes.

## 11. What the rubber-duck corrected (so reviewers can trust this revision)
1. **maxFlow needs a simple graph** — the generator only forbids self-loops, so the oracle fixture has
   parallel edges and `algo.maxFlow` errors on tensors; "no new fixture" was wrong (§3.1).
2. **`Tier::Full` ≠ opt-in** — `--repo-reads full` already means "all reads" and runs every PR; a
   separate selection axis is required so algorithms don't leak into the gate (§3.2).
3. **The record path hard-excludes algorithms and the profile enum is the A/B CLI's** — needs a
   synthetic-only family + `record_algorithm_reads()` + `algorithm_read_names()`, not
   `QueryCoverageProfile::Algorithm` (§3.3).
4. **Per-op budget/corpus is unwired for recorded shapes** and replay captures all 256 commands before
   checking policy — a real prerequisite, not annotation (§3.4).
5. **Capability must be per-procedure**, and result-N/A does **not** skip execution — needs
   probe-before-capture + skipped-op reporting (§3.5).
6. **Floats are fine to gate** once deterministic — canonicalization hashes `f64::to_bits()`, so
   `max_flow`/`msf` are sound `Gated` candidates after the topology fix (§6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated synthetic coverage design documentation to reflect that reads-scope work and the per-PR non-divergence gate have been merged.
  * Added a Phase 6 proposal for synthetic coverage of algorithm query shapes, including scope, rollout, acceptance criteria, and known implementation considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->