### PR TITLE
fix(synthetic): budgets and tiers for dynamic (recorded) op names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -485,8 +485,8 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   noise guard, defaulting to 10 % / 0.5 ms and overridable per-operation and per-operation×concurrency
   in a TOML file (`[default]` + `[op.<name>]` with a `concurrency` inline table). `<name>` may be a
   catalog op (`synthetic list-ops`) **or** a recorded repo-read shape (e.g. `single_vertex_read`);
-  every measured op resolves a budget — string-keyed override first, else `[default]` — and rolls
-  into its coverage tier. Unlike `--diff`,
+  every measured op resolves a budget — string-keyed override first, else `[default]`; catalog ops
+  and recorded repo-read shapes also roll into their coverage tier. Unlike `--diff`,
   it **never aborts**: an op whose `result_digest` differs is shown 🔴 with a `⚠ results differ`
   note and a perf verdict of **N/A** (a mismatched workload/config renders the whole report
   *not comparable*). The report **header echoes the resolved thresholds** (the default budget/floor

--- a/readme.md
+++ b/readme.md
@@ -483,7 +483,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   cell gets a **🟢 / 🔴 / N/A** verdict on **p50** — 🟢 if the candidate (B) is faster or slower
   within budget, 🔴 if slower beyond it. The budget is a `budget_pct` plus an absolute `floor_ms`
   noise guard, defaulting to 10 % / 0.5 ms and overridable per-operation and per-operation×concurrency
-  in a TOML file (`[default]` + `[op.<name>]` with a `concurrency` inline table). Unlike `--diff`,
+  in a TOML file (`[default]` + `[op.<name>]` with a `concurrency` inline table). `<name>` may be a
+  catalog op (`synthetic list-ops`) **or** a recorded repo-read shape (e.g. `single_vertex_read`);
+  every measured op resolves a budget — string-keyed override first, else `[default]` — and rolls
+  into its coverage tier. Unlike `--diff`,
   it **never aborts**: an op whose `result_digest` differs is shown 🔴 with a `⚠ results differ`
   note and a perf verdict of **N/A** (a mismatched workload/config renders the whole report
   *not comparable*). The report **header echoes the resolved thresholds** (the default budget/floor

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -6,10 +6,18 @@
 use crate::synthetic::baseline::RegressionGuard;
 use crate::synthetic::provenance::decode_module_version;
 use crate::synthetic::report::{md_cell, LevelMetrics, LevelReport, Report};
+use crate::synthetic::shapes::repo_read_tier;
 use crate::synthetic::thresholds::{Thresholds, Verdict};
 use crate::synthetic::{OpName, Tier};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+
+/// Coverage [`Tier`] for an op key of either kind: legacy catalog tags resolve via
+/// [`OpName::from_tag`]; dynamic (string-keyed) repo read shapes via the shape registry
+/// ([`repo_read_tier`]); names known to neither have no tier.
+fn op_tier(op: &str) -> Option<Tier> {
+    OpName::from_tag(op).map(OpName::tier).or_else(|| repo_read_tier(op))
+}
 
 /// Which cache mode of a [`LevelReport`] to read.
 #[derive(Clone, Copy)]
@@ -336,7 +344,6 @@ pub fn regression_markdown(
         .collect();
     for op in ops {
         let op_diverged = diverged.contains(op);
-        let opname = OpName::from_tag(op);
         let regressed_before = regressed;
         let comparable_before = comparable_cells;
         // Render this op's cache-mode tables into a temp buffer so the whole op section can be
@@ -344,8 +351,8 @@ pub fn regression_markdown(
         let mut op_body = String::new();
         for mode in [Mode::Cached, Mode::Uncached] {
             render_regression_mode(
-                &mut op_body, baseline, candidate, op, opname, mode, op_diverged, thresholds, &la,
-                &lb, &mut regressed, &mut comparable_cells,
+                &mut op_body, baseline, candidate, op, mode, op_diverged, thresholds, &la, &lb,
+                &mut regressed, &mut comparable_cells,
             );
         }
         if op_body.trim().is_empty() {
@@ -411,7 +418,6 @@ fn render_regression_mode(
     a: &Report,
     b: &Report,
     op: &str,
-    opname: Option<OpName>,
     mode: Mode,
     op_diverged: bool,
     thresholds: &Thresholds,
@@ -446,8 +452,10 @@ fn render_regression_mode(
         let ap = am.map(|m| m.metrics.total_ms.median);
         let bp = bm.map(|m| m.metrics.total_ms.median);
         // Resolve the budget ONCE per (op, C) and reuse it for both the printed guard and the
-        // verdict, so the shown threshold can never disagree with the one that was applied.
-        let resolved = opname.map(|name| thresholds.resolve(name, c));
+        // verdict, so the shown threshold can never disagree with the one that was applied. The
+        // string-keyed lookup gives dynamic (recorded) op names the same budget resolution as
+        // static catalog ops: `[op.<name>]` override if configured, else `[default]`.
+        let resolved = thresholds.resolve_by_name(op, c);
 
         let a_cell = latency_cell(am);
         let b_cell = latency_cell(bm);
@@ -460,14 +468,14 @@ fn render_regression_mode(
             }
             _ => "—".to_string(),
         };
-        // The configured guard for this exact cell — only resolvable for a known op.
-        let guard = resolved.map(|r| r.guard_cell()).unwrap_or_else(|| "—".to_string());
+        // The configured guard for this exact cell.
+        let guard = resolved.guard_cell();
         let verdict = if op_diverged {
             "🔴 N/A".to_string()
         } else {
-            match (ap, bp, resolved) {
-                (Some(x), Some(y), Some(r)) => {
-                    let v = r.verdict(x, y);
+            match (ap, bp) {
+                (Some(x), Some(y)) => {
+                    let v = resolved.verdict(x, y);
                     match v {
                         Verdict::Regressed => {
                             *regressed += 1;
@@ -620,7 +628,6 @@ fn op_cell_counts(
     op: &str,
     thresholds: &Thresholds,
 ) -> Option<(usize, usize)> {
-    let opname = OpName::from_tag(op);
     let mut regressed = 0usize;
     let mut comparable = 0usize;
     let mut had_cell = false;
@@ -639,9 +646,9 @@ fn op_cell_counts(
             had_cell = true;
             let ap = level_metrics(baseline, op, c, mode).map(|m| m.metrics.total_ms.median);
             let bp = level_metrics(candidate, op, c, mode).map(|m| m.metrics.total_ms.median);
-            let resolved = opname.map(|name| thresholds.resolve(name, c));
-            if let (Some(x), Some(y), Some(r)) = (ap, bp, resolved) {
-                match r.verdict(x, y) {
+            let resolved = thresholds.resolve_by_name(op, c);
+            if let (Some(x), Some(y)) = (ap, bp) {
+                match resolved.verdict(x, y) {
                     Verdict::Regressed => {
                         regressed += 1;
                         comparable += 1;
@@ -785,7 +792,7 @@ pub fn summarize(
         }
 
         totals.add(outcome);
-        let tier = OpName::from_tag(op).map(OpName::tier);
+        let tier = op_tier(op);
         match tier {
             Some(Tier::Core) => core.add(outcome),
             Some(Tier::Full) => full.add(outcome),
@@ -809,7 +816,7 @@ pub fn summarize(
         if !offenders.iter().any(|o| &o.op == op) {
             offenders.push(Offender {
                 op: op.clone(),
-                tier: OpName::from_tag(op).map(|n| n.tier().as_str().to_string()),
+                tier: op_tier(op).map(|t| t.as_str().to_string()),
                 diverged: true,
                 regressed_cells: 0,
             });
@@ -1585,9 +1592,10 @@ mod tests {
     }
 
     #[test]
-    fn summarize_excludes_unknown_tag_ops_from_tier_counts() {
-        // A dynamic, string-keyed op (Phase 1a) whose tag is not a static OpName has no tier and
-        // no resolvable budget, so it counts as N/A in the totals but toward neither tier.
+    fn summarize_gates_unknown_tag_ops_but_excludes_them_from_tier_counts() {
+        // A string-keyed op known to neither the catalog nor the repo read shape registry still
+        // resolves a budget (`[default]` fallback) so it gets a real verdict, but it has no tier:
+        // it counts in the totals yet toward neither `core` nor `full`.
         let a = rpt("main", 42001, &[("mystery_op", 1.0, "d1")]);
         let b = rpt("pr", 42002, &[("mystery_op", 1.0, "d1")]);
         let g = regression_guard(&a, &b);
@@ -1595,9 +1603,9 @@ mod tests {
         assert_eq!(
             s.totals,
             OutcomeCounts {
-                pass: 0,
+                pass: 1,
                 regressed: 0,
-                not_applicable: 1
+                not_applicable: 0
             }
         );
         let core = s.per_tier.iter().find(|t| t.tier == "core").unwrap();
@@ -1605,6 +1613,33 @@ mod tests {
         assert_eq!(core.counts, OutcomeCounts::default());
         assert_eq!(full.counts, OutcomeCounts::default());
         assert!(s.worst_offenders.is_empty());
+    }
+
+    #[test]
+    fn dynamic_repo_read_shape_gets_budget_and_tier_end_to_end() {
+        // The full A0 path (design §4 of synthetic-three-way-report.md): a recorded repo read
+        // shape — a dynamic op name that is NOT a catalog `OpName` — gets its `[op.*]` TOML
+        // override applied in the rendered report and rolls up into its registry tier.
+        let toml = "[op.single_vertex_read]\nbudget_pct = 50.0\nfloor_ms = 0.1\n";
+        let t = Thresholds::from_toml_str(toml).unwrap();
+        // 2.0 → 2.6 ms = +30%, Δ0.6 ms: within the 50% override (pass), but over the strict
+        // built-in default (10% AND 0.5 ms) — proving the override, not the default, was applied.
+        let a = rpt("main", 42001, &[("single_vertex_read", 2.0, "d1")]);
+        let b = rpt("pr", 42002, &[("single_vertex_read", 2.6, "d1")]);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&a, &b, &g, &t, None);
+        assert!(md.contains("50% AND 0.1 ms"), "guard column shows the override:\n{md}");
+        assert!(md.contains("🟢 <code>single_vertex_read</code>"), "{md}");
+        let s = summarize(&a, &b, &g, &t);
+        assert_eq!(s.totals.pass, 1, "{s:?}");
+        // `single_vertex_read` is a Tier::Core repo read shape (shapes.rs registry).
+        let core = s.per_tier.iter().find(|t| t.tier == "core").unwrap();
+        assert_eq!(core.counts.pass, 1, "{s:?}");
+        // Same inputs under the strict built-in default (10% AND 0.5 ms): +30%/Δ0.6 ms regresses,
+        // and the offender carries the registry tier.
+        let strict = summarize(&a, &b, &g, &Thresholds::builtin());
+        assert_eq!(strict.totals.regressed, 1, "{strict:?}");
+        assert_eq!(strict.worst_offenders[0].tier.as_deref(), Some("core"), "{strict:?}");
     }
 
     #[test]

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -261,6 +261,16 @@ pub fn repo_read_shapes() -> Vec<ShapeSpec> {
     shapes
 }
 
+/// The coverage [`Tier`] of the repo read shape named `name`, or `None` when no repo read shape has
+/// that name. Lets string-keyed consumers (thresholds validation, report tier rollups) resolve a
+/// dynamic recorded op exactly like a static catalog op.
+pub fn repo_read_tier(name: &str) -> Option<Tier> {
+    repo_read_shapes()
+        .into_iter()
+        .find(|shape| shape.name == name)
+        .map(|shape| shape.tier)
+}
+
 /// The repo read shapes the given `tier` selects, in record order: [`Tier::Full`] selects every repo
 /// read; [`Tier::Core`] selects only the core subset. Shared by [`record_repo_reads`] and
 /// [`repo_reads_need_fixture`] so the two agree on what a tier records.
@@ -375,6 +385,15 @@ mod tests {
     /// The set of names in the annotation table.
     fn annotated_names() -> BTreeSet<&'static str> {
         baseline_read_shapes().iter().map(|s| s.name).collect()
+    }
+
+    #[test]
+    fn repo_read_tier_resolves_by_name() {
+        // String-keyed tier lookup over the registry: a core shape, a full shape, and a miss.
+        assert_eq!(repo_read_tier("single_vertex_read"), Some(Tier::Core));
+        let full = repo_read_shapes().into_iter().find(|s| s.tier == Tier::Full).unwrap();
+        assert_eq!(repo_read_tier(full.name), Some(Tier::Full));
+        assert_eq!(repo_read_tier("not_a_shape"), None);
     }
 
     #[test]

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -265,8 +265,12 @@ pub fn repo_read_shapes() -> Vec<ShapeSpec> {
 /// that name. Lets string-keyed consumers (thresholds validation, report tier rollups) resolve a
 /// dynamic recorded op exactly like a static catalog op.
 pub fn repo_read_tier(name: &str) -> Option<Tier> {
-    repo_read_shapes()
+    // Chain the component lists (same order as `repo_read_shapes`) instead of materializing the
+    // combined Vec on every lookup; `repo_read_tier_covers_every_repo_read_shape` guards drift.
+    baseline_read_shapes()
         .into_iter()
+        .chain(extended_core_read_shapes())
+        .chain(fixture_dependent_read_shapes())
         .find(|shape| shape.name == name)
         .map(|shape| shape.tier)
 }
@@ -393,6 +397,15 @@ mod tests {
         assert_eq!(repo_read_tier("single_vertex_read"), Some(Tier::Core));
         assert_eq!(repo_read_tier("vector_query_nodes_smoke"), Some(Tier::Full));
         assert_eq!(repo_read_tier("not_a_shape"), None);
+    }
+
+    #[test]
+    fn repo_read_tier_covers_every_repo_read_shape() {
+        // Drift guard for the chained lookup: every shape in the combined registry must resolve
+        // to its own tier, so a new component list can't silently escape `repo_read_tier`.
+        for shape in repo_read_shapes() {
+            assert_eq!(repo_read_tier(shape.name), Some(shape.tier), "{}", shape.name);
+        }
     }
 
     #[test]

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -391,8 +391,7 @@ mod tests {
     fn repo_read_tier_resolves_by_name() {
         // String-keyed tier lookup over the registry: a core shape, a full shape, and a miss.
         assert_eq!(repo_read_tier("single_vertex_read"), Some(Tier::Core));
-        let full = repo_read_shapes().into_iter().find(|s| s.tier == Tier::Full).unwrap();
-        assert_eq!(repo_read_tier(full.name), Some(Tier::Full));
+        assert_eq!(repo_read_tier("vector_query_nodes_smoke"), Some(Tier::Full));
         assert_eq!(repo_read_tier("not_a_shape"), None);
     }
 

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -214,11 +214,17 @@ impl Thresholds {
 
         let mut ops = BTreeMap::new();
         for (name, raw_op) in raw.op {
-            // Validate the name maps to a known op, but key the map by the **string name** so a
-            // dynamic (string-keyed) op resolves exactly like a built-in one (design §3.1).
-            OpName::from_tag(&name).ok_or_else(|| {
-                format!("unknown operation '{name}' in [op.{name}] — see `synthetic list-ops`")
-            })?;
+            // Validate the name maps to a known op — a legacy catalog tag or a recorded repo read
+            // shape — but key the map by the **string name** so a dynamic (string-keyed) op
+            // resolves exactly like a built-in one (design §3.1).
+            let known = OpName::from_tag(&name).is_some()
+                || crate::synthetic::shapes::repo_read_tier(&name).is_some();
+            if !known {
+                return Err(format!(
+                    "unknown operation '{name}' in [op.{name}] — not a catalog op (see \
+                     `synthetic list-ops`) or a recorded repo read shape"
+                ));
+            }
             if let Some(m) = raw_op.metric {
                 check_metric(m)?;
             }
@@ -445,6 +451,19 @@ concurrency = { 32 = 40.0 }
     fn rejects_unknown_op_key() {
         let err = Thresholds::from_toml_str("[op.not_a_real_op]\nbudget_pct = 5.0\n").unwrap_err();
         assert!(err.contains("unknown operation 'not_a_real_op'"), "{err}");
+    }
+
+    #[test]
+    fn accepts_repo_read_shape_op_key() {
+        // A dynamic repo read shape name (not a catalog `OpName`) is a valid `[op.*]` key and its
+        // override resolves through the same string-keyed lookup as a built-in op (design §4 A0 of
+        // synthetic-three-way-report.md).
+        let cfg = "[op.single_vertex_read]\nbudget_pct = 33.0\nfloor_ms = 0.2\n";
+        let t = Thresholds::from_toml_str(cfg).unwrap();
+        assert!(OpName::from_tag("single_vertex_read").is_none(), "shape must be dynamic");
+        let r = t.resolve_by_name("single_vertex_read", 4);
+        assert_eq!(r.budget_pct, 33.0);
+        assert_eq!(r.floor_ms, 0.2);
     }
 
     #[test]


### PR DESCRIPTION
## What

Latent bug fix — **A0 of the [three-way report design](https://github.com/FalkorDB/benchmark/pull/254)** (full design section embedded below): budget + tier resolution only worked for legacy catalog `OpName`s, so every **dynamic recorded op** (`--repo-reads` shapes — 49 of the 50 ops in falkordb-rs-next-gen's CI workload) silently got **no budget** (guard `—`, verdict N/A) and **no tier** in the summary.

## Why it matters (worked example)

falkordb-rs-next-gen's per-PR synthetic check records the repo-read workload and gates on `report --regression`. Before this fix, a report row for a recorded shape rendered like:

```text
| single_vertex_read | 1 | uncached | 0.42 | 0.55 | +31.0% | — | N/A |
```

— the `—` guard means "no budget resolved", so a **+31% regression sails through as N/A**. Only the one legacy catalog op got a real verdict; the check was ~98% blind. After this fix the same row resolves its budget (TOML override or `[default]`) and gates:

```text
| single_vertex_read | 1 | uncached | 0.42 | 0.55 | +31.0% | 10% AND 0.5 ms | 🔴 |
```

and the op rolls into its `core`/`full` tier in the summary's outcome counts.

## Design (from the approved doc, §4 A0 — verbatim)

### A0. Prerequisite fix: budgets + tiers for dynamic op names (G1)

A **latent bug fix** independent of the three-way feature, delivered first as its own PR:

- `diff.rs`: replace every `OpName::from_tag(op)`-based budget resolution with
  `Thresholds::resolve_by_name(op, c)` (already implemented + tested), in the regression render,
  the summary counts, and the tier rollup.
- Tier lookup by **name**: `shapes.rs` owns the repo-read shape registry (name + `Tier`,
  enumerable without a recording — verified feasible at `shapes.rs:93-107,254-261`); add a
  string-keyed tier lookup consulting the legacy catalog first, then the shape registry, else
  `None`.
- `thresholds.rs::from_toml_str`: accept `[op.<name>]` keys naming either a legacy catalog tag
  **or** a known repo-read shape; keep rejecting unknown keys (typo guard).
- Tests: end-to-end regression-render test where a dynamic op (`single_vertex_read`) gets a real
  budget from TOML and a tier in the summary; TOML parse accepts shape names, rejects typos.
- **No schema/format change** — #745 stays pinned to its current `SYNTHETIC_BENCHMARK_REF` and
  simply picks this up at the next ref bump (verified: no compat trap).


## How (implementation)

- `diff.rs`: budget resolution goes through the string-keyed `Thresholds::resolve_by_name` (existed, tested, never wired) in the regression render **and** the summary cell counts; new `op_tier` helper resolves tiers via the catalog first, then the repo-read shape registry (`shapes::repo_read_tier`).
- `shapes.rs`: new `repo_read_tier(name)` string-keyed lookup; chains the component shape lists (no combined-Vec allocation per lookup) with a drift-guard test covering every registry shape.
- `thresholds.rs`: `[op.<name>]` TOML keys accept recorded repo-read shape names (still rejecting unknown keys as typos), e.g.:

```toml
[default]
budget_pct = 10.0
floor_ms = 0.5

[op.single_vertex_read]          # a recorded repo-read shape — now valid
budget_pct = 5.0
floor_ms = 0.2
concurrency = { 8 = { budget_pct = 15.0 } }
```

- Deliberate semantics change: an op unknown to **both** the catalog and the shape registry now resolves the `[default]` budget (comparable, gated) instead of N/A — it still carries no tier, so it counts in overall totals but not in `core`/`full` rollups.

## Tests

- End-to-end: a dynamic shape (`single_vertex_read`) gets its TOML override applied in the rendered report (guard column + verdict) and rolls into its `core` tier; same inputs regress under the strict builtin default; offender carries the tier.
- TOML: accepts a shape-name key, still rejects `not_a_real_op`.
- `repo_read_tier`: core hit (`single_vertex_read`), full hit (`vector_query_nodes_smoke`), miss, plus the every-shape drift guard.
- Updated: unknown-to-both ops now get the default budget (comparable) but still no tier.

`just ci` + `just coverage` green locally. **No schema/format change** — #745 stays pinned to its `SYNTHETIC_BENCHMARK_REF` and picks this up at the next ref bump.
