### PR TITLE
feat(synthetic): guarantee a simple generated graph (Phase 6 PR-1: no parallel :Friend edges)

### DIFF
--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -1,7 +1,8 @@
 # Design — cover the A/B benchmark's algorithm shapes in the synthetic check (Phase 6)
 
-**Status:** proposal for review — **not implemented**. Draft for maintainer review before any code
-(per the workflow). **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+**Status:** approved — **phased implementation in progress** (per-phase markers in §7; the empirical
+§3.1 facts are confirmed and recorded inline). **Rubber-duck reviewed**; this revision folds in the
+review's corrections — the
 first draft understated the work (see §11). Follows the reads-scope work (design
 [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5, merged in
 PRs #240–#250): the per-op non-divergence gate now covers the **50 A/B read shapes** but deliberately
@@ -56,7 +57,15 @@ duplicate `(src,dst)` pairs. On a multigraph FalkorDB's `algo.maxFlow` errors
 **false for maxFlow**. **Fix:** a deterministic **simple-graph guarantee** for the algorithm fixture
 (dedupe `(src,dst)` at generation, keeping the count/`bench_capacity` deterministic) or an
 algorithm-specific simple fixture; add a "no parallel `:Friend` edges" test + a live maxFlow smoke
-test. *(Empirically confirm the dup-pair count and the tensors error first.)*
+test. *(Empirically confirmed before implementation: the seed=7 1000/5000 oracle fixture contained
+**8 duplicate `(src,dst)` pairs** (4992 distinct of 5000), and `algo.maxFlow` on that graph fails
+with exactly `algo.maxFlow: relationship type must not contain multi-edges (tensors)` — for **any**
+`(s,t)` pair, the check is per relationship type, on `falkordb/falkordb:edge`.)* ✅ implemented: the
+generator now guarantees a simple graph for **every** dataset (`GENERATOR_VERSION` bumped to
+`synthbench/v5`; duplicate draws re-probe deterministically, count and `bench_capacity` unchanged in
+non-colliding slots), `edges` is capped at `nodes × (nodes − 1)`, and a live
+`max_flow_runs_on_the_generated_simple_graph` smoke test loads the oracle fixture and runs the real
+repo shape.
 
 ### 3.2 `Tier::Full` cannot double as "algorithm opt-in"
 `--repo-reads` is `Option<Tier>` (`src/cli.rs:542`); selection filters **only** by tier
@@ -137,7 +146,7 @@ Default **all four to N/A**; promote `max_flow`/`msf` to `Gated` **only after** 
 digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synthetic-only `ORDER BY`.
 
 ## 7. Phasing (prerequisites first, each its own PR)
-1. **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
+1. ✅ **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
 2. **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the dynamic
    path; N/A shapes skip full reference capture.
 3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -136,7 +136,7 @@ execution + compilation) modes, and derives the per-level **compilation cost** f
 synthetic benchmark — endpoint falkor://127.0.0.1:6381  graph falkor  samples 100  warmup 50  concurrency [1,2,4,8,16,32]  seed 7  connection pool(size=1) per worker
 server — falkordb module ver 4.20.1  redis 8.6.3  CACHE_SIZE 25
 client host — bench-host · macOS · Apple M1 Pro (10c/10t) · 16.0 GiB · arm64
-dataset — seed 7  nodes 1000  edges 5000  workload_hash sha256:b74e5a1d…7c1e70
+dataset — seed 7  nodes 1000  edges 5000  workload_hash sha256:81a8fa1f…704d4c
 
 aggregate_count
   [cached — plan reused, execution only]
@@ -179,7 +179,7 @@ seed and the knobs, it is fully offline and reproducible.
 **What you get:**
 
 ```text
-recorded 9 op(s) into rec (workload_hash sha256:b74e5a1d…7c1e70)
+recorded 9 op(s) into rec (workload_hash sha256:81a8fa1f…704d4c)
 rec: commands  graph.jsonl  manifest.json
 rec/commands: aggregate_count.jsonl aggregate_group.jsonl expand_1_hop.jsonl
   expand_hops_5.jsonl match_by_index.jsonl match_by_label_scan.jsonl
@@ -191,10 +191,10 @@ rec/commands: aggregate_count.jsonl aggregate_group.jsonl expand_1_hop.jsonl
 ```json
 {
   "format_version": 1,
-  "generator_version": "synthbench/v4",
+  "generator_version": "synthbench/v5",
   "dataset": { "seed": 7, "nodes": 1000, "edges": 5000 },
   "ops": [ { "name": "return_const", "count": 256 }, { "name": "match_by_index", "count": 256 } ],
-  "workload_hash": "sha256:b74e5a1d…7c1e70"
+  "workload_hash": "sha256:81a8fa1f…704d4c"
 }
 ```
 
@@ -244,7 +244,7 @@ and (b) two runs of the same workload against the same FalkorDB **do not diverge
 # (a) Determinism: record the same workload twice, compare the workload_hash — must be identical.
 benchmark synthetic record --op all --nodes 1000 --edges 5000 --seed 7 --out-dir rec
 benchmark synthetic record --op all --nodes 1000 --edges 5000 --seed 7 --out-dir rec_again
-# → both print the SAME `workload_hash sha256:b74e5a1d…7c1e70`
+# → both print the SAME `workload_hash sha256:81a8fa1f…704d4c`
 
 # (b) Non-divergence (the CI gate): record all A/B read shapes (--repo-reads full), run twice against
 #     ONE FalkorDB at concurrency 1,8 uncached, and fail if any result digest differs. Spins its own
@@ -267,8 +267,8 @@ query/client timeouts, or a missing `workload_hash`/per-op digest), which is int
 **What you get:**
 
 ```text
-first : sha256:b74e5a1d…7c1e70
-again : sha256:b74e5a1d…7c1e70      ← identical ⇒ deterministic
+first : sha256:81a8fa1f…704d4c
+again : sha256:81a8fa1f…704d4c      ← identical ⇒ deterministic
 
 # …and the final line from `just synthetic-verify`:
 synthetic-verify OK — no divergence across --repo-reads full × concurrency 1,8 × uncached

--- a/docs/synthetic/sample-recording-manifest.json
+++ b/docs/synthetic/sample-recording-manifest.json
@@ -1,6 +1,6 @@
 {
   "format_version": 1,
-  "generator_version": "synthbench/v4",
+  "generator_version": "synthbench/v5",
   "tool_version": "0.1.0",
   "dataset": {
     "seed": 42,
@@ -13,17 +13,23 @@
   "ops": [
     {
       "name": "match_by_index",
+      "kind": "Read",
+      "result_gated": true,
       "count": 256
     },
     {
       "name": "expand_1_hop",
+      "kind": "Read",
+      "result_gated": true,
       "count": 256
     },
     {
       "name": "aggregate_count",
+      "kind": "Read",
+      "result_gated": true,
       "count": 256
     }
   ],
-  "workload_hash": "sha256:eeaff0294bcda9a9f36b79c910a47163854eba4a075e3954dcc84997e993af45",
-  "created_at_epoch_secs": 1784720696
+  "workload_hash": "sha256:c894d1f43e665c71fcf345d8c20c8c8ea8e80ca130a9209c1f2e9339d2ee4061",
+  "created_at_epoch_secs": 1784985971
 }

--- a/readme.md
+++ b/readme.md
@@ -384,8 +384,11 @@ just synthetic-bench --graph bench --generate --nodes 100000 --edges 1000000 \
   never authorized by a config file alone). It creates the `:User(id)` index, then bulk-loads the
   nodes and edges via `UNWIND` batches.
 - The graph is generated deterministically from `--seed`: `edges` must be `≥ nodes` (a ring backbone
-  guarantees connectivity for expansions/shortest paths); `edges` counts relationships. The same
-  seed + knobs reproduce the exact same graph and the same operation corpora everywhere.
+  guarantees connectivity for expansions/shortest paths) and `≤ nodes × (nodes − 1)`; `edges` counts
+  relationships. The generated graph is always **simple** — no self-loops and no parallel
+  `(src, dst)` `:Friend` pairs — so whole-graph algorithms like `algo.maxFlow` (which rejects
+  multigraphs) run on it. The same seed + knobs reproduce the exact same graph and the same
+  operation corpora everywhere.
 - When a dataset is generated, the report's `meta.dataset` records `{seed, nodes, edges,
   workload_hash}`. **`workload_hash`** (`sha256:…`) is a stable fingerprint of the whole workload —
   the dataset knobs, the selected operations (in order) and their query bodies, and the sampled input

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -2,7 +2,10 @@
 //!
 //! Generates a deterministic `:User {id, age}` / `(:User)-[:Friend {bench_capacity}]->(:User)`
 //! graph from a [`DatasetSpec`] and bulk-loads it via `UNWIND` batches, so operation numbers are
-//! controlled and comparable across runs. To mirror the A/B benchmark's baseline fixture (design
+//! controlled and comparable across runs. The generated graph is always **simple** — no self-loops
+//! and no parallel `(src, dst)` `:Friend` pairs — because FalkorDB's `algo.maxFlow` rejects
+//! multigraphs ("relationship type must not contain multi-edges (tensors)"; design
+//! `synthetic-cover-algorithms-phase6` §3.1). To mirror the A/B benchmark's baseline fixture (design
 //! §3.4) it builds **both** the `:User(id)` and `:User(age)` indexes and stamps every `:Friend`
 //! edge with a deterministic [`bench_capacity`](crate::data_prep::bench_capacity), so shapes that
 //! filter on `age` or `r.bench_capacity` exercise the intended plan/predicate rather than a
@@ -21,13 +24,15 @@ use crate::synthetic::OpName;
 use falkordb::AsyncGraph;
 use futures::StreamExt;
 use sha2::{Digest, Sha256};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write as _;
 use std::time::Duration;
 
 /// Bumped whenever the generator algorithm or the operation catalog's query bodies change, so a
 /// [`corpus_hash`] from an older build never compares equal to a newer, differently-generated one.
-pub const GENERATOR_VERSION: &str = "synthbench/v4";
+/// v5: the edge generator guarantees a **simple** graph (no parallel `(src,dst)` `:Friend` pairs),
+/// re-probing duplicate draws deterministically (design `synthetic-cover-algorithms-phase6` §3.1).
+pub const GENERATOR_VERSION: &str = "synthbench/v5";
 
 /// Max distinct `:User` ids sampled into the [`DatasetHandle`] id pool.
 const POOL_IDS: usize = 4096;
@@ -101,6 +106,17 @@ impl DatasetSpec {
         if self.edges > i64::MAX as usize {
             return Err(OtherError(format!("dataset edges ({}) too large", self.edges)));
         }
+        // The generator guarantees a simple graph (no parallel `(src,dst)` pairs, no self-loops),
+        // so a directed graph on `nodes` vertices holds at most `nodes * (nodes - 1)` edges.
+        if self.edges as u64 > self.nodes as u64 * (self.nodes as u64 - 1) {
+            return Err(OtherError(format!(
+                "dataset edges ({}) exceeds the simple-graph capacity of {} nodes ({} distinct \
+                 ordered pairs)",
+                self.edges,
+                self.nodes,
+                self.nodes as u64 * (self.nodes as u64 - 1)
+            )));
+        }
         Ok(())
     }
 
@@ -112,12 +128,15 @@ impl DatasetSpec {
         18 + (mix(self.seed, DOMAIN_AGE, id as u64) % 60) as i32
     }
 
-    /// The `e`-th directed `:Friend` edge as `(src_id, dst_id)`.
+    /// The `e`-th **candidate** directed `:Friend` edge as `(src_id, dst_id)`.
     ///
-    /// The first `nodes` edges form a ring `i -> (i mod nodes) + 1` (a connected backbone that
-    /// guarantees every node is reachable and gives shortest-path/expansions structure). Any edges
-    /// beyond that are seeded-random with a non-zero offset, so `src != dst` without retry loops.
-    fn edge_at(
+    /// The first `nodes` candidates form a ring `i -> (i mod nodes) + 1` (a connected backbone
+    /// that guarantees every node is reachable and gives shortest-path/expansions structure —
+    /// and is duplicate-free by construction). Any candidates beyond that are seeded-random with
+    /// a non-zero offset, so `src != dst` without retry loops. Candidates may collide with an
+    /// earlier pair; [`edge_pairs`](Self::edge_pairs) resolves collisions deterministically so
+    /// the emitted edge list is always **simple** (no parallel edges).
+    fn edge_candidate(
         &self,
         e: usize,
     ) -> (i32, i32) {
@@ -132,6 +151,46 @@ impl DatasetSpec {
             let dst0 = (src0 + offset) % n;
             ((src0 + 1) as i32, (dst0 + 1) as i32)
         }
+    }
+
+    /// All `edges` directed `:Friend` edges, in load order, guaranteed **simple**: no self-loops
+    /// and no duplicate `(src, dst)` pairs (`algo.maxFlow` rejects multigraphs with a
+    /// "must not contain multi-edges (tensors)" error — design
+    /// `synthetic-cover-algorithms-phase6` §3.1). Each edge's first candidate is
+    /// [`edge_candidate`](Self::edge_candidate) — so a non-colliding draw is byte-identical to
+    /// the pre-v5 generator — and a colliding draw deterministically re-probes: it scans offsets
+    /// (then source nodes) in a fixed order until an unused pair is found. `validate()` caps
+    /// `edges` at `nodes * (nodes - 1)`, so a free pair always exists and the sweep terminates.
+    ///
+    /// Deterministic: same spec ⇒ same sequence. Sequential by design (each edge depends on the
+    /// set of earlier pairs); the tracking set costs `O(edges)` transient memory while a stream
+    /// of statements is generated.
+    pub(crate) fn edge_pairs(&self) -> impl Iterator<Item = (i32, i32)> + '_ {
+        let mut used: HashSet<(i32, i32)> = HashSet::with_capacity(self.edges);
+        (0..self.edges).map(move |e| {
+            let (src0, dst0) = self.edge_candidate(e);
+            if used.insert((src0, dst0)) {
+                return (src0, dst0);
+            }
+            let n = self.nodes as u64;
+            // Deterministic re-probe: keep the drawn source, walk the remaining offsets; if the
+            // source is saturated (all n-1 destinations used), advance to the next source. The
+            // 0-based candidate offset is recovered from the pair so the walk continues from it.
+            let s0 = (src0 - 1) as u64;
+            let off0 = ((dst0 - 1) as u64 + n - s0) % n; // 1..=n-1
+            for j in 0..n {
+                let src = (s0 + j) % n;
+                for k in 1..n {
+                    let off = 1 + ((off0 - 1 + k) % (n - 1));
+                    let dst = (src + off) % n;
+                    let pair = ((src + 1) as i32, (dst + 1) as i32);
+                    if used.insert(pair) {
+                        return pair;
+                    }
+                }
+            }
+            unreachable!("validate() caps edges at nodes*(nodes-1), so a free pair exists")
+        })
     }
 
     /// A deterministic, sorted sample of up to [`POOL_IDS`] distinct `:User` ids.
@@ -308,21 +367,16 @@ fn node_batch(
     format!("UNWIND [{}] AS row CREATE (u:User) SET u = row", maps)
 }
 
-/// One edge `UNWIND` batch covering edge indices `lo..hi` (half-open). Each `:Friend` edge carries
+/// One edge `UNWIND` batch covering the given `(src, dst)` pairs. Each `:Friend` edge carries
 /// a deterministic [`bench_capacity`] (same formula as the A/B fixture) so shapes that filter on
 /// `r.bench_capacity` exercise a real predicate instead of always matching zero rows (design §3.4).
-fn edge_batch(
-    spec: &DatasetSpec,
-    lo: usize,
-    hi: usize,
-) -> String {
+fn edge_batch(pairs: &[(i32, i32)]) -> String {
     let mut maps = String::new();
-    for e in lo..hi {
-        if e != lo {
+    for (i, (src, dst)) in pairs.iter().enumerate() {
+        if i != 0 {
             maps.push(',');
         }
-        let (src, dst) = spec.edge_at(e);
-        let capacity = bench_capacity(src as u64, dst as u64);
+        let capacity = bench_capacity(*src as u64, *dst as u64);
         let _ = write!(maps, "{{src:{},dst:{},capacity:{}}}", src, dst, capacity);
     }
     format!(
@@ -334,17 +388,17 @@ fn edge_batch(
 /// The exact ordered sequence of load statements that builds `spec`'s dataset: the index DDL (both
 /// the `:User(id)` and `:User(age)` indexes), then `batch_size`-sized node `UNWIND` batches, then
 /// edge batches. **Lazy** — each batch string is built on demand as the iterator advances, so only
-/// one batch is materialized at a time (no full-script `Vec`). Shared by the live loader
-/// ([`generate_and_load`]) and the offline recorder so a replay loads a byte-identical graph to
-/// what a `--generate` run would. Callers must pass a validated `spec` (`spec.validate()`) and
-/// `batch_size >= 1`.
+/// one batch is materialized at a time (no full-script `Vec`; the simple-graph guarantee keeps an
+/// `O(edges)` pair set while edges stream — see [`DatasetSpec::edge_pairs`]). Shared by the live
+/// loader ([`generate_and_load`]) and the offline recorder so a replay loads a byte-identical
+/// graph to what a `--generate` run would. Callers must pass a validated `spec`
+/// (`spec.validate()`) and `batch_size >= 1`.
 pub(crate) fn load_statements(
     spec: &DatasetSpec,
     batch_size: usize,
 ) -> impl Iterator<Item = (LoadPhase, String)> + '_ {
     debug_assert!(batch_size >= 1, "batch_size must be >= 1");
     let nodes = spec.nodes as i32;
-    let edges = spec.edges;
     let index = INDEX_STMTS
         .iter()
         .map(|stmt| (LoadPhase::Index, (*stmt).to_string()));
@@ -353,10 +407,13 @@ pub(crate) fn load_statements(
         let hi = ((lo as i64) + (batch_size as i64) - 1).min(nodes as i64) as i32;
         (LoadPhase::Nodes, node_batch(spec, lo, hi))
     });
-    let edge_batches = (0..edges).step_by(batch_size).map(move |lo| {
-        let hi = (lo + batch_size).min(edges);
-        (LoadPhase::Edges, edge_batch(spec, lo, hi))
-    });
+    let edge_batches = {
+        let mut pairs = spec.edge_pairs();
+        std::iter::from_fn(move || {
+            let batch: Vec<(i32, i32)> = pairs.by_ref().take(batch_size).collect();
+            (!batch.is_empty()).then(|| (LoadPhase::Edges, edge_batch(&batch)))
+        })
+    };
     index.chain(node_batches).chain(edge_batches)
 }
 
@@ -555,7 +612,8 @@ mod tests {
         assert!(spec(1, 1, 5).validate().is_err()); // < 2 nodes
         assert!(spec(1, 10, 9).validate().is_err()); // edges < nodes
         assert!(spec(1, 10, 10).validate().is_ok());
-        assert!(spec(1, 10, 100).validate().is_ok());
+        assert!(spec(1, 10, 90).validate().is_ok()); // exactly the simple-graph capacity
+        assert!(spec(1, 10, 91).validate().is_err()); // beyond nodes*(nodes-1) distinct pairs
         // nodes beyond the i32 id range are rejected.
         assert!(spec(1, i32::MAX as usize + 1, i32::MAX as usize + 1)
             .validate()
@@ -601,10 +659,10 @@ mod tests {
                 s.node_age(5)
             )
         );
-        // First edge batch covers edge indices 0,1 (the ring backbone start), each stamped with its
-        // deterministic bench_capacity.
-        let (e0s, e0d) = s.edge_at(0);
-        let (e1s, e1d) = s.edge_at(1);
+        // First edge batch covers the first two emitted pairs (the ring backbone start), each
+        // stamped with its deterministic bench_capacity.
+        let pairs: Vec<(i32, i32)> = s.edge_pairs().take(2).collect();
+        let ((e0s, e0d), (e1s, e1d)) = (pairs[0], pairs[1]);
         let e0c = bench_capacity(e0s as u64, e0d as u64);
         let e1c = bench_capacity(e1s as u64, e1d as u64);
         assert_eq!(
@@ -679,22 +737,71 @@ mod tests {
     #[test]
     fn edges_are_deterministic_and_never_self_loops() {
         let s = spec(42, 50, 400);
-        for e in 0..s.edges {
-            let (a, b) = s.edge_at(e);
+        let pairs: Vec<(i32, i32)> = s.edge_pairs().collect();
+        assert_eq!(pairs.len(), s.edges);
+        for (e, &(a, b)) in pairs.iter().enumerate() {
             assert_ne!(a, b, "edge {e} is a self-loop");
             assert!((1..=50).contains(&a) && (1..=50).contains(&b));
-            // Deterministic: same spec, same edge.
-            assert_eq!(s.edge_at(e), spec(42, 50, 400).edge_at(e));
         }
+        // Deterministic: same spec, same sequence.
+        assert_eq!(pairs, spec(42, 50, 400).edge_pairs().collect::<Vec<_>>());
         // The first `nodes` edges are the ring backbone.
-        assert_eq!(s.edge_at(0), (1, 2));
-        assert_eq!(s.edge_at(49), (50, 1));
+        assert_eq!(pairs[0], (1, 2));
+        assert_eq!(pairs[49], (50, 1));
+    }
+
+    #[test]
+    fn edges_never_contain_parallel_pairs() {
+        // The simple-graph guarantee (design synthetic-cover-algorithms-phase6 §3.1): every
+        // emitted `(src, dst)` pair is distinct, so `algo.maxFlow` never sees a multigraph. The
+        // seed=7 1000/5000 spec is the CI oracle fixture (Justfile synthetic-verify/sanity): the
+        // pre-v5 generator emitted 8 duplicate pairs there (empirically measured — 4992 distinct
+        // pairs out of 5000), which made `algo.maxFlow` fail with "relationship type must not
+        // contain multi-edges (tensors)".
+        for s in [spec(7, 1000, 5000), spec(42, 50, 400), spec(0, 100, 2000)] {
+            let pairs: Vec<(i32, i32)> = s.edge_pairs().collect();
+            let distinct: HashSet<(i32, i32)> = pairs.iter().copied().collect();
+            assert_eq!(
+                distinct.len(),
+                pairs.len(),
+                "seed={} nodes={} edges={} emitted parallel edges",
+                s.seed,
+                s.nodes,
+                s.edges
+            );
+            assert_eq!(pairs.len(), s.edges);
+        }
+    }
+
+    #[test]
+    fn edges_can_saturate_the_full_simple_graph_capacity() {
+        // Forcing every pair to be emitted exercises the re-probe sweep (offset walk + source
+        // fallback) and proves it terminates at exactly the simple-graph capacity.
+        let s = spec(1, 3, 6);
+        assert!(s.validate().is_ok());
+        let pairs: HashSet<(i32, i32)> = s.edge_pairs().collect();
+        let all: HashSet<(i32, i32)> =
+            [(1, 2), (1, 3), (2, 1), (2, 3), (3, 1), (3, 2)].into_iter().collect();
+        assert_eq!(pairs, all);
+        // The 2-node graph has exactly two ordered pairs.
+        let two: HashSet<(i32, i32)> = spec(9, 2, 2).edge_pairs().collect();
+        assert_eq!(two, [(1, 2), (2, 1)].into_iter().collect::<HashSet<_>>());
+    }
+
+    #[test]
+    fn validate_rejects_edges_beyond_simple_graph_capacity() {
+        // 3 nodes hold at most 3*2 = 6 distinct ordered pairs.
+        let err = spec(1, 3, 7).validate().expect_err("7 edges must not fit 3 nodes");
+        assert!(
+            format!("{err}").contains("simple-graph capacity"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn different_seed_changes_edges() {
-        let a: Vec<_> = (0..400).map(|e| spec(1, 50, 400).edge_at(e)).collect();
-        let b: Vec<_> = (0..400).map(|e| spec(2, 50, 400).edge_at(e)).collect();
+        let a: Vec<_> = spec(1, 50, 400).edge_pairs().collect();
+        let b: Vec<_> = spec(2, 50, 400).edge_pairs().collect();
         assert_ne!(a, b);
     }
 
@@ -812,6 +919,8 @@ mod tests {
         // A fixed config must always hash to the same value, on any machine/toolchain — this is the
         // cross-process/version stability the comparability gate depends on. If this ever changes,
         // bump GENERATOR_VERSION deliberately (it invalidates prior comparisons).
+        // Repinned for synthbench/v5 (the simple-graph edge generator, design
+        // synthetic-cover-algorithms-phase6 §3.1).
         let s = DatasetSpec {
             seed: 42,
             nodes: 1000,
@@ -823,7 +932,7 @@ mod tests {
         )];
         assert_eq!(
             corpus_hash(&s, 0, 256, &bodies, &s.handle()),
-            "sha256:9be33d3926a50d91f3ec80d5c0a0abb3256e5700945ab3a1fd202950e8f7e450"
+            "sha256:736029cfbe68758fc986e2cbc7ad82435bde059bf05dc29438d2be5ed870be37"
         );
     }
 }

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -774,6 +774,47 @@ mod tests {
     }
 
     #[test]
+    fn oracle_fixture_v5_changes_exactly_the_eight_duplicate_slots() {
+        // Pins the v4→v5 generator delta on the seed=7 1000/5000 CI oracle fixture. The
+        // historical (v4) formula — recomputed inline below, independent of `edge_candidate` —
+        // must agree with the v5 generator on the full (src, dst, bench_capacity) tuple
+        // everywhere EXCEPT the 8 second occurrences of duplicated pairs, which re-probe.
+        // A generated run's corpus_hash does not cover edge content, so this test is the guard
+        // against the re-probe logic silently reshuffling edges.
+        let s = spec(7, 1000, 5000);
+        let v4 = |e: usize| -> (i32, i32) {
+            // The synthbench/v4 edge formula, verbatim (ring backbone, then seeded-random).
+            let n = s.nodes as u64;
+            if (e as u64) < n {
+                let src = e as u64 + 1;
+                (src as i32, ((src % n) + 1) as i32)
+            } else {
+                let src0 = mix(s.seed, DOMAIN_EDGE_SRC, e as u64) % n;
+                let offset = 1 + (mix(s.seed, DOMAIN_EDGE_OFF, e as u64) % (n - 1));
+                ((src0 + 1) as i32, (((src0 + offset) % n) + 1) as i32)
+            }
+        };
+        let tuple = |(src, dst): (i32, i32)| (src, dst, bench_capacity(src as u64, dst as u64));
+        let v5: Vec<(i32, i32)> = s.edge_pairs().collect();
+        let changed: Vec<usize> =
+            (0..s.edges).filter(|&e| tuple(v5[e]) != tuple(v4(e))).collect();
+        assert_eq!(
+            changed,
+            vec![2553, 2635, 3353, 3751, 3953, 4464, 4556, 4979],
+            "the v4→v5 delta must be exactly the 8 known duplicate slots"
+        );
+        // Each changed slot's v4 candidate duplicates an earlier emitted pair (that is WHY it
+        // re-probed), so the delta is explained, not arbitrary.
+        for &e in &changed {
+            let dup = v4(e);
+            assert!(
+                v5[..e].contains(&dup),
+                "slot {e}'s v4 candidate {dup:?} must duplicate an earlier pair"
+            );
+        }
+    }
+
+    #[test]
     fn edges_can_saturate_the_full_simple_graph_capacity() {
         // Forcing every pair to be emitted exercises the re-probe sweep (offset walk + source
         // fallback) and proves it terminates at exactly the simple-graph capacity.

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1340,10 +1340,12 @@ async fn max_flow_runs_on_the_generated_simple_graph() {
     run(&cfg).await.expect("generate + load the oracle dataset");
 
     let mut g = open_graph(&endpoint(), graph).await.expect("open loaded graph");
-    // No parallel edges made it into the store.
+    // No parallel edges made it into the store. The relationship variable MUST be bound
+    // (`[r:Friend]`, `count(r)`): an unnamed `[:Friend]` pattern collapses tensor multi-edges
+    // and returns 0 even on a known multigraph (verified live on falkordb/falkordb:edge).
     let mut dup = g
         .ro_query(
-            "MATCH (a:User)-[:Friend]->(b:User) WITH a, b, count(*) AS c WHERE c > 1 \
+            "MATCH (a:User)-[r:Friend]->(b:User) WITH a, b, count(r) AS c WHERE c > 1 \
              RETURN count(*)",
         )
         .execute()

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1310,3 +1310,82 @@ async fn replay_concurrency_sweep_verifies_results_and_reports_levels() {
     std::fs::remove_dir_all(&dir).ok();
     drop_graph(graph).await;
 }
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn max_flow_runs_on_the_generated_simple_graph() {
+    // Design synthetic-cover-algorithms-phase6 §3.1: the pre-v5 generator emitted 8 parallel
+    // (src,dst) `:Friend` pairs in the seed=7 1000/5000 CI oracle fixture, and FalkorDB's
+    // `algo.maxFlow` rejects multigraphs ("relationship type must not contain multi-edges
+    // (tensors)"). The generator now guarantees a simple graph; prove it live by loading the exact
+    // oracle fixture through the production loader and running the repository's real maxFlow shape.
+    use benchmark::queries_repository::{
+        AlgorithmQuerySelection, Flavour, QueryCoverageProfile, UsersQueriesRepository,
+    };
+    use futures::StreamExt;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    let graph = "syn_it_maxflow_simple";
+    drop_graph(graph).await;
+    let cfg = Config {
+        graph: graph.to_string(),
+        dataset: Some(DatasetSpec { seed: 7, nodes: 1000, edges: 5000 }),
+        ops: vec![OpName::ReturnConst],
+        samples: 1,
+        warmup: 0,
+        cache: CacheSelection::Cached,
+        ..base_config(graph)
+    };
+    run(&cfg).await.expect("generate + load the oracle dataset");
+
+    let mut g = open_graph(&endpoint(), graph).await.expect("open loaded graph");
+    // No parallel edges made it into the store.
+    let mut dup = g
+        .ro_query(
+            "MATCH (a:User)-[:Friend]->(b:User) WITH a, b, count(*) AS c WHERE c > 1 \
+             RETURN count(*)",
+        )
+        .execute()
+        .await
+        .expect("duplicate-pair count query");
+    let dups: i64 = dup
+        .data
+        .next()
+        .await
+        .expect("one count row")
+        .expect("count row decodes")
+        .try_get_at(0)
+        .expect("count is an integer");
+    assert_eq!(dups, 0, "the loaded graph contains {dups} parallel (src,dst) :Friend pairs");
+
+    // The repository's real maxFlow read runs without the tensors error and yields a positive
+    // flow (the ring backbone connects every seeded (source, target) pair; bench_capacity >= 1).
+    let repo = UsersQueriesRepository::new(
+        1000,
+        5000,
+        Flavour::FalkorDB,
+        AlgorithmQuerySelection::default(),
+        QueryCoverageProfile::Baseline,
+    );
+    let mut rng = StdRng::seed_from_u64(7);
+    let prepared = repo
+        .render_read_with_rng("algo_max_flow_single_pair", &mut rng)
+        .expect("render the maxFlow shape");
+    let mut res = g
+        .ro_query(&prepared.cypher)
+        .execute()
+        .await
+        .expect("algo.maxFlow must not hit the multigraph (tensors) error");
+    let flow: f64 = res
+        .data
+        .next()
+        .await
+        .expect("maxFlow yields one row")
+        .expect("maxFlow row decodes")
+        .try_get_at(0)
+        .expect("max_flow is a float");
+    assert!(flow > 0.0, "ring backbone connects every pair, got max_flow = {flow}");
+
+    drop_graph(graph).await;
+}


### PR DESCRIPTION
Phase 6, PR-1 of 5 — the **simple-graph prerequisite** from the approved design
[`docs/design/synthetic-cover-algorithms-phase6.md`](../blob/master/docs/design/synthetic-cover-algorithms-phase6.md) (§3.1, §7.1). Implemented **empirically first**, as the design demands: both §3.1 facts were measured/reproduced before any code changed.

## What / why

The synthetic dataset generator forbade self-loops but **not parallel `(src, dst)` `:Friend` pairs**: `edge_at` drew seeded-random endpoints with no dedup, and the only edge test asserted `a != b`. That is fatal for Phase 6: FalkorDB's `algo.maxFlow` refuses multigraphs, so the algorithm shapes (the whole point of Phase 6) can never run against the generated fixture.

This PR makes **every** generated graph simple — deterministically, keeping the edge count and `bench_capacity` exact — so the upcoming algorithm-shape recording (PR-3) needs no special fixture.

## Empirical verification (design §3.1 asked for this first)

**Fact 1 — the CI oracle fixture is a multigraph.** Enumerating the generator's output for the exact `synthetic-verify`/`synthetic-sanity` spec (`seed=7`, 1000 nodes / 5000 edges):

```text
distinct pairs: 4992
pairs with multiplicity>1: 8
surplus (parallel) edges: 8
worst: [(2, (785, 329)), (2, (687, 300)), (2, (617, 251)), (2, (531, 402)), (2, (502, 881))]
```

**Fact 2 — `algo.maxFlow` errors on it.** Loading that graph into a throwaway `falkordb/falkordb:edge` container and running the repository's real `algo_max_flow_single_pair` Cypher:

```text
algo.maxFlow: relationship type must not contain multi-edges (tensors)
```

The error fires for **any** `(s, t)` pair — the multi-edge check is per relationship type, not per path — so no amount of endpoint re-seeding avoids it; the topology itself must be simple.

## How the guarantee works

- The historical formula (`ring backbone` + seeded-random draws) is kept as each edge's **first candidate**, so every non-colliding draw is **byte-identical** to the old generator — the seed=7 oracle graph changes in exactly its 8 duplicate slots.
- A colliding draw **re-probes deterministically**: walk the remaining offsets for the drawn source, then advance to the next source — a fixed-order sweep of the whole pair space, so the result is a pure function of the spec.
- `validate()` now also caps `edges ≤ nodes × (nodes − 1)` (the simple-graph capacity), which guarantees the sweep terminates. E.g.:

```text
dataset edges (7) exceeds the simple-graph capacity of 3 nodes (6 distinct ordered pairs)
```

- `GENERATOR_VERSION` bumped `synthbench/v4` → **`synthbench/v5`** and the pinned `corpus_hash` golden repinned **deliberately**: a v4 recording and a v5 recording describe different graphs, so `report --diff` correctly refuses to compare them (workload mismatch), rather than comparing silently across the topology change. Existing recorded bundles keep replaying byte-identically — they carry their own `graph.jsonl`.

## Worked example — before/after

```bash
# Load the oracle fixture and run the real maxFlow shape (now an #[ignore]d live smoke test):
FALKORDB_HOST=127.0.0.1 FALKORDB_PORT=16407 \
  cargo test --test synthetic_probe max_flow_runs_on_the_generated_simple_graph -- --ignored
```

| | before (synthbench/v4) | after (synthbench/v5) |
|---|---|---|
| `seed=7 1000/5000` distinct pairs | 4992 of 5000 (8 parallel) | **5000 of 5000** |
| `algo.maxFlow` on the fixture | `relationship type must not contain multi-edges (tensors)` | returns a positive `max_flow` |
| `MATCH (a)-[:Friend]->(b) WITH a,b,count(*) AS c WHERE c>1` | 8 rows | **0 rows** |

The smoke test loads the fixture through the **production loader** (`Config.dataset` → `run()`), asserts zero parallel pairs in the store, renders `algo_max_flow_single_pair` from an all-algorithms `UsersQueriesRepository`, and asserts a positive flow (the ring backbone connects every pair; `bench_capacity ≥ 1`).

## Design (verbatim)

From `docs/design/synthetic-cover-algorithms-phase6.md` on `master`:

> ### 3.1 `algo.maxFlow` needs a **simple** graph; the synthetic generator does not guarantee one
> The generator forbids self-loops but **not parallel edges** — `edges_are_deterministic_and_never_self_loops`
> (`src/synthetic/dataset.rs:680-684`) asserts only `a != b`, and `edge_at` (`:120-135`) can emit
> duplicate `(src,dst)` pairs. On a multigraph FalkorDB's `algo.maxFlow` errors
> (`relationship type must not contain multi-edges (tensors)`), and the exact CI oracle fixture
> (`seed=7`, 1000/5000, `Justfile:322-324`) contains duplicate endpoint pairs. So "no new fixture" is
> **false for maxFlow**. **Fix:** a deterministic **simple-graph guarantee** for the algorithm fixture
> (dedupe `(src,dst)` at generation, keeping the count/`bench_capacity` deterministic) or an
> algorithm-specific simple fixture; add a "no parallel `:Friend` edges" test + a live maxFlow smoke
> test. *(Empirically confirm the dup-pair count and the tensors error first.)*

> ## 7. Phasing (prerequisites first, each its own PR)
> 1. **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
> 2. **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the dynamic
>    path; N/A shapes skip full reference capture.
> 3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
>    `algorithm_read_names()` + drift-guard, `record_algorithm_reads()`, `--repo-algorithms`. Record +
>    replay the 4 shapes end-to-end, opt-in.
> 4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
> 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
> 6. **Docs:** cookbook + readme.

## Implementation notes

- `edge_at` → `edge_candidate` (first candidate, unchanged formula) + `edge_pairs()` (the guaranteed-simple, stateful sequential iterator). `load_statements` batches from `edge_pairs()` via `iter::from_fn`, staying lazy (one batch materialized at a time; the dedup set is `O(edges)` transient, documented).
- The design offered two options — dedupe at generation vs. an algorithm-specific fixture. Chose **dedupe at generation** (the design's first-listed option, and the one §8.1's risk language assumes): one topology for all shapes, no fixture bifurcation, `verify_counts` untouched, and the guarantee holds for every future dataset. The cost — new recordings hash differently from old ones — is exactly what `GENERATOR_VERSION` exists for.
- Design §3.1's status + empirical numbers were folded into the design doc (its own convention: ✅ markers per phase), and the readme's dataset-generation section documents the simple-graph guarantee + the new `edges` upper bound.

## Tests

- `edges_never_contain_parallel_pairs` — the no-parallel-edges guard over three specs **including the seed=7 1000/5000 oracle** (the design's named test).
- `edges_can_saturate_the_full_simple_graph_capacity` — `n=3, e=6` emits exactly all 6 ordered pairs; `n=2, e=2` emits both — exercises the full re-probe sweep (offset walk + source fallback) and proves termination at capacity.
- `validate_rejects_edges_beyond_simple_graph_capacity` + `validate_rejects_bad_knobs` extended (90 ok / 91 err for 10 nodes).
- `edges_are_deterministic_and_never_self_loops` — rewritten over `edge_pairs()` (determinism, ring pinning, self-loop ban).
- `corpus_hash_golden_value_is_pinned` — repinned for `synthbench/v5` with a comment saying why.
- `max_flow_runs_on_the_generated_simple_graph` — the live `#[ignore]`d smoke (runs under `just coverage` / CI's FalkorDB service), described above.

## Validation

- `just ci` green (340 lib tests; clippy `-D warnings`; doctests).
- `just coverage` green against a live FalkorDB — **patch coverage 98.7 %** (77/78; the only uncovered line is the `unreachable!` terminator of the re-probe sweep, unreachable by the capacity proof).
- `just synthetic-sanity` green end-to-end with the new generator (record ×2 with identical `workload_hash`, replay C=1/4, `report --diff`, cross-engine + advisory artifacts).
- `just doc-links` green.
- Live smoke run against `falkordb/falkordb:edge`: pass (and the identical scenario reproduced the tensors error before the fix).

Next up (each its own stacked PR, per the design's §7 phasing): PR-2 recorded-shape budget/corpus plumbing (§3.4), PR-3 the synthetic-only algorithm family + `--repo-algorithms` (§3.3/§3.2), PR-4 per-procedure capability + skipped-op reporting (§3.5), PR-5 digest byte-stability verification (§6).
