### PR TITLE
feat(synthetic): per-op budget + corpus-size plumbing for recorded shapes (Phase 6, §3.4)

### DIFF
--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -102,6 +102,10 @@ implemented: `ShapeSpec` carries `corpus_size` + `budget`, `RecordedOp`/`OpEntry
 serde `RecordedBudget` (omitted from the manifest when fully inherited; **not** folded into the
 `workload_hash` — replay policy, not workload content), and replay overlays each op's budget
 (validated like the global config) and probes only the **first** command of a result-N/A op.
+Because budgets are outside the `workload_hash`, each budgeted op's **resolved effective policy**
+is persisted on its report entry (`OperationReport::policy`) and the diff/regression/baseline
+guards compare it **per-op**, refusing (like a workload mismatch) to compare runs that measured
+the same workload under different per-op conditions.
 
 ### 3.5 One coarse capability is wrong, and N/A does not skip execution
 FalkorDB capabilities are detected **per procedure** (`src/falkor/falkor_driver.rs:520-550`), and

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -97,7 +97,11 @@ consulted**
 (`replay.rs:133-151`). Whole-graph algorithms are ~40–80 ms/call locally, so a 256-command reference
 pass is ~11–20 s **per op** — untenable. **Fix (prerequisite):** wire a per-shape **budget + corpus
 size** into the recorded-shape path (1 command for the parameterless pageRank/Harmonic/MSF; a small
-seeded pair set for maxFlow) and **skip the full reference capture for result-N/A shapes**.
+seeded pair set for maxFlow) and **skip the full reference capture for result-N/A shapes**. ✅
+implemented: `ShapeSpec` carries `corpus_size` + `budget`, `RecordedOp`/`OpEntry` carry an owned
+serde `RecordedBudget` (omitted from the manifest when fully inherited; **not** folded into the
+`workload_hash` — replay policy, not workload content), and replay overlays each op's budget
+(validated like the global config) and probes only the **first** command of a result-N/A op.
 
 ### 3.5 One coarse capability is wrong, and N/A does not skip execution
 FalkorDB capabilities are detected **per procedure** (`src/falkor/falkor_driver.rs:520-550`), and
@@ -147,8 +151,8 @@ digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synth
 
 ## 7. Phasing (prerequisites first, each its own PR)
 1. ✅ **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
-2. **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the dynamic
-   path; N/A shapes skip full reference capture.
+2. ✅ **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the
+   dynamic path; N/A shapes skip full reference capture.
 3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
    `algorithm_read_names()` + drift-guard, `record_algorithm_reads()`, `--repo-algorithms`. Record +
    replay the 4 shapes end-to-end, opt-in.

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -200,6 +200,9 @@ rec/commands: aggregate_count.jsonl aggregate_group.jsonl expand_1_hop.jsonl
 
 A full manifest is in
 [`docs/synthetic/sample-recording-manifest.json`](synthetic/sample-recording-manifest.json).
+Each op entry may also carry a **`budget`** — per-op overrides for
+`samples`/`warmup`/`concurrency`/`cache` and the timeouts that replay applies to that op only
+(omitted when fully inherited, and never part of the `workload_hash`).
 `just synthetic-record <name>` wraps this and writes under `recordings/<name>/` (git-ignored).
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -466,12 +466,23 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   bakes that fixture into the recorded graph **once**, so every replay endpoint gets the identical
   fixture. (That fixture uses FalkorDB-specific DDL/procedures, so these shapes are for the
   FalkorDB-vs-FalkorDB A/B — two FalkorDB versions — not cross-database runs.)
+  Each shape also pins a **per-op corpus size** (every current read shape uses the full 256-command
+  corpus) and an optional **per-op budget** — overrides for `samples`/`warmup`/`concurrency`/`cache`
+  and the timeouts, written into the manifest's `budget` field (omitted when fully inherited, so
+  existing bundles are unchanged). The budget is **replay policy, not workload content**: it is not
+  folded into the `workload_hash`. This is the plumbing that lets whole-graph algorithm shapes
+  (~40–80 ms/call) record a 1-command corpus with a tight budget instead of the default 256×sweep.
   `--repo-reads` is mutually exclusive with `--op`/`--all-reads`/`--tier`.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result
   values). It also **verifies results are identical at the highest concurrency** (an untimed
-  concurrent pass) so a wrong result under concurrency is a hard fail. `--no-load` skips the reload
+  concurrent pass) so a wrong result under concurrency is a hard fail. Ops whose manifest entry
+  carries a **`budget`** are measured under that budget (their own sweep/cache/samples/timeouts —
+  validated like the global config) while every other op uses the run's global knobs; the report's
+  `meta` echoes the global knobs. **Result-N/A** ops skip the full untimed reference capture — only
+  their first command is probed (fail-fast) — since no digest is ever gated on them. `--no-load`
+  skips the reload
   for a load-once / run-many flow (still count-verifying first). `just synthetic-replay <name>
   <endpoint>` wraps this. Pass **`--label <name>`** (e.g. `pr`/`main`) to name the run — the label
   becomes the column header in `report --diff`/`--regression`.

--- a/readme.md
+++ b/readme.md
@@ -480,7 +480,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   concurrent pass) so a wrong result under concurrency is a hard fail. Ops whose manifest entry
   carries a **`budget`** are measured under that budget (their own sweep/cache/samples/timeouts —
   validated like the global config) while every other op uses the run's global knobs; the report's
-  `meta` echoes the global knobs. **Result-N/A** ops skip the full untimed reference capture — only
+  `meta` echoes the global knobs, and each budgeted op's **resolved effective policy** is persisted
+  on its report entry (`policy`), so `report --diff`/`--regression` and the Criterion baseline
+  guard **refuse per-op** to compare runs that measured the same workload under different per-op
+  conditions (budgets are outside the `workload_hash`, so this is what guards them).
+  **Result-N/A** ops skip the full untimed reference capture — only
   their first command is probed (fail-fast) — since no digest is ever gated on them. `--no-load`
   skips the reload
   for a load-once / run-many flow (still count-verifying first). `just synthetic-replay <name>

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -770,6 +770,7 @@ mod tests {
                         compilation_ms_median: None,
                     }],
                     result_digest: digest.map(str::to_string),
+                    policy: None,
                 },
             );
         }

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -80,7 +80,7 @@ fn op_policy_mismatch(
         let c = candidate.get(op);
         if b != c {
             let render = |p: Option<&OpPolicy>| {
-                p.map_or_else(|| "inherits the global knobs".to_string(), OpPolicy::to_string)
+                p.map_or_else(|| "inherits the global knobs".to_string(), |p| p.to_string())
             };
             return Some(format!(
                 "per-op measurement policy differs for '{op}' — baseline: {}; candidate: {}. The \

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -8,7 +8,7 @@
 //! latency comparison would be meaningless. Keeping this logic in the library (rather than the
 //! Criterion bench harness) makes it unit-testable.
 
-use crate::synthetic::report::{Report, ServerInfo};
+use crate::synthetic::report::{OpPolicy, Report, ServerInfo};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -27,6 +27,13 @@ pub struct BaselineKey {
     /// two versions must agree, or a wrong/empty-but-faster result could look like a win.
     #[serde(default)]
     pub result_digests: BTreeMap<String, String>,
+    /// Per-op **effective measurement policy** for ops whose budget overrode the global knobs
+    /// (design §3.4). Budgets are outside the `workload_hash`, so this map is compared op-by-op:
+    /// two runs that measured the same workload under different per-op sampling/cache/sweep/
+    /// timeout conditions must not have their latencies compared. Empty for pre-budget reports
+    /// and for runs where every op inherited the global knobs.
+    #[serde(default)]
+    pub op_policies: BTreeMap<String, OpPolicy>,
 }
 
 impl BaselineKey {
@@ -41,6 +48,11 @@ impl BaselineKey {
                 .iter()
                 .filter_map(|(name, op)| op.result_digest.clone().map(|d| (name.clone(), d)))
                 .collect(),
+            op_policies: report
+                .operations
+                .iter()
+                .filter_map(|(name, op)| op.policy.clone().map(|p| (name.clone(), p)))
+                .collect(),
         }
     }
 }
@@ -52,6 +64,33 @@ pub enum GuardOutcome {
     Proceed { warnings: Vec<String> },
     /// Must **not** compare (workload mismatch or unfingerprintable workload).
     Abort { reason: String },
+}
+
+/// The first per-op **effective-policy** mismatch between two runs, as a human-readable refusal
+/// reason (`None` when every op's policy matches). Compared over the union of budgeted ops: a
+/// policy present on one side only is a mismatch too — that op was measured under different
+/// conditions (e.g. one run's bundle carried a budget the other's didn't).
+fn op_policy_mismatch(
+    baseline: &BTreeMap<String, OpPolicy>,
+    candidate: &BTreeMap<String, OpPolicy>,
+) -> Option<String> {
+    let all: BTreeSet<&String> = baseline.keys().chain(candidate.keys()).collect();
+    for op in all {
+        let b = baseline.get(op);
+        let c = candidate.get(op);
+        if b != c {
+            let render = |p: Option<&OpPolicy>| {
+                p.map_or_else(|| "inherits the global knobs".to_string(), OpPolicy::to_string)
+            };
+            return Some(format!(
+                "per-op measurement policy differs for '{op}' — baseline: {}; candidate: {}. The \
+                 recorded budgets changed between the runs, so their latencies are not comparable",
+                render(b),
+                render(c)
+            ));
+        }
+    }
+    None
 }
 
 /// Guard a `candidate` run against a saved `baseline` before comparing their latencies.
@@ -81,6 +120,14 @@ pub fn guard(
                     .to_string(),
             };
         }
+    }
+
+    // Per-op measurement-policy gate: budgets are deliberately outside the workload_hash (replay
+    // policy, not workload content — design §3.4), so two runs of "the same workload" can still
+    // have measured an op under different sampling/cache/sweep/timeout conditions. Such latencies
+    // are not comparable — refuse, exactly like a workload mismatch.
+    if let Some(reason) = op_policy_mismatch(&baseline.op_policies, &candidate.op_policies) {
+        return GuardOutcome::Abort { reason };
     }
 
     // Result-correctness gate: for every op the baseline recorded a result digest for, the
@@ -228,6 +275,19 @@ pub fn regression_guard(
             };
         }
     }
+    // Per-op effective measurement policy (design §3.4): budgets are outside the workload_hash,
+    // so a matching hash does not prove each op was measured under the same conditions. A per-op
+    // policy mismatch is a *config* mismatch — the whole pair is NotComparable, exactly like the
+    // global sampling/sweep checks above.
+    let policies = |r: &Report| -> BTreeMap<String, OpPolicy> {
+        r.operations
+            .iter()
+            .filter_map(|(name, op)| op.policy.clone().map(|p| (name.clone(), p)))
+            .collect()
+    };
+    if let Some(reason) = op_policy_mismatch(&policies(baseline), &policies(candidate)) {
+        return RegressionGuard::NotComparable { reason };
+    }
 
     // 2. Per-op result divergence — reported, never fatal. Over the *union* of ops: two present
     //    digests that differ, or an asymmetric one-side-only digest, is diverged (we can't verify
@@ -324,6 +384,7 @@ mod tests {
             module_graph_ver: ver,
             server_image: None,
             result_digests: BTreeMap::new(),
+            op_policies: BTreeMap::new(),
         }
     }
 
@@ -339,6 +400,7 @@ mod tests {
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
+            op_policies: BTreeMap::new(),
         }
     }
 
@@ -353,6 +415,69 @@ mod tests {
             }
             other => panic!("expected Abort, got {other:?}"),
         }
+    }
+
+    fn policy(samples: usize) -> OpPolicy {
+        OpPolicy {
+            samples,
+            warmup: 0,
+            concurrency: vec![1],
+            cache: crate::synthetic::CacheSelection::Cached,
+            server_timeout_ms: 5000,
+            client_deadline_ms: 6000,
+        }
+    }
+
+    fn key_with_policies(policies: &[(&str, OpPolicy)]) -> BaselineKey {
+        BaselineKey {
+            workload_hash: Some("sha256:abc".to_string()),
+            module_graph_ver: Some(42001),
+            server_image: None,
+            result_digests: BTreeMap::new(),
+            op_policies: policies
+                .iter()
+                .map(|(k, p)| (k.to_string(), p.clone()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn aborts_on_op_policy_mismatch() {
+        // Same workload, but the op's recorded budget (samples here) changed between the runs.
+        let base = key_with_policies(&[("algo_max_flow", policy(1))]);
+        let cand = key_with_policies(&[("algo_max_flow", policy(3))]);
+        match guard(&base, &cand) {
+            GuardOutcome::Abort { reason } => {
+                assert!(
+                    reason.contains("measurement policy differs for 'algo_max_flow'"),
+                    "got: {reason}"
+                );
+                assert!(reason.contains("samples=1"), "got: {reason}");
+                assert!(reason.contains("samples=3"), "got: {reason}");
+            }
+            other => panic!("expected Abort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn aborts_when_op_policy_is_one_sided() {
+        // One run's bundle carried a budget the other's didn't: also not comparable.
+        let base = key_with_policies(&[("algo_max_flow", policy(1))]);
+        let cand = key_with_policies(&[]);
+        match guard(&base, &cand) {
+            GuardOutcome::Abort { reason } => {
+                assert!(reason.contains("'algo_max_flow'"), "got: {reason}");
+                assert!(reason.contains("inherits the global knobs"), "got: {reason}");
+            }
+            other => panic!("expected Abort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn proceeds_when_op_policies_match() {
+        let base = key_with_policies(&[("algo_max_flow", policy(1))]);
+        let cand = key_with_policies(&[("algo_max_flow", policy(1))]);
+        assert!(matches!(guard(&base, &cand), GuardOutcome::Proceed { .. }));
     }
 
     #[test]
@@ -471,12 +596,14 @@ mod tests {
             module_graph_ver: Some(42001),
             server_image: Some("falkordb@sha256:aaa".to_string()),
             result_digests: BTreeMap::new(),
+            op_policies: BTreeMap::new(),
         };
         let cand = BaselineKey {
             workload_hash: Some("sha256:abc".to_string()),
             module_graph_ver: Some(42002),
             server_image: Some("falkordb@sha256:bbb".to_string()),
             result_digests: BTreeMap::new(),
+            op_policies: BTreeMap::new(),
         };
         match guard(&base, &cand) {
             GuardOutcome::Proceed { warnings } => {
@@ -511,6 +638,7 @@ mod regression_guard_tests {
                 OperationReport {
                     levels: vec![],
                     result_digest: dig.map(|s| s.to_string()),
+                    policy: None,
                 },
             );
         }
@@ -683,5 +811,59 @@ mod regression_guard_tests {
             }
             other => panic!("expected Comparable, got {other:?}"),
         }
+    }
+
+    fn policy(samples: usize) -> OpPolicy {
+        OpPolicy {
+            samples,
+            warmup: 0,
+            concurrency: vec![1],
+            cache: crate::synthetic::CacheSelection::Cached,
+            server_timeout_ms: 5000,
+            client_deadline_ms: 6000,
+        }
+    }
+
+    #[test]
+    fn per_op_policy_mismatch_is_not_comparable() {
+        // Same workload_hash and global knobs, but one op was measured under a different
+        // recorded budget — the pair must be refused like any other config mismatch.
+        let mut a = rep("h", 100, 50, vec![1], None, None, &[("algo_max_flow", None)]);
+        let mut b = rep("h", 100, 50, vec![1], None, None, &[("algo_max_flow", None)]);
+        a.operations.get_mut("algo_max_flow").unwrap().policy = Some(policy(1));
+        b.operations.get_mut("algo_max_flow").unwrap().policy = Some(policy(3));
+        match regression_guard(&a, &b) {
+            RegressionGuard::NotComparable { reason } => {
+                assert!(
+                    reason.contains("measurement policy differs for 'algo_max_flow'"),
+                    "got: {reason}"
+                );
+            }
+            other => panic!("expected NotComparable, got {other:?}"),
+        }
+        // One-sided policy (e.g. an old-tool report vs a budget-carrying rerun): also refused —
+        // the policy-less run really did measure that op under the global knobs.
+        b.operations.get_mut("algo_max_flow").unwrap().policy = None;
+        assert!(matches!(regression_guard(&a, &b), RegressionGuard::NotComparable { .. }));
+    }
+
+    #[test]
+    fn matching_per_op_policies_are_comparable() {
+        let mut a = rep("h", 100, 50, vec![1], None, None, &[("algo_max_flow", None)]);
+        let mut b = rep("h", 100, 50, vec![1], None, None, &[("algo_max_flow", None)]);
+        a.operations.get_mut("algo_max_flow").unwrap().policy = Some(policy(1));
+        b.operations.get_mut("algo_max_flow").unwrap().policy = Some(policy(1));
+        assert!(matches!(regression_guard(&a, &b), RegressionGuard::Comparable { .. }));
+    }
+
+    #[test]
+    fn baseline_key_collects_per_op_policies_from_a_report() {
+        let mut r =
+            rep("h", 100, 50, vec![1], None, None, &[("algo_max_flow", None), ("scan", None)]);
+        r.operations.get_mut("algo_max_flow").unwrap().policy = Some(policy(1));
+        let key = BaselineKey::from_report(&r);
+        // Only the budgeted op lands in the key; inherit-everything ops stay absent.
+        assert_eq!(key.op_policies.len(), 1);
+        assert_eq!(key.op_policies.get("algo_max_flow"), Some(&policy(1)));
     }
 }

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -84,7 +84,8 @@ fn op_policy_mismatch(
             };
             return Some(format!(
                 "per-op measurement policy differs for '{op}' — baseline: {}; candidate: {}. The \
-                 recorded budgets changed between the runs, so their latencies are not comparable",
+                 op's effective measurement conditions (its recorded budget and/or the global \
+                 knobs it inherits) changed between the runs, so their latencies are not comparable",
                 render(b),
                 render(c)
             ));
@@ -261,6 +262,23 @@ pub fn regression_guard(
     if bc != cc {
         return RegressionGuard::NotComparable {
             reason: format!("concurrency sweep differs — baseline {bc:?} vs candidate {cc:?}"),
+        };
+    }
+    // Global timeouts are measurement config like samples/sweep: every op that inherits them (no
+    // per-op policy below) was measured under these values, so a known difference disqualifies the
+    // pair the same way. (Cache selection needs no guard here — cells are compared per cache mode,
+    // so a mode measured on one side only is simply absent, never mis-paired.)
+    if baseline.meta.server_timeout_ms != candidate.meta.server_timeout_ms
+        || baseline.meta.client_deadline_ms != candidate.meta.client_deadline_ms
+    {
+        return RegressionGuard::NotComparable {
+            reason: format!(
+                "timeouts differ — baseline {}/{} vs candidate {}/{} (server_timeout_ms/client_deadline_ms)",
+                baseline.meta.server_timeout_ms,
+                baseline.meta.client_deadline_ms,
+                candidate.meta.server_timeout_ms,
+                candidate.meta.client_deadline_ms
+            ),
         };
     }
     // Server settings that affect sustained throughput (recorded when readable). Only a *known*
@@ -811,6 +829,24 @@ mod regression_guard_tests {
             }
             other => panic!("expected Comparable, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn differing_global_timeouts_are_not_comparable() {
+        // Global timeouts are inherited by every op without a per-op policy, so a known
+        // difference is a config mismatch exactly like samples/sweep.
+        let a = rep("h", 100, 50, vec![1], None, None, &[]);
+        let mut b = rep("h", 100, 50, vec![1], None, None, &[]);
+        b.meta.server_timeout_ms = 30_000;
+        match regression_guard(&a, &b) {
+            RegressionGuard::NotComparable { reason } => {
+                assert!(reason.contains("timeouts differ"), "got: {reason}");
+            }
+            other => panic!("expected NotComparable, got {other:?}"),
+        }
+        let mut c = rep("h", 100, 50, vec![1], None, None, &[]);
+        c.meta.client_deadline_ms = 60_000;
+        assert!(matches!(regression_guard(&a, &c), RegressionGuard::NotComparable { .. }));
     }
 
     fn policy(samples: usize) -> OpPolicy {

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -15,6 +15,7 @@ use crate::query::{Query, QueryBuilder};
 use crate::synthetic::writes::{ExpectedMutation, WritePlan, WriteScratch};
 use crate::synthetic::{CacheSelection, OpName, Tier};
 use rand::{Rng, RngExt};
+use serde::{Deserialize, Serialize};
 
 /// Number of distinct parameterizations pre-generated per operation. The measured loop cycles
 /// through this corpus, so varying parameter *values* exercise real binding while the query
@@ -122,6 +123,56 @@ impl OpBudget {
         server_timeout_ms: None,
         client_deadline_ms: None,
     };
+}
+
+/// The owned, serializable twin of [`OpBudget`], carried per op in a recorded bundle's manifest
+/// (`OpEntry::budget`) so `synthetic run --recording` applies the same per-op overrides a generated
+/// run applies from the catalog (design §3.4). `Default` is full inheritance — exactly
+/// [`OpBudget::INHERIT`] — and an inherit budget is omitted from the manifest entirely, so every
+/// existing bundle deserializes unchanged. Like `kind`/`result_gated`, the budget is **replay
+/// policy, not workload content**: it is *not* folded into the bundle's `workload_hash`.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecordedBudget {
+    /// Override the measured sample count for this op.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub samples: Option<usize>,
+    /// Override the warm-up (discarded) sample count for this op.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub warmup: Option<usize>,
+    /// Replace the concurrency sweep for this op (closed-loop worker counts).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<Vec<usize>>,
+    /// Override which plan-cache condition(s) to measure this op under.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache: Option<CacheSelection>,
+    /// Override the per-query server timeout (ms) for this op.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_timeout_ms: Option<i64>,
+    /// Override the per-query client deadline (ms) for this op.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_deadline_ms: Option<u64>,
+}
+
+impl RecordedBudget {
+    /// `true` when no knob is overridden (the [`Default`]), i.e. the op inherits every global knob.
+    /// Serde uses this to omit inherit budgets from the manifest.
+    pub fn is_inherit(&self) -> bool {
+        *self == RecordedBudget::default()
+    }
+}
+
+impl From<OpBudget> for RecordedBudget {
+    fn from(b: OpBudget) -> Self {
+        RecordedBudget {
+            samples: b.samples,
+            warmup: b.warmup,
+            concurrency: b.concurrency.map(<[usize]>::to_vec),
+            cache: b.cache,
+            server_timeout_ms: b.server_timeout_ms,
+            client_deadline_ms: b.client_deadline_ms,
+        }
+    }
 }
 
 /// One catalog entry: an operation's identity, its read/write kind, a one-line description, the
@@ -1008,5 +1059,60 @@ mod tests {
         // merge_hit is drift-free, so its reset issues no statements.
         let scratch = WriteScratch::new(0xE, 0, 10).unwrap();
         assert!(write_noop(&scratch).unwrap().is_empty());
+    }
+
+    #[test]
+    fn recorded_budget_mirrors_op_budget_field_for_field() {
+        // `From<OpBudget>` must carry every knob into the owned manifest form — a dropped field
+        // here would silently strip that override from every recorded bundle.
+        static SWEEP: [usize; 2] = [1, 4];
+        let full = OpBudget {
+            samples: Some(3),
+            warmup: Some(1),
+            concurrency: Some(&SWEEP),
+            cache: Some(CacheSelection::Cached),
+            server_timeout_ms: Some(30_000),
+            client_deadline_ms: Some(31_000),
+        };
+        let recorded = RecordedBudget::from(full);
+        assert_eq!(
+            recorded,
+            RecordedBudget {
+                samples: Some(3),
+                warmup: Some(1),
+                concurrency: Some(vec![1, 4]),
+                cache: Some(CacheSelection::Cached),
+                server_timeout_ms: Some(30_000),
+                client_deadline_ms: Some(31_000),
+            }
+        );
+        assert!(!recorded.is_inherit());
+        // INHERIT maps to the default (all-None) form — the one serde omits from the manifest.
+        let inherit = RecordedBudget::from(OpBudget::INHERIT);
+        assert_eq!(inherit, RecordedBudget::default());
+        assert!(inherit.is_inherit());
+    }
+
+    #[test]
+    fn recorded_budget_serde_round_trips_and_omits_inherited_knobs() {
+        // Partial budget: only overridden knobs appear in the JSON (each `None` is skipped)…
+        let budget = RecordedBudget {
+            samples: Some(5),
+            concurrency: Some(vec![1]),
+            cache: Some(CacheSelection::Uncached),
+            ..RecordedBudget::default()
+        };
+        let json = serde_json::to_string(&budget).unwrap();
+        assert_eq!(json, r#"{"samples":5,"concurrency":[1],"cache":"uncached"}"#);
+        let back: RecordedBudget = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, budget);
+        // …an inherit budget serializes to an empty object and deserializes from one…
+        assert_eq!(serde_json::to_string(&RecordedBudget::default()).unwrap(), "{}");
+        let empty: RecordedBudget = serde_json::from_str("{}").unwrap();
+        assert!(empty.is_inherit());
+        // …and an unknown knob is rejected (deny_unknown_fields), so a manifest typo can't
+        // silently become "inherit".
+        let err = serde_json::from_str::<RecordedBudget>(r#"{"sample":5}"#).unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "{err}");
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -762,6 +762,7 @@ mod tests {
                     compilation_ms_median: None,
                 }],
                 result_digest: Some("sha256:aa".to_string()),
+                policy: None,
             },
         );
         Report {
@@ -1090,7 +1091,11 @@ mod tests {
                 .collect();
             operations.insert(
                 op.to_string(),
-                OperationReport { levels, result_digest: Some("sha256:aa".to_string()) },
+                OperationReport {
+                    levels,
+                    result_digest: Some("sha256:aa".to_string()),
+                    policy: None,
+                },
             );
         }
         let mut r = report(ver, 1.0, 1000.0);
@@ -1173,6 +1178,7 @@ mod tests {
                         compilation_ms_median: None,
                     }],
                     result_digest: Some((*digest).to_string()),
+                    policy: None,
                 },
             );
         }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -784,6 +784,17 @@ pub(crate) fn validate_op_config(op: &str, cfg: &Config) -> BenchmarkResult<()> 
             "operation '{op}' resolved to a per-op budget with samples = 0; samples must be greater than 0"
         )));
     }
+    if cfg.server_timeout_ms <= 0 {
+        return Err(OtherError(format!(
+            "operation '{op}' resolved to a per-op budget with server_timeout_ms = {}; the timeout must be positive",
+            cfg.server_timeout_ms
+        )));
+    }
+    if cfg.client_deadline_ms == 0 {
+        return Err(OtherError(format!(
+            "operation '{op}' resolved to a per-op budget with client_deadline_ms = 0; the deadline must be positive"
+        )));
+    }
     if let Err(e) = normalize_concurrency(&cfg.concurrency) {
         // Unwrap the inner message so the op-prefixed error isn't double-wrapped with "Other error:".
         let detail = match e {
@@ -2163,6 +2174,25 @@ mod tests {
             .to_string();
         assert!(msg.contains("match_by_index"), "{msg}");
         assert!(msg.contains(">= 1"), "{msg}");
+        // A non-positive server timeout — e.g. a manifest typo of -1 — fails fast, op-named.
+        let bad_timeout = base.with_budget(&OpBudget {
+            server_timeout_ms: Some(-1),
+            ..OpBudget::INHERIT
+        });
+        let msg = validate_op_config(OpName::ReturnConst.as_str(), &bad_timeout)
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("server_timeout_ms = -1"), "{msg}");
+        assert!(msg.contains("return_const"), "{msg}");
+        // A zero client deadline — the driver would otherwise time out every call confusingly.
+        let bad_deadline = base.with_budget(&OpBudget {
+            client_deadline_ms: Some(0),
+            ..OpBudget::INHERIT
+        });
+        let msg = validate_op_config(OpName::ReturnConst.as_str(), &bad_deadline)
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("client_deadline_ms = 0"), "{msg}");
         // A fully valid (inherited) config passes.
         validate_op_config(OpName::ReturnConst.as_str(), &base).unwrap();
     }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -45,7 +45,7 @@ use crate::synthetic::dataset::DatasetSpec;
 use crate::synthetic::engine::{run_closed_loop, OpInvoker};
 use crate::synthetic::op_runner::{run_and_drain, OpSample};
 use crate::synthetic::report::{
-    DatasetInfo, LevelMetrics, LevelReport, Meta, OperationReport, Report,
+    DatasetInfo, LevelMetrics, LevelReport, Meta, OperationReport, OpPolicy, Report,
 };
 use crate::synthetic::thresholds::BudgetProfile;
 use crate::synthetic::writes::{verify_mutation, WritePlan, WriteScratch};
@@ -505,6 +505,23 @@ impl Config {
         }
         cfg
     }
+
+    /// The fully resolved per-op measurement policy this config describes, with `sweep` as the
+    /// op's normalized concurrency levels — persisted on [`OperationReport::policy`] for ops whose
+    /// budget overrode any global knob, so the diff/regression/baseline guards can compare it.
+    pub(crate) fn resolved_policy(
+        &self,
+        sweep: &[usize],
+    ) -> OpPolicy {
+        OpPolicy {
+            samples: self.samples,
+            warmup: self.warmup,
+            concurrency: sweep.to_vec(),
+            cache: self.cache,
+            server_timeout_ms: self.server_timeout_ms,
+            client_deadline_ms: self.client_deadline_ms,
+        }
+    }
 }
 
 /// Print the available operations (for `synthetic list-ops`).
@@ -702,7 +719,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         // render per-invocation, so this is unused for them). This is the same string a recorded
         // bundle stores, so a generated run and a `--recording` run measure identically.
         let rendered: Arc<Vec<String>> = Arc::new(corpus.iter().map(|q| q.to_cypher()).collect());
-        let op_report = measure_op(
+        let mut op_report = measure_op(
             &op_config,
             &op_concurrency,
             MeasureTarget::from_spec(&op_spec),
@@ -712,6 +729,10 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             op_client_deadline,
         )
         .await?;
+        // Persist the op's effective measurement policy when its catalog budget overrode any
+        // global knob (all-INHERIT today), so a cross-run comparison can guard it per-op.
+        op_report.policy =
+            (op_spec.budget != OpBudget::INHERIT).then(|| op_config.resolved_policy(&op_concurrency));
         operations.insert(op.as_str().to_string(), op_report);
     }
 
@@ -1093,6 +1114,7 @@ pub(crate) async fn measure_op(
     Ok(OperationReport {
         levels,
         result_digest: None,
+        policy: None,
     })
 }
 
@@ -2454,6 +2476,45 @@ mod tests {
             let entry = bundle.manifest.ops.iter().find(|o| o.name == name).unwrap();
             assert!(!entry.result_gated, "{name} must be result-N/A (top-k)");
         }
+        std::fs::remove_dir_all(&out_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn repo_reads_full_workload_hash_golden_is_pinned() {
+        // GOLDEN: `synthetic record --graph verify --repo-reads full --seed 7 --nodes 1000
+        // --edges 5000` must keep producing this exact workload_hash. The hash is a length-framed
+        // SHA-256 over the recording header, every graph load statement (fixture included) and
+        // every rendered command — so this single value pins the complete `--repo-reads full`
+        // command stream byte-for-byte, proving the "recorded bundles are byte-identical across
+        // code changes" claim (design §3.4) rather than spot-checking defaults. If this test
+        // fails, a code change altered the recorded workload: bump the recording
+        // `GENERATOR_VERSION`, regenerate any saved bundles, and update this golden deliberately.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let out_dir = std::env::temp_dir().join(format!(
+            "syn-rec-golden-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let command = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: Some("verify".to_string()),
+            ops: vec![],
+            all_reads: false,
+            tier: None,
+            repo_reads: Some(Tier::Full),
+            seed: Some(7),
+            nodes: Some(1000),
+            edges: Some(5000),
+            out_dir: out_dir.to_string_lossy().into_owned(),
+        };
+        run_command(command).await.expect("offline full repo-reads record succeeds");
+        let bundle = recording::load(&out_dir).expect("golden bundle loads");
+        assert_eq!(
+            bundle.manifest.workload_hash,
+            "sha256:830faf23b57ed61be8e1728a2ec73f09cf3d6fe2d24f0d70b6f8c11ed00c8de4",
+            "the --repo-reads full command stream changed byte-wise"
+        );
         std::fs::remove_dir_all(&out_dir).ok();
     }
 

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -39,7 +39,7 @@ use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
 use crate::query::Query;
 use crate::synthetic::catalog::{
-    spec, DatasetHandle, DatasetRequirement, OpBudget, OperationSpec, CORPUS_SIZE,
+    spec, DatasetHandle, DatasetRequirement, OpBudget, OperationSpec, RecordedBudget, CORPUS_SIZE,
 };
 use crate::synthetic::dataset::DatasetSpec;
 use crate::synthetic::engine::{run_closed_loop, OpInvoker};
@@ -55,7 +55,7 @@ use futures::StreamExt;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde::de::{self, Deserializer};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -363,7 +363,7 @@ impl Tier {
 }
 
 /// Which plan-cache condition to measure an operation under.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
 #[value(rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum CacheSelection {
@@ -477,6 +477,13 @@ impl Config {
     /// record-once / replay-verbatim A/B comparability for every current op. Used per op by [`run`]
     /// to derive that op's effective knobs before measuring it.
     pub fn with_budget(&self, budget: &OpBudget) -> Config {
+        self.with_recorded_budget(&RecordedBudget::from(*budget))
+    }
+
+    /// [`Self::with_budget`] for the owned manifest form ([`RecordedBudget`], design §3.4): the
+    /// single overlay implementation, shared by the catalog path (via [`Self::with_budget`]) and
+    /// the recorded-bundle replay path, so the two can't drift.
+    pub fn with_recorded_budget(&self, budget: &RecordedBudget) -> Config {
         let mut cfg = self.clone();
         if let Some(samples) = budget.samples {
             cfg.samples = samples;
@@ -484,8 +491,8 @@ impl Config {
         if let Some(warmup) = budget.warmup {
             cfg.warmup = warmup;
         }
-        if let Some(concurrency) = budget.concurrency {
-            cfg.concurrency = concurrency.to_vec();
+        if let Some(concurrency) = &budget.concurrency {
+            cfg.concurrency = concurrency.clone();
         }
         if let Some(cache) = budget.cache {
             cfg.cache = cache;
@@ -678,7 +685,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         // is unchanged. The corpus is still seeded from the global `config.seed` (never budgeted),
         // so the recorded query strings stay identical regardless of any budget.
         let op_config = config.with_budget(&op_spec.budget);
-        validate_op_config(op, &op_config)?;
+        validate_op_config(op.as_str(), &op_config)?;
         let op_concurrency = normalize_concurrency(&op_config.concurrency)?;
         let op_client_deadline = Duration::from_millis(op_config.client_deadline_ms);
         // Seed each op's corpus deterministically (same --seed ⇒ byte-identical corpus).
@@ -767,14 +774,14 @@ pub(crate) fn normalize_concurrency(concurrency: &[usize]) -> BenchmarkResult<Ve
 }
 
 /// Validate a per-op resolved [`Config`]: the global `run()` guard only checks the global knobs, so
-/// a per-op [`OpBudget`] that zeroed `samples` or set an invalid concurrency sweep would slip past
-/// it and fail later with a less actionable error. Reject it up front, naming the op. Concurrency
-/// reuses [`normalize_concurrency`]'s rules (kept the single source of truth) with the op prefixed.
-pub(crate) fn validate_op_config(op: OpName, cfg: &Config) -> BenchmarkResult<()> {
+/// a per-op budget — a catalog [`OpBudget`] or a recorded bundle's [`RecordedBudget`] — that zeroed
+/// `samples` or set an invalid concurrency sweep would slip past it and fail later with a less
+/// actionable error. Reject it up front, naming the op. Concurrency reuses
+/// [`normalize_concurrency`]'s rules (kept the single source of truth) with the op prefixed.
+pub(crate) fn validate_op_config(op: &str, cfg: &Config) -> BenchmarkResult<()> {
     if cfg.samples == 0 {
         return Err(OtherError(format!(
-            "operation '{}' resolved to a per-op budget with samples = 0; samples must be greater than 0",
-            op.as_str()
+            "operation '{op}' resolved to a per-op budget with samples = 0; samples must be greater than 0"
         )));
     }
     if let Err(e) = normalize_concurrency(&cfg.concurrency) {
@@ -783,7 +790,7 @@ pub(crate) fn validate_op_config(op: OpName, cfg: &Config) -> BenchmarkResult<()
             OtherError(m) => m,
             other => other.to_string(),
         };
-        return Err(OtherError(format!("operation '{}': {detail}", op.as_str())));
+        return Err(OtherError(format!("operation '{op}': {detail}")));
     }
     Ok(())
 }
@@ -2081,6 +2088,43 @@ mod tests {
     }
 
     #[test]
+    fn with_recorded_budget_matches_the_catalog_overlay() {
+        // `with_budget` delegates to `with_recorded_budget` (one overlay implementation), so a
+        // recorded bundle's owned budget must resolve exactly like the catalog's static form —
+        // replay and generated runs can't drift apart.
+        let base = Config {
+            samples: 100,
+            warmup: 20,
+            concurrency: vec![1, 8],
+            ..Config::default()
+        };
+        static SWEEP: [usize; 1] = [2];
+        let catalog_form = OpBudget {
+            samples: Some(1),
+            concurrency: Some(&SWEEP),
+            cache: Some(CacheSelection::Cached),
+            ..OpBudget::INHERIT
+        };
+        let via_catalog = base.with_budget(&catalog_form);
+        let via_recorded = base.with_recorded_budget(&RecordedBudget::from(catalog_form));
+        assert_eq!(via_catalog.samples, via_recorded.samples);
+        assert_eq!(via_catalog.warmup, via_recorded.warmup);
+        assert_eq!(via_catalog.concurrency, via_recorded.concurrency);
+        assert_eq!(via_catalog.cache, via_recorded.cache);
+        assert_eq!(via_catalog.server_timeout_ms, via_recorded.server_timeout_ms);
+        assert_eq!(via_catalog.client_deadline_ms, via_recorded.client_deadline_ms);
+        assert_eq!(via_recorded.samples, 1);
+        assert_eq!(via_recorded.concurrency, vec![2]);
+        assert_eq!(via_recorded.cache, CacheSelection::Cached);
+        // An inherit (default) recorded budget — every pre-field bundle — changes nothing.
+        let inherited = base.with_recorded_budget(&RecordedBudget::default());
+        assert_eq!(inherited.samples, base.samples);
+        assert_eq!(inherited.warmup, base.warmup);
+        assert_eq!(inherited.concurrency, base.concurrency);
+        assert_eq!(inherited.cache, base.cache);
+    }
+
+    #[test]
     fn validate_op_config_rejects_invalid_per_op_budgets() {
         // The global `run()` guard only checks the global knobs; a per-op budget that zeroed
         // samples or produced an invalid concurrency sweep must fail fast, naming the offending op.
@@ -2094,7 +2138,7 @@ mod tests {
             samples: Some(0),
             ..OpBudget::INHERIT
         });
-        let msg = validate_op_config(OpName::ReturnConst, &zeroed)
+        let msg = validate_op_config(OpName::ReturnConst.as_str(), &zeroed)
             .unwrap_err()
             .to_string();
         assert!(msg.contains("samples must be greater than 0"), "{msg}");
@@ -2104,7 +2148,7 @@ mod tests {
             concurrency: vec![],
             ..base.clone()
         };
-        let msg = validate_op_config(OpName::MatchByIndex, &empty)
+        let msg = validate_op_config(OpName::MatchByIndex.as_str(), &empty)
             .unwrap_err()
             .to_string();
         assert!(msg.contains("match_by_index"), "{msg}");
@@ -2114,13 +2158,13 @@ mod tests {
             concurrency: vec![0],
             ..base.clone()
         };
-        let msg = validate_op_config(OpName::MatchByIndex, &zero_level)
+        let msg = validate_op_config(OpName::MatchByIndex.as_str(), &zero_level)
             .unwrap_err()
             .to_string();
         assert!(msg.contains("match_by_index"), "{msg}");
         assert!(msg.contains(">= 1"), "{msg}");
         // A fully valid (inherited) config passes.
-        validate_op_config(OpName::ReturnConst, &base).unwrap();
+        validate_op_config(OpName::ReturnConst.as_str(), &base).unwrap();
     }
 
     #[test]

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -25,7 +25,7 @@
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
-use crate::synthetic::catalog::spec;
+use crate::synthetic::catalog::{spec, RecordedBudget};
 use crate::synthetic::dataset::{
     fixture_statements, load_statements, DatasetSpec, LoadPhase, GENERATOR_VERSION,
 };
@@ -77,6 +77,15 @@ pub struct OpEntry {
     /// and defaults to `true` for bundles written before this field existed.
     #[serde(default = "default_result_gated")]
     pub result_gated: bool,
+    /// Per-op runtime budget replay overlays on its global config ([`RecordedBudget`], design
+    /// §3.4), so a heavy recorded shape (e.g. a whole-graph algorithm) can dial its own
+    /// samples/warmup/concurrency/cache/timeouts down without perturbing the rest of the bundle.
+    /// Defaults to full inheritance — the value for every op recorded before this field existed —
+    /// and an inherit budget is omitted when serializing. Like [`Self::kind`]/[`Self::result_gated`]
+    /// it is **not** folded into the [`Manifest::workload_hash`] (replay policy, not workload
+    /// content).
+    #[serde(default, skip_serializing_if = "RecordedBudget::is_inherit")]
+    pub budget: RecordedBudget,
     pub count: usize,
 }
 
@@ -244,6 +253,8 @@ pub struct RecordedOp {
     /// Whether replay gates this op's result digest — see [`OpEntry::result_gated`]. `true` for
     /// every built-in catalog op and byte-stable shape; `false` marks a result-N/A shape.
     pub result_gated: bool,
+    /// Per-op replay budget — see [`OpEntry::budget`]. Inherit (the default) for every current op.
+    pub budget: RecordedBudget,
     pub commands: Vec<String>,
 }
 
@@ -296,6 +307,9 @@ pub fn record(
             key: OpKey::from(op),
             // Every built-in catalog op projects byte-stable scalars, so its result is gated.
             result_gated: true,
+            // Propagate the catalog's per-op budget (inherit for every current op) so replay
+            // applies the same overrides a generated run applies from the spec.
+            budget: spec(op).budget.into(),
             commands: render_commands(op, dataset, corpus_seed)?,
         });
     }
@@ -442,6 +456,7 @@ fn record_rendered_impl(
             name: name.to_string(),
             kind: op.key.kind(),
             result_gated: op.result_gated,
+            budget: op.budget.clone(),
             count: cyphers.len(),
         });
     }
@@ -781,6 +796,7 @@ mod tests {
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("single_vertex_read", QueryType::Read),
             result_gated: true,
+            budget: RecordedBudget::default(),
             commands: vec![
                 "CYPHER id=1 MATCH (n:User {id:$id}) RETURN n".to_string(),
                 "CYPHER id=2 MATCH (n:User {id:$id}) RETURN n".to_string(),
@@ -817,6 +833,7 @@ mod tests {
             // Mirrors a fixture-dependent shape: a non-gated (result-N/A) read.
             key: OpKey::dynamic("vector_query_nodes_smoke", QueryType::Read),
             result_gated: false,
+            budget: RecordedBudget::default(),
             commands: vec![
                 "CALL db.idx.vector.queryNodes('User', 'embedding', 10, vecf32([0.1, 0.2, 0.3])) \
                  YIELD node, score RETURN id(node), score LIMIT 10"
@@ -869,6 +886,7 @@ mod tests {
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("bulk_insert", QueryType::Write),
             result_gated: true,
+            budget: RecordedBudget::default(),
             commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -887,6 +905,7 @@ mod tests {
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("empty_shape", QueryType::Read),
             result_gated: true,
+            budget: RecordedBudget::default(),
             commands: vec![],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -906,11 +925,13 @@ mod tests {
             RecordedOp {
                 key: OpKey::dynamic("a_read", QueryType::Read),
                 result_gated: true,
+                budget: RecordedBudget::default(),
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("a_read", QueryType::Read),
                 result_gated: true,
+                budget: RecordedBudget::default(),
                 commands: vec!["CYPHER  RETURN 2".to_string()],
             },
         ];
@@ -942,6 +963,7 @@ mod tests {
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("../escape", QueryType::Read),
             result_gated: true,
+            budget: RecordedBudget::default(),
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -963,11 +985,13 @@ mod tests {
             RecordedOp {
                 key: OpKey::dynamic("dup", QueryType::Read),
                 result_gated: true,
+                budget: RecordedBudget::default(),
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("dup", QueryType::Write),
                 result_gated: true,
+                budget: RecordedBudget::default(),
                 commands: vec!["CYPHER  CREATE (n)".to_string()],
             },
         ];
@@ -989,6 +1013,7 @@ mod tests {
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("safe_read", QueryType::Read),
             result_gated: true,
+            budget: RecordedBudget::default(),
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -1015,6 +1040,7 @@ mod tests {
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("safe_read", QueryType::Read),
             result_gated: true,
+            budget: RecordedBudget::default(),
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -1043,11 +1069,13 @@ mod tests {
             RecordedOp {
                 key: OpKey::dynamic("gated_read", QueryType::Read),
                 result_gated: true,
+                budget: RecordedBudget::default(),
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("na_read", QueryType::Read),
                 result_gated: false,
+                budget: RecordedBudget::default(),
                 commands: vec!["CYPHER  MATCH (n) RETURN n LIMIT 1".to_string()],
             },
         ];
@@ -1075,6 +1103,7 @@ mod tests {
             let ops = vec![RecordedOp {
                 key: OpKey::dynamic("shape", QueryType::Read),
                 result_gated: gated,
+                budget: RecordedBudget::default(),
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             }];
             let m = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -1092,6 +1121,81 @@ mod tests {
             serde_json::from_str(r#"{"name":"legacy_op","count":3}"#).unwrap();
         assert_eq!(entry.kind, QueryType::Read);
         assert!(entry.result_gated, "a pre-field op defaults to gated");
+        assert!(entry.budget.is_inherit(), "a pre-field op inherits every global knob");
+    }
+
+    #[test]
+    fn budget_is_not_folded_into_the_workload_hash() {
+        // Like `kind`/`result_gated`, the per-op budget is replay policy, not workload content: two
+        // bundles that differ ONLY in a budget must share a `workload_hash`, so budgeting an op
+        // never breaks A/B comparability with an unbudgeted recording of the same workload.
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 20,
+            edges: 60,
+        };
+        let make = |budget: RecordedBudget| {
+            let dir = temp_bundle_dir(if budget.is_inherit() { "synthrec-bi" } else { "synthrec-bb" });
+            let ops = vec![RecordedOp {
+                key: OpKey::dynamic("shape", QueryType::Read),
+                result_gated: true,
+                budget,
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            }];
+            let m = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+            std::fs::remove_dir_all(&dir).ok();
+            m.workload_hash
+        };
+        let budgeted = RecordedBudget {
+            samples: Some(1),
+            concurrency: Some(vec![1]),
+            ..RecordedBudget::default()
+        };
+        assert_eq!(make(RecordedBudget::default()), make(budgeted));
+    }
+
+    #[test]
+    fn budget_round_trips_through_the_manifest_and_inherit_is_omitted() {
+        // A budgeted op's overrides survive record → load; an inherit budget is omitted from the
+        // manifest JSON entirely, so every pre-field bundle (and the docs' sample manifest) stays
+        // byte-compatible.
+        let dir = temp_bundle_dir("synthrec-budget");
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 20,
+            edges: 60,
+        };
+        let budget = RecordedBudget {
+            samples: Some(2),
+            warmup: Some(1),
+            concurrency: Some(vec![1, 2]),
+            cache: Some(crate::synthetic::CacheSelection::Cached),
+            server_timeout_ms: Some(30_000),
+            client_deadline_ms: Some(31_000),
+        };
+        let ops = vec![
+            RecordedOp {
+                key: OpKey::dynamic("heavy_shape", QueryType::Read),
+                result_gated: false,
+                budget: budget.clone(),
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            },
+            RecordedOp {
+                key: OpKey::dynamic("plain_shape", QueryType::Read),
+                result_gated: true,
+                budget: RecordedBudget::default(),
+                commands: vec!["CYPHER  RETURN 2".to_string()],
+            },
+        ];
+        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.manifest.ops[0].budget, budget);
+        assert!(bundle.manifest.ops[1].budget.is_inherit());
+        // The manifest text carries a `budget` key only for the budgeted op.
+        let manifest_json = std::fs::read_to_string(dir.join("manifest.json")).unwrap();
+        assert_eq!(manifest_json.matches("\"budget\"").count(), 1);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -8,7 +8,7 @@
 //! single-flight **reference pass** (capturing each result-gated command's result shape; a
 //! result-N/A op skips the full capture — design §3.4), then measures each op through the shared
 //! closed-loop engine across the configured **concurrency sweep + cache modes** — overlaying each
-//! op's recorded [`RecordedBudget`] on the run's global knobs, exactly as a generated run overlays
+//! op's recorded [`RecordedBudget`](crate::synthetic::catalog::RecordedBudget) on the run's global knobs, exactly as a generated run overlays
 //! the catalog's per-op budget — and, at each op's highest concurrency, **verifies results are
 //! unchanged under concurrency**.
 //!
@@ -21,7 +21,7 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
-use crate::synthetic::catalog::{RecordedBudget, DEFAULT_RESET_EVERY};
+use crate::synthetic::catalog::DEFAULT_RESET_EVERY;
 use crate::synthetic::dataset::{self, DatasetSpec};
 use crate::synthetic::op_runner::{capture_result, ResultShape};
 use crate::synthetic::recording::{self, Bundle};
@@ -138,21 +138,19 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // set isn't byte-stable (LIMIT-without-ORDER, top-k, float scores — design §3.2 / Decision 4)
     // — is still loaded, replayed, and timed, but its result is neither captured in full, nor
     // cross-concurrency-verified, nor digested, so a benign result difference never fails the A/B
-    // non-divergence gate. Unknown names default to gated + inherit (the safe defaults).
-    let inherit_budget = recording::OpEntry {
-        name: String::new(),
-        kind: QueryType::Read,
-        result_gated: true,
-        budget: RecordedBudget::default(),
-        count: 0,
-    };
+    // non-divergence gate. `load()` builds `bundle.commands` from `manifest.ops`, so every replayed
+    // name has an entry by construction — a miss is bundle corruption and must fail loudly.
     let op_entries: std::collections::HashMap<&str, &recording::OpEntry> = bundle
         .manifest
         .ops
         .iter()
         .map(|e| (e.name.as_str(), e))
         .collect();
-    let entry_for = |name: &str| *op_entries.get(name).unwrap_or(&&inherit_budget);
+    let entry_for = |name: &str| {
+        *op_entries
+            .get(name)
+            .unwrap_or_else(|| panic!("op '{name}' replayed without a manifest entry (corrupt bundle)"))
+    };
 
     // Engine config for the recorded workload (writes/reset are irrelevant — recorded ops are reads).
     let engine_config = Config {

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -154,6 +154,36 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         .collect();
     let entry_for = |name: &str| *op_entries.get(name).unwrap_or(&&inherit_budget);
 
+    // Engine config for the recorded workload (writes/reset are irrelevant — recorded ops are reads).
+    let engine_config = Config {
+        endpoint: config.endpoint.clone(),
+        graph: graph_name.clone(),
+        // `ops` is unused by the measurement path (`measure_op` replays the passed-in corpus, not
+        // the config's op list) — leave it empty rather than lossily mapping string-keyed `OpKey`s
+        // back to the `OpName` enum this field holds.
+        ops: Vec::new(),
+        samples: config.samples,
+        warmup: config.warmup,
+        concurrency: concurrency.clone(),
+        reset_every: DEFAULT_RESET_EVERY,
+        seed: bundle.manifest.corpus_seed,
+        server_timeout_ms: config.server_timeout_ms,
+        client_deadline_ms: config.client_deadline_ms,
+        cache: config.cache,
+        out: config.out.clone(),
+        server_image: config.server_image.clone(),
+        label: config.label.clone(),
+        dataset: None,
+    };
+
+    // Validate every op's resolved budget overlay up front — before the reference pass uses its
+    // timeouts — so a malformed manifest (zeroed samples, a non-positive timeout, an empty sweep)
+    // fails closed with an error naming the op instead of a confusing driver error mid-capture.
+    for (op, _) in &bundle.commands {
+        let op_config = engine_config.with_recorded_budget(&entry_for(op.name()).budget);
+        validate_op_config(op.name(), &op_config)?;
+    }
+
     // Reference pass (untimed, single-flight): capture each result's shape (cardinality +
     // order-independent value digest) for every **result-gated** command — the correctness oracle,
     // which also primes the plan cache. A result-N/A op's shapes are never verified or digested, so
@@ -192,27 +222,6 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // Setup connection done; drop it so it isn't an idle extra connection during the sweep.
     drop(graph);
 
-    // Engine config for the recorded workload (writes/reset are irrelevant — recorded ops are reads).
-    let engine_config = Config {
-        endpoint: config.endpoint.clone(),
-        graph: graph_name.clone(),
-        // `ops` is unused by the measurement path (`measure_op` replays the passed-in corpus, not
-        // the config's op list) — leave it empty rather than lossily mapping string-keyed `OpKey`s
-        // back to the `OpName` enum this field holds.
-        ops: Vec::new(),
-        samples: config.samples,
-        warmup: config.warmup,
-        concurrency: concurrency.clone(),
-        reset_every: DEFAULT_RESET_EVERY,
-        seed: bundle.manifest.corpus_seed,
-        server_timeout_ms: config.server_timeout_ms,
-        client_deadline_ms: config.client_deadline_ms,
-        cache: config.cache,
-        out: config.out.clone(),
-        server_image: config.server_image.clone(),
-        label: config.label.clone(),
-        dataset: None,
-    };
     let run_token = rand::random_range(0..=u64::MAX);
     let uid_alloc = AtomicU64::new(0);
 
@@ -221,10 +230,9 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         let entry = entry_for(op.name());
         let is_gated = entry.result_gated;
         // Overlay this op's recorded budget on the run's global config (the same per-op overlay a
-        // generated run applies from the catalog spec), validating the resolved knobs up front so
-        // a hand-tuned bundle with a zeroed budget fails with an error naming the op.
+        // generated run applies from the catalog spec) — already validated before the reference
+        // pass, so the resolved knobs are known-good here.
         let op_config = engine_config.with_recorded_budget(&entry.budget);
-        validate_op_config(op.name(), &op_config)?;
         let op_concurrency = normalize_concurrency(&op_config.concurrency)?;
         let op_deadline = Duration::from_millis(op_config.client_deadline_ms);
         let op_max_c = op_concurrency.iter().copied().max().unwrap_or(1);

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -5,9 +5,12 @@
 //! run) and the Criterion baseline (whose iteration count adapts to observed latency), this **loads
 //! the recorded graph** and measures the **recorded command stream** — the same graph and the same
 //! commands on every version, so two versions' reports are genuinely comparable. It runs an untimed
-//! single-flight **reference pass** (capturing each command's result shape), then measures each op
-//! through the shared closed-loop engine across the configured **concurrency sweep + cache modes**,
-//! and — at the highest concurrency — **verifies results are unchanged under concurrency**.
+//! single-flight **reference pass** (capturing each result-gated command's result shape; a
+//! result-N/A op skips the full capture — design §3.4), then measures each op through the shared
+//! closed-loop engine across the configured **concurrency sweep + cache modes** — overlaying each
+//! op's recorded [`RecordedBudget`] on the run's global knobs, exactly as a generated run overlays
+//! the catalog's per-op budget — and, at each op's highest concurrency, **verifies results are
+//! unchanged under concurrency**.
 //!
 //! The measured latency itself is still subject to environment noise; the *hard* guarantees are
 //! integrity (the bundle's `workload_hash` is verified on load), graph fidelity (drop + load +
@@ -18,14 +21,14 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
-use crate::synthetic::catalog::DEFAULT_RESET_EVERY;
+use crate::synthetic::catalog::{RecordedBudget, DEFAULT_RESET_EVERY};
 use crate::synthetic::dataset::{self, DatasetSpec};
 use crate::synthetic::op_runner::{capture_result, ResultShape};
 use crate::synthetic::recording::{self, Bundle};
 use crate::synthetic::report::{DatasetInfo, Meta, Report, ServerInfo, SCHEMA_VERSION};
 use crate::synthetic::{
-    measure_op, normalize_concurrency, open_graph, provenance, redact_endpoint, write_report,
-    CacheSelection, Config, MeasureTarget, OpKey,
+    measure_op, normalize_concurrency, open_graph, provenance, redact_endpoint,
+    validate_op_config, write_report, CacheSelection, Config, MeasureTarget, OpKey,
 };
 use falkordb::AsyncGraph;
 use sha2::{Digest, Sha256};
@@ -130,23 +133,59 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             })?;
     }
 
-    // Reference pass (untimed, single-flight) over every recorded command: capture each result's
-    // shape (cardinality + order-independent value digest). This is the correctness oracle and also
-    // primes the plan cache. Reads return scalars, so a single connection is safe.
-    let st = config.server_timeout_ms;
+    // Per-op replay policy from the recorded manifest (keyed by the op's unique name):
+    // `result_gated` + the per-op `budget` (design §3.4). A result-N/A op — a shape whose result
+    // set isn't byte-stable (LIMIT-without-ORDER, top-k, float scores — design §3.2 / Decision 4)
+    // — is still loaded, replayed, and timed, but its result is neither captured in full, nor
+    // cross-concurrency-verified, nor digested, so a benign result difference never fails the A/B
+    // non-divergence gate. Unknown names default to gated + inherit (the safe defaults).
+    let inherit_budget = recording::OpEntry {
+        name: String::new(),
+        kind: QueryType::Read,
+        result_gated: true,
+        budget: RecordedBudget::default(),
+        count: 0,
+    };
+    let op_entries: std::collections::HashMap<&str, &recording::OpEntry> = bundle
+        .manifest
+        .ops
+        .iter()
+        .map(|e| (e.name.as_str(), e))
+        .collect();
+    let entry_for = |name: &str| *op_entries.get(name).unwrap_or(&&inherit_budget);
+
+    // Reference pass (untimed, single-flight): capture each result's shape (cardinality +
+    // order-independent value digest) for every **result-gated** command — the correctness oracle,
+    // which also primes the plan cache. A result-N/A op's shapes are never verified or digested, so
+    // it skips the full capture (a heavy shape would pay corpus × per-call latency for nothing —
+    // design §3.4) and only its first command runs once, to fail fast on a broken recorded command.
+    // Captures run under the op's budgeted timeouts so a budgeted heavy op can't trip the global
+    // deadline before measurement starts. Reads return scalars, so a single connection is safe.
     let mut reference: Vec<(OpKey, Arc<Vec<String>>, Vec<ResultShape>)> =
         Vec::with_capacity(bundle.commands.len());
     for (op, cyphers) in &bundle.commands {
         if cyphers.is_empty() {
             return Err(OtherError(format!("op '{}' has no recorded commands", op.name())));
         }
-        let mut shapes = Vec::with_capacity(cyphers.len());
-        for c in cyphers {
+        let entry = entry_for(op.name());
+        let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);
+        let op_deadline = entry
+            .budget
+            .client_deadline_ms
+            .map(Duration::from_millis)
+            .unwrap_or(client_deadline);
+        let to_capture: &[String] = if entry.result_gated { cyphers } else { &cyphers[..1] };
+        let mut shapes = Vec::with_capacity(to_capture.len());
+        for c in to_capture {
             shapes.push(
-                capture_result(&mut graph, c, st, client_deadline)
+                capture_result(&mut graph, c, op_st, op_deadline)
                     .await
                     .map_err(|e| OtherError(format!("capturing '{}': {}", op.name(), e)))?,
             );
+        }
+        if !entry.result_gated {
+            // The probe shape is discarded: downstream code treats a shapeless op as result-N/A.
+            shapes.clear();
         }
         reference.push((op.clone(), Arc::new(cyphers.clone()), shapes));
     }
@@ -176,54 +215,50 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     };
     let run_token = rand::random_range(0..=u64::MAX);
     let uid_alloc = AtomicU64::new(0);
-    let max_c = concurrency.iter().copied().max().unwrap_or(1);
-
-    // Per-op result-gating policy from the recorded manifest (keyed by the op's unique name). A
-    // result-N/A op — a shape whose result set isn't byte-stable (LIMIT-without-ORDER, top-k,
-    // float scores — design §3.2 / Decision 4) — is still loaded, replayed, and timed, but its
-    // result is neither cross-concurrency-verified nor digested, so a benign result difference
-    // never fails the A/B non-divergence gate. Unknown names default to gated (the safe default).
-    let result_gated: std::collections::HashMap<&str, bool> = bundle
-        .manifest
-        .ops
-        .iter()
-        .map(|e| (e.name.as_str(), e.result_gated))
-        .collect();
 
     let mut operations = BTreeMap::new();
     for (op, corpus, shapes) in &reference {
-        let is_gated = result_gated.get(op.name()).copied().unwrap_or(true);
-        // Verify results are IDENTICAL at the highest concurrency (untimed) before trusting the
-        // measured latencies — a concurrent path that returns different/wrong results is a hard
-        // fail. Skipped for result-N/A ops, whose results aren't required to be stable.
-        if max_c > 1 && is_gated {
+        let entry = entry_for(op.name());
+        let is_gated = entry.result_gated;
+        // Overlay this op's recorded budget on the run's global config (the same per-op overlay a
+        // generated run applies from the catalog spec), validating the resolved knobs up front so
+        // a hand-tuned bundle with a zeroed budget fails with an error naming the op.
+        let op_config = engine_config.with_recorded_budget(&entry.budget);
+        validate_op_config(op.name(), &op_config)?;
+        let op_concurrency = normalize_concurrency(&op_config.concurrency)?;
+        let op_deadline = Duration::from_millis(op_config.client_deadline_ms);
+        let op_max_c = op_concurrency.iter().copied().max().unwrap_or(1);
+        // Verify results are IDENTICAL at the op's highest concurrency (untimed) before trusting
+        // the measured latencies — a concurrent path that returns different/wrong results is a
+        // hard fail. Skipped for result-N/A ops, whose results aren't required to be stable.
+        if op_max_c > 1 && is_gated {
             verify_concurrent(
                 &config.endpoint,
                 &graph_name,
                 corpus,
                 shapes,
-                max_c,
-                st,
-                client_deadline,
+                op_max_c,
+                op_config.server_timeout_ms,
+                op_deadline,
             )
             .await
             .map_err(|e| {
                 OtherError(format!(
                     "op '{}' returned different results at concurrency {}: {}",
                     op.name(),
-                    max_c,
+                    op_max_c,
                     e
                 ))
             })?;
         }
         let mut op_report = measure_op(
-            &engine_config,
-            &concurrency,
+            &op_config,
+            &op_concurrency,
             MeasureTarget::read(),
             Arc::clone(corpus),
             run_token,
             &uid_alloc,
-            client_deadline,
+            op_deadline,
         )
         .await?;
         // Gate the result only for byte-stable shapes; a result-N/A op reports `None` so the diff

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -273,6 +273,12 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         // guard renders it N/A instead of comparing a non-deterministic digest.
         op_report.result_digest =
             is_gated.then(|| op_result_digest(op.name(), shapes));
+        // Persist the op's effective measurement policy when its recorded budget overrode any
+        // global knob (design §3.4): budgets are deliberately outside the workload_hash, so this
+        // block is what lets the diff/regression/baseline guards refuse to compare two runs that
+        // measured the same workload under different per-op conditions.
+        op_report.policy =
+            (!entry.budget.is_inherit()).then(|| op_config.resolved_policy(&op_concurrency));
         operations.insert(op.name().to_string(), op_report);
     }
 

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -138,18 +138,28 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // set isn't byte-stable (LIMIT-without-ORDER, top-k, float scores — design §3.2 / Decision 4)
     // — is still loaded, replayed, and timed, but its result is neither captured in full, nor
     // cross-concurrency-verified, nor digested, so a benign result difference never fails the A/B
-    // non-divergence gate. `load()` builds `bundle.commands` from `manifest.ops`, so every replayed
-    // name has an entry by construction — a miss is bundle corruption and must fail loudly.
+    // non-divergence gate.
     let op_entries: std::collections::HashMap<&str, &recording::OpEntry> = bundle
         .manifest
         .ops
         .iter()
         .map(|e| (e.name.as_str(), e))
         .collect();
+    // `load()` builds `bundle.commands` from `manifest.ops`, so every replayed name has an entry
+    // by construction — verify anyway so a future load-path change fails gracefully, not deep in
+    // the measurement loops.
+    for (op, _) in &bundle.commands {
+        if !op_entries.contains_key(op.name()) {
+            return Err(OtherError(format!(
+                "op '{}' replayed without a manifest entry (corrupt bundle)",
+                op.name()
+            )));
+        }
+    }
     let entry_for = |name: &str| {
         *op_entries
             .get(name)
-            .unwrap_or_else(|| panic!("op '{name}' replayed without a manifest entry (corrupt bundle)"))
+            .expect("every replayed op name was validated against the manifest above")
     };
 
     // Engine config for the recorded workload (writes/reset are irrelevant — recorded ops are reads).

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -173,6 +173,42 @@ pub struct LevelReport {
     pub compilation_ms_median: Option<f64>,
 }
 
+/// The **effective measurement policy** an operation was measured under when a per-op budget
+/// (design §3.4) overrode any of the run's global knobs — the fully resolved values, not the
+/// overlay. Absent (`None` on [`OperationReport::policy`]) for an op that inherits every global
+/// knob: the [`Meta`] block already describes those, and every report written before budgets
+/// existed reads as all-inherit. Budgets are replay *policy*, deliberately excluded from the
+/// bundle's `workload_hash` — so this block is what lets the diff/baseline guards refuse to
+/// compare two runs that measured the same workload under different per-op conditions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpPolicy {
+    pub samples: usize,
+    pub warmup: usize,
+    /// The op's own (normalized) concurrency sweep.
+    pub concurrency: Vec<usize>,
+    pub cache: crate::synthetic::CacheSelection,
+    pub server_timeout_ms: i64,
+    pub client_deadline_ms: u64,
+}
+
+impl std::fmt::Display for OpPolicy {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(
+            f,
+            "samples={} warmup={} concurrency={:?} cache={:?} server_timeout_ms={} client_deadline_ms={}",
+            self.samples,
+            self.warmup,
+            self.concurrency,
+            self.cache,
+            self.server_timeout_ms,
+            self.client_deadline_ms
+        )
+    }
+}
+
 /// Stats for one operation across the whole concurrency sweep.
 ///
 /// Each entry of `levels` is the same operation measured at one concurrency `C`; together they
@@ -188,6 +224,11 @@ pub struct OperationReport {
     /// masquerade as an improvement. `None` for a plain `synthetic run`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub result_digest: Option<String>,
+    /// The effective per-op measurement policy ([`OpPolicy`]) when this op's recorded/catalog
+    /// budget overrode the global knobs; `None` when it inherited them all. Compared per-op by
+    /// the diff/regression/baseline guards.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<OpPolicy>,
 }
 
 impl OperationReport {
@@ -643,6 +684,7 @@ mod tests {
                     },
                 ],
                 result_digest: None,
+                policy: None,
             },
         );
         Report {
@@ -704,6 +746,34 @@ mod tests {
         let _ = l0.cached.as_ref().unwrap().metrics.server_ms.p95;
         assert_eq!(back.meta.server.module_graph_ver, Some(42001));
         assert_eq!(back.meta.server.cache_size, Some(25));
+    }
+
+    #[test]
+    fn op_policy_round_trips_and_defaults_to_none() {
+        // An op measured under a per-op budget carries its resolved policy through JSON…
+        let mut report = sample_report();
+        let pol = OpPolicy {
+            samples: 1,
+            warmup: 0,
+            concurrency: vec![1],
+            cache: crate::synthetic::CacheSelection::Cached,
+            server_timeout_ms: 60_000,
+            client_deadline_ms: 61_000,
+        };
+        report.operations.get_mut("return_const").unwrap().policy = Some(pol.clone());
+        let json = report.to_json().unwrap();
+        assert!(json.contains("\"policy\""));
+        let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.operations.get("return_const").unwrap().policy, Some(pol.clone()));
+        // …while an inherit-everything op (and any pre-budget report) reads back as None, and
+        // its serialized form omits the field entirely.
+        let plain = sample_report().to_json().unwrap();
+        assert!(!plain.contains("\"policy\""));
+        let legacy: OperationReport = serde_json::from_str(r#"{"levels": []}"#).unwrap();
+        assert_eq!(legacy.policy, None);
+        // Display renders every knob (used verbatim in guard refusal messages).
+        let shown = pol.to_string();
+        assert!(shown.contains("samples=1") && shown.contains("client_deadline_ms=61000"));
     }
 
     #[test]
@@ -909,6 +979,7 @@ mod tests {
                     },
                 ],
                 result_digest: None,
+                policy: None,
             },
         );
         ops.insert(
@@ -921,6 +992,7 @@ mod tests {
                     compilation_ms_median: None,
                 }],
                 result_digest: None,
+                policy: None,
             },
         );
         ops.insert(
@@ -942,6 +1014,7 @@ mod tests {
                     },
                 ],
                 result_digest: None,
+                policy: None,
             },
         );
         r.operations = ops;

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -38,7 +38,7 @@ use crate::error::BenchmarkResult;
 use crate::queries_repository::{
     AlgorithmQuerySelection, Flavour, QueryCoverageProfile, QueryType, UsersQueriesRepository,
 };
-use crate::synthetic::catalog::CORPUS_SIZE;
+use crate::synthetic::catalog::{OpBudget, CORPUS_SIZE};
 use crate::synthetic::recording::RecordedOp;
 use crate::synthetic::{OpKey, Tier};
 use rand::rngs::StdRng;
@@ -83,9 +83,14 @@ pub enum ShapeCapability {
 
 /// One repo read shape's synthetic metadata: its stable [`queries_repository`] name, coverage
 /// **profile** (Baseline / ExtendedCore / FixtureDependent), coverage **tier** (Decision 1), result
-/// policy (Decision 4), and optional **capability** (Phase 5 fulltext/vector).
+/// policy (Decision 4), optional **capability** (Phase 5 fulltext/vector), and its record-time
+/// **corpus size** + replay **budget** (design §3.4).
 ///
-/// Kind is always `Read` for this table; per-op **budget** is deferred to its phase. The Baseline and
+/// Kind is always `Read` for this table. Every current repo read renders a full
+/// [`CORPUS_SIZE`]-command corpus and inherits the global runtime knobs
+/// ([`OpBudget::INHERIT`] — pinned by a drift-guard test); the fields exist so heavier future
+/// shapes (whole-graph algorithms, ~40–80 ms/call) can record a small corpus and dial their own
+/// samples/concurrency/timeouts down without perturbing the rest of the bundle. The Baseline and
 /// ExtendedCore reads need no capability (`capability = None`); the FixtureDependent fulltext/vector
 /// reads carry the [`ShapeCapability`] they exercise — see the module docs.
 ///
@@ -104,6 +109,12 @@ pub struct ShapeSpec {
     pub result_policy: ResultPolicy,
     /// The engine capability this shape requires, or `None` for plain-Cypher reads ([`ShapeCapability`]).
     pub capability: Option<ShapeCapability>,
+    /// How many commands to render into the recorded corpus (must be ≥ 1). [`CORPUS_SIZE`] for
+    /// every current repo read; a parameterless or heavy shape can record fewer.
+    pub corpus_size: usize,
+    /// Per-op runtime budget recorded into the bundle ([`OpBudget`], design §3.4) and overlaid on
+    /// the global config at replay. [`OpBudget::INHERIT`] for every current repo read.
+    pub budget: OpBudget,
 }
 
 /// The curated annotation for the **46 baseline non-algorithm read shapes** (design §3.4).
@@ -121,7 +132,8 @@ pub struct ShapeSpec {
 pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
     use ResultPolicy::{Gated, NotApplicable};
     use Tier::{Core, Full};
-    // `s(name, tier, policy)` keeps the table dense and readable — every row is a `Baseline` read.
+    // `s(name, tier, policy)` keeps the table dense and readable — every row is a `Baseline` read
+    // with a full corpus and an inherited (global) runtime budget.
     fn s(
         name: &'static str,
         tier: Tier,
@@ -133,6 +145,8 @@ pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
             tier,
             result_policy,
             capability: None,
+            corpus_size: CORPUS_SIZE,
+            budget: OpBudget::INHERIT,
         }
     }
     vec![
@@ -209,6 +223,8 @@ pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
         tier: Tier::Core,
         result_policy: ResultPolicy::Gated,
         capability: None,
+        corpus_size: CORPUS_SIZE,
+        budget: OpBudget::INHERIT,
     }]
 }
 
@@ -229,7 +245,8 @@ pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
 /// reads the `FixtureDependent` profile adds over `ExtendedCore`.
 pub fn fixture_dependent_read_shapes() -> Vec<ShapeSpec> {
     use ShapeCapability::{FulltextQueryNodes, FulltextQueryRelationships, VectorQueryNodes};
-    // Every row is a FixtureDependent, Full-tier, result-N/A read; only the name + capability differ.
+    // Every row is a FixtureDependent, Full-tier, result-N/A read with a full corpus and an
+    // inherited (global) runtime budget; only the name + capability differ.
     fn s(
         name: &'static str,
         capability: ShapeCapability,
@@ -242,6 +259,8 @@ pub fn fixture_dependent_read_shapes() -> Vec<ShapeSpec> {
                 "vector/fulltext top-k ordering is non-deterministic",
             ),
             capability: Some(capability),
+            corpus_size: CORPUS_SIZE,
+            budget: OpBudget::INHERIT,
         }
     }
     vec![
@@ -324,11 +343,12 @@ fn read_shapes_repository(
 /// Render the selected `tier`'s repo read shapes into [`RecordedOp`]s, ready for
 /// [`record_rendered`](crate::synthetic::recording::record_rendered) — **offline**, no server.
 ///
-/// Each shape's corpus is [`CORPUS_SIZE`] renders drawn from a fixed per-shape seed
-/// (`corpus_seed ^ salt`, the op's [`OpKey::salt`]), so a given seed yields a byte-identical corpus
-/// (record-once → replay-verbatim). [`Tier::Full`] selects every repo read; [`Tier::Core`] selects
-/// only the core subset. Returns an error if the annotation table names a shape that isn't an
-/// auto-discovered `queries_repository` non-algorithm read (annotation drift).
+/// Each shape's corpus is `corpus_size` renders ([`CORPUS_SIZE`] for every current repo read) drawn
+/// from a fixed per-shape seed (`corpus_seed ^ salt`, the op's [`OpKey::salt`]), so a given seed
+/// yields a byte-identical corpus (record-once → replay-verbatim); its [`OpBudget`] is recorded
+/// alongside so replay applies the same per-op overrides. [`Tier::Full`] selects every repo read;
+/// [`Tier::Core`] selects only the core subset. Returns an error if the annotation table names a
+/// shape that isn't an auto-discovered `queries_repository` non-algorithm read (annotation drift).
 pub fn record_repo_reads(
     tier: Tier,
     vertices: i32,
@@ -366,8 +386,8 @@ fn record_selected_shapes(
         }
         let key = OpKey::dynamic(shape.name.to_string(), QueryType::Read);
         let mut rng = StdRng::seed_from_u64(corpus_seed ^ key.salt());
-        let mut commands = Vec::with_capacity(CORPUS_SIZE);
-        for _ in 0..CORPUS_SIZE {
+        let mut commands = Vec::with_capacity(shape.corpus_size);
+        for _ in 0..shape.corpus_size {
             let prepared = repo.render_read_with_rng(shape.name, &mut rng).ok_or_else(|| {
                 OtherError(format!("repo read shape '{}' failed to render", shape.name))
             })?;
@@ -376,6 +396,7 @@ fn record_selected_shapes(
         ops.push(RecordedOp {
             key,
             result_gated: shape.result_policy.is_gated(),
+            budget: shape.budget.into(),
             commands,
         });
     }
@@ -385,6 +406,7 @@ fn record_selected_shapes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::synthetic::catalog::RecordedBudget;
 
     /// The set of names in the annotation table.
     fn annotated_names() -> BTreeSet<&'static str> {
@@ -702,11 +724,65 @@ mod tests {
             tier: Tier::Full,
             result_policy: ResultPolicy::Gated,
             capability: None,
+            corpus_size: CORPUS_SIZE,
+            budget: OpBudget::INHERIT,
         }];
         let err = record_selected_shapes(&bogus, 1000, 5000, 1).unwrap_err();
         assert!(
             format!("{err}").contains("annotation drift"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn every_current_repo_read_inherits_the_global_budget_and_full_corpus() {
+        // Pin today's behaviour: no repo read overrides the global runtime knobs or records a
+        // reduced corpus, so recorded bundles — and their pinned workload_hashes — are unchanged
+        // by the budget/corpus plumbing (design §3.4). A future shape that needs a budget (e.g.
+        // the Phase 6 algorithm reads) belongs in its own table, not here.
+        for shape in repo_read_shapes() {
+            assert_eq!(shape.budget, OpBudget::INHERIT, "'{}' must inherit", shape.name);
+            assert_eq!(shape.corpus_size, CORPUS_SIZE, "'{}' must render a full corpus", shape.name);
+        }
+    }
+
+    #[test]
+    fn record_selected_shapes_honors_corpus_size_and_budget() {
+        // A shape's `corpus_size` bounds its rendered corpus, its `budget` lands on the recorded
+        // op (owned manifest form), and a truncated corpus is a strict prefix of the full render
+        // (the corpus RNG stream is unchanged — smaller just stops earlier).
+        static SWEEP: [usize; 1] = [1];
+        let small = [ShapeSpec {
+            name: "single_vertex_read",
+            profile: QueryCoverageProfile::Baseline,
+            tier: Tier::Core,
+            result_policy: ResultPolicy::Gated,
+            capability: None,
+            corpus_size: 3,
+            budget: OpBudget {
+                samples: Some(1),
+                concurrency: Some(&SWEEP),
+                ..OpBudget::INHERIT
+            },
+        }];
+        let ops = record_selected_shapes(&small, 1000, 5000, 42).unwrap();
+        assert_eq!(ops.len(), 1);
+        assert_eq!(ops[0].commands.len(), 3, "corpus_size bounds the rendered corpus");
+        assert_eq!(
+            ops[0].budget,
+            RecordedBudget {
+                samples: Some(1),
+                concurrency: Some(vec![1]),
+                ..RecordedBudget::default()
+            },
+            "the shape's budget lands on the recorded op"
+        );
+        let full = record_repo_reads(Tier::Full, 1000, 5000, 42).unwrap();
+        let full_svr = full.iter().find(|o| o.key.name() == "single_vertex_read").unwrap();
+        assert_eq!(
+            ops[0].commands.as_slice(),
+            &full_svr.commands[..3],
+            "a reduced corpus is a prefix of the full render"
         );
     }
 }

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -384,6 +384,13 @@ fn record_selected_shapes(
                 shape.name
             )));
         }
+        if shape.corpus_size == 0 {
+            return Err(OtherError(format!(
+                "repo read shape '{}' has corpus_size 0 — every shape must render at least one \
+                 command (fix its ShapeSpec in src/synthetic/shapes.rs)",
+                shape.name
+            )));
+        }
         let key = OpKey::dynamic(shape.name.to_string(), QueryType::Read);
         let mut rng = StdRng::seed_from_u64(corpus_seed ^ key.salt());
         let mut commands = Vec::with_capacity(shape.corpus_size);
@@ -783,6 +790,25 @@ mod tests {
             ops[0].commands.as_slice(),
             &full_svr.commands[..3],
             "a reduced corpus is a prefix of the full render"
+        );
+    }
+
+    #[test]
+    fn record_selected_shapes_rejects_a_zero_corpus_naming_the_shape() {
+        let bogus = [ShapeSpec {
+            name: "single_vertex_read",
+            profile: QueryCoverageProfile::Baseline,
+            tier: Tier::Core,
+            result_policy: ResultPolicy::Gated,
+            capability: None,
+            corpus_size: 0,
+            budget: OpBudget::INHERIT,
+        }];
+        let err = record_selected_shapes(&bogus, 1000, 5000, 42).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("single_vertex_read") && msg.contains("corpus_size 0"),
+            "the error must name the shape and the zero corpus, got: {msg}"
         );
     }
 }

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1230,6 +1230,21 @@ async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
     assert!(budgeted.levels[0].cached.is_some(), "budgeted_op measures cached");
     assert!(budgeted.levels[0].uncached.is_none(), "budgeted_op skips uncached (budget)");
     assert!(budgeted.result_digest.is_some(), "budgeted_op stays result-gated");
+    // Its effective (resolved) measurement policy is persisted so the diff/baseline guards can
+    // refuse a comparison against a run that measured it under different conditions.
+    let expected_policy = benchmark::synthetic::report::OpPolicy {
+        samples: 1,
+        warmup: 0,
+        concurrency: vec![1],
+        cache: benchmark::synthetic::CacheSelection::Cached,
+        server_timeout_ms: 5_000, // inherited from the run's global knobs
+        client_deadline_ms: 6_000,
+    };
+    assert_eq!(
+        budgeted.policy.as_ref(),
+        Some(&expected_policy),
+        "budgeted_op persists its resolved per-op policy"
+    );
 
     // global_op: the full global sweep, both cache modes, result-gated.
     let global = &report.operations["global_op"];
@@ -1240,12 +1255,18 @@ async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
         assert!(level.uncached.is_some(), "global_op measures uncached");
     }
     assert!(global.result_digest.is_some(), "global_op stays result-gated");
+    assert!(global.policy.is_none(), "an inherit-everything op persists no per-op policy");
 
     // na_probe_op: replay succeeded despite the broken third command (capture skipped), no digest.
     let na = &report.operations["na_probe_op"];
     assert!(na.result_digest.is_none(), "na_probe_op is result-N/A");
     let levels: Vec<usize> = na.levels.iter().map(|l| l.concurrency).collect();
     assert_eq!(levels, vec![1], "na_probe_op must measure only its budgeted sweep");
+    assert_eq!(
+        na.policy.as_ref(),
+        Some(&expected_policy),
+        "the result-N/A op carries the same tight budget, so the same resolved policy"
+    );
 
     // The report's meta echoes the run's global knobs (budgets are per-op policy).
     assert_eq!(report.meta.concurrency, vec![1, 2]);

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1149,6 +1149,110 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
     drop_graph(graph).await;
 }
 
+/// Per-op budget + result-N/A reference-capture skip at replay (design §3.4).
+///
+/// Records a bundle whose ops carry different [`RecordedBudget`]s and replays it once under a
+/// global `concurrency [1, 2]` / `cache both` config:
+/// - `budgeted_op` (samples 1, warmup 0, concurrency `[1]`, cached-only) must measure exactly one
+///   C=1 cached level — its recorded budget overrides the run's global sweep and cache selection;
+/// - `global_op` (no budget) must measure the full global sweep under both cache modes;
+/// - `na_probe_op` (result-N/A, same tight budget) carries a **deliberately broken third
+///   command**: replay must still succeed because a result-N/A op skips the full reference
+///   capture (only its first command is probed) and its 1-sample C=1 cached measured loop (one
+///   untimed prime + one sample) never cycles past `corpus[1]`. Before the skip, the reference
+///   pass captured every command and this bundle failed hard.
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
+    use benchmark::synthetic::catalog::RecordedBudget;
+    use benchmark::synthetic::recording::RecordedOp;
+    use benchmark::synthetic::OpKey;
+
+    let graph = "syn_it_budget";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-budget");
+    let spec = DatasetSpec {
+        seed: 9,
+        nodes: 200,
+        edges: 400,
+    };
+    let tight = RecordedBudget {
+        samples: Some(1),
+        warmup: Some(0),
+        concurrency: Some(vec![1]),
+        cache: Some(benchmark::synthetic::CacheSelection::Cached),
+        ..RecordedBudget::default()
+    };
+    let ops = vec![
+        RecordedOp {
+            key: OpKey::dynamic("budgeted_op", QueryType::Read),
+            result_gated: true,
+            budget: tight.clone(),
+            commands: vec!["MATCH (u:User {id: 1}) RETURN u.id".to_string()],
+        },
+        RecordedOp {
+            key: OpKey::dynamic("global_op", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            commands: vec![
+                "MATCH (u:User {id: 2}) RETURN u.id".to_string(),
+                "MATCH (u:User {id: 3}) RETURN u.id".to_string(),
+            ],
+        },
+        RecordedOp {
+            key: OpKey::dynamic("na_probe_op", QueryType::Read),
+            result_gated: false,
+            budget: tight.clone(),
+            commands: vec![
+                "MATCH (u:User {id: 4}) RETURN u.id".to_string(),
+                "MATCH (u:User {id: 5}) RETURN u.id".to_string(),
+                // Invalid on purpose: only reachable by a full reference capture.
+                "MATCH (u:User RETURN syntax_error".to_string(),
+            ],
+        },
+    ];
+    recording::record_rendered(&spec, graph, &ops, spec.seed, 256, &dir).expect("record");
+
+    let out = dir.join("r.json").to_string_lossy().into_owned();
+    let mut config = replay_config(&dir, graph, &out, true);
+    config.samples = 3;
+    config.warmup = 1;
+    config.concurrency = vec![1, 2];
+    config.cache = benchmark::synthetic::CacheSelection::Both;
+    let report = replay::run(&config).await.expect("replay with per-op budgets");
+
+    // budgeted_op: exactly one C=1 level, cached-only, result-gated.
+    let budgeted = &report.operations["budgeted_op"];
+    let levels: Vec<usize> = budgeted.levels.iter().map(|l| l.concurrency).collect();
+    assert_eq!(levels, vec![1], "budgeted_op must measure only its budgeted sweep");
+    assert!(budgeted.levels[0].cached.is_some(), "budgeted_op measures cached");
+    assert!(budgeted.levels[0].uncached.is_none(), "budgeted_op skips uncached (budget)");
+    assert!(budgeted.result_digest.is_some(), "budgeted_op stays result-gated");
+
+    // global_op: the full global sweep, both cache modes, result-gated.
+    let global = &report.operations["global_op"];
+    let levels: Vec<usize> = global.levels.iter().map(|l| l.concurrency).collect();
+    assert_eq!(levels, vec![1, 2], "global_op inherits the global sweep");
+    for level in &global.levels {
+        assert!(level.cached.is_some(), "global_op measures cached");
+        assert!(level.uncached.is_some(), "global_op measures uncached");
+    }
+    assert!(global.result_digest.is_some(), "global_op stays result-gated");
+
+    // na_probe_op: replay succeeded despite the broken second command (capture skipped), no digest.
+    let na = &report.operations["na_probe_op"];
+    assert!(na.result_digest.is_none(), "na_probe_op is result-N/A");
+    let levels: Vec<usize> = na.levels.iter().map(|l| l.concurrency).collect();
+    assert_eq!(levels, vec![1], "na_probe_op must measure only its budgeted sweep");
+
+    // The report's meta echoes the run's global knobs (budgets are per-op policy).
+    assert_eq!(report.meta.concurrency, vec![1, 2]);
+    assert_eq!(report.meta.samples, 3);
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
 /// replay --no-load against a graph that doesn't hold the recorded dataset fails closed (the
 /// count-verify rejects it) rather than silently measuring the wrong graph.
 #[tokio::test]

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1161,7 +1161,9 @@ async fn record_repo_reads_then_replay_roundtrips_byte_identically() {
 ///   capture (only its first command is probed) and its 1-sample C=1 cached measured loop (one
 ///   untimed prime + one sample) never cycles past `corpus[1]`. Before the skip, the reference
 ///   pass captured every command and this bundle failed hard.
-#[tokio::test]
+///
+/// Multi-thread runtime: FalkorDB entity decoding uses `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
 async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
     use benchmark::synthetic::catalog::RecordedBudget;

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1239,7 +1239,7 @@ async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
     }
     assert!(global.result_digest.is_some(), "global_op stays result-gated");
 
-    // na_probe_op: replay succeeded despite the broken second command (capture skipped), no digest.
+    // na_probe_op: replay succeeded despite the broken third command (capture skipped), no digest.
     let na = &report.operations["na_probe_op"];
     assert!(na.result_digest.is_none(), "na_probe_op is result-N/A");
     let levels: Vec<usize> = na.levels.iter().map(|l| l.concurrency).collect();


### PR DESCRIPTION
Phase 6, PR-2 of 5 — implements **§3.4** of the binding design
[`docs/design/synthetic-cover-algorithms-phase6.md`](https://github.com/FalkorDB/benchmark/blob/master/docs/design/synthetic-cover-algorithms-phase6.md)
(phasing step **§7.2**). Stacked on the merged PR-1 (#259, simple-graph fixture). PR-3 (the
algorithm shapes themselves) consumes this plumbing.

## What / why

The recorded-shape (dynamic) path treats every op identically: a 256-command corpus, a full untimed
reference capture of **all** 256 commands, and the run's single global config (samples, warmup,
concurrency sweep, cache modes, timeouts). That is right for the ~µs–ms read shapes, but whole-graph
algorithms (`algo.pageRank`, MSF, …) run **~40–80 ms per call**, so just the reference pass would
cost **~11–20 s per op** — before a single measured sample. And three of the four algorithm shapes
are **result-N/A** (their digest is never gated), so capturing all 256 reference results buys
nothing.

This PR wires the prerequisite plumbing end-to-end, changing **no current behavior** (every existing
shape pins today's defaults, proven by drift-guard tests):

1. **`ShapeSpec` gains `corpus_size` + `budget`** — a shape can now say "render 1 command" and
   "measure me with 1 sample at C=1, cached-only, with a longer server timeout".
2. **`RecordedOp` / `OpEntry` gain a `budget`** (`RecordedBudget`, an owned serde twin of the
   catalog's `OpBudget`) — the budget travels **inside the bundle**, so a replay endpoint honors it
   with no extra flags. Fully-inherited budgets are **omitted from the manifest** (existing bundles
   stay byte-identical) and the budget is **not folded into `workload_hash`** (replay policy, not
   workload content — same precedent as `kind`/`result_gated`; all pinned golden hashes stay valid).
3. **Replay overlays each op's budget** (`Config::with_recorded_budget`, validated per-op like the
   global config) — its own sweep, cache selection, samples/warmup, and timeouts — while every other
   op keeps the run's global knobs.
4. **Result-N/A ops skip the full reference capture** — only their **first** command is probed
   (fail-fast: a broken op still errors with its name before any measuring starts).
5. **The effective per-op policy is guarded end-to-end.** Budgets are outside the `workload_hash`
   (by design — replay policy, not workload content), so a matching hash alone no longer proves two
   runs measured each op identically. Every budgeted op therefore persists its **resolved**
   measurement policy (`OperationReport::policy` — samples, warmup, sweep, cache, timeouts; absent
   for inherit-everything ops, so existing reports are unchanged), and all three comparison paths —
   `report --diff`, `report --regression`, and the Criterion baseline guard — compare it **per-op**,
   refusing the pair exactly like a workload mismatch when any op's policy differs:

   ```text
   error: per-op measurement policy differs for 'algo_max_flow' — baseline: samples=1 warmup=0
   concurrency=[1] cache=Cached server_timeout_ms=60000 client_deadline_ms=61000; candidate:
   inherits the global knobs. The recorded budgets changed between the runs, so their latencies
   are not comparable
   ```

## Worked example

Record a bundle where one op carries a budget (what PR-3's algorithm shapes will produce):

```text
$ benchmark synthetic record --repo-reads full --seed 7 --nodes 1000 --edges 5000 --graph verify --out-dir rec
recorded 50 op(s) into rec (workload_hash sha256:830faf23…c8de4)   # unchanged vs master — pinned by a golden test
```

`manifest.json` op entry **with** a budget (new; inherit budgets are omitted entirely):

```json
{
  "name": "algo_pagerank_summary",
  "kind": "read",
  "result_gated": false,
  "budget": { "samples": 25, "warmup": 3, "concurrency": [1], "cache": "cached", "server_timeout_ms": 60000 },
  "count": 1
}
```

At replay (`synthetic run --recording rec --concurrency 1,8 --cache both --samples 200`):

| op | reference capture | measured |
| --- | --- | --- |
| `single_vertex_read` (gated, no budget) | all 256 commands | C=1,8 × cached+uncached × 200 samples (global) |
| `algo_pagerank_summary` (N/A, budgeted) | **first command only** (probe) | **C=1 × cached × 25 samples** (its budget) |

Cost impact for a whole-graph algorithm op at ~50 ms/call: reference pass 256×50 ms ≈ **12.8 s →
0.05 s**, measured pass global 2×2×200×50 ms ≈ **40 s → 1.4 s**.

## Design (verbatim)

> ### 3.4 Per-op budget + corpus size are not wired for **recorded** (dynamic) shapes
> `OpBudget` is applied only to catalog `OpName`s (`src/synthetic/mod.rs:671-705`); `ShapeSpec`,
> `RecordedOp`, and `OpEntry` carry **no** budget (`shapes.rs`, `recording.rs`), and replay applies one
> global config and **captures all `CORPUS_SIZE` (256) commands — `result_policy` is never
> consulted**
> (`replay.rs:133-151`). Whole-graph algorithms are ~40–80 ms/call locally, so a 256-command reference
> pass is ~11–20 s **per op** — untenable. **Fix (prerequisite):** wire a per-shape **budget + corpus
> size** into the recorded-shape path (1 command for the parameterless pageRank/Harmonic/MSF; a small
> seeded pair set for maxFlow) and **skip the full reference capture for result-N/A shapes**.

> ## 7. Phasing (prerequisites first, each its own PR)
> 1. ✅ **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
> 2. **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the dynamic
>    path; N/A shapes skip full reference capture.
> 3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
>    `algorithm_read_names()` + drift-guard, `record_algorithm_reads()`, `--repo-algorithms`. Record +
>    replay the 4 shapes end-to-end, opt-in.
> 4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
> 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
> 6. **Docs:** cookbook + readme.

*(This PR is step 2. The ✅ markers for §3.4/§7.2 are updated in the design doc in this PR.)*

## Implementation notes

- **`RecordedBudget`** (`catalog.rs`): `OpBudget` is `Copy` with `concurrency: Option<&'static
  [usize]>`, so it cannot be deserialized. `RecordedBudget` is its owned mirror (`samples`,
  `warmup`, `concurrency: Option<Vec<usize>>`, `cache`, `server_timeout_ms`, `client_deadline_ms`),
  `deny_unknown_fields`, every field `skip_serializing_if = Option::is_none`, plus
  `is_inherit()` and `From<OpBudget>`. A field-for-field mirror test pins the two in sync.
- **One overlay implementation**: `Config::with_budget(OpBudget)` now delegates to the new
  `Config::with_recorded_budget(&RecordedBudget)`, so catalog and recorded budgets can never
  diverge. `validate_op_config` is `&str`-keyed (was `OpName`) so budgeted dynamic ops get the same
  "budget must produce a valid config" guard as catalog ops.
- **Recording**: `record()` (catalog path) propagates `spec(op).budget` into the bundle;
  `record_rendered` (dynamic path) writes each `RecordedOp.budget` into its `OpEntry`.
  `WorkloadHasher` never sees the budget (by construction — it hashes name/count/commands only),
  and a test pins that. `OpEntry.budget` uses `#[serde(default)]`, so pre-budget bundles load fine.
- **Replay** (`replay.rs`): builds a per-op `OpEntry` map up-front; the reference pass uses each
  op's budgeted timeouts and captures `&cyphers[..1]` for `!result_gated` ops (then clears the
  shapes — the digest/`verify_concurrent` paths are already gated); the measurement loop overlays
  `with_recorded_budget`, validates, normalizes the op's sweep, and runs `verify_concurrent` at the
  op's own max concurrency. Report `meta` still echoes the **global** knobs (status quo for catalog
  budgets); each budgeted op additionally persists its resolved `OpPolicy` on its report entry.
- **Shapes**: every current repo-read shape pins `CORPUS_SIZE` + `OpBudget::INHERIT`, so `--repo-reads
  full` records **exactly** what it did on master — a drift-guard test asserts it (and the corpus of a
  truncated shape is a strict prefix of the full render), and a **golden test pins the complete
  `--repo-reads full` command stream** byte-for-byte through the real CLI Record path: seed=7
  1000/5000 must keep hashing to `sha256:830faf23b57ed61be8e1728a2ec73f09cf3d6fe2d24f0d70b6f8c11ed00c8de4`.
- **`OpPolicy` guard** (`report.rs`/`baseline.rs`): `BaselineKey` gains an `op_policies` map
  (`#[serde(default)]` — old saved Criterion baselines still load); `regression_guard` builds the
  same map from both reports. `op_policy_mismatch` compares the union of budgeted ops — a policy
  present on one side only is a mismatch too (that run really measured the op under the global
  knobs) — and the first difference aborts with both sides rendered in the refusal.

## Tests

- `catalog.rs`: `RecordedBudget` ↔ `OpBudget` mirror test; serde round-trip + exact-JSON + inherit
  omission + `deny_unknown_fields` rejection.
- `mod.rs`: `with_recorded_budget` matches the `with_budget` overlay field-for-field.
- `recording.rs`: budget is **not** folded into `workload_hash`; budget round-trips through the
  manifest; inherit budgets serialize to nothing; pre-budget bundles default to inherit.
- `shapes.rs`: drift-pin (every current shape = full corpus + inherit budget);
  `record_selected_shapes` honors `corpus_size` (renders a strict prefix) + `budget`.
- `tests/synthetic_probe.rs` (live, `#[ignore]`d, runs under coverage):
  `replay_honors_per_op_budgets_and_result_na_skips_reference_capture` — records a 3-op bundle
  (budgeted gated op, inherit gated op, budgeted result-N/A op **whose third command is deliberately
  invalid**) and replays it under a global `C=[1,2] × both-cache` config. Asserts the budgeted op
  measures only C=1 cached, the inherit op measures the full sweep with a digest, the N/A op has no
  digest — and the replay **succeeds**, which is only possible because the reference capture skipped
  the broken command (on master this bundle fails hard; the invalid command sits past the 1-sample
  C=1 measured window, so only the capture path could reach it). Now also asserts the persisted
  policies: both budgeted ops carry the resolved `OpPolicy` (inherited timeouts included), the
  inherit op carries none.
- `baseline.rs`: policy mismatch → `Abort`/`NotComparable` (differing values **and** one-sided),
  identical policies → `Proceed`/`Comparable`; `BaselineKey::from_report` collects exactly the
  budgeted ops.
- `report.rs`: `OpPolicy` serde round-trip; inherit ops omit the field; legacy JSON (no `policy`
  field) deserializes to `None`; `Display` renders every knob.
- `mod.rs`: `repo_reads_full_workload_hash_golden_is_pinned` — the byte-identity golden.

## Validation

- `just ci` — green (build + clippy deny-warnings + tests; 358 lib tests, doc-tests).
- `just coverage` against a live FalkorDB (`falkordb/falkordb:edge`) — green, all 25 ignored
  integration tests passed; **patch coverage 553/559 = 98.9%** (vs master; the only
  uncovered added lines are test `panic!` arms and one defensive bundle-integrity error).
- `just doc-links` — green (0 errors).
- Full ignored integration suite run live against a throwaway container before push.

Docs updated in this PR: `readme.md` (record/replay bullets), the cookbook (manifest `budget`
field), and the design doc's §3.4/§7.2 ✅ markers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-operation benchmark budgets (samples, warmup, concurrency sweep, cache selection, and timeouts).
  * Recorded bundles now preserve per-operation budgets and apply/verify them during replay, including per-operation concurrency and result checks.
  * Result-N/A operations use a lightweight probe (skipping full reference capture).
  * Synthetic read shapes now support per-shape corpus sizing and per-shape budget, and reports persist the resolved per-operation measurement policy.
  * Regression/diff/baseline comparisons refuse to proceed when per-operation policies differ.
* **Documentation**
  * Expanded the synthetic “record/run/report” walkthrough to cover per-operation budgets, workload identity behavior, graph verification details, and result-digest rules (including Result-N/A handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


