### PR TITLE
feat(synthetic): opt-in algorithm read shapes (--repo-algorithms, record + replay)

### DIFF
--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -164,7 +164,13 @@ digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synth
    `record_algorithm_reads()` renders from an all-algorithms-enabled repository with its own
    drift-guard; `--repo-algorithms` composes orthogonally with `--repo-reads`, and tests pin that
    `repo_read_shapes()`/`--repo-reads full` remain exactly the 50 reads with the pinned
-   `workload_hash` golden. Capability variants are annotation-only until step 4.)*
+   `workload_hash` golden. Capability variants are annotation-only until step 4. Review hardening:
+   the shape→tier lookup is family-agnostic (`shape_tier`), so algorithm ops roll into the `full`
+   tier bucket of summaries/diffs and are valid `[op.*]`/`[cross-engine.op.*]` threshold keys —
+   selection stays per-family, untouched; and distinct-corpus completion (the maxFlow pair set) is
+   deterministic **and total**: bounded seeded draws byte-compatible with the original rejection
+   loop, then an exhaustive walk of the ordered-pair space, so it succeeds whenever the space
+   suffices and the too-small error is proven, never draw luck.)*
 4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
 6. **Docs:** cookbook + readme.

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -157,9 +157,14 @@ digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synth
 1. ✅ **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
 2. ✅ **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the
    dynamic path; N/A shapes skip full reference capture.
-3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
+3. ✅ **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
    `algorithm_read_names()` + drift-guard, `record_algorithm_reads()`, `--repo-algorithms`. Record +
-   replay the 4 shapes end-to-end, opt-in.
+   replay the 4 shapes end-to-end, opt-in. *(Implemented: `CoverageFamily::{Reads(profile),
+   Algorithm}` replaces `ShapeSpec.profile` — the A/B `QueryCoverageProfile` is untouched;
+   `record_algorithm_reads()` renders from an all-algorithms-enabled repository with its own
+   drift-guard; `--repo-algorithms` composes orthogonally with `--repo-reads`, and tests pin that
+   `repo_read_shapes()`/`--repo-reads full` remain exactly the 50 reads with the pinned
+   `workload_hash` golden. Capability variants are annotation-only until step 4.)*
 4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
 6. **Docs:** cookbook + readme.

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -205,6 +205,24 @@ Each op entry may also carry a **`budget`** — per-op overrides for
 (omitted when fully inherited, and never part of the `workload_hash`).
 `just synthetic-record <name>` wraps this and writes under `recordings/<name>/` (git-ignored).
 
+**Variant — the opt-in algorithm shapes.** `--repo-algorithms` appends the 4 whole-graph algorithm
+read shapes (`algo.pageRank` / `algo.maxFlow` / `algo.MSF` / `algo.HarmonicCentrality`) to the
+bundle, alone or on top of `--repo-reads`:
+
+```bash
+# The 50 A/B read shapes + the 4 algorithm shapes in one bundle (54 ops), or algorithms alone:
+benchmark synthetic record --repo-reads full --repo-algorithms \
+  --nodes 1000 --edges 5000 --seed 7 --out-dir rec-algos
+benchmark synthetic record --repo-algorithms --nodes 1000 --edges 5000 --seed 7 --out-dir rec-algos-only
+```
+
+Each algorithm shape records a tight per-op `budget` (25 samples, warm-up 2, C=1, cached-only,
+60 s server timeout) and a reduced corpus (1 command each; a small seeded `(source, target)` pair
+set for maxFlow), and starts **result-N/A** — latency/trend coverage, not divergence gating.
+Algorithms never enter `--repo-reads full` or the per-PR `synthetic-verify` gate; every generated
+graph is already simple (no parallel `:Friend` edges) with `bench_capacity` on every edge, so the
+flow/MSF shapes need no extra fixture.
+
 ---
 
 <a id="story-4"></a>

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -212,7 +212,7 @@ bundle, alone or on top of `--repo-reads`:
 ```bash
 # The 50 A/B read shapes + the 4 algorithm shapes in one bundle (54 ops), or algorithms alone:
 benchmark synthetic record --repo-reads full --repo-algorithms \
-  --nodes 1000 --edges 5000 --seed 7 --out-dir rec-algos
+  --nodes 1000 --edges 5000 --seed 7 --out-dir rec-reads-plus-algos
 benchmark synthetic record --repo-algorithms --nodes 1000 --edges 5000 --seed 7 --out-dir rec-algos-only
 ```
 

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -217,8 +217,9 @@ benchmark synthetic record --repo-algorithms --nodes 1000 --edges 5000 --seed 7 
 ```
 
 Each algorithm shape records a tight per-op `budget` (25 samples, warm-up 2, C=1, cached-only,
-60 s server timeout) and a reduced corpus (1 command each; a small seeded `(source, target)` pair
-set for maxFlow), and starts **result-N/A** — latency/trend coverage, not divergence gating.
+60 s server timeout) and a reduced corpus (1 command each; a small seeded set of distinct
+`(source, target)` pairs for maxFlow), and starts **result-N/A** — latency/trend coverage, not
+divergence gating.
 Algorithms never enter `--repo-reads full` or the per-PR `synthetic-verify` gate; every generated
 graph is already simple (no parallel `:Friend` edges) with `bench_capacity` on every edge, so the
 flow/MSF shapes need no extra fixture.

--- a/readme.md
+++ b/readme.md
@@ -473,6 +473,17 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   folded into the `workload_hash`. This is the plumbing that lets whole-graph algorithm shapes
   (~40–80 ms/call) record a 1-command corpus with a tight budget instead of the default 256×sweep.
   `--repo-reads` is mutually exclusive with `--op`/`--all-reads`/`--tier`.
+  **`--repo-algorithms`** additionally records the **4 opt-in whole-graph algorithm read shapes**
+  (`algo.pageRank` / `algo.maxFlow` / `algo.MSF` / `algo.HarmonicCentrality`), each with a tight
+  per-op budget (25 samples, warm-up 2, C=1, cached-only, 60 s server timeout) and a reduced corpus
+  (1 command for the parameterless shapes; a small seeded `(source, target)` pair set for maxFlow).
+  All four start **result-N/A** (their values aren't verified byte-stable yet — `max_flow`/`msf`
+  are gating candidates pending that verification), so they add latency/trend coverage without
+  joining the divergence gate. The selector is **orthogonal** to `--repo-reads` (combinable with it
+  or usable alone; also mutually exclusive with `--op`/`--all-reads`/`--tier`): algorithm shapes are
+  **never** part of `--repo-reads full` nor the per-PR `synthetic-verify` gate. They need no extra
+  fixture — every generated graph is **simple** (no parallel `:Friend` edges, which `algo.maxFlow`
+  rejects) and every `:Friend` edge carries the `bench_capacity` property the flow/MSF shapes use.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result

--- a/readme.md
+++ b/readme.md
@@ -513,9 +513,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   within budget, 🔴 if slower beyond it. The budget is a `budget_pct` plus an absolute `floor_ms`
   noise guard, defaulting to 10 % / 0.5 ms and overridable per-operation and per-operation×concurrency
   in a TOML file (`[default]` + `[op.<name>]` with a `concurrency` inline table). `<name>` may be a
-  catalog op (`synthetic list-ops`) **or** a recorded repo-read shape (e.g. `single_vertex_read`);
+  catalog op (`synthetic list-ops`) **or** any recorded shape — a repo read (e.g.
+  `single_vertex_read`) or an algorithm shape (e.g. `algo_max_flow_single_pair`);
   every measured op resolves a budget — string-keyed override first, else `[default]`; catalog ops
-  and recorded repo-read shapes also roll into their coverage tier. Unlike `--diff`,
+  and recorded shapes also roll into their coverage tier (algorithm shapes count as `full`). Unlike `--diff`,
   it **never aborts**: an op whose `result_digest` differs is shown 🔴 with a `⚠ results differ`
   note and a perf verdict of **N/A** (a mismatched workload/config renders the whole report
   *not comparable*). The report **header echoes the resolved thresholds** (the default budget/floor

--- a/readme.md
+++ b/readme.md
@@ -476,7 +476,7 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   **`--repo-algorithms`** additionally records the **4 opt-in whole-graph algorithm read shapes**
   (`algo.pageRank` / `algo.maxFlow` / `algo.MSF` / `algo.HarmonicCentrality`), each with a tight
   per-op budget (25 samples, warm-up 2, C=1, cached-only, 60 s server timeout) and a reduced corpus
-  (1 command for the parameterless shapes; a small seeded `(source, target)` pair set for maxFlow).
+  (1 command for the parameterless shapes; a small seeded set of distinct `(source, target)` pairs for maxFlow).
   All four start **result-N/A** (their values aren't verified byte-stable yet — `max_flow`/`msf`
   are gating candidates pending that verification), so they add latency/trend coverage without
   joining the divergence gate. The selector is **orthogonal** to `--repo-reads` (combinable with it

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -541,6 +541,12 @@ pub enum SyntheticCommands {
         )]
         repo_reads: Option<Tier>,
         #[arg(
+            long = "repo-algorithms",
+            conflicts_with_all = ["ops", "all_reads", "tier"],
+            help = "additionally record the 4 opt-in whole-graph algorithm read shapes (algo.pageRank / algo.maxFlow / algo.MSF / algo.HarmonicCentrality) — all result-N/A, each with a tight per-op budget (C=1, cached, 25 samples) and a small corpus. Orthogonal to --repo-reads (combinable with it or usable alone); never part of --repo-reads or the per-PR gate. Mutually exclusive with --op/--all-reads/--tier."
+        )]
+        repo_algorithms: bool,
+        #[arg(
             long,
             help = "seed for the dataset and the per-operation corpora (same seed + same tool build ⇒ identical bundle; default 0)"
         )]

--- a/src/queries_repository.rs
+++ b/src/queries_repository.rs
@@ -103,7 +103,8 @@ impl QueryGenerator {
     {
         QueryGenerator {
             query_type,
-            generator: Box::new(generator),
+            // Plain generators have no path draw to preempt; the forced path is ignored.
+            generator: Box::new(move |rng, _path| generator(rng)),
         }
     }
 
@@ -112,18 +113,27 @@ impl QueryGenerator {
     /// stream, so successive renders vary without any caller-supplied seed.
     pub fn generate(&self) -> Query {
         let mut rng = rand::rng();
-        (self.generator)(&mut rng)
+        (self.generator)(&mut rng, None)
     }
 
     /// Render this query from a caller-supplied RNG, so a fixed seed yields a byte-identical
     /// Cypher+params corpus (design §4.1 — the seedable named-generation entry).
     pub fn generate_with_rng(&self, rng: &mut dyn Rng) -> Query {
-        (self.generator)(rng)
+        (self.generator)(rng, None)
+    }
+
+    /// Render this query with an explicit `(source, target)` path preempting the generator's own
+    /// path draw ([`RandomUtil::random_path`]); any other draws still come from `rng`. This is the
+    /// deterministic, total entry the synthetic distinct-corpus fallback enumerates the pair space
+    /// through (`src/synthetic/shapes.rs`); generators that never draw a path render as usual.
+    pub fn generate_with_path(&self, rng: &mut dyn Rng, path: (i32, i32)) -> Query {
+        (self.generator)(rng, Some(path))
     }
 }
 
-// Define a type alias for the function type
-type QueryFn = Box<dyn Fn(&mut dyn Rng) -> Query + Send + Sync>;
+// Define a type alias for the function type: a query generator draws from the supplied RNG, with
+// an optional forced path preempting its `random_path` draw (see `RandomUtil::random_path`).
+type QueryFn = Box<dyn Fn(&mut dyn Rng, Option<(i32, i32)>) -> Query + Send + Sync>;
 
 // Define a type alias for the tuple
 type QueryEntry = (String, QueryType, QueryFn);
@@ -175,11 +185,12 @@ impl QueriesRepositoryBuilder<Flavour> {
         self.queries.push((
             name.into(),
             query_type,
-            Box::new(move |rng: &mut dyn Rng| {
+            Box::new(move |rng: &mut dyn Rng, forced_path: Option<(i32, i32)>| {
                 let mut random = RandomUtil {
                     rng,
                     vertices,
                     _edges: edges,
+                    forced_path,
                 };
                 generator(&mut random, flavour)
             }),
@@ -231,15 +242,13 @@ impl QueriesRepository {
         }
     }
 
-    fn add_with_id<F>(
+    fn add_with_id(
         &mut self,
         id: u16,
         name: impl Into<String>,
         query_type: QueryType,
-        generator: F,
-    ) where
-        F: Fn(&mut dyn Rng) -> Query + Send + Sync + 'static,
-    {
+        generator: QueryFn,
+    ) {
         let name = name.into();
         self.name_to_id.insert(name.clone(), id);
         self.catalog.push(QueryCatalogEntry {
@@ -248,6 +257,10 @@ impl QueriesRepository {
             q_type: query_type,
         });
 
+        let generator = QueryGenerator {
+            query_type,
+            generator,
+        };
         match query_type {
             QueryType::Read => {
                 self.read_query_names.push(name.clone());
@@ -256,13 +269,11 @@ impl QueriesRepository {
                 } else {
                     self.non_algorithm_read_query_names.push(name.clone());
                 }
-                self.read_queries
-                    .insert(name, QueryGenerator::new(query_type, generator));
+                self.read_queries.insert(name, generator);
             }
             QueryType::Write => {
                 self.write_query_names.push(name.clone());
-                self.write_queries
-                    .insert(name, QueryGenerator::new(query_type, generator));
+                self.write_queries.insert(name, generator);
             }
         }
     }
@@ -301,6 +312,26 @@ impl QueriesRepository {
             name.to_string(),
             generator.query_type,
             generator.generate_with_rng(rng),
+        ))
+    }
+
+    /// Render the read shape `name` with an explicit `(source, target)` path preempting its own
+    /// path draw — the deterministic, total entry the synthetic distinct-corpus fallback walks the
+    /// pair space through (`src/synthetic/shapes.rs`). Any non-path draws still come from `rng`.
+    /// Returns `None` if `name` is not a known read shape.
+    pub fn render_read_with_path(
+        &self,
+        name: &str,
+        rng: &mut dyn Rng,
+        path: (i32, i32),
+    ) -> Option<PreparedQuery> {
+        let generator = self.read_queries.get(name)?;
+        let q_id = *self.name_to_id.get(name)?;
+        Some(PreparedQuery::new(
+            q_id,
+            name.to_string(),
+            generator.query_type,
+            generator.generate_with_path(rng, path),
         ))
     }
 
@@ -349,6 +380,10 @@ struct RandomUtil<'a> {
     rng: &'a mut dyn Rng,
     vertices: i32,
     _edges: i32,
+    /// When set, the next [`Self::random_path`] returns this pair instead of drawing — the
+    /// deterministic entry the synthetic distinct-corpus fallback renders explicit pairs through
+    /// ([`QueryGenerator::generate_with_path`]).
+    forced_path: Option<(i32, i32)>,
 }
 
 impl RandomUtil<'_> {
@@ -357,6 +392,9 @@ impl RandomUtil<'_> {
     }
     #[allow(dead_code)]
     fn random_path(&mut self) -> (i32, i32) {
+        if let Some(path) = self.forced_path.take() {
+            return path;
+        }
         let start = self.random_vertex();
         let mut end = self.random_vertex();
 
@@ -396,6 +434,17 @@ impl UsersQueriesRepository {
         rng: &mut dyn Rng,
     ) -> Option<PreparedQuery> {
         self.queries_repository.render_read_with_rng(name, rng)
+    }
+
+    /// See [`QueriesRepository::render_read_with_path`] — the deterministic explicit-pair render
+    /// entry for the synthetic distinct-corpus fallback.
+    pub fn render_read_with_path(
+        &self,
+        name: &str,
+        rng: &mut dyn Rng,
+        path: (i32, i32),
+    ) -> Option<PreparedQuery> {
+        self.queries_repository.render_read_with_path(name, rng, path)
     }
 
     pub fn random_queries(

--- a/src/queries_repository.rs
+++ b/src/queries_repository.rs
@@ -278,6 +278,13 @@ impl QueriesRepository {
         &self.non_algorithm_read_query_names
     }
 
+    /// The algorithm read shape names, in definition order — the opt-in whole-graph algorithm
+    /// shapes the synthetic check records via [`Self::render_read_with_rng`] (Phase 6 §3.3).
+    /// Empty unless the repository was built with an [`AlgorithmQuerySelection`] enabling them.
+    pub fn algorithm_read_names(&self) -> &[String] {
+        &self.algorithm_read_query_names
+    }
+
     /// Render the read shape `name` from a caller-supplied RNG, so a fixed seed yields a
     /// byte-identical Cypher+params corpus (design §4.1 — the seedable entry the record-once /
     /// replay-verbatim synthetic path renders each shape's corpus with). Returns `None` if `name`
@@ -373,6 +380,12 @@ impl UsersQueriesRepository {
     /// synthetic check records via [`Self::render_read_with_rng`] (design §3.4).
     pub fn non_algorithm_read_names(&self) -> &[String] {
         self.queries_repository.non_algorithm_read_names()
+    }
+
+    /// The algorithm read shape names, in definition order (Phase 6 §3.3). Empty unless the
+    /// repository was built with an [`AlgorithmQuerySelection`] enabling them.
+    pub fn algorithm_read_names(&self) -> &[String] {
+        self.queries_repository.algorithm_read_names()
     }
 
     /// Render the read shape `name` from a caller-supplied RNG (record-once determinism, §4.1).

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -8,7 +8,7 @@
 use crate::synthetic::baseline::RegressionGuard;
 use crate::synthetic::provenance::decode_module_version;
 use crate::synthetic::report::{LevelMetrics, LevelReport, Report};
-use crate::synthetic::shapes::repo_read_tier;
+use crate::synthetic::shapes::shape_tier;
 use crate::synthetic::thresholds::{
     BudgetProfile, ResolvedBudget, Thresholds, ThresholdsEcho, Verdict,
 };
@@ -390,10 +390,10 @@ impl RegressionAnalysis {
 }
 
 /// Coverage [`Tier`] for an op key of either kind: legacy catalog tags resolve via
-/// [`OpName::from_tag`]; dynamic (string-keyed) repo read shapes via the shape registry
-/// ([`repo_read_tier`]); names known to neither have no tier.
+/// [`OpName::from_tag`]; dynamic (string-keyed) recorded shapes — repo reads and algorithm shapes
+/// alike — via the shape registry ([`shape_tier`]); names known to neither have no tier.
 pub(crate) fn op_tier(op: &str) -> Option<Tier> {
-    OpName::from_tag(op).map(OpName::tier).or_else(|| repo_read_tier(op))
+    OpName::from_tag(op).map(OpName::tier).or_else(|| shape_tier(op))
 }
 
 /// The display name for a run's column: its `--label` if set, else the caller-supplied `fallback`.

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -1441,6 +1441,37 @@ mod tests {
     }
 
     #[test]
+    fn algorithm_shape_gets_budget_and_tier_end_to_end() {
+        // Phase 6 duck finding: algorithm ops must be first-class in reporting/thresholds — an
+        // `[op.algo_*]` override applies, the op rolls into its registry tier (`full`, from the
+        // family-agnostic `shape_tier`) rather than vanishing from the per-tier buckets, and an
+        // offender carries that tier.
+        let toml = "[op.algo_max_flow_single_pair]\nbudget_pct = 50.0\nfloor_ms = 0.1\n";
+        let t = Thresholds::from_toml_str(toml).unwrap();
+        // 2.0 → 2.6 ms = +30%, Δ0.6 ms: within the 50% override (pass), but over the strict
+        // built-in default (10% AND 0.5 ms) — proving the override, not the default, was applied.
+        let a = rpt("main", 42001, &[("algo_max_flow_single_pair", 2.0, "d1")]);
+        let b = rpt("pr", 42002, &[("algo_max_flow_single_pair", 2.6, "d1")]);
+        let g = regression_guard(&a, &b);
+        let md = regression_md(&a, &b, &g, &t, None);
+        assert!(md.contains("50% AND 0.1 ms"), "guard column shows the override:\n{md}");
+        assert!(md.contains("🟢 <code>algo_max_flow_single_pair</code>"), "{md}");
+        let s = summarize_gate(&a, &b, &g, &t);
+        assert_eq!(s.totals.pass, 1, "{s:?}");
+        // `algo_max_flow_single_pair` is a Tier::Full algorithm shape (shapes.rs registry) — it
+        // must count in `full`, not fall out of both buckets like an unknown tag.
+        let full = s.per_tier.iter().find(|t| t.tier == "full").unwrap();
+        assert_eq!(full.counts.pass, 1, "{s:?}");
+        let core = s.per_tier.iter().find(|t| t.tier == "core").unwrap();
+        assert_eq!(core.counts, OutcomeCounts::default(), "{s:?}");
+        // Same inputs under the strict built-in default: +30%/Δ0.6 ms regresses, and the offender
+        // carries the registry tier.
+        let strict = summarize_gate(&a, &b, &g, &Thresholds::builtin());
+        assert_eq!(strict.totals.regressed, 1, "{strict:?}");
+        assert_eq!(strict.worst_offenders[0].tier.as_deref(), Some("full"), "{strict:?}");
+    }
+
+    #[test]
     fn summarize_and_regression_markdown_agree_on_every_op() {
         // One green (Core), one red (Full), one diverged (Core), one N/A (Core, zero baseline).
         let a = rpt(

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1470,6 +1470,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             all_reads,
             tier,
             repo_reads,
+            repo_algorithms,
             seed,
             nodes,
             edges,
@@ -1479,13 +1480,14 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let ops = crate::cli::expand_op_selectors(&ops);
             // Reuse the run-config resolution (with generate=true) to validate + resolve the
             // dataset knobs, graph and read-op selection, then record OFFLINE (no server).
-            // `--repo-reads` selects the repo read SHAPES implicitly (not catalog ops), so it
-            // forces `all_reads` only to satisfy op resolution; the resolved ops are ignored below.
+            // `--repo-reads`/`--repo-algorithms` select repo SHAPES implicitly (not catalog ops),
+            // so they force `all_reads` only to satisfy op resolution; the resolved ops are
+            // ignored below.
             let overrides = config::CliOverrides {
                 endpoint: None,
                 graph,
                 ops,
-                all_reads: all_reads || repo_reads.is_some(),
+                all_reads: all_reads || repo_reads.is_some() || repo_algorithms,
                 tier,
                 samples: None,
                 warmup: None,
@@ -1507,24 +1509,37 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let spec = resolved.dataset.ok_or_else(|| {
                 OtherError("record requires --nodes/--edges (or a config) to generate a dataset".to_string())
             })?;
-            let manifest = if let Some(tier) = repo_reads {
+            let manifest = if repo_reads.is_some() || repo_algorithms {
                 // Phase 3/4/5: record the queries_repository read shapes (Baseline reads +
                 // ExtendedCore `temporal_spatial_roundtrip` + the FixtureDependent fulltext/vector
-                // reads). Each shape's corpus is rendered ONCE here from `resolved.seed ^ salt`
-                // (record-once → replay-verbatim), then `record_rendered[_with_fixture]` writes the
-                // identical bundle format the catalog path produces (so `workload_hash` stays
-                // byte-identical across replay endpoints — the A/B compares two FalkorDB versions).
-                // When the selected tier includes any FixtureDependent shape, the fulltext/vector
-                // fixture is baked into the recorded graph (once), so every replay gets the identical
-                // fixture (that fixture DDL is FalkorDB-specific — FalkorDB-vs-FalkorDB, not
-                // cross-database).
-                let recorded = crate::synthetic::shapes::record_repo_reads(
-                    tier,
-                    spec.nodes as i32,
-                    spec.edges as i32,
-                    resolved.seed,
-                )?;
-                if crate::synthetic::shapes::repo_reads_need_fixture(tier) {
+                // reads); Phase 6: optionally append the 4 opt-in algorithm shapes
+                // (`--repo-algorithms`, orthogonal to `--repo-reads`). Each shape's corpus is
+                // rendered ONCE here from `resolved.seed ^ salt` (record-once → replay-verbatim),
+                // then `record_rendered[_with_fixture]` writes the identical bundle format the
+                // catalog path produces (so `workload_hash` stays byte-identical across replay
+                // endpoints — the A/B compares two FalkorDB versions). When the selected reads tier
+                // includes any FixtureDependent shape, the fulltext/vector fixture is baked into
+                // the recorded graph (once), so every replay gets the identical fixture (that
+                // fixture DDL is FalkorDB-specific — FalkorDB-vs-FalkorDB, not cross-database).
+                // The algorithm shapes need no fixture: every generated graph is simple
+                // (synthbench/v5) and every `:Friend` edge carries `bench_capacity`.
+                let mut recorded = match repo_reads {
+                    Some(tier) => crate::synthetic::shapes::record_repo_reads(
+                        tier,
+                        spec.nodes as i32,
+                        spec.edges as i32,
+                        resolved.seed,
+                    )?,
+                    None => Vec::new(),
+                };
+                if repo_algorithms {
+                    recorded.extend(crate::synthetic::shapes::record_algorithm_reads(
+                        spec.nodes as i32,
+                        spec.edges as i32,
+                        resolved.seed,
+                    )?);
+                }
+                if repo_reads.is_some_and(crate::synthetic::shapes::repo_reads_need_fixture) {
                     recording::record_rendered_with_fixture(
                         &spec,
                         &resolved.graph,
@@ -2334,6 +2349,7 @@ mod tests {
             all_reads: false,
             tier: Some(Tier::Core),
             repo_reads: None,
+            repo_algorithms: false,
             seed: Some(3),
             nodes: Some(200),
             edges: Some(600),
@@ -2372,6 +2388,7 @@ mod tests {
             all_reads: false,
             tier: None,
             repo_reads: Some(Tier::Core),
+            repo_algorithms: false,
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
@@ -2437,6 +2454,7 @@ mod tests {
             all_reads: false,
             tier: None,
             repo_reads: Some(Tier::Full),
+            repo_algorithms: false,
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
@@ -2503,6 +2521,7 @@ mod tests {
             all_reads: false,
             tier: None,
             repo_reads: Some(Tier::Full),
+            repo_algorithms: false,
             seed: Some(7),
             nodes: Some(1000),
             edges: Some(5000),
@@ -2514,6 +2533,117 @@ mod tests {
             bundle.manifest.workload_hash,
             "sha256:830faf23b57ed61be8e1728a2ec73f09cf3d6fe2d24f0d70b6f8c11ed00c8de4",
             "the --repo-reads full command stream changed byte-wise"
+        );
+        std::fs::remove_dir_all(&out_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_command_record_offline_records_algorithm_shapes() {
+        // `synthetic record --repo-algorithms` runs OFFLINE (Phase 6 §7.3): it writes a bundle
+        // containing exactly the 4 opt-in algorithm shapes — each result-N/A with its recorded
+        // per-op budget — and, without --repo-reads, no read shape and no fulltext/vector fixture
+        // (the algorithm shapes run on the plain simple graph). Exercises the Record handler's
+        // `repo_algorithms` plumbing end-to-end (shapes::record_algorithm_reads → record_rendered).
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let out_dir = std::env::temp_dir().join(format!(
+            "syn-rec-repoalgos-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let command = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: Some("galgos".to_string()),
+            ops: vec![],
+            all_reads: false,
+            tier: None,
+            repo_reads: None,
+            repo_algorithms: true,
+            seed: Some(5),
+            nodes: Some(300),
+            edges: Some(900),
+            out_dir: out_dir.to_string_lossy().into_owned(),
+        };
+        run_command(command)
+            .await
+            .expect("offline algorithm record succeeds without a server");
+        let bundle = recording::load(&out_dir).expect("algorithm bundle loads");
+        let names: Vec<&str> = bundle.manifest.ops.iter().map(|o| o.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "algo_pagerank_summary",
+                "algo_max_flow_single_pair",
+                "algo_msf_summary",
+                "algo_harmonic_summary"
+            ],
+            "exactly the 4 algorithm shapes, in definition order"
+        );
+        for entry in &bundle.manifest.ops {
+            assert!(!entry.result_gated, "{} must start result-N/A (design §6)", entry.name);
+            assert!(
+                !entry.budget.is_inherit(),
+                "{} must carry its recorded per-op budget",
+                entry.name
+            );
+        }
+        // No fixture: the algorithm shapes address the plain generated (simple) graph.
+        assert!(
+            !bundle
+                .graph_statements
+                .iter()
+                .any(|(phase, _)| *phase == crate::synthetic::dataset::LoadPhase::Fixture),
+            "an algorithms-only bundle must not bake the fulltext/vector fixture"
+        );
+        std::fs::remove_dir_all(&out_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_command_record_combines_repo_reads_with_algorithms() {
+        // --repo-algorithms is ORTHOGONAL to --repo-reads (design §3.2): combined, the bundle is
+        // the 50 full-tier reads followed by the 4 algorithm shapes (54 ops), with the fixture
+        // still baked for the FixtureDependent reads.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let out_dir = std::env::temp_dir().join(format!(
+            "syn-rec-reads-plus-algos-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let command = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: Some("gcombined".to_string()),
+            ops: vec![],
+            all_reads: false,
+            tier: None,
+            repo_reads: Some(Tier::Full),
+            repo_algorithms: true,
+            seed: Some(5),
+            nodes: Some(300),
+            edges: Some(900),
+            out_dir: out_dir.to_string_lossy().into_owned(),
+        };
+        run_command(command).await.expect("offline combined record succeeds");
+        let bundle = recording::load(&out_dir).expect("combined bundle loads");
+        assert_eq!(bundle.manifest.ops.len(), 54, "50 reads + 4 algorithm shapes");
+        let names: Vec<&str> = bundle.manifest.ops.iter().map(|o| o.name.as_str()).collect();
+        assert_eq!(names[0], "single_vertex_read", "reads come first, in record order");
+        assert_eq!(
+            &names[50..],
+            [
+                "algo_pagerank_summary",
+                "algo_max_flow_single_pair",
+                "algo_msf_summary",
+                "algo_harmonic_summary"
+            ],
+            "algorithm shapes are appended after the reads"
+        );
+        assert!(
+            bundle
+                .graph_statements
+                .iter()
+                .any(|(phase, _)| *phase == crate::synthetic::dataset::LoadPhase::Fixture),
+            "the FixtureDependent reads still bake the fixture"
         );
         std::fs::remove_dir_all(&out_dir).ok();
     }

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -557,14 +557,14 @@ fn render_shapes(
     for shape in shapes {
         if !available.contains(shape.name) {
             return Err(OtherError(format!(
-                "repo read shape '{}' is annotated but not a queries_repository {kind} \
+                "shape '{}' is annotated but not a queries_repository {kind} \
                  (annotation drift — update src/synthetic/shapes.rs)",
                 shape.name
             )));
         }
         if shape.corpus_size == 0 {
             return Err(OtherError(format!(
-                "repo read shape '{}' has corpus_size 0 — every shape must render at least one \
+                "shape '{}' has corpus_size 0 — every shape must render at least one \
                  command (fix its ShapeSpec in src/synthetic/shapes.rs)",
                 shape.name
             )));
@@ -574,7 +574,7 @@ fn render_shapes(
         let mut commands = Vec::with_capacity(shape.corpus_size);
         for _ in 0..shape.corpus_size {
             let prepared = repo.render_read_with_rng(shape.name, &mut rng).ok_or_else(|| {
-                OtherError(format!("repo read shape '{}' failed to render", shape.name))
+                OtherError(format!("shape '{}' failed to render", shape.name))
             })?;
             commands.push(prepared.cypher);
         }

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -308,16 +308,20 @@ pub fn repo_read_shapes() -> Vec<ShapeSpec> {
     shapes
 }
 
-/// The coverage [`Tier`] of the repo read shape named `name`, or `None` when no repo read shape has
-/// that name. Lets string-keyed consumers (thresholds validation, report tier rollups) resolve a
-/// dynamic recorded op exactly like a static catalog op.
-pub fn repo_read_tier(name: &str) -> Option<Tier> {
-    // Chain the component lists (same order as `repo_read_shapes`) instead of materializing the
-    // combined Vec on every lookup; `repo_read_tier_covers_every_repo_read_shape` guards drift.
+/// The coverage [`Tier`] of the recorded shape named `name` — **family-agnostic**: repo read
+/// shapes and the Phase 6 algorithm shapes alike — or `None` when no shape has that name. Lets
+/// string-keyed consumers (thresholds validation, report tier rollups) resolve a dynamic recorded
+/// op exactly like a static catalog op. Selection stays per-family ([`record_repo_reads`] /
+/// [`record_algorithm_reads`]) — this is a lookup, not a selector.
+pub fn shape_tier(name: &str) -> Option<Tier> {
+    // Chain the component lists (same order as `repo_read_shapes`, then the algorithm family)
+    // instead of materializing the combined Vec on every lookup;
+    // `shape_tier_covers_every_shape` guards drift.
     baseline_read_shapes()
         .into_iter()
         .chain(extended_core_read_shapes())
         .chain(fixture_dependent_read_shapes())
+        .chain(algorithm_read_shapes())
         .find(|shape| shape.name == name)
         .map(|shape| shape.tier)
 }
@@ -502,7 +506,7 @@ fn record_selected_shapes(
         .iter()
         .map(String::as_str)
         .collect();
-    render_shapes(&repo, &available, "non-algorithm read", shapes, corpus_seed)
+    render_shapes(&repo, &available, "non-algorithm read", shapes, vertices, corpus_seed)
 }
 
 /// Render the 4 opt-in algorithm read shapes ([`algorithm_read_shapes`]) into [`RecordedOp`]s —
@@ -537,6 +541,7 @@ pub fn record_algorithm_reads(
         &available,
         "algorithm read",
         &algorithm_read_shapes(),
+        vertices,
         corpus_seed,
     )
 }
@@ -551,6 +556,7 @@ fn render_shapes(
     available: &BTreeSet<&str>,
     kind: &str,
     shapes: &[ShapeSpec],
+    vertices: i32,
     corpus_seed: u64,
 ) -> BenchmarkResult<Vec<RecordedOp>> {
     let mut ops = Vec::with_capacity(shapes.len());
@@ -581,19 +587,8 @@ fn render_shapes(
         let mut seen = BTreeSet::new();
         let max_attempts = shape.corpus_size * 16;
         let mut attempts = 0usize;
-        while commands.len() < shape.corpus_size {
+        while commands.len() < shape.corpus_size && attempts < max_attempts {
             attempts += 1;
-            if attempts > max_attempts {
-                return Err(OtherError(format!(
-                    "shape '{}' rendered only {} distinct command(s) of the {} its corpus needs \
-                     within {max_attempts} attempts — its parameter space is too small for its \
-                     corpus_size (shrink corpus_size in src/synthetic/shapes.rs or enlarge the \
-                     dataset)",
-                    shape.name,
-                    commands.len(),
-                    shape.corpus_size
-                )));
-            }
             let prepared = repo.render_read_with_rng(shape.name, &mut rng).ok_or_else(|| {
                 OtherError(format!("shape '{}' failed to render", shape.name))
             })?;
@@ -601,6 +596,43 @@ fn render_shapes(
                 continue;
             }
             commands.push(prepared.cypher);
+        }
+        if commands.len() < shape.corpus_size {
+            // Exhaustive fallback (the #259 dedup pattern): the bounded random draws above could
+            // not fill the distinct corpus, so walk the entire ordered-pair space in canonical
+            // order and take the first unused renders. This makes completion deterministic AND
+            // total — it succeeds whenever enough distinct commands exist, so the error below
+            // proves the space is genuinely too small (never draw luck). Only distinct corpora
+            // can be short here: a plain corpus keeps every draw and fills within its budget.
+            'walk: for source in 1..=vertices {
+                for target in 1..=vertices {
+                    if source == target {
+                        continue;
+                    }
+                    let prepared = repo
+                        .render_read_with_path(shape.name, &mut rng, (source, target))
+                        .ok_or_else(|| {
+                            OtherError(format!("shape '{}' failed to render", shape.name))
+                        })?;
+                    if !seen.insert(prepared.cypher.clone()) {
+                        continue;
+                    }
+                    commands.push(prepared.cypher);
+                    if commands.len() == shape.corpus_size {
+                        break 'walk;
+                    }
+                }
+            }
+        }
+        if commands.len() < shape.corpus_size {
+            return Err(OtherError(format!(
+                "shape '{}' can render only {} distinct command(s) of the {} its corpus needs — \
+                 exhaustively verified over every (source, target) pair of the {vertices}-vertex \
+                 dataset (shrink corpus_size in src/synthetic/shapes.rs or enlarge the dataset)",
+                shape.name,
+                commands.len(),
+                shape.corpus_size
+            )));
         }
         ops.push(RecordedOp {
             key,
@@ -623,19 +655,21 @@ mod tests {
     }
 
     #[test]
-    fn repo_read_tier_resolves_by_name() {
-        // String-keyed tier lookup over the registry: a core shape, a full shape, and a miss.
-        assert_eq!(repo_read_tier("single_vertex_read"), Some(Tier::Core));
-        assert_eq!(repo_read_tier("vector_query_nodes_smoke"), Some(Tier::Full));
-        assert_eq!(repo_read_tier("not_a_shape"), None);
+    fn shape_tier_resolves_by_name() {
+        // String-keyed tier lookup over the registry: a core read, a full read, an algorithm
+        // shape (family-agnostic — algorithm ops roll up into tier buckets too), and a miss.
+        assert_eq!(shape_tier("single_vertex_read"), Some(Tier::Core));
+        assert_eq!(shape_tier("vector_query_nodes_smoke"), Some(Tier::Full));
+        assert_eq!(shape_tier("algo_max_flow_single_pair"), Some(Tier::Full));
+        assert_eq!(shape_tier("not_a_shape"), None);
     }
 
     #[test]
-    fn repo_read_tier_covers_every_repo_read_shape() {
-        // Drift guard for the chained lookup: every shape in the combined registry must resolve
-        // to its own tier, so a new component list can't silently escape `repo_read_tier`.
-        for shape in repo_read_shapes() {
-            assert_eq!(repo_read_tier(shape.name), Some(shape.tier), "{}", shape.name);
+    fn shape_tier_covers_every_shape() {
+        // Drift guard for the chained lookup: every shape in every family registry must resolve
+        // to its own tier, so a new component list can't silently escape `shape_tier`.
+        for shape in repo_read_shapes().into_iter().chain(algorithm_read_shapes()) {
+            assert_eq!(shape_tier(shape.name), Some(shape.tier), "{}", shape.name);
         }
     }
 
@@ -813,9 +847,10 @@ mod tests {
         );
         for name in &algo_names {
             assert_eq!(
-                repo_read_tier(name),
-                None,
-                "'{name}' must not resolve to a repo read tier (algorithms are outside --repo-reads)"
+                shape_tier(name),
+                Some(Tier::Full),
+                "'{name}' stays outside --repo-reads selection but must still resolve a tier \
+                 for rollups/thresholds (family-agnostic shape_tier)"
             );
         }
     }
@@ -875,6 +910,53 @@ mod tests {
         assert_eq!(max_flow.commands.len(), MAX_FLOW_CORPUS_SIZE);
         let unique: BTreeSet<&str> = max_flow.commands.iter().map(String::as_str).collect();
         assert_eq!(unique.len(), MAX_FLOW_CORPUS_SIZE, "corpus must be distinct despite collisions");
+    }
+
+    #[test]
+    fn max_flow_distinct_corpus_is_total_when_the_pair_space_barely_fits() {
+        // 3 vertices ⇒ EXACTLY 6 ordered (source, target) pairs. A corpus needing all 6 can never
+        // be guaranteed by bounded random draws (coupon-collector tail) — the exhaustive fallback
+        // must deliver every pair, for ANY seed, twice-identically. (The real maxFlow corpus is 4;
+        // sizing it to the whole space exercises the totality property the random phase lacks.)
+        let mut shape = algorithm_read_shapes().remove(1);
+        assert_eq!(shape.name, "algo_max_flow_single_pair");
+        shape.corpus_size = 6;
+        let repo = UsersQueriesRepository::new(
+            3,
+            6,
+            Flavour::FalkorDB,
+            all_algorithms(),
+            QueryCoverageProfile::Baseline,
+        );
+        let available: BTreeSet<&str> =
+            repo.algorithm_read_names().iter().map(String::as_str).collect();
+        for seed in [7u64, 0, 42, u64::MAX] {
+            let shapes = std::slice::from_ref(&shape);
+            let ops = render_shapes(&repo, &available, "algorithm read", shapes, 3, seed)
+                .unwrap_or_else(|e| panic!("seed {seed}: the space suffices, must fill: {e}"));
+            let unique: BTreeSet<&str> = ops[0].commands.iter().map(String::as_str).collect();
+            assert_eq!(unique.len(), 6, "seed {seed}: all 6 ordered pairs — no draw luck");
+            let again = render_shapes(&repo, &available, "algorithm read", shapes, 3, seed)
+                .expect("re-render");
+            assert_eq!(ops[0].commands, again[0].commands, "seed {seed}: deterministic");
+        }
+    }
+
+    #[test]
+    fn seed7_max_flow_corpus_renders_the_historical_pair_sequence() {
+        // Golden for the exhaustive-fallback change: the bounded random phase stays
+        // byte-compatible with the pre-fallback rejection loop, so the seed=7 1000/5000 oracle
+        // corpus — `workload_hash`-relevant bytes in recorded bundles — must render exactly the
+        // historical (source, target) sequence, in order.
+        let ops = record_algorithm_reads(1000, 5000, 7).expect("record");
+        let max_flow = &ops[1];
+        assert_eq!(max_flow.key.name(), "algo_max_flow_single_pair");
+        let expected = [(834, 998), (251, 200), (243, 109), (916, 109)];
+        assert_eq!(max_flow.commands.len(), expected.len());
+        for (cmd, (source, target)) in max_flow.commands.iter().zip(expected) {
+            let prefix = format!("CYPHER source_id = {source} target_id = {target} ");
+            assert!(cmd.starts_with(&prefix), "expected `{prefix}…`, got: {cmd}");
+        }
     }
 
     #[test]

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -40,7 +40,7 @@ use crate::queries_repository::{
 };
 use crate::synthetic::catalog::{OpBudget, CORPUS_SIZE};
 use crate::synthetic::recording::RecordedOp;
-use crate::synthetic::{OpKey, Tier};
+use crate::synthetic::{CacheSelection, OpKey, Tier};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::collections::BTreeSet;
@@ -79,10 +79,38 @@ pub enum ShapeCapability {
     FulltextQueryNodes,
     /// `db.idx.fulltext.queryRelationships` — a fulltext index over `:Friend(ft_text)`.
     FulltextQueryRelationships,
+    /// `algo.pageRank` — whole-graph PageRank (Phase 6, per-procedure per design §3.5).
+    AlgoPageRank,
+    /// `algo.maxFlow` — single-pair max flow over `bench_capacity` (Phase 6).
+    AlgoMaxFlow,
+    /// `algo.MSF` — minimum spanning forest over `bench_capacity` (Phase 6).
+    AlgoMsf,
+    /// `algo.HarmonicCentrality` — whole-graph harmonic centrality (Phase 6).
+    AlgoHarmonic,
+}
+
+/// The **synthetic-only** coverage family a shape belongs to (design Phase 6 §3.3): which curated
+/// annotation table defines it and which record-time selector picks it up.
+///
+/// Deliberately **not** [`QueryCoverageProfile`] — that enum is the global A/B `--query-profile`
+/// CLI surface (`clap::ValueEnum`), so an `Algorithm` member there would expose a misleading
+/// `--query-profile algorithm` on the A/B benchmark that still wouldn't enable algorithm queries
+/// (that's [`AlgorithmQuerySelection`]). This family axis exists only inside the synthetic check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageFamily {
+    /// A non-algorithm repo read, tagged with the A/B [`QueryCoverageProfile`] that introduced it
+    /// (`Baseline` Phase 3, `ExtendedCore` Phase 4, `FixtureDependent` Phase 5). Selected by
+    /// `--repo-reads <tier>`.
+    Reads(QueryCoverageProfile),
+    /// An opt-in whole-graph algorithm read (Phase 6) — selected **only** by `--repo-algorithms`,
+    /// never by `--repo-reads`/tier, never in the per-PR gate, and absent from the A/B
+    /// `--query-profile`.
+    Algorithm,
 }
 
 /// One repo read shape's synthetic metadata: its stable [`queries_repository`] name, coverage
-/// **profile** (Baseline / ExtendedCore / FixtureDependent), coverage **tier** (Decision 1), result
+/// **family** (non-algorithm read tagged with its A/B profile, or opt-in algorithm — Phase 6),
+/// coverage **tier** (Decision 1), result
 /// policy (Decision 4), optional **capability** (Phase 5 fulltext/vector), and its record-time
 /// **corpus size** + replay **budget** (design §3.4).
 ///
@@ -99,10 +127,10 @@ pub enum ShapeCapability {
 pub struct ShapeSpec {
     /// The shape's stable `queries_repository` read name (also the recorded op's key).
     pub name: &'static str,
-    /// Coverage profile the shape belongs to: [`QueryCoverageProfile::Baseline`] (Phase 3),
-    /// [`QueryCoverageProfile::ExtendedCore`] (Phase 4), or [`QueryCoverageProfile::FixtureDependent`]
-    /// (Phase 5).
-    pub profile: QueryCoverageProfile,
+    /// The synthetic-only [`CoverageFamily`] the shape belongs to: a non-algorithm read tagged
+    /// with the [`QueryCoverageProfile`] that introduced it (Phases 3–5), or an opt-in
+    /// [`CoverageFamily::Algorithm`] shape (Phase 6).
+    pub family: CoverageFamily,
     /// Coverage tier: [`Tier::Core`] gates every PR; [`Tier::Full`] runs nightly/on-demand.
     pub tier: Tier,
     /// Whether replay gates this shape's result digest ([`ResultPolicy`]).
@@ -141,7 +169,7 @@ pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
     ) -> ShapeSpec {
         ShapeSpec {
             name,
-            profile: QueryCoverageProfile::Baseline,
+            family: CoverageFamily::Reads(QueryCoverageProfile::Baseline),
             tier,
             result_policy,
             capability: None,
@@ -219,7 +247,7 @@ pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
 pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
     vec![ShapeSpec {
         name: "temporal_spatial_roundtrip",
-        profile: QueryCoverageProfile::ExtendedCore,
+        family: CoverageFamily::Reads(QueryCoverageProfile::ExtendedCore),
         tier: Tier::Core,
         result_policy: ResultPolicy::Gated,
         capability: None,
@@ -253,7 +281,7 @@ pub fn fixture_dependent_read_shapes() -> Vec<ShapeSpec> {
     ) -> ShapeSpec {
         ShapeSpec {
             name,
-            profile: QueryCoverageProfile::FixtureDependent,
+            family: CoverageFamily::Reads(QueryCoverageProfile::FixtureDependent),
             tier: Tier::Full,
             result_policy: ResultPolicy::NotApplicable(
                 "vector/fulltext top-k ordering is non-deterministic",
@@ -312,7 +340,107 @@ fn selected_shapes(tier: Tier) -> Vec<ShapeSpec> {
 pub fn repo_reads_need_fixture(tier: Tier) -> bool {
     selected_shapes(tier)
         .iter()
-        .any(|shape| shape.profile == QueryCoverageProfile::FixtureDependent)
+        .any(|shape| shape.family == CoverageFamily::Reads(QueryCoverageProfile::FixtureDependent))
+}
+
+/// The concurrency sweep every algorithm shape measures: a single closed-loop worker. Whole-graph
+/// algorithms saturate the engine by themselves, so a concurrency curve adds runtime without
+/// information.
+static ALGORITHM_SWEEP: [usize; 1] = [1];
+
+/// The corpus size for `algo_max_flow_single_pair` — a small seeded set of distinct
+/// `(source, target)` pairs (design §3.4), instead of the [`CORPUS_SIZE`]-command corpus a cheap
+/// read records.
+const MAX_FLOW_CORPUS_SIZE: usize = 4;
+
+/// The per-op budget every algorithm shape records (design §3.4): whole-graph algorithms are
+/// ~40–80 ms/call, so they dial samples/concurrency down and their timeouts up instead of
+/// inheriting the global read-tuned knobs. Recorded into the bundle ([`RecordedBudget`]) and
+/// overlaid on the global config at replay; the resolved effective policy is persisted per op and
+/// guarded by `report --diff`.
+///
+/// [`RecordedBudget`]: crate::synthetic::catalog::RecordedBudget
+const ALGORITHM_BUDGET: OpBudget = OpBudget {
+    samples: Some(25),
+    warmup: Some(2),
+    concurrency: Some(&ALGORITHM_SWEEP),
+    cache: Some(CacheSelection::Cached),
+    server_timeout_ms: Some(60_000),
+    client_deadline_ms: Some(75_000),
+};
+
+/// The curated annotation for the **4 opt-in whole-graph algorithm read shapes** (design Phase 6
+/// §7.3), in `queries_repository` definition order. Selected **only** by `--repo-algorithms` —
+/// never by `--repo-reads`/tier, never in the per-PR gate ([`repo_read_shapes`] is exactly the 50
+/// non-algorithm reads).
+///
+/// The op *set* is auto-discovered: the drift-guard test asserts this table's names are **exactly**
+/// [`UsersQueriesRepository::algorithm_read_names`] of an all-algorithms-enabled repository, so
+/// adding/removing an algorithm read there fails the build until this table is updated.
+///
+/// All four start [`ResultPolicy::NotApplicable`] per the design's §6 determinism table;
+/// `max_flow`/`msf` are gating **candidates**, promoted only after byte-stability across ≥2
+/// independent record runs on the same image is verified (design §7.5). Never force determinism
+/// with a synthetic-only `ORDER BY`. Each carries the per-procedure [`ShapeCapability`] it
+/// exercises (annotation in this phase; probe-before-capture is design §3.5).
+pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {
+    use ShapeCapability::{AlgoHarmonic, AlgoMaxFlow, AlgoMsf, AlgoPageRank};
+    // Every row is an Algorithm-family, Full-tier shape with the algorithm budget; only the
+    // corpus size (1 for parameterless shapes, a small seeded pair set for maxFlow), capability
+    // and N/A reason vary.
+    fn s(
+        name: &'static str,
+        capability: ShapeCapability,
+        corpus_size: usize,
+        not_applicable_reason: &'static str,
+    ) -> ShapeSpec {
+        ShapeSpec {
+            name,
+            family: CoverageFamily::Algorithm,
+            tier: Tier::Full,
+            result_policy: ResultPolicy::NotApplicable(not_applicable_reason),
+            capability: Some(capability),
+            corpus_size,
+            budget: ALGORITHM_BUDGET,
+        }
+    }
+    vec![
+        s(
+            "algo_pagerank_summary",
+            AlgoPageRank,
+            1,
+            "RETURN score LIMIT 1 without ORDER BY — arbitrary single float",
+        ),
+        s(
+            "algo_max_flow_single_pair",
+            AlgoMaxFlow,
+            MAX_FLOW_CORPUS_SIZE,
+            "gating candidate — pending byte-stable digests across >=2 record runs (design §7.5)",
+        ),
+        s(
+            "algo_msf_summary",
+            AlgoMsf,
+            1,
+            "gating candidate — pending byte-stable digests across >=2 record runs (design §7.5)",
+        ),
+        s(
+            "algo_harmonic_summary",
+            AlgoHarmonic,
+            1,
+            "avg/max over all nodes — iterative float value stability unproven",
+        ),
+    ]
+}
+
+/// The algorithm selection [`record_algorithm_reads`] uses: **all four** enabled, so the
+/// repository registers every `algo_*` read and the drift-guard sees the complete set.
+fn all_algorithms() -> AlgorithmQuerySelection {
+    AlgorithmQuerySelection {
+        pagerank: true,
+        max_flow: true,
+        msf: true,
+        harmonic: true,
+    }
 }
 
 /// The algorithm selection the baseline-read source uses: **none**. Algorithm reads are opt-in and
@@ -374,12 +502,62 @@ fn record_selected_shapes(
         .iter()
         .map(String::as_str)
         .collect();
+    render_shapes(&repo, &available, "non-algorithm read", shapes, corpus_seed)
+}
 
+/// Render the 4 opt-in algorithm read shapes ([`algorithm_read_shapes`]) into [`RecordedOp`]s —
+/// **offline**, no server (design Phase 6 §7.3, selected by `--repo-algorithms`).
+///
+/// Renders from an **all-algorithms-enabled** repository (design §3.3 — the read-shape path builds
+/// with [`no_algorithms`], which never registers the `algo_*` reads) and validates the annotation
+/// table against [`UsersQueriesRepository::algorithm_read_names`] (annotation drift fails loudly).
+/// The rendered corpora address the plain generated dataset: since `synthbench/v5` every generated
+/// graph is **simple** (no parallel `:Friend` edges — `algo.maxFlow` rejects multi-edges) and every
+/// `:Friend` edge carries `bench_capacity` (maxFlow's `capacityProperty`, MSF's `weightAttribute`),
+/// so no extra fixture is baked.
+pub fn record_algorithm_reads(
+    vertices: i32,
+    edges: i32,
+    corpus_seed: u64,
+) -> BenchmarkResult<Vec<RecordedOp>> {
+    let repo = UsersQueriesRepository::new(
+        vertices,
+        edges,
+        Flavour::FalkorDB,
+        all_algorithms(),
+        QueryCoverageProfile::Baseline,
+    );
+    let available: BTreeSet<&str> = repo
+        .algorithm_read_names()
+        .iter()
+        .map(String::as_str)
+        .collect();
+    render_shapes(
+        &repo,
+        &available,
+        "algorithm read",
+        &algorithm_read_shapes(),
+        corpus_seed,
+    )
+}
+
+/// Render each of `shapes` into a [`RecordedOp`] from `repo`, seeding every shape's corpus with
+/// `corpus_seed ^ salt` (the op's [`OpKey::salt`]) so a given seed yields a byte-identical corpus
+/// (record-once → replay-verbatim). `available` is the repository's auto-discovered name set for
+/// the family being rendered; `kind` names it in the annotation-drift error. Shared by
+/// [`record_selected_shapes`] (non-algorithm reads) and [`record_algorithm_reads`] (Phase 6).
+fn render_shapes(
+    repo: &UsersQueriesRepository,
+    available: &BTreeSet<&str>,
+    kind: &str,
+    shapes: &[ShapeSpec],
+    corpus_seed: u64,
+) -> BenchmarkResult<Vec<RecordedOp>> {
     let mut ops = Vec::with_capacity(shapes.len());
     for shape in shapes {
         if !available.contains(shape.name) {
             return Err(OtherError(format!(
-                "repo read shape '{}' is annotated but not a queries_repository non-algorithm read \
+                "repo read shape '{}' is annotated but not a queries_repository {kind} \
                  (annotation drift — update src/synthetic/shapes.rs)",
                 shape.name
             )));
@@ -479,7 +657,7 @@ mod tests {
         assert_eq!(added, annotated, "ExtendedCore adds exactly the annotated extended-core reads");
         assert!(added.contains("temporal_spatial_roundtrip"));
         for shape in extended_core_read_shapes() {
-            assert_eq!(shape.profile, QueryCoverageProfile::ExtendedCore);
+            assert_eq!(shape.family, CoverageFamily::Reads(QueryCoverageProfile::ExtendedCore));
         }
     }
 
@@ -509,7 +687,10 @@ mod tests {
         );
         // Every fixture shape is FixtureDependent, Full-tier, result-N/A, and carries a capability.
         for shape in fixture_dependent_read_shapes() {
-            assert_eq!(shape.profile, QueryCoverageProfile::FixtureDependent);
+            assert_eq!(
+                shape.family,
+                CoverageFamily::Reads(QueryCoverageProfile::FixtureDependent)
+            );
             assert_eq!(shape.tier, Tier::Full);
             assert!(!shape.result_policy.is_gated(), "top-k reads are result-N/A");
             assert!(shape.capability.is_some(), "fixture reads carry a capability");
@@ -540,6 +721,126 @@ mod tests {
     }
 
     #[test]
+    fn algorithm_shapes_match_exactly_the_repo_algorithm_read_names() {
+        // Derive-with-annotation for Phase 6: the annotation table must be EXACTLY the algorithm
+        // reads an all-algorithms-enabled repository auto-discovers, in definition order. If
+        // `queries_repository` adds/renames/removes an `algo_*` read, this fails until
+        // `algorithm_read_shapes()` is updated.
+        let repo = UsersQueriesRepository::new(
+            1000,
+            5000,
+            Flavour::FalkorDB,
+            all_algorithms(),
+            QueryCoverageProfile::Baseline,
+        );
+        let discovered: Vec<&str> =
+            repo.algorithm_read_names().iter().map(String::as_str).collect();
+        let annotated: Vec<&str> = algorithm_read_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(annotated, discovered, "algorithm shapes drifted from repo algorithm reads");
+        // The read-shape repository (no_algorithms) must discover NO algorithm reads — the family
+        // is reachable only through record_algorithm_reads.
+        let reads_repo = read_shapes_repository(QueryCoverageProfile::FixtureDependent, 1000, 5000);
+        assert!(reads_repo.algorithm_read_names().is_empty());
+    }
+
+    #[test]
+    fn algorithm_shapes_are_all_result_na_full_tier_with_per_procedure_capabilities() {
+        // Design §6: all four start result-N/A (max_flow/msf promote only after §7.5 byte-stability
+        // verification); §3.5: each carries its per-procedure capability; §3.4: each records a
+        // reduced corpus (1, or the small seeded maxFlow pair set) under the algorithm budget.
+        let shapes = algorithm_read_shapes();
+        assert_eq!(shapes.len(), 4);
+        for shape in &shapes {
+            assert_eq!(shape.family, CoverageFamily::Algorithm, "'{}'", shape.name);
+            assert_eq!(shape.tier, Tier::Full, "'{}'", shape.name);
+            assert!(!shape.result_policy.is_gated(), "'{}' must start result-N/A", shape.name);
+            assert_eq!(shape.budget, ALGORITHM_BUDGET, "'{}'", shape.name);
+        }
+        let caps: Vec<Option<ShapeCapability>> = shapes.iter().map(|s| s.capability).collect();
+        assert_eq!(
+            caps,
+            vec![
+                Some(ShapeCapability::AlgoPageRank),
+                Some(ShapeCapability::AlgoMaxFlow),
+                Some(ShapeCapability::AlgoMsf),
+                Some(ShapeCapability::AlgoHarmonic),
+            ]
+        );
+        let corpora: Vec<usize> = shapes.iter().map(|s| s.corpus_size).collect();
+        assert_eq!(
+            corpora,
+            vec![1, MAX_FLOW_CORPUS_SIZE, 1, 1],
+            "parameterless shapes render once; maxFlow renders its seeded pair set"
+        );
+    }
+
+    #[test]
+    fn repo_read_shapes_exclude_algorithms_and_stay_exactly_todays_50_reads() {
+        // Design §3.2: `repo_read_shapes()` / `--repo-reads full` remain EXACTLY today's 50
+        // non-algorithm reads — algorithms are selected only by the orthogonal --repo-algorithms
+        // (never by tier, never in the per-PR gate). The workload-hash golden in mod.rs pins the
+        // recorded byte stream; this pins the selection sets.
+        let read_names: BTreeSet<&str> = repo_read_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(read_names.len(), 50);
+        let algo_names: BTreeSet<&str> = algorithm_read_shapes().iter().map(|s| s.name).collect();
+        assert!(
+            read_names.is_disjoint(&algo_names),
+            "algorithm shapes must never enter repo_read_shapes()"
+        );
+        for name in &algo_names {
+            assert_eq!(
+                repo_read_tier(name),
+                None,
+                "'{name}' must not resolve to a repo read tier (algorithms are outside --repo-reads)"
+            );
+        }
+    }
+
+    #[test]
+    fn record_algorithm_reads_renders_seeded_budgeted_corpora() {
+        // The Phase 6 record path end-to-end (offline): 4 ops in definition order, each carrying
+        // the algorithm budget and its reduced corpus, byte-identical for a fixed seed.
+        let ops = record_algorithm_reads(1000, 5000, 7).expect("record algorithm reads");
+        let names: Vec<&str> = ops.iter().map(|op| op.key.name()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "algo_pagerank_summary",
+                "algo_max_flow_single_pair",
+                "algo_msf_summary",
+                "algo_harmonic_summary"
+            ]
+        );
+        for op in &ops {
+            assert!(!op.result_gated, "'{}' starts result-N/A (design §6)", op.key.name());
+            assert_eq!(
+                op.budget,
+                RecordedBudget::from(ALGORITHM_BUDGET),
+                "'{}' must record the algorithm budget",
+                op.key.name()
+            );
+        }
+        let corpora: Vec<usize> = ops.iter().map(|op| op.commands.len()).collect();
+        assert_eq!(corpora, vec![1, MAX_FLOW_CORPUS_SIZE, 1, 1]);
+        // The rendered Cypher exercises the real procedures…
+        assert!(ops[0].commands[0].contains("algo.pageRank"), "{}", ops[0].commands[0]);
+        assert!(ops[1].commands[0].contains("algo.maxFlow"), "{}", ops[1].commands[0]);
+        assert!(ops[1].commands[0].contains("bench_capacity"), "{}", ops[1].commands[0]);
+        assert!(ops[2].commands[0].contains("algo.MSF"), "{}", ops[2].commands[0]);
+        assert!(ops[3].commands[0].contains("algo.HarmonicCentrality"), "{}", ops[3].commands[0]);
+        // …the maxFlow corpus is a seeded set of distinct (source, target) pairs (deterministic
+        // for the fixed seed, so distinctness is a stable fact)…
+        let unique_pairs: BTreeSet<&str> =
+            ops[1].commands.iter().map(String::as_str).collect();
+        assert_eq!(unique_pairs.len(), MAX_FLOW_CORPUS_SIZE, "seeded pairs must differ");
+        // …and the same seed reproduces the identical corpus (record-once → replay-verbatim).
+        let again = record_algorithm_reads(1000, 5000, 7).expect("re-record");
+        for (a, b) in ops.iter().zip(&again) {
+            assert_eq!(a.commands, b.commands, "'{}' corpus must be seed-stable", a.key.name());
+        }
+    }
+
+    #[test]
     fn there_are_forty_six_baseline_reads_with_a_nonempty_core_subset() {
         let shapes = baseline_read_shapes();
         assert_eq!(shapes.len(), 46, "expected the 46 baseline reads (design §3.4)");
@@ -557,18 +858,26 @@ mod tests {
         let names: BTreeSet<&str> = shapes.iter().map(|s| s.name).collect();
         assert_eq!(names.len(), 50, "shape names must be unique across profiles");
         assert_eq!(
-            shapes.iter().filter(|s| s.profile == QueryCoverageProfile::ExtendedCore).count(),
+            shapes
+                .iter()
+                .filter(|s| s.family == CoverageFamily::Reads(QueryCoverageProfile::ExtendedCore))
+                .count(),
             1,
             "exactly one extended-core read"
         );
         assert_eq!(
-            shapes.iter().filter(|s| s.profile == QueryCoverageProfile::FixtureDependent).count(),
+            shapes
+                .iter()
+                .filter(
+                    |s| s.family == CoverageFamily::Reads(QueryCoverageProfile::FixtureDependent)
+                )
+                .count(),
             3,
             "exactly three fixture-dependent reads"
         );
         // `temporal_spatial_roundtrip` is ExtendedCore, Core-tier, and result-gated.
         let ts = shapes.iter().find(|s| s.name == "temporal_spatial_roundtrip").unwrap();
-        assert_eq!(ts.profile, QueryCoverageProfile::ExtendedCore);
+        assert_eq!(ts.family, CoverageFamily::Reads(QueryCoverageProfile::ExtendedCore));
         assert_eq!(ts.tier, Tier::Core);
         assert!(ts.result_policy.is_gated());
         assert_eq!(ts.capability, None);
@@ -579,7 +888,10 @@ mod tests {
             "fulltext_query_relationships_smoke",
         ] {
             let s = shapes.iter().find(|s| s.name == name).unwrap();
-            assert_eq!(s.profile, QueryCoverageProfile::FixtureDependent);
+            assert_eq!(
+                s.family,
+                CoverageFamily::Reads(QueryCoverageProfile::FixtureDependent)
+            );
             assert_eq!(s.tier, Tier::Full);
             assert!(!s.result_policy.is_gated());
             assert!(s.capability.is_some());
@@ -727,7 +1039,7 @@ mod tests {
         // safety net behind the derive-with-annotation model.
         let bogus = [ShapeSpec {
             name: "__not_a_repo_read__",
-            profile: QueryCoverageProfile::Baseline,
+            family: CoverageFamily::Reads(QueryCoverageProfile::Baseline),
             tier: Tier::Full,
             result_policy: ResultPolicy::Gated,
             capability: None,
@@ -761,7 +1073,7 @@ mod tests {
         static SWEEP: [usize; 1] = [1];
         let small = [ShapeSpec {
             name: "single_vertex_read",
-            profile: QueryCoverageProfile::Baseline,
+            family: CoverageFamily::Reads(QueryCoverageProfile::Baseline),
             tier: Tier::Core,
             result_policy: ResultPolicy::Gated,
             capability: None,
@@ -797,7 +1109,7 @@ mod tests {
     fn record_selected_shapes_rejects_a_zero_corpus_naming_the_shape() {
         let bogus = [ShapeSpec {
             name: "single_vertex_read",
-            profile: QueryCoverageProfile::Baseline,
+            family: CoverageFamily::Reads(QueryCoverageProfile::Baseline),
             tier: Tier::Core,
             result_policy: ResultPolicy::Gated,
             capability: None,

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -348,9 +348,9 @@ pub fn repo_reads_need_fixture(tier: Tier) -> bool {
 /// information.
 static ALGORITHM_SWEEP: [usize; 1] = [1];
 
-/// The corpus size for `algo_max_flow_single_pair` — a small seeded set of distinct
-/// `(source, target)` pairs (design §3.4), instead of the [`CORPUS_SIZE`]-command corpus a cheap
-/// read records.
+/// The corpus size for `algo_max_flow_single_pair` — a small seeded set of **distinct**
+/// `(source, target)` pairs (design §3.4; duplicate draws re-render, bounded), instead of the
+/// [`CORPUS_SIZE`]-command corpus a cheap read records.
 const MAX_FLOW_CORPUS_SIZE: usize = 4;
 
 /// The per-op budget every algorithm shape records (design §3.4): whole-graph algorithms are
@@ -572,10 +572,34 @@ fn render_shapes(
         let key = OpKey::dynamic(shape.name.to_string(), QueryType::Read);
         let mut rng = StdRng::seed_from_u64(corpus_seed ^ key.salt());
         let mut commands = Vec::with_capacity(shape.corpus_size);
-        for _ in 0..shape.corpus_size {
+        // An Algorithm-family multi-command corpus is a seeded set of DISTINCT commands (the
+        // maxFlow pair set — measuring the same pair twice adds runtime without coverage), so
+        // duplicate draws re-render, bounded and deterministically (same seed ⇒ same skips ⇒ same
+        // corpus). Read corpora keep plain sequential draws: duplicates there are legitimate
+        // (a parameterless read renders CORPUS_SIZE identical commands by design).
+        let need_distinct = shape.family == CoverageFamily::Algorithm && shape.corpus_size > 1;
+        let mut seen = BTreeSet::new();
+        let max_attempts = shape.corpus_size * 16;
+        let mut attempts = 0usize;
+        while commands.len() < shape.corpus_size {
+            attempts += 1;
+            if attempts > max_attempts {
+                return Err(OtherError(format!(
+                    "shape '{}' rendered only {} distinct command(s) of the {} its corpus needs \
+                     within {max_attempts} attempts — its parameter space is too small for its \
+                     corpus_size (shrink corpus_size in src/synthetic/shapes.rs or enlarge the \
+                     dataset)",
+                    shape.name,
+                    commands.len(),
+                    shape.corpus_size
+                )));
+            }
             let prepared = repo.render_read_with_rng(shape.name, &mut rng).ok_or_else(|| {
                 OtherError(format!("shape '{}' failed to render", shape.name))
             })?;
+            if need_distinct && !seen.insert(prepared.cypher.clone()) {
+                continue;
+            }
             commands.push(prepared.cypher);
         }
         ops.push(RecordedOp {
@@ -838,6 +862,31 @@ mod tests {
         for (a, b) in ops.iter().zip(&again) {
             assert_eq!(a.commands, b.commands, "'{}' corpus must be seed-stable", a.key.name());
         }
+    }
+
+    #[test]
+    fn max_flow_corpus_stays_distinct_even_when_draws_collide() {
+        // With 3 vertices there are only 6 ordered (source, target) pairs, so 4 seeded draws are
+        // near-certain to collide — the bounded re-render must still deliver 4 DISTINCT maxFlow
+        // commands (deterministically: same seed ⇒ same skips ⇒ same corpus).
+        let ops = record_algorithm_reads(3, 6, 7).expect("record on a tiny pair space");
+        let max_flow = &ops[1];
+        assert_eq!(max_flow.key.name(), "algo_max_flow_single_pair");
+        assert_eq!(max_flow.commands.len(), MAX_FLOW_CORPUS_SIZE);
+        let unique: BTreeSet<&str> = max_flow.commands.iter().map(String::as_str).collect();
+        assert_eq!(unique.len(), MAX_FLOW_CORPUS_SIZE, "corpus must be distinct despite collisions");
+    }
+
+    #[test]
+    fn algorithm_corpus_fails_clearly_when_the_pair_space_is_too_small() {
+        // 2 vertices ⇒ only 2 ordered pairs < MAX_FLOW_CORPUS_SIZE: the bounded retry must give
+        // up with an actionable error instead of looping forever or silently recording dups.
+        let err = record_algorithm_reads(2, 2, 7).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("algo_max_flow_single_pair") && msg.contains("distinct"),
+            "unexpected error: {msg}"
+        );
     }
 
     #[test]

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -321,15 +321,15 @@ impl Thresholds {
 
         let mut ops = BTreeMap::new();
         for (name, raw_op) in raw_ops {
-            // Validate the name maps to a known op — a legacy catalog tag or a recorded repo read
-            // shape — but key the map by the **string name** so a dynamic (string-keyed) op
-            // resolves exactly like a built-in one (design §3.1).
+            // Validate the name maps to a known op — a legacy catalog tag or a recorded shape
+            // (repo read or algorithm) — but key the map by the **string name** so a dynamic
+            // (string-keyed) op resolves exactly like a built-in one (design §3.1).
             let known = OpName::from_tag(&name).is_some()
-                || crate::synthetic::shapes::repo_read_tier(&name).is_some();
+                || crate::synthetic::shapes::shape_tier(&name).is_some();
             if !known {
                 return Err(format!(
                     "unknown operation '{name}' in [{section}op.{name}] — not a catalog op (see \
-                     `synthetic list-ops`) or a recorded repo read shape"
+                     `synthetic list-ops`) or a recorded shape"
                 ));
             }
             if let Some(m) = raw_op.metric {
@@ -628,6 +628,22 @@ concurrency = { 32 = 40.0 }
         let r = t.resolve_by_name("single_vertex_read", 4);
         assert_eq!(r.budget_pct, 33.0);
         assert_eq!(r.floor_ms, 0.2);
+    }
+
+    #[test]
+    fn accepts_algorithm_shape_op_key_in_both_profiles() {
+        // Phase 6: an algorithm shape name is a valid `[op.*]` AND `[cross-engine.op.*]` key —
+        // the known-op validation is family-agnostic (`shape_tier`), so per-op budgets can be
+        // tuned for the heavy algorithm reads exactly like any repo read.
+        let cfg = "[op.algo_max_flow_single_pair]\nbudget_pct = 60.0\nfloor_ms = 2.0\n\
+                   [cross-engine.op.algo_msf_summary]\nbudget_pct = 80.0\n";
+        let t = Thresholds::from_toml_str(cfg).unwrap();
+        assert!(OpName::from_tag("algo_max_flow_single_pair").is_none(), "must be dynamic");
+        let r = t.resolve_by_name("algo_max_flow_single_pair", 1);
+        assert_eq!(r.budget_pct, 60.0);
+        assert_eq!(r.floor_ms, 2.0);
+        let ce = Thresholds::from_toml_str_with_profile(cfg, BudgetProfile::CrossEngine).unwrap();
+        assert_eq!(ce.resolve_by_name("algo_msf_summary", 1).budget_pct, 80.0);
     }
 
     #[test]

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1327,6 +1327,7 @@ async fn record_and_replay_via_run_command() {
         all_reads: false,
         tier: None,
         repo_reads: None,
+        repo_algorithms: false,
         seed: Some(11),
         nodes: Some(400),
         edges: Some(1200),
@@ -1374,8 +1375,73 @@ async fn record_and_replay_via_run_command() {
     drop_graph(graph).await;
 }
 
-/// A recorded workload replayed at concurrency > 1 (both cache modes) must return identical results
-/// (the untimed concurrent verify passes) and produce a per-level, per-mode report.
+/// Phase 6 §7.3 acceptance: `record --repo-algorithms` (offline, via the CLI arm) then a live
+/// replay measures all 4 whole-graph algorithm shapes end-to-end on the generated **simple** graph
+/// (synthbench/v5 — `algo.maxFlow` rejects parallel edges, so this passing proves the guarantee).
+/// Each op must obey its recorded per-op budget (C=1, cached-only), stay result-N/A (no digest),
+/// and persist its resolved effective policy.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn record_and_replay_algorithm_shapes_end_to_end() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::run_command;
+
+    let graph = "syn_it_algos";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-algos");
+    let out_dir = dir.to_string_lossy().into_owned();
+
+    run_command(SyntheticCommands::Record {
+        config: None,
+        graph: Some(graph.to_string()),
+        ops: vec![],
+        all_reads: false,
+        tier: None,
+        repo_reads: None,
+        repo_algorithms: true,
+        seed: Some(7),
+        nodes: Some(300),
+        edges: Some(900),
+        out_dir: out_dir.clone(),
+    })
+    .await
+    .expect("record --repo-algorithms via run_command");
+
+    let out = dir.join("algos.json").to_string_lossy().into_owned();
+    let mut config = replay_config(&dir, graph, &out, true);
+    // Global knobs the per-op budgets must override (sweep + cache) or inherit (nothing: the
+    // algorithm budget pins samples/warmup/cache/sweep/timeouts).
+    config.samples = 3;
+    config.warmup = 1;
+    config.concurrency = vec![1, 2];
+    config.cache = benchmark::synthetic::CacheSelection::Both;
+    let report = replay::run(&config).await.expect("replay the 4 algorithm shapes");
+
+    for name in [
+        "algo_pagerank_summary",
+        "algo_max_flow_single_pair",
+        "algo_msf_summary",
+        "algo_harmonic_summary",
+    ] {
+        let op = report
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} missing from the replay report"));
+        let levels: Vec<usize> = op.levels.iter().map(|l| l.concurrency).collect();
+        assert_eq!(levels, vec![1], "{name} must measure only its budgeted C=1 sweep");
+        assert!(op.levels[0].cached.is_some(), "{name} measures cached");
+        assert!(op.levels[0].uncached.is_none(), "{name} skips uncached (budget)");
+        assert!(op.result_digest.is_none(), "{name} starts result-N/A (design §6)");
+        let policy = op.policy.as_ref().unwrap_or_else(|| panic!("{name} must persist policy"));
+        assert_eq!(policy.samples, 25, "{name} budgeted samples");
+        assert_eq!(policy.concurrency, vec![1], "{name} budgeted sweep");
+        assert_eq!(policy.server_timeout_ms, 60_000, "{name} budgeted server timeout");
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
 #[tokio::test]
 #[ignore = "requires a running FalkorDB server"]
 async fn replay_concurrency_sweep_verifies_results_and_reports_levels() {


### PR DESCRIPTION
## What

Phase 6, step 3 of [`docs/design/synthetic-cover-algorithms-phase6.md`](https://github.com/FalkorDB/benchmark/blob/master/docs/design/synthetic-cover-algorithms-phase6.md) (§7.3 — *"Annotation + selection (all N/A)"*): the synthetic check can now **record and replay the 4 whole-graph algorithm read shapes** — `algo.pageRank`, `algo.maxFlow`, `algo.MSF`, `algo.HarmonicCentrality` — as an **opt-in** family selected by a new `synthetic record --repo-algorithms` flag.

Everything about the family is deliberately conservative, per the design:

- **All four shapes start `result-N/A`** (§6 determinism table): they are recorded + timed (latency/trend coverage) but their result digests are never gated. `max_flow`/`msf` are gating *candidates* — promotion happens in the §7.5 phase only after byte-stability across ≥2 independent record runs is verified.
- **Never in the per-PR gate**: `repo_read_shapes()` / `--repo-reads full` remain **exactly today's 50 non-algorithm reads** — proven by a selection-disjointness test *and* by the untouched `--repo-reads full` `workload_hash` golden from #260.
- **Tight per-op budgets** (the #260 plumbing, used for real for the first time): each algorithm shape records `samples 25, warmup 2, concurrency [1], cached-only, 60s/75s timeouts` and a reduced corpus (1 command for the parameterless shapes; a small seeded 4-pair set for maxFlow) instead of the default 256-command corpus × global sweep.

## Why

Whole-graph algorithms are the biggest uncovered query family in the synthetic check (~40–80 ms/call — three orders of magnitude above the point reads). The prerequisites landed in #259 (simple-graph guarantee — `algo.maxFlow` rejects parallel edges) and #260 (per-op budget/corpus plumbing); this PR adds the family itself without disturbing the per-PR read gate, the A/B `--query-profile` surface, or any recorded read bundle.

## Worked example

Record the algorithm shapes (offline, no server), alone or on top of the read shapes:

```bash
# algorithms only → 4 ops
benchmark synthetic record --repo-algorithms --nodes 300 --edges 900 --seed 7 --out-dir rec-algos
# recorded 4 op(s) into rec-algos (workload_hash sha256:9ab94eceb00729eeb517cce6b6c25b4758830069da8fef60527dcdc4e4686924)

# orthogonal: reads + algorithms in one bundle → 54 ops (50 reads first, algorithms appended)
benchmark synthetic record --repo-reads full --repo-algorithms --nodes 1000 --edges 5000 --seed 7 --out-dir rec-all
```

The manifest op entry for maxFlow (real output from the first command above) — note the per-op `budget` and the 4-command seeded corpus:

```json
{
  "name": "algo_max_flow_single_pair",
  "kind": "Read",
  "result_gated": false,
  "budget": {
    "samples": 25,
    "warmup": 2,
    "concurrency": [1],
    "cache": "cached",
    "server_timeout_ms": 60000,
    "client_deadline_ms": 75000
  },
  "count": 4
}
```

One rendered maxFlow command (`commands/algo_max_flow_single_pair.jsonl`, seeded pair inlined):

```
CYPHER source_id = 251 target_id = 300 MATCH (s:User {id: $source_id}), (t:User {id: $target_id})
  CALL db.relationshipTypes() YIELD relationshipType WITH s, t, relationshipType
  ORDER BY relationshipType LIMIT 1
  CALL algo.maxFlow({ sourceNodes: [s], targetNodes: [t], relationshipTypes: [relationshipType],
                     capacityProperty: 'bench_capacity' })
  YIELD maxFlow RETURN coalesce(toFloat(maxFlow), 0.0) AS max_flow
```

`synthetic run --recording rec-algos` then loads the graph and measures each op **under its recorded budget** (C=1, cached-only, 25 samples), persists the resolved per-op `policy` on the report (so `report --diff` refuses to compare runs measured under different per-op conditions — the #260 guard), and skips reference capture / digest gating for all four (result-N/A).

## Design (verbatim)

The binding sections of `docs/design/synthetic-cover-algorithms-phase6.md`:

### 3.2 `Tier::Full` cannot double as "algorithm opt-in"
`--repo-reads` is `Option<Tier>` (`src/cli.rs:542`); selection filters **only** by tier
(`shapes.rs:selected_shapes`); `Tier::Full` is the *complete read set* and `Core ⊆ Full`
(`mod.rs:340-352`); and CI already runs **`--repo-reads full`** (`Justfile:323-324`). So adding
Full-tier algorithms to `repo_read_shapes()` would **silently pull them into every PR**, while keeping
them separate makes them unreachable by tier. **Fix:** an **orthogonal** selection dimension — a
`--repo-algorithms` flag (or `RepoShapeSelection::{Reads(Tier), Algorithms}`) — leaving
`repo_read_shapes()` and `--repo-reads full` as **exactly** today's 50 reads.

### 3.3 The record path hard-excludes algorithms, and the profile enum is shared with the A/B CLI
`read_shapes_repository()` always builds with **`no_algorithms()`** and `record_selected_shapes()`
always builds a `FixtureDependent` repo and validates only **`non_algorithm_read_names()`**
(`src/synthetic/shapes.rs`); `ShapeSpec.profile` is never consulted for repo construction. Worse,
`QueryCoverageProfile` is the **global A/B `--query-profile` enum** (`queries_repository.rs:64`, used
at `cli.rs:205-208,264-271`) — so a `QueryCoverageProfile::Algorithm` would expose a misleading
`--query-profile algorithm` on the A/B benchmark **and still wouldn't enable algorithms** (that's
`AlgorithmQuerySelection`). **Fix:** a **synthetic-only** shape family (not `QueryCoverageProfile`), a
separate `record_algorithm_reads()` that builds an **all-algorithms-enabled** repository with its
**own** drift-guard, and a new `algorithm_read_names()` accessor added alongside
`non_algorithm_read_names()` on both the inner repo (`queries_repository.rs:274-279`) and the
wrapper (`:372-376`).

## 4. Approach — a synthetic-only algorithm family, opt-in, behind prerequisites

Mirror the reads' **derive-with-annotation** coupling (one source of truth in `queries_repository`,
curated metadata in `shapes.rs`), but on a **separate axis** from reads:

1. **Prerequisites first:** the simple-graph algorithm fixture (§3.1) and the recorded-shape
   budget/corpus plumbing (§3.4).
2. A **synthetic-only** `CoverageFamily` (or decouple `ShapeSpec.profile` from the A/B enum) with an
   `Algorithm` member — no change to the A/B `--query-profile`.
3. `algorithm_read_shapes() -> Vec<ShapeSpec>` (4 shapes, per-procedure `capability`, `result_policy`
   per §6, per-op budget/corpus) + `algorithm_read_names()` accessor + a drift-guard asserting the
   table equals the repo's algorithm names.
4. `record_algorithm_reads()` rendering from an **all-algorithms-enabled** repository (not
   `no_algorithms()`), against the **simple-graph** fixture.
5. An **orthogonal** opt-in selector (`--repo-algorithms`); algorithms never in `--repo-reads full`
   nor the per-PR gate; documented in cookbook + readme.

## 6. Determinism per shape
Floats are digested by `f64::to_bits()` (exact), so the question is **value** stability run-to-run on
the same image:

| Shape | Proposed `result_policy` | Why |
| --- | --- | --- |
| `algo_pagerank_summary` | **N/A** | `RETURN score LIMIT 1` (no `ORDER BY`) — arbitrary single float. |
| `algo_harmonic_summary` | **N/A** (pending) | `avg`/`max` over all nodes; iterative/aggregation value stability unproven. |
| `algo_max_flow_single_pair` | **Gated (candidate)** | Max-flow of a fixed simple graph + capacities + seeded pair is a unique integral value coerced to exact `f64`. |
| `algo_msf_summary` | **Gated (candidate)** | `edge_count` and MSF `total_weight` are unique (tie-breaking cannot change the minimum total). |

Default **all four to N/A**; promote `max_flow`/`msf` to `Gated` **only after** confirming byte-stable
digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synthetic-only `ORDER BY`.

## 7. Phasing (prerequisites first, each its own PR)
1. ✅ **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
2. ✅ **Recorded-shape budget/corpus plumbing** (§3.4) — per-shape corpus size + budget on the
   dynamic path; N/A shapes skip full reference capture.
3. **Annotation + selection (all N/A):** synthetic-only family, `algorithm_read_shapes()`,
   `algorithm_read_names()` + drift-guard, `record_algorithm_reads()`, `--repo-algorithms`. Record +
   replay the 4 shapes end-to-end, opt-in.
4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
6. **Docs:** cookbook + readme.

## Implementation notes

1. **`CoverageFamily` (synthetic-only) replaces `ShapeSpec.profile`** (`src/synthetic/shapes.rs`): `Reads(QueryCoverageProfile)` tags the Phase 3–5 read shapes with the A/B profile that introduced them; `Algorithm` is the new member. The A/B `--query-profile` enum (`QueryCoverageProfile`) is untouched — no misleading `--query-profile algorithm` value exists (§3.3).
2. **`algorithm_read_shapes()`**: 4 rows in `queries_repository` definition order. Each carries its per-procedure `ShapeCapability` (`AlgoPageRank`/`AlgoMaxFlow`/`AlgoMsf`/`AlgoHarmonic` — **annotation only** in this phase; probe-before-capture is §3.5 / the next PR), `Tier::Full`, `ResultPolicy::NotApplicable` with the §6 reason, `corpus_size` 1 (maxFlow: 4), and the shared `ALGORITHM_BUDGET`.
3. **`algorithm_read_names()`** accessors added on the inner `QueriesRepository` and the `UsersQueriesRepository` wrapper, next to their `non_algorithm_read_names()` siblings (§3.3).
4. **`record_algorithm_reads()`** builds an **all-algorithms-enabled** repository (the read path keeps building with `no_algorithms()`) and validates the annotation table against `algorithm_read_names()` — its own drift-guard, same hard-error style as the reads. The common renderer is factored into `render_shapes()` (shared with `record_selected_shapes()`), so corpus seeding (`corpus_seed ^ salt`), zero-corpus rejection and annotation-drift errors are identical for both families.
5. **`--repo-algorithms`** (`src/cli.rs`, `Record`): orthogonal opt-in — combinable with `--repo-reads` (reads recorded first, algorithms appended) or usable alone; mutually exclusive with `--op`/`--all-reads`/`--tier` like `--repo-reads`. An algorithms-only bundle bakes **no** fulltext/vector fixture; the fixture decision still depends only on the reads tier. No extra fixture is needed: since `synthbench/v5` (#259) every generated graph is simple and every `:Friend` edge carries `bench_capacity`.
6. **Docs**: readme `--repo-algorithms` bullet, cookbook Story 3 variant (record example + semantics), design doc §7.3 marked ✅ implemented.

## Tests

- `algorithm_shapes_match_exactly_the_repo_algorithm_read_names` — drift-guard: annotation table == auto-discovered `algorithm_read_names()` of an all-algorithms repo, in order; the read-shape repo (no_algorithms) discovers none.
- `algorithm_shapes_are_all_result_na_full_tier_with_per_procedure_capabilities` — §6/§3.5 pinning: 4 shapes, all N/A, per-procedure capabilities 1:1, corpus sizes `[1, 4, 1, 1]`, shared budget.
- `repo_read_shapes_exclude_algorithms_and_stay_exactly_todays_50_reads` — §3.2 orthogonality: 50 reads, disjoint from algorithm names, name-set disjointness (reads vs algorithms) with `selected_shapes` untouched; plus the untouched `repo_reads_full_workload_hash_golden_is_pinned` golden (`sha256:830faf23…c8de4`) still passes, pinning the byte stream.
- `record_algorithm_reads_renders_seeded_budgeted_corpora` — 4 ops in order, result-N/A, algorithm budget recorded, corpora `[1,4,1,1]`, real procedure text, 4 **distinct** seeded maxFlow pairs, byte-identical re-render for the same seed.
- `run_command_record_offline_records_algorithm_shapes` / `run_command_record_combines_repo_reads_with_algorithms` — CLI arm end-to-end offline: algorithms-only bundle (4 ops, budgets in manifest, **no fixture**) and combined bundle (54 ops, reads first, fixture still baked).
- `record_and_replay_algorithm_shapes_end_to_end` (`#[ignore]`d, runs under coverage) — **live acceptance**: `record --repo-algorithms` via the CLI arm, replay against FalkorDB, all 4 shapes measured under the budgeted C=1 cached-only sweep, no digests, per-op `policy` persisted (samples 25, C=[1], 60s). maxFlow passing live also re-proves the #259 simple-graph guarantee.

## Validation

- `just ci` (build + clippy + test) — green.
- `just coverage` against a live FalkorDB — all tests (incl. the 26 `#[ignore]`d integration tests) green; **patch coverage 255/258 = 98.8%** (misses: two `?` error-branch artifacts on the record plumbing, one test-assert message line).
- `just doc-links` + `just doc-shell` — green.
- Live `record_and_replay_algorithm_shapes_end_to_end` run explicitly against `falkordb/falkordb:edge` — green.

A release/tag follows merge (not cut here). Next phases: §3.5 probe-before-capture + skipped-op reporting (PR-4), §7.5 byte-stability verification → possible `max_flow`/`msf` promotion (PR-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--repo-algorithms` option for synthetic workload recording.
  * Added four whole-graph algorithm shapes (PageRank, max flow, minimum spanning forest, harmonic centrality) with dedicated per-op budgets and result-N/A behavior.
  * Can be combined with repository reads; algorithm shapes are excluded from `--repo-reads full` and the per-PR synthetic verification gate.

* **Documentation**
  * Expanded the recording guides and benchmark cookbook with selection rules, command examples, and graph/corpus expectations.

* **Bug Fixes**
  * Synthetic threshold configuration now recognizes algorithm shape operation keys.

* **Tests**
  * Added/updated coverage for algorithm-only recording, combined workloads, deterministic rendering, and end-to-end replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review fixes (duck conformance round)

**1. Family-agnostic shape→tier lookup (MAJOR).** `repo_read_tier` resolved only repo-read names, so algorithm ops were invisible to summary tier buckets (`totals.pass=1` but `full.pass=0`, `tier: null` in cells JSON) and `[op.algo_*]` threshold overrides were **rejected** as unknown ops. Renamed to `shape_tier` and chained **all** shape families (baseline + extended core + fixture-dependent + algorithms); `analysis.rs::op_tier` and `thresholds.rs` known-op validation now use it. **Selection semantics untouched** — `selected_shapes` still filters `repo_read_shapes()` only; the 50-read `workload_hash` golden and the read/algorithm name-disjointness assert pin that. New tests: `shape_tier_resolves_by_name`, `shape_tier_covers_every_shape` (drift guard over every family), `accepts_algorithm_shape_op_key_in_both_profiles` (`[op.*]` + `[cross-engine.op.*]`), and `algorithm_shape_gets_budget_and_tier_end_to_end` (override applied, `full` bucket tallies, offender tier `full`).

**2. Total distinct-corpus completion (IMPORTANT).** The distinct-maxFlow-pair loop was 64 bounded random draws — it could fail even when enough distinct pairs exist. Now deterministic **and total**: phase 1 keeps the byte-compatible bounded seeded rejection loop (seed-7 corpus verified **byte-identical** before/after, so the pinned `workload_hash` golden is unchanged — no repin); phase 2 exhaustively walks the ordered vertex-pair space `(1..=V)×(1..=V), s≠t` via forced-path rendering (`QueryFn` now threads `Option<(i32,i32)>`; `random_path()` consumes the forced pair), so the corpus completes whenever the pair space suffices and the too-small error is proven by exhaustion, never draw luck. New tests: `max_flow_distinct_corpus_is_total_when_the_pair_space_barely_fits` (V=3 ⇒ exactly 6 ordered pairs, corpus 6, across seeds incl. `u64::MAX`, twice-identical) and `seed7_max_flow_corpus_renders_the_historical_pair_sequence` (golden pair sequence pin).

