### PR TITLE
feat(synthetic): capability probe-before-capture with skipped-op reporting (Phase 6, PR-4)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -247,7 +247,7 @@ synthetic-compare-versions name endpoint_a endpoint_b:
 # recording), then REPLAY it (load) and re-replay (no-load) and GUARD (workload_hash + result
 # digests must match), then exercise the REGRESSION artifacts end-to-end: `report --regression`
 # with a `[cross-engine]` budget profile, `--divergence-policy advisory`, and the machine outputs
-# (`--summary` schema v2 + `--cells` analysis model). Passes iff recording is deterministic and
+# (`--summary` schema v3 + `--cells` analysis model). Passes iff recording is deterministic and
 # the replay + report pipelines complete + guard clean; latency is NOT asserted (environment
 # noise). Tears the server down afterwards.
 synthetic-sanity:
@@ -283,7 +283,7 @@ synthetic-sanity:
     cargo run --quiet --bin benchmark -- synthetic report \
         --diff recordings/_sanity_a/ref.json recordings/_sanity_a/cand.json --out recordings/_sanity_a/diff.md
     # Regression flavor end-to-end: a [cross-engine] budget profile + advisory divergence policy +
-    # the machine artifacts (--summary schema v2, --cells analysis model). The two runs measured
+    # the machine artifacts (--summary schema v3, --cells analysis model). The two runs measured
     # identical work on one server, so this checks the plumbing, never latency.
     cat > recordings/_sanity_a/thresholds.toml <<'TOML'
     [default]
@@ -304,7 +304,8 @@ synthetic-sanity:
         --out recordings/_sanity_a/regression.md \
         --summary recordings/_sanity_a/summary.json \
         --cells recordings/_sanity_a/cells.json
-    grep -q '"schema_version": 2' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary is not schema v2"; exit 1; }
+    grep -q '"schema_version": 3' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary is not schema v3"; exit 1; }
+    grep -q '"schema_version": 2' recordings/_sanity_a/cells.json || { echo "SANITY FAIL: cells JSON is not schema v2"; exit 1; }
     grep -q '"budget_profile": "cross-engine"' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary lacks the cross-engine profile"; exit 1; }
     grep -q '"divergence_policy": "advisory"' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary lacks the advisory policy"; exit 1; }
     grep -q '"overall_verdict"' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary lacks overall_verdict"; exit 1; }

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -182,9 +182,12 @@ digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synth
    from the per-op policy guard and the asymmetric-digest divergence rule, perf cells N/A,
    correctness `not_gated`, tallied in its own `skipped` bucket (analysis schema v2, summary
    schema v3, `OpOutcome::Skipped` ⏭), never an offender, never caps the verdict below what the
-   measured ops earn (all-skipped ⇒ the existing zero-comparable-cells ⇒ Advisory rule). The
-   fulltext/vector fixture reads carry their `db.idx.*` capabilities too, so they skip cleanly on
-   engines without those indexes.
+   measured ops earn (all-skipped ⇒ the existing zero-comparable-cells ⇒ Advisory rule).
+   Capabilities stay **algorithm-only**: the fulltext/vector fixture reads are capability-free
+   because their index DDL is part of the graph load, which runs before any probe could skip
+   them — annotating them would fail the per-PR `--repo-reads full` gate at load on an engine
+   lacking the indexes instead of skipping cleanly. Capability-aware *loading* (fixture DDL gated
+   on a pre-load probe) is future work if a later phase needs fixture reads to skip.
 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
 6. **Docs:** cookbook + readme.
 

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -171,7 +171,20 @@ digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synth
    deterministic **and total**: bounded seeded draws byte-compatible with the original rejection
    loop, then an exhaustive walk of the ordered-pair space, so it succeeds whenever the space
    suffices and the too-small error is proven, never draw luck.)*
-4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
+4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting. ✅
+   implemented: `ShapeCapability::procedure()` maps each variant to its exact registry name;
+   `RecordedOp`/`OpEntry` carry an optional `capability` string (omitted when absent; **not**
+   folded into the `workload_hash` — replay policy, not workload content); replay issues **one**
+   `CALL dbms.procedures()` probe per run (only when ≥1 op is annotated, case-insensitive
+   matching) and **skips** annotated ops whose procedure is missing — never executed, reported as
+   `OperationReport::skipped: Some(reason)` with no levels/digest/policy. Skip semantics (§8.5):
+   a skipped op is **neither a pass nor a divergence** under both divergence policies — exempt
+   from the per-op policy guard and the asymmetric-digest divergence rule, perf cells N/A,
+   correctness `not_gated`, tallied in its own `skipped` bucket (analysis schema v2, summary
+   schema v3, `OpOutcome::Skipped` ⏭), never an offender, never caps the verdict below what the
+   measured ops earn (all-skipped ⇒ the existing zero-comparable-cells ⇒ Advisory rule). The
+   fulltext/vector fixture reads carry their `db.idx.*` capabilities too, so they skip cleanly on
+   engines without those indexes.
 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
 6. **Docs:** cookbook + readme.
 
@@ -185,7 +198,8 @@ digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synth
 4. **Budget/corpus plumbing is real work (§3.4)**, not annotation — it is a prerequisite, and it also
    benefits any future heavy read.
 5. **Skipped-op semantics (§3.5)** — how a capability-absent op appears in `report --diff` needs
-   defining so it neither reads as a pass nor a divergence.
+   defining so it neither reads as a pass nor a divergence. *(Resolved with step 4: a dedicated
+   `skipped` outcome — see the step-4 note in §7.)*
 
 ## 9. Acceptance
 Opt-in record + replay of the 4 algorithm shapes end-to-end on the FalkorDB per-PR image against the

--- a/docs/design/synthetic-three-way-report.md
+++ b/docs/design/synthetic-three-way-report.md
@@ -457,9 +457,13 @@ new contract (original sketches in §A1/§A5 left intact for history):
 - `OpAnalysis.op_outcome` gains a `"skipped"` variant (rendered ⏭).
 - New per-op fields `skipped_baseline` / `skipped_candidate`: `Option<String>` skip reasons
   (omitted when absent, e.g. `engine lacks procedure 'algo.maxFlow'`).
-- A skipped op carries `cells: []` and `correctness: "not_gated"` — skipped on ≥1 side means
-  that side never ran, so no correctness or latency claim is made; skips are exempt from the
-  per-op measurement-policy guard and can never gate or count as diverged.
+- A skipped op carries `correctness: "not_gated"` and its cells make no gated claim — skipped
+  on ≥1 side means that side never ran; skips are exempt from the per-op measurement-policy
+  guard and can never gate or count as diverged. Skipped on **both** sides ⇒ `cells: []`;
+  skipped on **one** side ⇒ the measured side's cells are retained (per-side p50/context only —
+  no deltas, and every cell's `perf_verdict` is forced `not_applicable`).
+- `totals` (the per-comparison `OutcomeCounts`) gains a `skipped` count — ops capability-skipped
+  on ≥1 side, under both divergence policies (a skip is never a regression or a divergence).
 - `tier` now also resolves for algorithm-family ops (`"full"`); previously only catalog/repo
   reads had a tier.
 

--- a/docs/design/synthetic-three-way-report.md
+++ b/docs/design/synthetic-three-way-report.md
@@ -92,6 +92,9 @@ A **latent bug fix** independent of the three-way feature, delivered first as it
 Build the comparison **once** into a serializable `RegressionAnalysis` and render everything
 from it. Sketch (field names final at implementation; serde snake_case):
 
+_The `schema_version: 1` sketch below is the original Part A contract; benchmark PR
+[#262](https://github.com/FalkorDB/benchmark/pull/262) amends it to v2 (see §9)._
+
 ```text
 RegressionAnalysis {
   schema_version: 1,
@@ -204,6 +207,9 @@ budget_pct = 40.0
 fallback). Existing built-in defaults (10% / 0.5 ms) are unchanged.
 
 ### A5. Summary schema v2 (G7)
+
+_Amended: benchmark PR [#262](https://github.com/FalkorDB/benchmark/pull/262) bumps the summary
+to v3 (see §9)._
 
 `SyntheticSummary` bumps `schema_version` to 2, adding `budget_profile`, `divergence_policy`,
 `gated_metric`, `elapsed_secs: Option<f64>`, and a `diverged` count in `OutcomeCounts` (+ the
@@ -337,7 +343,9 @@ v2 summaries; ⚠ diverged counts shown for cross-engine lines; `not_comparable_
 unavailable ones), the total wall-clock from `run-meta.json`, worst offenders for `main-pr`
 only (the gating signal), and one link to the interactive page. Markers
 (`<!-- synthetic-benchmark -->` / `-arm`) unchanged. The renderer hard-checks
-`schema_version == 2` per summary and warns-and-skips otherwise (existing behavior).
+`schema_version == 2` per summary and warns-and-skips otherwise (existing behavior). _Amended:
+once the pinned benchmark ref carries Phase 6 (summary v3, §9) the renderer must accept v3;
+that renderer update is tracked in falkordb-rs-next-gen, not this repo._
 
 ### B5. Workflow wiring (`_benchmark.yml` / `benchmark.yml`)
 
@@ -431,3 +439,37 @@ Each PR: design-first (this doc), ≥90% patch coverage on Rust changes, `just c
   trend storage for synthetic results; comparing more than the three fixed images; fork-PR
   support; per-cache-mode op rollups in the cells schema (future rev); changing the A/B
   (non-synthetic) benchmark.
+
+## 9. Amendments
+
+### 9.1 Phase 6 (capability skips): cells v2, summary v3 — benchmark PR [#262](https://github.com/FalkorDB/benchmark/pull/262)
+
+The algorithm-coverage work
+([`synthetic-cover-algorithms-phase6.md`](synthetic-cover-algorithms-phase6.md)) introduced
+**capability-skipped ops**: before capture/measure, the replayer probes the engine for each
+op's required procedure (algorithm shapes only) and records ops the engine cannot run as
+*skipped* instead of failing. A skip is **neither a pass nor a divergence** and is never an
+offender. This extends the two machine schemas this document froze; the deltas below are the
+new contract (original sketches in §A1/§A5 left intact for history):
+
+**Cells / `RegressionAnalysis` v1 → v2** (`schema_version: 2`):
+
+- `OpAnalysis.op_outcome` gains a `"skipped"` variant (rendered ⏭).
+- New per-op fields `skipped_baseline` / `skipped_candidate`: `Option<String>` skip reasons
+  (omitted when absent, e.g. `engine lacks procedure 'algo.maxFlow'`).
+- A skipped op carries `cells: []` and `correctness: "not_gated"` — skipped on ≥1 side means
+  that side never ran, so no correctness or latency claim is made; skips are exempt from the
+  per-op measurement-policy guard and can never gate or count as diverged.
+- `tier` now also resolves for algorithm-family ops (`"full"`); previously only catalog/repo
+  reads had a tier.
+
+**Summary v2 → v3** (`schema_version: 3`):
+
+- `OutcomeCounts` gains a `skipped` bucket (in `totals` and each `per_tier[].counts`).
+- Per-op outcomes may be `"skipped"`; the tier table gains a ⏭ column.
+- The headline gains `; N op(s) skipped (engine lacks their required procedure)` when N > 0.
+
+**Verdict semantics**: skips never affect `Pass`/`Regressed`; the §A1 rule "zero comparable
+perf cells anywhere is never green" still applies, so an everything-skipped comparison caps at
+`Advisory`. The §B4 renderer must accept summary v3 when the pinned ref carries Phase 6 (that
+update lives in falkordb-rs-next-gen).

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -220,6 +220,10 @@ Each algorithm shape records a tight per-op `budget` (25 samples, warm-up 2, C=1
 60 s server timeout) and a reduced corpus (1 command each; a small seeded set of distinct
 `(source, target)` pairs for maxFlow), and starts **result-N/A** — latency/trend coverage, not
 divergence gating.
+Each also records its required procedure as a `capability` (replay policy like `budget`, outside
+the `workload_hash`): at replay, one `CALL dbms.procedures()` probe **skips** any op whose
+procedure the engine lacks — reported as `skipped: <reason>` (⏭ in the diff, its own `skipped`
+bucket in the summary — neither a pass nor a divergence) instead of failing the run.
 Algorithms never enter `--repo-reads full` or the per-PR `synthetic-verify` gate; every generated
 graph is already simple (no parallel `:Friend` edges) with `bench_capacity` on every edge, so the
 flow/MSF shapes need no extra fixture.

--- a/readme.md
+++ b/readme.md
@@ -479,7 +479,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   (1 command for the parameterless shapes; a small seeded set of distinct `(source, target)` pairs for maxFlow).
   All four start **result-N/A** (their values aren't verified byte-stable yet — `max_flow`/`msf`
   are gating candidates pending that verification), so they add latency/trend coverage without
-  joining the divergence gate. The selector is **orthogonal** to `--repo-reads` (combinable with it
+  joining the divergence gate. Each shape also records its required procedure (`capability` in the
+  manifest — replay policy like `budget`, not folded into the `workload_hash`): at replay a single
+  `CALL dbms.procedures()` probe **skips** any op whose procedure the engine lacks (reported, never
+  executed) instead of failing the run — the fulltext/vector fixture reads carry their `db.idx.*`
+  capabilities the same way. The selector is **orthogonal** to `--repo-reads` (combinable with it
   or usable alone; also mutually exclusive with `--op`/`--all-reads`/`--tier`): algorithm shapes are
   **never** part of `--repo-reads full` nor the per-PR `synthetic-verify` gate. They need no extra
   fixture — every generated graph is **simple** (no parallel `:Friend` edges, which `algo.maxFlow`
@@ -496,7 +500,12 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   guard **refuse per-op** to compare runs that measured the same workload under different per-op
   conditions (budgets are outside the `workload_hash`, so this is what guards them).
   **Result-N/A** ops skip the full untimed reference capture — only
-  their first command is probed (fail-fast) — since no digest is ever gated on them. `--no-load`
+  their first command is probed (fail-fast) — since no digest is ever gated on them. Ops whose
+  manifest entry carries a **`capability`** (a required procedure name) are checked against the
+  engine's `dbms.procedures()` registry up front (one probe per run, case-insensitive): a missing
+  procedure **skips** the op entirely — never executed, reported with `skipped: <reason>` and no
+  levels/digest/policy — so a recording with algorithm shapes still replays cleanly on an engine
+  without them. `--no-load`
   skips the reload
   for a load-once / run-many flow (still count-verifying first). `just synthetic-replay <name>
   <endpoint>` wraps this. Pass **`--label <name>`** (e.g. `pr`/`main`) to name the run — the label
@@ -532,15 +541,22 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   counts) ▸ **regressed** (≥1 cell over budget, or a divergence under the `gate` policy) ▸
   **advisory** (⚠ — a divergence under the `advisory` policy, or **zero comparable cells**, which is
   never a green pass) ▸ **pass** (≥1 comparable cell, nothing wrong). Version/image mismatches are
-  advisory *warnings*, never comparability guards. Optional flags (all with `--regression`):
-  - **`--summary <file>`** writes a compact machine-usable JSON summary (schema **v2**:
-    `overall_verdict`, headline, per-tier 🟢/🔴/⚠/N-A `totals` incl. the `diverged` bucket, worst
+  advisory *warnings*, never comparability guards. An op **skipped** on either side (capability
+  probe — the engine lacks its required procedure) is **neither a pass nor a divergence** under
+  both policies: its perf cells are N/A, it never gates or caps the verdict, it is tallied in its
+  own **`skipped`** bucket (⏭ in the reports) and exempt from the per-op policy/digest guards —
+  though all-skipped still lands in the zero-comparable-cells advisory, never a green pass.
+  Optional flags (all with `--regression`):
+  - **`--summary <file>`** writes a compact machine-usable JSON summary (schema **v3**:
+    `overall_verdict`, headline, per-tier 🟢/🔴/⚠/⏭/N-A `totals` incl. the `diverged` and `skipped`
+    buckets, worst
     offenders, `budget_profile`, `divergence_policy`, `gated_metric`, `elapsed_secs`, and a stable
     `slug` for linking the externally-hosted full report) — small enough for a PR comment.
-  - **`--cells <file>`** writes the **full analysis model** as JSON (schema v1): the meta block
+  - **`--cells <file>`** writes the **full analysis model** as JSON (schema v2): the meta block
     (labels, module versions, images, `workload_hash`, samples/warmup, thresholds echo) plus every
     op × cache-mode × concurrency cell with baseline/candidate p50, `delta_pct`/`delta_ms`, the
     resolved budget and the per-cell verdict — source material for an interactive report page.
+    Skipped ops carry their reason in `skipped_baseline`/`skipped_candidate` (omitted otherwise).
   - **`--divergence-policy <gate|advisory>`** (default `gate`) sets how a result divergence lands:
     under `gate` a diverged op is 🔴 and fails the comparison; under `advisory` (for cross-engine
     runs, where different engines can legitimately return different results) it is ⚠, counts in the

--- a/readme.md
+++ b/readme.md
@@ -482,9 +482,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   joining the divergence gate. Each shape also records its required procedure (`capability` in the
   manifest — replay policy like `budget`, not folded into the `workload_hash`): at replay a single
   `CALL dbms.procedures()` probe **skips** any op whose procedure the engine lacks (reported, never
-  executed) instead of failing the run — the fulltext/vector fixture reads carry their `db.idx.*`
-  capabilities the same way. The selector is **orthogonal** to `--repo-reads` (combinable with it
-  or usable alone; also mutually exclusive with `--op`/`--all-reads`/`--tier`): algorithm shapes are
+  executed) instead of failing the run. Only algorithm shapes carry a capability — read shapes
+  (including the fulltext/vector fixture reads, whose index DDL loads with the graph before any
+  probe) stay capability-free, so a `--repo-reads` replay never probes. The selector is
+  **orthogonal** to `--repo-reads` (combinable with it or usable alone; also mutually exclusive
+  with `--op`/`--all-reads`/`--tier`): algorithm shapes are
   **never** part of `--repo-reads full` nor the per-PR `synthetic-verify` gate. They need no extra
   fixture — every generated graph is **simple** (no parallel `:Friend` edges, which `algo.maxFlow`
   rejects) and every `:Friend` edge carries the `bench_capacity` property the flow/MSF shapes use.

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -17,8 +17,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// Schema version of the serialized [`RegressionAnalysis`] (`report --cells`), bumped on any
-/// breaking field change.
-pub const ANALYSIS_SCHEMA_VERSION: u32 = 1;
+/// breaking field change. v2 (design Phase 6 §3.5): adds the `skipped` [`OpOutcome`] value and
+/// [`OutcomeCounts`] bucket plus the per-op `skipped_baseline`/`skipped_candidate` reasons —
+/// a v1 consumer parsing `op_outcome` exhaustively would reject `"skipped"`, so this is a bump,
+/// not a silent extension.
+pub const ANALYSIS_SCHEMA_VERSION: u32 = 2;
 
 /// The gated metric id carried in [`RegressionAnalysis::gated_metric`]: only the total-latency
 /// median is gated; every other metric is informational context.
@@ -77,7 +80,8 @@ pub enum Correctness {
 }
 
 /// Per-op outcome — the collapsed-row verdict, rolled up across every cache mode and concurrency
-/// (worst cell wins: `Regressed` > `DivergedAdvisory` > `Pass` > `NotApplicable`).
+/// (worst cell wins: `Regressed` > `DivergedAdvisory` > `Pass` > `NotApplicable`; a `Skipped` op
+/// never has a comparable cell, so it never competes with the others).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OpOutcome {
@@ -87,23 +91,28 @@ pub enum OpOutcome {
     Regressed,
     /// Results diverged under the `advisory` policy — needs a human look, not a gate (⚠).
     DivergedAdvisory,
+    /// Capability-skipped on ≥1 side (design Phase 6 §3.5) — recorded but never executed there
+    /// because the engine lacks the op's required procedure. Neither a pass nor a divergence, and
+    /// never a gate (⏭).
+    Skipped,
     /// No evaluable cell and no divergence signal — no verdict (N/A).
     NotApplicable,
 }
 
 impl OpOutcome {
-    /// The marker shown on the op's collapsed row (`🟢`/`🔴`/`⚠`/`N/A`).
+    /// The marker shown on the op's collapsed row (`🟢`/`🔴`/`⚠`/`⏭`/`N/A`).
     pub fn emoji(self) -> &'static str {
         match self {
             OpOutcome::Pass => "🟢",
             OpOutcome::Regressed => "🔴",
             OpOutcome::DivergedAdvisory => "⚠",
+            OpOutcome::Skipped => "⏭",
             OpOutcome::NotApplicable => "N/A",
         }
     }
 }
 
-/// A 🟢 / 🔴 / ⚠ / N-A tally of per-op outcomes.
+/// A 🟢 / 🔴 / ⚠ / ⏭ / N-A tally of per-op outcomes.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OutcomeCounts {
     pub pass: usize,
@@ -111,6 +120,9 @@ pub struct OutcomeCounts {
     /// Ops diverged under the `advisory` policy ([`OpOutcome::DivergedAdvisory`]). Always 0 under
     /// the `gate` policy, where a divergence counts in `regressed`.
     pub diverged: usize,
+    /// Ops capability-skipped on ≥1 side ([`OpOutcome::Skipped`]) — under **both** policies:
+    /// a skip is an expected engine limitation, never a regression or a divergence.
+    pub skipped: usize,
     pub not_applicable: usize,
 }
 
@@ -123,6 +135,7 @@ impl OutcomeCounts {
             OpOutcome::Pass => self.pass += 1,
             OpOutcome::Regressed => self.regressed += 1,
             OpOutcome::DivergedAdvisory => self.diverged += 1,
+            OpOutcome::Skipped => self.skipped += 1,
             OpOutcome::NotApplicable => self.not_applicable += 1,
         }
     }
@@ -290,12 +303,20 @@ pub struct CellAnalysis {
 /// One op's analysis: correctness, the rolled-up outcome and every measured cell.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OpAnalysis {
-    /// Coverage tier (`"core"`/`"full"`) from the catalog or the repo-read shape registry; `None`
-    /// for names known to neither.
+    /// Coverage tier (`"core"`/`"full"`) from the catalog or the recorded-shape registry (repo
+    /// reads and algorithm shapes); `None` for names known to neither.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tier: Option<String>,
     pub correctness: Correctness,
     pub op_outcome: OpOutcome,
+    /// Why the **baseline** run skipped this op (capability probe — design Phase 6 §3.5), or
+    /// `None` when it measured it. A skipped side has no cells; the other side's raw numbers stay
+    /// visible for context but no cell is comparable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skipped_baseline: Option<String>,
+    /// Why the **candidate** run skipped this op, or `None` when it measured it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skipped_candidate: Option<String>,
     pub cells: Vec<CellAnalysis>,
 }
 
@@ -319,7 +340,8 @@ pub struct RegressionAnalysis {
     pub verdict: OverallVerdict,
     /// Per-op outcome tallies. Every op with ≥1 measured cell is tallied; a **diverged** op is
     /// tallied even with no cell (gate ⇒ `regressed`, advisory ⇒ `diverged` — every divergence
-    /// counts). Only a cell-less non-diverged op has nothing to tally.
+    /// counts), and so is a **skipped** op (every skip is visible). Only a cell-less non-diverged,
+    /// non-skipped op has nothing to tally.
     pub totals: OutcomeCounts,
     /// Cells with a real verdict (🟢 or 🔴) across all ops; a diverged op's cells are N/A and
     /// never counted.
@@ -343,7 +365,7 @@ impl RegressionAnalysis {
     pub fn verdict_line(&self) -> (&'static str, String) {
         let emoji = self.verdict.emoji();
         let diverged = self.diverged_ops().len();
-        let headline = match self.verdict {
+        let mut headline = match self.verdict {
             OverallVerdict::NotComparable => {
                 let reason = self.status.not_comparable_reason().unwrap_or("unknown reason");
                 format!("not comparable — {reason}")
@@ -370,6 +392,14 @@ impl RegressionAnalysis {
                 self.comparable_cells
             ),
         };
+        // Skips are annotated, never gated (design Phase 6 §3.5) — visible on every comparable
+        // verdict so a partially-supported engine can't silently shrink the compared set.
+        if self.verdict != OverallVerdict::NotComparable && self.totals.skipped > 0 {
+            headline.push_str(&format!(
+                "; {} op(s) skipped (engine lacks their required procedure)",
+                self.totals.skipped
+            ));
+        }
         (emoji, headline)
     }
 
@@ -504,6 +534,14 @@ fn analyze_op(
     thresholds: &Thresholds,
     policy: DivergencePolicy,
 ) -> OpAnalysis {
+    // Skip reasons (capability probe — design Phase 6 §3.5), per side. A skipped side recorded no
+    // levels, so its cells are one-sided; forcing the verdict N/A below also covers a hand-crafted
+    // report that pairs a skip reason with levels.
+    let skipped_side = |rep: &Report| rep.operations.get(op).and_then(|o| o.skipped.clone());
+    let skipped_baseline = skipped_side(baseline);
+    let skipped_candidate = skipped_side(candidate);
+    let skipped = skipped_baseline.is_some() || skipped_candidate.is_some();
+
     let mut cells = Vec::new();
     for mode in [CacheMode::Cached, CacheMode::Uncached] {
         let mut levels: BTreeSet<usize> = BTreeSet::new();
@@ -523,8 +561,9 @@ fn analyze_op(
             let bp = bm.map(|m| m.metrics.total_ms.median);
             let budget = thresholds.resolve_by_name(op, c);
             // Perf verdict: N/A for every cell of a diverged op (different work ⇒ a latency
-            // comparison is meaningless, under BOTH policies), else the budget rule.
-            let perf_verdict = if diverged {
+            // comparison is meaningless, under BOTH policies) and of a skipped op (one side never
+            // executed it), else the budget rule.
+            let perf_verdict = if diverged || skipped {
                 Verdict::NotApplicable
             } else {
                 match (ap, bp) {
@@ -559,6 +598,10 @@ fn analyze_op(
 
     let correctness = if diverged {
         Correctness::Diverged
+    } else if skipped {
+        // Skipped on ≥1 side ⇒ that side never ran ⇒ no correctness claim, even when the measured
+        // side recorded a digest.
+        Correctness::NotGated
     } else {
         // Non-diverged ⇒ the digests either match on both sides or are absent on both.
         let has_digest = baseline
@@ -570,8 +613,12 @@ fn analyze_op(
     };
 
     // Worst cell wins: Regressed > DivergedAdvisory > Pass > NotApplicable. A diverged op's cells
-    // are all N/A, so divergence and a cell regression are mutually exclusive.
-    let op_outcome = if diverged {
+    // are all N/A, so divergence and a cell regression are mutually exclusive. A skip on either
+    // side outranks everything: the op was never executed there, so no comparison exists — it is
+    // neither a pass nor a divergence, and never a gate.
+    let op_outcome = if skipped {
+        OpOutcome::Skipped
+    } else if diverged {
         match policy {
             DivergencePolicy::Gate => OpOutcome::Regressed,
             DivergencePolicy::Advisory => OpOutcome::DivergedAdvisory,
@@ -588,6 +635,8 @@ fn analyze_op(
         tier: op_tier(op).map(|t| t.as_str().to_string()),
         correctness,
         op_outcome,
+        skipped_baseline,
+        skipped_candidate,
         cells,
     }
 }
@@ -682,8 +731,13 @@ pub fn analyze(
         }
         // Every op with a measured cell is tallied — and so is a cell-less **diverged** op
         // (gate ⇒ `regressed`, advisory ⇒ `diverged`): every divergence counts in the outcome
-        // table. Only a cell-less non-diverged op has nothing to tally.
-        if !oa.cells.is_empty() || oa.correctness == Correctness::Diverged {
+        // table. A **skipped** op is always tallied too (every skip is visible — design Phase 6
+        // §3.5), even when the measured side contributed no cell. Only a cell-less non-diverged,
+        // non-skipped op has nothing to tally.
+        if !oa.cells.is_empty()
+            || oa.correctness == Correctness::Diverged
+            || oa.op_outcome == OpOutcome::Skipped
+        {
             totals.add(oa.op_outcome);
         }
         ops.insert(op.clone(), oa);
@@ -771,6 +825,7 @@ mod tests {
                     }],
                     result_digest: digest.map(str::to_string),
                     policy: None,
+                    skipped: None,
                 },
             );
         }
@@ -833,7 +888,13 @@ mod tests {
         assert_eq!(an.regressed_cells, 0);
         assert_eq!(
             an.totals,
-            OutcomeCounts { pass: 1, regressed: 0, diverged: 0, not_applicable: 0 }
+            OutcomeCounts {
+                pass: 1,
+                regressed: 0,
+                diverged: 0,
+                skipped: 0,
+                not_applicable: 0
+            }
         );
         let op = &an.ops["match_by_index"];
         assert_eq!(op.correctness, Correctness::Match);
@@ -903,12 +964,21 @@ mod tests {
         // The diverged bucket counts it; `regressed` never does.
         assert_eq!(
             an.totals,
-            OutcomeCounts { pass: 1, regressed: 0, diverged: 1, not_applicable: 0 }
+            OutcomeCounts {
+                pass: 1,
+                regressed: 0,
+                diverged: 1,
+                skipped: 0,
+                not_applicable: 0
+            }
         );
         let (emoji, headline) = an.verdict_line();
         assert_eq!(emoji, "⚠");
         assert!(headline.starts_with("pass, 1 diverged"), "{headline}");
-        assert!(headline.contains("advisory under this policy"), "{headline}");
+        assert!(
+            headline.contains("advisory under this policy"),
+            "{headline}"
+        );
     }
 
     #[test]
@@ -923,6 +993,199 @@ mod tests {
         let (emoji, headline) = an.verdict_line();
         assert_eq!(emoji, "⚠");
         assert!(headline.starts_with("no comparable cells"), "{headline}");
+    }
+
+    /// Mark `op` in `rep` as capability-skipped: no levels, no digest, no policy — exactly what
+    /// replay writes for an op whose required procedure the engine lacks (design Phase 6 §3.5).
+    fn skip_op(
+        rep: &mut Report,
+        op: &str,
+        reason: &str,
+    ) {
+        let o = rep.operations.get_mut(op).expect("op present");
+        o.levels = vec![];
+        o.result_digest = None;
+        o.policy = None;
+        o.skipped = Some(reason.to_string());
+    }
+
+    #[test]
+    fn skipped_op_is_neither_pass_nor_divergence() {
+        // Baseline measured `aggregate_count` (with a digest); the candidate engine lacks its
+        // procedure and skipped it. The clean op still compares; the skipped op is ⏭ — not a
+        // pass, not a divergence, not a gate — under BOTH policies.
+        let a = rpt(
+            "main",
+            42001,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("d2")),
+            ],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("d2")),
+            ],
+        );
+        skip_op(
+            &mut b,
+            "aggregate_count",
+            "engine lacks procedure 'algo.maxFlow' (capability probe)",
+        );
+        for an in [gate(&a, &b), advisory(&a, &b)] {
+            assert_eq!(
+                an.verdict,
+                OverallVerdict::Pass,
+                "a skip never gates or caps"
+            );
+            assert!(an.diverged_ops().is_empty(), "a skip is not a divergence");
+            let oa = &an.ops["aggregate_count"];
+            assert_eq!(oa.op_outcome, OpOutcome::Skipped);
+            assert_eq!(oa.correctness, Correctness::NotGated);
+            assert!(oa.skipped_baseline.is_none());
+            assert_eq!(
+                oa.skipped_candidate.as_deref(),
+                Some("engine lacks procedure 'algo.maxFlow' (capability probe)")
+            );
+            // The measured side's cell stays visible for context but is never comparable.
+            assert!(oa
+                .cells
+                .iter()
+                .all(|c| c.perf_verdict == Verdict::NotApplicable));
+            assert_eq!(
+                an.totals,
+                OutcomeCounts {
+                    pass: 1,
+                    regressed: 0,
+                    diverged: 0,
+                    skipped: 1,
+                    not_applicable: 0
+                }
+            );
+            assert_eq!(an.comparable_cells, 1);
+            let (emoji, headline) = an.verdict_line();
+            assert_eq!(emoji, "🟢");
+            assert!(
+                headline.contains("1 op(s) skipped (engine lacks their required procedure)"),
+                "{headline}"
+            );
+        }
+    }
+
+    #[test]
+    fn op_skipped_on_both_sides_is_tallied_without_cells() {
+        let mut a = rpt(
+            "main",
+            42001,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("d2")),
+            ],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("d2")),
+            ],
+        );
+        skip_op(
+            &mut a,
+            "aggregate_count",
+            "engine lacks procedure 'algo.MSF' (capability probe)",
+        );
+        skip_op(
+            &mut b,
+            "aggregate_count",
+            "engine lacks procedure 'algo.MSF' (capability probe)",
+        );
+        let an = gate(&a, &b);
+        let oa = &an.ops["aggregate_count"];
+        assert!(
+            oa.cells.is_empty(),
+            "skipped on both sides ⇒ no measured cell"
+        );
+        assert_eq!(oa.op_outcome, OpOutcome::Skipped);
+        assert!(oa.skipped_baseline.is_some() && oa.skipped_candidate.is_some());
+        // Every skip is visible in the tallies, even with no cell.
+        assert_eq!(an.totals.skipped, 1);
+        assert_eq!(an.verdict, OverallVerdict::Pass);
+    }
+
+    #[test]
+    fn all_ops_skipped_is_advisory_never_green() {
+        let a = rpt("main", 42001, &[("match_by_index", 1.0, Some("d1"))]);
+        let mut b = rpt("pr", 42002, &[("match_by_index", 1.0, Some("d1"))]);
+        skip_op(
+            &mut b,
+            "match_by_index",
+            "engine lacks procedure 'algo.pageRank' (capability probe)",
+        );
+        let an = gate(&a, &b);
+        // The only op is skipped ⇒ zero comparable cells ⇒ Advisory (never a silent green).
+        assert_eq!(an.verdict, OverallVerdict::Advisory);
+        assert_eq!(an.comparable_cells, 0);
+        assert_eq!(
+            an.totals,
+            OutcomeCounts {
+                pass: 0,
+                regressed: 0,
+                diverged: 0,
+                skipped: 1,
+                not_applicable: 0
+            }
+        );
+        let (emoji, headline) = an.verdict_line();
+        assert_eq!(emoji, "⚠");
+        assert!(headline.starts_with("no comparable cells"), "{headline}");
+        assert!(headline.contains("1 op(s) skipped"), "{headline}");
+    }
+
+    #[test]
+    fn cells_json_carries_skip_reasons_and_skipped_outcome() {
+        // The serialized skip contract: `op_outcome: "skipped"`, the per-side reason fields
+        // present exactly when a side skipped, and the `skipped` bucket in `totals`.
+        let a = rpt(
+            "main",
+            42001,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("d2")),
+            ],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("d2")),
+            ],
+        );
+        skip_op(
+            &mut b,
+            "aggregate_count",
+            "engine lacks procedure 'algo.maxFlow' (capability probe)",
+        );
+        let an = gate(&a, &b);
+        let value: serde_json::Value = serde_json::from_str(&an.to_json().unwrap()).unwrap();
+        let op = &value["ops"]["aggregate_count"];
+        assert_eq!(op["op_outcome"], "skipped");
+        assert!(
+            op.get("skipped_baseline").is_none(),
+            "absent side omits its skip field"
+        );
+        assert_eq!(
+            op["skipped_candidate"],
+            "engine lacks procedure 'algo.maxFlow' (capability probe)"
+        );
+        assert_eq!(value["totals"]["skipped"], 1);
+        // Round-trips through serde (the skip fields deserialize too).
+        let back: RegressionAnalysis = serde_json::from_value(value).unwrap();
+        assert_eq!(back, an);
     }
 
     #[test]
@@ -1117,7 +1380,24 @@ mod tests {
                 "warnings",
             ]
         );
-        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema_version"], 2);
+        // …and the per-op shape: the op-level field set (skip fields are omitted when absent —
+        // they appear exactly when a side skipped the op) plus the outcome-counts bucket set.
+        let op = &value["ops"]["match_by_index"];
+        let mut op_keys: Vec<&str> = op.as_object().unwrap().keys().map(String::as_str).collect();
+        op_keys.sort_unstable();
+        assert_eq!(op_keys, vec!["cells", "correctness", "op_outcome", "tier"]);
+        let mut count_keys: Vec<&str> = value["totals"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        count_keys.sort_unstable();
+        assert_eq!(
+            count_keys,
+            vec!["diverged", "not_applicable", "pass", "regressed", "skipped"]
+        );
         // …and the per-cell shape (what the interactive page consumes).
         let cell = &value["ops"]["match_by_index"]["cells"][0];
         let mut cell_keys: Vec<&str> =

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -34,6 +34,12 @@ pub struct BaselineKey {
     /// and for runs where every op inherited the global knobs.
     #[serde(default)]
     pub op_policies: BTreeMap<String, OpPolicy>,
+    /// Ops the run **skipped** (capability probe — design Phase 6 §3.5): recorded but never
+    /// executed because the engine lacks their required procedure. An op skipped on either side
+    /// is exempt from the per-op policy and result-digest gates (it carries neither), and reads
+    /// as neither a pass nor a divergence. Empty for pre-Phase-6 reports.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub skipped_ops: BTreeSet<String>,
 }
 
 impl BaselineKey {
@@ -53,6 +59,12 @@ impl BaselineKey {
                 .iter()
                 .filter_map(|(name, op)| op.policy.clone().map(|p| (name.clone(), p)))
                 .collect(),
+            skipped_ops: report
+                .operations
+                .iter()
+                .filter(|(_, op)| op.skipped.is_some())
+                .map(|(name, _)| name.clone())
+                .collect(),
         }
     }
 }
@@ -69,13 +81,19 @@ pub enum GuardOutcome {
 /// The first per-op **effective-policy** mismatch between two runs, as a human-readable refusal
 /// reason (`None` when every op's policy matches). Compared over the union of budgeted ops: a
 /// policy present on one side only is a mismatch too — that op was measured under different
-/// conditions (e.g. one run's bundle carried a budget the other's didn't).
+/// conditions (e.g. one run's bundle carried a budget the other's didn't). Ops in `skipped` —
+/// capability-skipped on either side (design Phase 6 §3.5) — are exempt: a skipped op was never
+/// measured, so its structurally-absent policy is not a config mismatch.
 fn op_policy_mismatch(
     baseline: &BTreeMap<String, OpPolicy>,
     candidate: &BTreeMap<String, OpPolicy>,
+    skipped: &BTreeSet<String>,
 ) -> Option<String> {
     let all: BTreeSet<&String> = baseline.keys().chain(candidate.keys()).collect();
     for op in all {
+        if skipped.contains(op.as_str()) {
+            continue;
+        }
         let b = baseline.get(op);
         let c = candidate.get(op);
         if b != c {
@@ -126,8 +144,18 @@ pub fn guard(
     // Per-op measurement-policy gate: budgets are deliberately outside the workload_hash (replay
     // policy, not workload content — design §3.4), so two runs of "the same workload" can still
     // have measured an op under different sampling/cache/sweep/timeout conditions. Such latencies
-    // are not comparable — refuse, exactly like a workload mismatch.
-    if let Some(reason) = op_policy_mismatch(&baseline.op_policies, &candidate.op_policies) {
+    // are not comparable — refuse, exactly like a workload mismatch. Ops capability-skipped on
+    // either side are exempt (never measured ⇒ nothing to compare — design Phase 6 §3.5).
+    let skipped_either: BTreeSet<String> = baseline
+        .skipped_ops
+        .union(&candidate.skipped_ops)
+        .cloned()
+        .collect();
+    if let Some(reason) = op_policy_mismatch(
+        &baseline.op_policies,
+        &candidate.op_policies,
+        &skipped_either,
+    ) {
         return GuardOutcome::Abort { reason };
     }
 
@@ -136,8 +164,13 @@ pub fn guard(
     // results faster could masquerade as an improvement. A candidate that is missing a digest the
     // baseline has is also a mismatch (fail closed, matching the docs' "every op" guarantee).
     // Digests are present for `synthetic run --recording` runs; a `synthetic run` baseline has none, so the
-    // loop is a no-op there (and such runs already differ on `workload_hash` above).
+    // loop is a no-op there (and such runs already differ on `workload_hash` above). An op
+    // capability-skipped on either side is exempt: its absent digest means "never ran", not
+    // "returned different results".
     for (op, base_dig) in &baseline.result_digests {
+        if skipped_either.contains(op) {
+            continue;
+        }
         match candidate.result_digests.get(op) {
             Some(cand_dig) if cand_dig == base_dig => {}
             Some(cand_dig) => {
@@ -296,21 +329,36 @@ pub fn regression_guard(
     // Per-op effective measurement policy (design §3.4): budgets are outside the workload_hash,
     // so a matching hash does not prove each op was measured under the same conditions. A per-op
     // policy mismatch is a *config* mismatch — the whole pair is NotComparable, exactly like the
-    // global sampling/sweep checks above.
+    // global sampling/sweep checks above. Ops capability-skipped on either side (design Phase 6
+    // §3.5) are exempt — never measured ⇒ no measurement conditions to mismatch.
+    let skipped = |r: &Report| -> Vec<String> {
+        r.operations
+            .iter()
+            .filter(|(_, op)| op.skipped.is_some())
+            .map(|(name, _)| name.clone())
+            .collect()
+    };
+    let skipped_either: BTreeSet<String> = skipped(baseline)
+        .into_iter()
+        .chain(skipped(candidate))
+        .collect();
     let policies = |r: &Report| -> BTreeMap<String, OpPolicy> {
         r.operations
             .iter()
             .filter_map(|(name, op)| op.policy.clone().map(|p| (name.clone(), p)))
             .collect()
     };
-    if let Some(reason) = op_policy_mismatch(&policies(baseline), &policies(candidate)) {
+    if let Some(reason) =
+        op_policy_mismatch(&policies(baseline), &policies(candidate), &skipped_either)
+    {
         return RegressionGuard::NotComparable { reason };
     }
 
     // 2. Per-op result divergence — reported, never fatal. Over the *union* of ops: two present
     //    digests that differ, or an asymmetric one-side-only digest, is diverged (we can't verify
     //    correctness). Two absent digests carry no correctness info (e.g. a non-recording run) and
-    //    are left comparable, matching the strict guard.
+    //    are left comparable, matching the strict guard. An op capability-skipped on either side
+    //    is never diverged — its absent digest means "never ran", not "returned different results".
     let mut diverged_ops = BTreeSet::new();
     let all_ops: BTreeSet<&String> = baseline
         .operations
@@ -318,6 +366,9 @@ pub fn regression_guard(
         .chain(candidate.operations.keys())
         .collect();
     for op in all_ops {
+        if skipped_either.contains(op.as_str()) {
+            continue;
+        }
         let bd = baseline.operations.get(op).and_then(|o| o.result_digest.as_ref());
         let cd = candidate.operations.get(op).and_then(|o| o.result_digest.as_ref());
         let diverged = match (bd, cd) {
@@ -403,6 +454,7 @@ mod tests {
             server_image: None,
             result_digests: BTreeMap::new(),
             op_policies: BTreeMap::new(),
+            skipped_ops: BTreeSet::new(),
         }
     }
 
@@ -419,6 +471,7 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
             op_policies: BTreeMap::new(),
+            skipped_ops: BTreeSet::new(),
         }
     }
 
@@ -456,6 +509,7 @@ mod tests {
                 .iter()
                 .map(|(k, p)| (k.to_string(), p.clone()))
                 .collect(),
+            skipped_ops: BTreeSet::new(),
         }
     }
 
@@ -496,6 +550,21 @@ mod tests {
         let base = key_with_policies(&[("algo_max_flow", policy(1))]);
         let cand = key_with_policies(&[("algo_max_flow", policy(1))]);
         assert!(matches!(guard(&base, &cand), GuardOutcome::Proceed { .. }));
+    }
+
+    #[test]
+    fn skipped_op_is_exempt_from_the_policy_and_digest_gates() {
+        // The baseline measured `algo_max_flow` under a budget and gated its digest; the candidate
+        // engine lacks the procedure and skipped the op. Its structurally-absent policy/digest is
+        // "never ran", not a config or correctness mismatch — the pair stays comparable
+        // (design Phase 6 §3.5). Both skip directions are exempt.
+        let mut base = key_with_policies(&[("algo_max_flow", policy(1))]);
+        base.result_digests
+            .insert("algo_max_flow".to_string(), "sha256:aaa".to_string());
+        let mut cand = key_with_policies(&[]);
+        cand.skipped_ops.insert("algo_max_flow".to_string());
+        assert!(matches!(guard(&base, &cand), GuardOutcome::Proceed { .. }));
+        assert!(matches!(guard(&cand, &base), GuardOutcome::Proceed { .. }));
     }
 
     #[test]
@@ -615,6 +684,7 @@ mod tests {
             server_image: Some("falkordb@sha256:aaa".to_string()),
             result_digests: BTreeMap::new(),
             op_policies: BTreeMap::new(),
+            skipped_ops: BTreeSet::new(),
         };
         let cand = BaselineKey {
             workload_hash: Some("sha256:abc".to_string()),
@@ -622,6 +692,7 @@ mod tests {
             server_image: Some("falkordb@sha256:bbb".to_string()),
             result_digests: BTreeMap::new(),
             op_policies: BTreeMap::new(),
+            skipped_ops: BTreeSet::new(),
         };
         match guard(&base, &cand) {
             GuardOutcome::Proceed { warnings } => {
@@ -657,6 +728,7 @@ mod regression_guard_tests {
                     levels: vec![],
                     result_digest: dig.map(|s| s.to_string()),
                     policy: None,
+                    skipped: None,
                 },
             );
         }
@@ -901,5 +973,111 @@ mod regression_guard_tests {
         // Only the budgeted op lands in the key; inherit-everything ops stay absent.
         assert_eq!(key.op_policies.len(), 1);
         assert_eq!(key.op_policies.get("algo_max_flow"), Some(&policy(1)));
+    }
+
+    /// Mark `op` in `rep` as capability-skipped, exactly as replay records it (design Phase 6
+    /// §3.5): a skip reason, no levels, no digest, no policy.
+    fn skip_op(
+        rep: &mut Report,
+        op: &str,
+    ) {
+        let o = rep.operations.get_mut(op).unwrap();
+        o.levels = vec![];
+        o.result_digest = None;
+        o.policy = None;
+        o.skipped = Some("engine lacks procedure 'algo.maxFlow' (capability probe)".to_string());
+    }
+
+    #[test]
+    fn regression_guard_exempts_skipped_ops_from_the_policy_gate() {
+        // The baseline measured `algo_max_flow` under a recorded budget; the candidate engine
+        // lacks its procedure and skipped it (so it carries no policy). That asymmetry is
+        // "never ran", not a config mismatch — the pair stays comparable, in both directions.
+        let mut a = rep(
+            "h",
+            100,
+            50,
+            vec![1],
+            None,
+            None,
+            &[("algo_max_flow", None), ("scan", Some("d"))],
+        );
+        let mut b = rep(
+            "h",
+            100,
+            50,
+            vec![1],
+            None,
+            None,
+            &[("algo_max_flow", None), ("scan", Some("d"))],
+        );
+        a.operations.get_mut("algo_max_flow").unwrap().policy = Some(policy(1));
+        skip_op(&mut b, "algo_max_flow");
+        assert!(matches!(
+            regression_guard(&a, &b),
+            RegressionGuard::Comparable { .. }
+        ));
+        assert!(matches!(
+            regression_guard(&b, &a),
+            RegressionGuard::Comparable { .. }
+        ));
+    }
+
+    #[test]
+    fn regression_guard_never_marks_a_skipped_op_diverged() {
+        // The measured side has a digest, the skipped side has none — the usual asymmetric-digest
+        // divergence rule must NOT fire for a skip (nothing ran, so nothing differed).
+        let a = rep(
+            "h",
+            100,
+            50,
+            vec![1],
+            None,
+            None,
+            &[("algo_max_flow", Some("d1")), ("scan", Some("d"))],
+        );
+        let mut b = rep(
+            "h",
+            100,
+            50,
+            vec![1],
+            None,
+            None,
+            &[("algo_max_flow", Some("d1")), ("scan", Some("d"))],
+        );
+        skip_op(&mut b, "algo_max_flow");
+        match regression_guard(&a, &b) {
+            RegressionGuard::Comparable { diverged_ops, .. } => {
+                assert!(
+                    diverged_ops.is_empty(),
+                    "skip is never a divergence: {diverged_ops:?}"
+                );
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn baseline_key_collects_skipped_ops_from_a_report() {
+        let mut r = rep(
+            "h",
+            100,
+            50,
+            vec![1],
+            None,
+            None,
+            &[("algo_max_flow", None), ("scan", None)],
+        );
+        skip_op(&mut r, "algo_max_flow");
+        let key = BaselineKey::from_report(&r);
+        assert_eq!(key.skipped_ops.len(), 1);
+        assert!(key.skipped_ops.contains("algo_max_flow"));
+        // …and a fully-measured report yields an empty set (which serialization omits, keeping
+        // pre-Phase-6 baseline JSON byte-identical).
+        let clean = rep("h", 100, 50, vec![1], None, None, &[("scan", None)]);
+        let clean_key = BaselineKey::from_report(&clean);
+        assert!(clean_key.skipped_ops.is_empty());
+        let json = serde_json::to_string(&clean_key).unwrap();
+        assert!(!json.contains("skipped_ops"), "{json}");
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -349,8 +349,13 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
         for mode in [CacheMode::Cached, CacheMode::Uncached] {
             render_regression_mode(&mut op_body, oa, mode, analysis.divergence_policy, la, lb);
         }
-        // Ops with no measured cell get no report section; the totals still tally them when
-        // they diverged (gate → regressed, advisory → diverged).
+        // A skipped op keeps its section even with no measured cell — the skip reason is the
+        // content (design Phase 6 §3.5). Other ops with no measured cell get no report section;
+        // the totals still tally them when they diverged (gate → regressed, advisory → diverged).
+        let skip_note = skip_note(oa, la, lb);
+        if let Some(note) = &skip_note {
+            op_body.push_str(&format!("\n_{}_\n", md_cell(note)));
+        }
         if op_body.trim().is_empty() {
             continue;
         }
@@ -362,8 +367,13 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
         } else {
             ""
         };
+        let skipped_note = if skip_note.is_some() {
+            " — skipped (perf verdict N/A)"
+        } else {
+            ""
+        };
         body.push_str(&format!(
-            "\n<details><summary>{} <code>{}</code>{diverged_note}</summary>\n{op_body}\n</details>\n",
+            "\n<details><summary>{} <code>{}</code>{diverged_note}{skipped_note}</summary>\n{op_body}\n</details>\n",
             oa.op_outcome.emoji(),
             html_escape(op)
         ));
@@ -401,8 +411,35 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
              informational, never part of the verdict. Non-blocking.\n"
         }
     });
+    if analysis.totals.skipped > 0 {
+        out.push_str(
+            "\n_⏭ = skipped: the engine lacks the op's required procedure (capability probe) — \
+             recorded but never executed there, so it is neither a pass nor a divergence._\n",
+        );
+    }
     out.push_str(&body);
     out
+}
+
+/// The one-line skip explanation for an op skipped on either side (capability probe — design
+/// Phase 6 §3.5), or `None` for a measured op. Labels name the runs so an asymmetric skip reads
+/// unambiguously.
+fn skip_note(
+    oa: &OpAnalysis,
+    la: &str,
+    lb: &str,
+) -> Option<String> {
+    match (&oa.skipped_baseline, &oa.skipped_candidate) {
+        (Some(b), Some(c)) if b == c => Some(format!("⏭ skipped on both sides — {b}")),
+        (Some(b), Some(c)) => Some(format!("⏭ skipped on both sides — {la}: {b}; {lb}: {c}")),
+        (Some(b), None) => Some(format!(
+            "⏭ skipped on {la} — {b}; measured on {lb} only, so no cell is comparable"
+        )),
+        (None, Some(c)) => Some(format!(
+            "⏭ skipped on {lb} — {c}; measured on {la} only, so no cell is comparable"
+        )),
+        (None, None) => None,
+    }
 }
 
 /// Render one op × cache-mode regression table (rows = this mode's cells) with a verdict column.
@@ -459,7 +496,7 @@ fn render_regression_mode(
 //
 // The full `regression_markdown` report is authoritative but too big to embed in a PR comment for
 // the full 64-shape corpus (GitHub caps a comment at 65 KB). [`summarize`] distills the *same*
-// [`RegressionAnalysis`] model into a compact structure — overall verdict, per-tier 🟢/🔴/⚠/N-A
+// [`RegressionAnalysis`] model into a compact structure — overall verdict, per-tier 🟢/🔴/⚠/⏭/N-A
 // counts and the worst offenders — that CI can post inline while hosting the full report
 // externally under [`SyntheticSummary::slug`]. Because both renderers consume the same model,
 // drift is impossible by construction (a consistency test still pins the two together).
@@ -469,8 +506,11 @@ fn render_regression_mode(
 /// v2 (design §A5 of `synthetic-three-way-report.md`): adds `budget_profile`,
 /// `divergence_policy`, `gated_metric`, `elapsed_secs`, a `diverged` bucket in [`OutcomeCounts`]
 /// and the four-state [`OverallVerdict`] as `overall_verdict` (replacing v1's three-state
-/// `verdict`).
-pub const SUMMARY_SCHEMA_VERSION: u32 = 2;
+/// `verdict`). v3 (design Phase 6 §3.5 of `synthetic-cover-algorithms-phase6.md`): adds the
+/// `skipped` [`OpOutcome`] value and [`OutcomeCounts`] bucket for capability-skipped ops — a v2
+/// consumer parsing outcomes exhaustively would reject `"skipped"`, so this is a bump, not a
+/// silent extension.
+pub const SUMMARY_SCHEMA_VERSION: u32 = 3;
 
 /// Maximum number of regressed ops listed under "worst offenders" (keeps the comment compact).
 const MAX_OFFENDERS: usize = 5;
@@ -496,7 +536,7 @@ pub struct Offender {
 }
 
 /// A compact, machine-usable summary of a `report --diff --regression` comparison: overall verdict,
-/// per-tier 🟢/🔴/⚠/N-A counts and the worst offenders — small enough to embed in a PR comment while
+/// per-tier 🟢/🔴/⚠/⏭/N-A counts and the worst offenders — small enough to embed in a PR comment while
 /// the full Markdown report is hosted externally and linked by [`slug`](Self::slug). Emitted as JSON
 /// by `report --summary`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -570,11 +610,16 @@ pub fn summarize(analysis: &RegressionAnalysis) -> SyntheticSummary {
     let mut full = OutcomeCounts::default();
     let mut offenders: Vec<Offender> = Vec::new();
     for (op, oa) in &analysis.ops {
-        // Mirror the model's totals: ops with ≥1 cell are tallied, and a cell-less **diverged**
-        // op is tallied too (every divergence counts). Under the `gate` policy (divergence ⇒
-        // `Regressed`) it also surfaces as a worst offender below; under `advisory` it stays a
-        // `DivergedAdvisory` and is intentionally kept out of the offender list.
-        if !oa.cells.is_empty() || oa.correctness == Correctness::Diverged {
+        // Mirror the model's totals: ops with ≥1 cell are tallied, a cell-less **diverged**
+        // op is tallied too (every divergence counts), and so is a **skipped** op (every skip
+        // is visible — design Phase 6 §3.5). Under the `gate` policy (divergence ⇒ `Regressed`)
+        // a divergence also surfaces as a worst offender below; under `advisory` it stays a
+        // `DivergedAdvisory` and is intentionally kept out of the offender list, as is a skip
+        // (an expected engine limitation, not a failure).
+        if !oa.cells.is_empty()
+            || oa.correctness == Correctness::Diverged
+            || oa.op_outcome == OpOutcome::Skipped
+        {
             match oa.tier.as_deref() {
                 Some("core") => core.add(oa.op_outcome),
                 Some("full") => full.add(oa.op_outcome),
@@ -619,7 +664,7 @@ impl SyntheticSummary {
     }
 
     /// A compact Markdown rendering for a PR sticky comment (well under GitHub's 65 KB limit): the
-    /// verdict headline, a per-tier 🟢/🔴/⚠/N-A table and the worst offenders, ending with the
+    /// verdict headline, a per-tier 🟢/🔴/⚠/⏭/N-A table and the worst offenders, ending with the
     /// stable [`slug`](Self::slug) so CI can link the externally-hosted full report.
     pub fn to_markdown(&self) -> String {
         let mut out = String::new();
@@ -638,22 +683,24 @@ impl SyntheticSummary {
             out.push_str(&format!("\n_report: {}_\n", self.slug));
             return out;
         }
-        out.push_str("\n| tier | 🟢 | 🔴 | ⚠ | N/A |\n|---|---:|---:|---:|---:|\n");
+        out.push_str("\n| tier | 🟢 | 🔴 | ⚠ | ⏭ | N/A |\n|---|---:|---:|---:|---:|---:|\n");
         for t in &self.per_tier {
             out.push_str(&format!(
-                "| {} | {} | {} | {} | {} |\n",
+                "| {} | {} | {} | {} | {} | {} |\n",
                 md_cell(&t.tier),
                 t.counts.pass,
                 t.counts.regressed,
                 t.counts.diverged,
+                t.counts.skipped,
                 t.counts.not_applicable
             ));
         }
         out.push_str(&format!(
-            "| **all** | {} | {} | {} | {} |\n",
+            "| **all** | {} | {} | {} | {} | {} |\n",
             self.totals.pass,
             self.totals.regressed,
             self.totals.diverged,
+            self.totals.skipped,
             self.totals.not_applicable
         ));
         if !self.worst_offenders.is_empty() {
@@ -763,6 +810,7 @@ mod tests {
                 }],
                 result_digest: Some("sha256:aa".to_string()),
                 policy: None,
+                skipped: None,
             },
         );
         Report {
@@ -1095,6 +1143,7 @@ mod tests {
                     levels,
                     result_digest: Some("sha256:aa".to_string()),
                     policy: None,
+                    skipped: None,
                 },
             );
         }
@@ -1179,6 +1228,7 @@ mod tests {
                     }],
                     result_digest: Some((*digest).to_string()),
                     policy: None,
+                    skipped: None,
                 },
             );
         }
@@ -1243,6 +1293,7 @@ mod tests {
                 pass: 1,
                 regressed: 0,
                 diverged: 0,
+                skipped: 0,
                 not_applicable: 0
             }
         );
@@ -1258,6 +1309,7 @@ mod tests {
                 pass: 1,
                 regressed: 0,
                 diverged: 0,
+                skipped: 0,
                 not_applicable: 0
             }
         );
@@ -1360,6 +1412,7 @@ mod tests {
                 pass: 1,
                 regressed: 1,
                 diverged: 0,
+                skipped: 0,
                 not_applicable: 0
             }
         );
@@ -1371,6 +1424,7 @@ mod tests {
                 pass: 1,
                 regressed: 0,
                 diverged: 0,
+                skipped: 0,
                 not_applicable: 0
             }
         );
@@ -1380,6 +1434,7 @@ mod tests {
                 pass: 0,
                 regressed: 1,
                 diverged: 0,
+                skipped: 0,
                 not_applicable: 0
             }
         );
@@ -1403,6 +1458,7 @@ mod tests {
                 pass: 1,
                 regressed: 0,
                 diverged: 0,
+                skipped: 0,
                 not_applicable: 0
             }
         );
@@ -1635,8 +1691,8 @@ mod tests {
     }
 
     #[test]
-    fn summary_v2_freezes_the_top_level_field_set() {
-        // The summary JSON is a machine contract (schema v2). This test freezes the exact
+    fn summary_v3_freezes_the_top_level_field_set() {
+        // The summary JSON is a machine contract (schema v3). This test freezes the exact
         // top-level field set — adding/renaming/removing a field must bump
         // SUMMARY_SCHEMA_VERSION and update this list deliberately.
         let a = report(42001, 1.0, 1000.0);
@@ -1668,12 +1724,19 @@ mod tests {
                 "worst_offenders",
             ]
         );
-        assert_eq!(value["schema_version"], 2);
+        assert_eq!(value["schema_version"], 3);
         // The outcome-counts shape (shared by totals and per_tier) is part of the contract too.
-        let mut count_keys: Vec<&str> =
-            value["totals"].as_object().unwrap().keys().map(String::as_str).collect();
+        let mut count_keys: Vec<&str> = value["totals"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
         count_keys.sort_unstable();
-        assert_eq!(count_keys, vec!["diverged", "not_applicable", "pass", "regressed"]);
+        assert_eq!(
+            count_keys,
+            vec!["diverged", "not_applicable", "pass", "regressed", "skipped"]
+        );
     }
 
     #[test]
@@ -1752,17 +1815,23 @@ mod tests {
         // Diverged is its own bucket — never `regressed`.
         assert_eq!(
             s.totals,
-            OutcomeCounts { pass: 1, regressed: 0, diverged: 1, not_applicable: 0 }
+            OutcomeCounts {
+                pass: 1,
+                regressed: 0,
+                diverged: 1,
+                skipped: 0,
+                not_applicable: 0
+            }
         );
         assert_eq!(s.diverged_ops, vec!["aggregate_count".to_string()]);
         // Advisory-diverged ops are not "worst offenders" (nothing regressed).
         assert!(s.worst_offenders.is_empty(), "{s:?}");
         let md = s.to_markdown();
         assert!(md.contains("⚠ pass, 1 diverged"), "{md}");
-        // Tier table gains the ⚠ column; both ops are Core.
-        assert!(md.contains("| tier | 🟢 | 🔴 | ⚠ | N/A |"), "{md}");
-        assert!(md.contains("| core | 1 | 0 | 1 | 0 |"), "{md}");
-        assert!(md.contains("| **all** | 1 | 0 | 1 | 0 |"), "{md}");
+        // Tier table gains the ⚠ and ⏭ columns; both ops are Core.
+        assert!(md.contains("| tier | 🟢 | 🔴 | ⚠ | ⏭ | N/A |"), "{md}");
+        assert!(md.contains("| core | 1 | 0 | 1 | 0 | 0 |"), "{md}");
+        assert!(md.contains("| **all** | 1 | 0 | 1 | 0 | 0 |"), "{md}");
     }
 
     #[test]
@@ -1793,5 +1862,138 @@ mod tests {
         assert!(s.headline.starts_with("no comparable cells"), "{}", s.headline);
         let md = s.to_markdown();
         assert!(md.contains("⚠ no comparable cells"), "{md}");
+    }
+
+    /// Mark `op` in `rep` as capability-skipped, exactly as replay records it.
+    fn skip_op(
+        rep: &mut Report,
+        op: &str,
+        reason: &str,
+    ) {
+        let o = rep.operations.get_mut(op).unwrap();
+        o.levels = vec![];
+        o.result_digest = None;
+        o.policy = None;
+        o.skipped = Some(reason.to_string());
+    }
+
+    #[test]
+    fn skipped_op_renders_the_skip_note_and_lands_in_the_skipped_bucket() {
+        let a = rpt(
+            "main",
+            42001,
+            &[("match_by_index", 1.0, "d1"), ("algo_max_flow_single_pair", 1.0, "d2")],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[("match_by_index", 1.0, "d1"), ("algo_max_flow_single_pair", 1.0, "d2")],
+        );
+        skip_op(
+            &mut b,
+            "algo_max_flow_single_pair",
+            "engine lacks procedure 'algo.maxFlow'",
+        );
+        let g = regression_guard(&a, &b);
+        // The skip is not a divergence — the pair is Comparable and the other op still gates.
+        let analysis = analyze_gate(&a, &b, &g, &Thresholds::builtin());
+        assert_eq!(analysis.verdict, OverallVerdict::Pass);
+        let md = regression_markdown(&analysis);
+        // Op section survives with the asymmetric skip note, ⏭ emoji and legend line.
+        assert!(
+            md.contains(
+                "⏭ skipped on pr — engine lacks procedure 'algo.maxFlow'; measured on main only"
+            ),
+            "{md}"
+        );
+        assert!(md.contains("— skipped (perf verdict N/A)"), "{md}");
+        assert!(md.contains("_⏭ = skipped:"), "{md}");
+        assert_eq!(
+            md_collapsed_emoji(&md, "algo_max_flow_single_pair").as_deref(),
+            Some("⏭"),
+            "{md}"
+        );
+        // Headline annotates the skip; the summary tallies it in its own bucket, never offenders.
+        let s = summarize(&analysis);
+        assert_eq!(s.overall_verdict, OverallVerdict::Pass);
+        assert!(s.headline.contains("1 op(s) skipped"), "{}", s.headline);
+        assert_eq!(
+            s.totals,
+            OutcomeCounts {
+                pass: 1,
+                regressed: 0,
+                diverged: 0,
+                skipped: 1,
+                not_applicable: 0
+            }
+        );
+        assert!(s.worst_offenders.is_empty(), "{s:?}");
+        assert!(s.diverged_ops.is_empty(), "{s:?}");
+        // The tier table: the skipped op is a real algorithm shape, so `shape_tier` places it in
+        // the **full** row's ⏭ column, and the **all** row (fed by `totals`) shows it too — every
+        // skip is visible in the summary Markdown.
+        let smd = s.to_markdown();
+        assert!(smd.contains("| core | 1 | 0 | 0 | 0 | 0 |"), "{smd}");
+        assert!(smd.contains("| full | 0 | 0 | 0 | 1 | 0 |"), "{smd}");
+        assert!(smd.contains("| **all** | 1 | 0 | 0 | 1 | 0 |"), "{smd}");
+    }
+
+    #[test]
+    fn op_skipped_on_both_sides_renders_a_single_note() {
+        let a = rpt(
+            "main",
+            42001,
+            &[("match_by_index", 1.0, "d1"), ("algo_max_flow_single_pair", 1.0, "d2")],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[("match_by_index", 1.0, "d1"), ("algo_max_flow_single_pair", 1.0, "d2")],
+        );
+        let mut a2 = a.clone();
+        skip_op(
+            &mut a2,
+            "algo_max_flow_single_pair",
+            "engine lacks procedure 'algo.maxFlow'",
+        );
+        skip_op(
+            &mut b,
+            "algo_max_flow_single_pair",
+            "engine lacks procedure 'algo.maxFlow'",
+        );
+        let g = regression_guard(&a2, &b);
+        let analysis = analyze_gate(&a2, &b, &g, &Thresholds::builtin());
+        let md = regression_markdown(&analysis);
+        assert!(
+            md.contains("⏭ skipped on both sides — engine lacks procedure 'algo.maxFlow'"),
+            "{md}"
+        );
+        // Different per-side reasons render both, labeled by run.
+        skip_op(
+            &mut b,
+            "algo_max_flow_single_pair",
+            "engine lacks procedure 'algo.MaxFlowV2'",
+        );
+        let g = regression_guard(&a2, &b);
+        let analysis = analyze_gate(&a2, &b, &g, &Thresholds::builtin());
+        let md = regression_markdown(&analysis);
+        assert!(
+            md.contains(
+                "⏭ skipped on both sides — main: engine lacks procedure 'algo.maxFlow'; \
+                 pr: engine lacks procedure 'algo.MaxFlowV2'"
+            ),
+            "{md}"
+        );
+    }
+
+    #[test]
+    fn skip_free_comparisons_render_no_skip_legend() {
+        let a = rpt("main", 42001, &[("match_by_index", 1.0, "d1")]);
+        let b = rpt("pr", 42002, &[("match_by_index", 1.0, "d1")]);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&analyze_gate(&a, &b, &g, &Thresholds::builtin()));
+        assert!(!md.contains('⏭'), "{md}");
+        let s = summarize_gate(&a, &b, &g, &Thresholds::builtin());
+        assert!(!s.headline.contains("skipped"), "{}", s.headline);
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -100,13 +100,40 @@ pub fn diff_markdown(
         .keys()
         .chain(candidate.operations.keys())
         .collect();
+    let (la, lb) = (col_label(baseline, "A"), col_label(candidate, "B"));
     for op in ops {
         out.push_str(&format!("\n## `{op}`\n"));
+        // A capability-skipped op has no levels, so its tables render empty — say why instead
+        // (design Phase 6 §3.5), per side; reasons are manifest content, hence HTML-escaped.
+        if let Some(note) = diff_skip_note(baseline, candidate, op, &la, &lb) {
+            out.push_str(&format!("\n_{}_\n", md_cell(&html_escape(&note))));
+        }
         for mode in [Mode::Cached, Mode::Uncached] {
             render_mode(&mut out, baseline, candidate, op, mode);
         }
     }
     out
+}
+
+/// The ⏭ note for a per-side capability skip in the plain diff — same four cases as the
+/// regression report's [`skip_note`], derived straight from the two [`Report`]s.
+fn diff_skip_note(
+    a: &Report,
+    b: &Report,
+    op: &str,
+    la: &str,
+    lb: &str,
+) -> Option<String> {
+    let side = |r: &Report| r.operations.get(op).and_then(|o| o.skipped.clone());
+    match (side(a), side(b)) {
+        (Some(ra), Some(rb)) if ra == rb => Some(format!("⏭ skipped on both sides — {ra}")),
+        (Some(ra), Some(rb)) => {
+            Some(format!("⏭ skipped on both sides — {la}: {ra}; {lb}: {rb}"))
+        }
+        (Some(ra), None) => Some(format!("⏭ skipped on {la} — {ra}; measured on {lb} only")),
+        (None, Some(rb)) => Some(format!("⏭ skipped on {lb} — {rb}; measured on {la} only")),
+        (None, None) => None,
+    }
 }
 
 /// The display name for a run's column: its `--label` if set, else the caller-supplied `fallback`
@@ -882,6 +909,74 @@ mod tests {
         assert_eq!(pct(0.0, 5.0), "n/a");
         assert_eq!(pct(2.0, 3.0), "+50.0%");
         assert_eq!(pct(2.0, 1.0), "-50.0%");
+    }
+
+    #[test]
+    fn diff_renders_a_both_sides_skip_note() {
+        // A both-skipped op has no levels on either side — the plain diff must say why instead of
+        // rendering a bare heading; reasons are manifest content, hence HTML-escaped.
+        let mut a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        for r in [&mut a, &mut b] {
+            let o = r.operations.get_mut("match_by_index").unwrap();
+            o.levels = vec![];
+            o.result_digest = None;
+            o.skipped = Some("engine lacks procedure 'algo.maxFlow' <v2&up>".to_string());
+        }
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("## `match_by_index`"));
+        assert!(
+            md.contains(
+                "⏭ skipped on both sides — engine lacks procedure 'algo.maxFlow' &lt;v2&amp;up&gt;"
+            ),
+            "{md}"
+        );
+        assert!(!md.contains("<v2&up>"), "raw HTML leaked: {md}");
+        // Different per-side reasons render both, labeled by run (A/B fallbacks — no --label).
+        b.operations.get_mut("match_by_index").unwrap().skipped =
+            Some("engine lacks procedure 'algo.MaxFlowV2'".to_string());
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(
+            md.contains(
+                "⏭ skipped on both sides — A: engine lacks procedure 'algo.maxFlow' &lt;v2&amp;up&gt;; \
+                 B: engine lacks procedure 'algo.MaxFlowV2'"
+            ),
+            "{md}"
+        );
+    }
+
+    #[test]
+    fn diff_renders_a_one_sided_skip_note() {
+        // One-sided skip: the note names the skipping side and that the other side measured; the
+        // measured side's table still renders below the note.
+        let a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        {
+            let o = b.operations.get_mut("match_by_index").unwrap();
+            o.levels = vec![];
+            o.result_digest = None;
+            o.skipped = Some("engine lacks procedure 'algo.maxFlow'".to_string());
+        }
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(
+            md.contains(
+                "⏭ skipped on B — engine lacks procedure 'algo.maxFlow'; measured on A only"
+            ),
+            "{md}"
+        );
+        assert!(md.contains("| 1 | 1.000"), "A's measured cells still render: {md}");
+        // The skipping side labels by --label when set.
+        let mut a2 = a.clone();
+        a2.meta.label = Some("main".to_string());
+        let mut b2 = b.clone();
+        b2.meta.label = Some("pr".to_string());
+        let md = diff_markdown(&a2, &b2, &[]);
+        assert!(
+            md.contains(
+                "⏭ skipped on pr — engine lacks procedure 'algo.maxFlow'; measured on main only"
+            ),
+            "{md}"
+        );
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -12,7 +12,7 @@ use crate::synthetic::analysis::{
     OpAnalysis, OpOutcome, OutcomeCounts, OverallVerdict, RegressionAnalysis,
 };
 use crate::synthetic::provenance::decode_module_version;
-use crate::synthetic::report::{html_escape, md_cell, LevelMetrics, LevelReport, Report};
+use crate::synthetic::report::{html_escape, md_cell, md_inline, LevelMetrics, LevelReport, Report};
 use crate::synthetic::thresholds::{BudgetProfile, Verdict};
 use crate::synthetic::Tier;
 use serde::{Deserialize, Serialize};
@@ -106,7 +106,7 @@ pub fn diff_markdown(
         // A capability-skipped op has no levels, so its tables render empty — say why instead
         // (design Phase 6 §3.5), per side; reasons are manifest content, hence HTML-escaped.
         if let Some(note) = diff_skip_note(baseline, candidate, op, &la, &lb) {
-            out.push_str(&format!("\n_{}_\n", md_cell(&html_escape(&note))));
+            out.push_str(&format!("\n_{}_\n", md_cell(&md_inline(&html_escape(&note)))));
         }
         for mode in [Mode::Cached, Mode::Uncached] {
             render_mode(&mut out, baseline, candidate, op, mode);
@@ -374,7 +374,7 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
         // the totals still tally them when they diverged (gate → regressed, advisory → diverged).
         let skip_note = skip_note(oa, la, lb);
         if let Some(note) = &skip_note {
-            op_body.push_str(&format!("\n_{}_\n", md_cell(&html_escape(note))));
+            op_body.push_str(&format!("\n_{}_\n", md_cell(&md_inline(&html_escape(note)))));
         }
         if op_body.trim().is_empty() {
             continue;
@@ -977,6 +977,11 @@ mod tests {
             ),
             "{md}"
         );
+        // Markdown inline syntax in a reason must not terminate the note's `_…_` emphasis span.
+        b2.operations.get_mut("match_by_index").unwrap().skipped =
+            Some("lacks `algo_x` *v2*".to_string());
+        let md = diff_markdown(&a2, &b2, &[]);
+        assert!(md.contains(r"lacks \`algo\_x\` \*v2\*"), "markdown specials not escaped: {md}");
     }
 
     #[test]
@@ -2093,6 +2098,11 @@ mod tests {
         let md = regression_markdown(&analyze_gate(&a, &b, &g, &Thresholds::builtin()));
         assert!(md.contains("needs &lt;engine&amp;co&gt; v2"), "{md}");
         assert!(!md.contains("needs <engine&co> v2"), "raw HTML leaked: {md}");
+        // Markdown inline syntax in a reason must not terminate the note's `_…_` emphasis span.
+        skip_op(&mut b, "algo_max_flow_single_pair", "lacks `algo_x` *v2*");
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&analyze_gate(&a, &b, &g, &Thresholds::builtin()));
+        assert!(md.contains(r"lacks \`algo\_x\` \*v2\*"), "markdown specials not escaped: {md}");
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -12,7 +12,7 @@ use crate::synthetic::analysis::{
     OpAnalysis, OpOutcome, OutcomeCounts, OverallVerdict, RegressionAnalysis,
 };
 use crate::synthetic::provenance::decode_module_version;
-use crate::synthetic::report::{md_cell, LevelMetrics, LevelReport, Report};
+use crate::synthetic::report::{html_escape, md_cell, LevelMetrics, LevelReport, Report};
 use crate::synthetic::thresholds::{BudgetProfile, Verdict};
 use crate::synthetic::Tier;
 use serde::{Deserialize, Serialize};
@@ -206,13 +206,6 @@ fn latency_cell(
     }
 }
 
-/// Escape a string for safe embedding as **HTML text** (e.g. inside a `<code>`/`<summary>`): a
-/// crafted report could carry an op key with `<`, `>` or `&` that would otherwise break the
-/// `<details>` markup or inject HTML into the PR comment. Order matters — `&` first.
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
-}
-
 /// `100·(b−a)/a`, formatted with a sign; `n/a` when `a == 0`.
 fn pct(
     a: f64,
@@ -354,7 +347,7 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
         // the totals still tally them when they diverged (gate → regressed, advisory → diverged).
         let skip_note = skip_note(oa, la, lb);
         if let Some(note) = &skip_note {
-            op_body.push_str(&format!("\n_{}_\n", md_cell(note)));
+            op_body.push_str(&format!("\n_{}_\n", md_cell(&html_escape(note))));
         }
         if op_body.trim().is_empty() {
             continue;
@@ -1984,6 +1977,27 @@ mod tests {
             ),
             "{md}"
         );
+    }
+
+    #[test]
+    fn skip_reasons_are_html_escaped_in_the_regression_markdown() {
+        // Skip reasons flow from manifest/probe content — HTML-special chars must not break the
+        // <details> markup or inject markup into the PR comment.
+        let a = rpt(
+            "main",
+            42001,
+            &[("match_by_index", 1.0, "d1"), ("algo_max_flow_single_pair", 1.0, "d2")],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[("match_by_index", 1.0, "d1"), ("algo_max_flow_single_pair", 1.0, "d2")],
+        );
+        skip_op(&mut b, "algo_max_flow_single_pair", "needs <engine&co> v2");
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&analyze_gate(&a, &b, &g, &Thresholds::builtin()));
+        assert!(md.contains("needs &lt;engine&amp;co&gt; v2"), "{md}");
+        assert!(!md.contains("needs <engine&co> v2"), "raw HTML leaked: {md}");
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1115,6 +1115,7 @@ pub(crate) async fn measure_op(
         levels,
         result_digest: None,
         policy: None,
+        skipped: None,
     })
 }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -86,6 +86,14 @@ pub struct OpEntry {
     /// content).
     #[serde(default, skip_serializing_if = "RecordedBudget::is_inherit")]
     pub budget: RecordedBudget,
+    /// The engine procedure this op requires (e.g. `algo.maxFlow`), or `None` for plain Cypher —
+    /// [`crate::synthetic::shapes::ShapeCapability::procedure`] at record time. Replay probes the
+    /// engine's `dbms.procedures()` registry before the reference capture (design §3.5) and
+    /// **skips** an op whose procedure is absent instead of failing the replay. Like the other
+    /// replay-policy fields it is **not** folded into the [`Manifest::workload_hash`] and defaults
+    /// to `None` (never probed/skipped) for bundles written before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability: Option<String>,
     pub count: usize,
 }
 
@@ -255,6 +263,8 @@ pub struct RecordedOp {
     pub result_gated: bool,
     /// Per-op replay budget — see [`OpEntry::budget`]. Inherit (the default) for every current op.
     pub budget: RecordedBudget,
+    /// The engine procedure this op requires, if any — see [`OpEntry::capability`].
+    pub capability: Option<String>,
     pub commands: Vec<String>,
 }
 
@@ -310,6 +320,8 @@ pub fn record(
             // Propagate the catalog's per-op budget (inherit for every current op) so replay
             // applies the same overrides a generated run applies from the spec.
             budget: spec(op).budget.into(),
+            // Catalog ops are plain Cypher — no procedure to probe for.
+            capability: None,
             commands: render_commands(op, dataset, corpus_seed)?,
         });
     }
@@ -457,6 +469,7 @@ fn record_rendered_impl(
             kind: op.key.kind(),
             result_gated: op.result_gated,
             budget: op.budget.clone(),
+            capability: op.capability.clone(),
             count: cyphers.len(),
         });
     }
@@ -797,6 +810,7 @@ mod tests {
             key: OpKey::dynamic("single_vertex_read", QueryType::Read),
             result_gated: true,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec![
                 "CYPHER id=1 MATCH (n:User {id:$id}) RETURN n".to_string(),
                 "CYPHER id=2 MATCH (n:User {id:$id}) RETURN n".to_string(),
@@ -834,6 +848,7 @@ mod tests {
             key: OpKey::dynamic("vector_query_nodes_smoke", QueryType::Read),
             result_gated: false,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec![
                 "CALL db.idx.vector.queryNodes('User', 'embedding', 10, vecf32([0.1, 0.2, 0.3])) \
                  YIELD node, score RETURN id(node), score LIMIT 10"
@@ -887,6 +902,7 @@ mod tests {
             key: OpKey::dynamic("bulk_insert", QueryType::Write),
             result_gated: true,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -906,6 +922,7 @@ mod tests {
             key: OpKey::dynamic("empty_shape", QueryType::Read),
             result_gated: true,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec![],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -926,12 +943,14 @@ mod tests {
                 key: OpKey::dynamic("a_read", QueryType::Read),
                 result_gated: true,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("a_read", QueryType::Read),
                 result_gated: true,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  RETURN 2".to_string()],
             },
         ];
@@ -964,6 +983,7 @@ mod tests {
             key: OpKey::dynamic("../escape", QueryType::Read),
             result_gated: true,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
@@ -986,12 +1006,14 @@ mod tests {
                 key: OpKey::dynamic("dup", QueryType::Read),
                 result_gated: true,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("dup", QueryType::Write),
                 result_gated: true,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  CREATE (n)".to_string()],
             },
         ];
@@ -1014,6 +1036,7 @@ mod tests {
             key: OpKey::dynamic("safe_read", QueryType::Read),
             result_gated: true,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -1041,6 +1064,7 @@ mod tests {
             key: OpKey::dynamic("safe_read", QueryType::Read),
             result_gated: true,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec!["CYPHER  RETURN 1".to_string()],
         }];
         record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -1070,12 +1094,14 @@ mod tests {
                 key: OpKey::dynamic("gated_read", QueryType::Read),
                 result_gated: true,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("na_read", QueryType::Read),
                 result_gated: false,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  MATCH (n) RETURN n LIMIT 1".to_string()],
             },
         ];
@@ -1104,6 +1130,7 @@ mod tests {
                 key: OpKey::dynamic("shape", QueryType::Read),
                 result_gated: gated,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             }];
             let m = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -1140,6 +1167,7 @@ mod tests {
                 key: OpKey::dynamic("shape", QueryType::Read),
                 result_gated: true,
                 budget,
+                capability: None,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             }];
             let m = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
@@ -1178,12 +1206,14 @@ mod tests {
                 key: OpKey::dynamic("heavy_shape", QueryType::Read),
                 result_gated: false,
                 budget: budget.clone(),
+                capability: None,
                 commands: vec!["CYPHER  RETURN 1".to_string()],
             },
             RecordedOp {
                 key: OpKey::dynamic("plain_shape", QueryType::Read),
                 result_gated: true,
                 budget: RecordedBudget::default(),
+                capability: None,
                 commands: vec!["CYPHER  RETURN 2".to_string()],
             },
         ];
@@ -1195,6 +1225,78 @@ mod tests {
         // The manifest text carries a `budget` key only for the budgeted op.
         let manifest_json = std::fs::read_to_string(dir.join("manifest.json")).unwrap();
         assert_eq!(manifest_json.matches("\"budget\"").count(), 1);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn capability_is_not_folded_into_the_workload_hash() {
+        // Like `kind`/`result_gated`/`budget`, the capability annotation is replay policy (which
+        // procedure to probe for), not workload content: two bundles that differ ONLY in a
+        // capability must share a `workload_hash`, so annotating an op never breaks A/B
+        // comparability with an annotation-free recording of the same workload.
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 20,
+            edges: 60,
+        };
+        let make = |capability: Option<String>| {
+            let dir = temp_bundle_dir(if capability.is_some() {
+                "synthrec-cs"
+            } else {
+                "synthrec-cn"
+            });
+            let ops = vec![RecordedOp {
+                key: OpKey::dynamic("shape", QueryType::Read),
+                result_gated: true,
+                budget: RecordedBudget::default(),
+                capability,
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            }];
+            let m = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+            std::fs::remove_dir_all(&dir).ok();
+            m.workload_hash
+        };
+        assert_eq!(make(None), make(Some("algo.maxFlow".to_string())));
+    }
+
+    #[test]
+    fn capability_round_trips_through_the_manifest_and_none_is_omitted() {
+        // An annotated op's required procedure survives record → load; an annotation-free op is
+        // omitted from the manifest JSON entirely, so every pre-field bundle stays byte-compatible
+        // (and deserializes to `None`).
+        let dir = temp_bundle_dir("synthrec-capability");
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 20,
+            edges: 60,
+        };
+        let ops = vec![
+            RecordedOp {
+                key: OpKey::dynamic("algo_shape", QueryType::Read),
+                result_gated: false,
+                budget: RecordedBudget::default(),
+                capability: Some("algo.maxFlow".to_string()),
+                commands: vec!["CYPHER  RETURN 1".to_string()],
+            },
+            RecordedOp {
+                key: OpKey::dynamic("plain_shape", QueryType::Read),
+                result_gated: true,
+                budget: RecordedBudget::default(),
+                capability: None,
+                commands: vec!["CYPHER  RETURN 2".to_string()],
+            },
+        ];
+        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+
+        let bundle = load(&dir).unwrap();
+        assert_eq!(
+            bundle.manifest.ops[0].capability.as_deref(),
+            Some("algo.maxFlow")
+        );
+        assert_eq!(bundle.manifest.ops[1].capability, None);
+        // The manifest text carries a `capability` key only for the annotated op.
+        let manifest_json = std::fs::read_to_string(dir.join("manifest.json")).unwrap();
+        assert_eq!(manifest_json.matches("\"capability\"").count(), 1);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -206,11 +206,8 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     let available = if required.is_empty() {
         None
     } else {
-        Some(
-            probe_procedures(&mut graph, config.server_timeout_ms, client_deadline)
-                .await
-                .map_err(|e| OtherError(format!("capability probe failed: {}", e)))?,
-        )
+        // `probe_procedures` errors already name the capability probe — bubble them up as-is.
+        Some(probe_procedures(&mut graph, config.server_timeout_ms, client_deadline).await?)
     };
     let skip_reason = |name: &str| -> Option<String> {
         let procedure = entry_for(name).capability.as_deref()?;
@@ -404,15 +401,15 @@ async fn probe_procedures(
             .with_timeout(server_timeout_ms)
             .execute()
             .await
-            .map_err(|e| OtherError(format!("procedure registry query failed: {:?}", e)))?;
+            .map_err(|e| OtherError(format!("capability probe: procedure registry query failed: {:?}", e)))?;
         let mut names = BTreeSet::new();
         let mut data = query_result.data;
         while let Some(row) = data.next().await {
             let row = row
-                .map_err(|e| OtherError(format!("procedure registry row decode error: {:?}", e)))?;
+                .map_err(|e| OtherError(format!("capability probe: registry row decode error: {:?}", e)))?;
             let name: String = row.try_get_at(0).map_err(|e| {
                 OtherError(format!(
-                    "procedure registry returned a non-string name: {:?}",
+                    "capability probe: registry returned a non-string name: {:?}",
                     e
                 ))
             })?;
@@ -424,7 +421,7 @@ async fn probe_procedures(
         .await
         .map_err(|e| {
             OtherError(format!(
-                "client deadline ({} ms) exceeded probing procedures: {}",
+                "capability probe: client deadline ({} ms) exceeded: {}",
                 client_deadline.as_millis(),
                 e
             ))

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -198,16 +198,13 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // entry names a required procedure, ask the engine's registry once and **skip** every op whose
     // procedure is absent — recorded in the report with the reason, but never executed (a missing
     // procedure would otherwise fail the whole replay). Ops without a capability never probe.
-    let required: BTreeSet<&str> = bundle
-        .commands
-        .iter()
-        .filter_map(|(op, _)| entry_for(op.name()).capability.as_deref())
-        .collect();
-    let available = if required.is_empty() {
-        None
-    } else {
+    let any_capability =
+        bundle.commands.iter().any(|(op, _)| entry_for(op.name()).capability.is_some());
+    let available = if any_capability {
         // `probe_procedures` errors already name the capability probe — bubble them up as-is.
         Some(probe_procedures(&mut graph, config.server_timeout_ms, client_deadline).await?)
+    } else {
+        None
     };
     let skip_reason = |name: &str| -> Option<String> {
         let procedure = entry_for(name).capability.as_deref()?;

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -268,8 +268,9 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     let uid_alloc = AtomicU64::new(0);
 
     let mut operations = BTreeMap::new();
-    // Skipped ops first: an empty-levels entry carrying the skip reason, so the report keeps the
-    // full recorded op set and the diff/regression guards can tell "skipped" from "not recorded".
+    // Skipped ops get an empty-levels entry carrying the skip reason (BTreeMap renders by key),
+    // so the report keeps the full recorded op set and the diff/regression guards can tell
+    // "skipped" from "not recorded".
     for (name, reason) in skipped {
         operations.insert(
             name,

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -388,7 +388,6 @@ pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
     write_report(&report, &config.out).await
 }
 
-/// Drop `graph`, execute the bundle's recorded load statements, and verify the node/edge counts.
 /// Ask the engine which procedures it registers (`dbms.procedures()`), returning their
 /// **lowercased** names — the capability probe (design Phase 6 §3.5). One query per replay,
 /// mirroring the A/B driver's `detect_algorithm_capabilities` (matching is case-insensitive so a
@@ -432,6 +431,7 @@ async fn probe_procedures(
         })?
 }
 
+/// Drop `graph`, execute the bundle's recorded load statements, and verify the node/edge counts.
 async fn load_recorded_graph(
     graph: &mut AsyncGraph,
     bundle: &Bundle,

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -31,8 +31,10 @@ use crate::synthetic::{
     validate_op_config, write_report, CacheSelection, Config, MeasureTarget, OpKey,
 };
 use falkordb::AsyncGraph;
+use futures::StreamExt;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -192,6 +194,38 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         validate_op_config(op.name(), &op_config)?;
     }
 
+    // Capability probe (design Phase 6 §3.5), before the reference pass: when any op's manifest
+    // entry names a required procedure, ask the engine's registry once and **skip** every op whose
+    // procedure is absent — recorded in the report with the reason, but never executed (a missing
+    // procedure would otherwise fail the whole replay). Ops without a capability never probe.
+    let required: BTreeSet<&str> = bundle
+        .commands
+        .iter()
+        .filter_map(|(op, _)| entry_for(op.name()).capability.as_deref())
+        .collect();
+    let available = if required.is_empty() {
+        None
+    } else {
+        Some(
+            probe_procedures(&mut graph, config.server_timeout_ms, client_deadline)
+                .await
+                .map_err(|e| OtherError(format!("capability probe failed: {}", e)))?,
+        )
+    };
+    let skip_reason = |name: &str| -> Option<String> {
+        let procedure = entry_for(name).capability.as_deref()?;
+        let available = available.as_ref()?;
+        (!available.contains(&procedure.to_lowercase()))
+            .then(|| format!("engine lacks procedure '{}' (capability probe)", procedure))
+    };
+    let mut skipped: BTreeMap<String, String> = BTreeMap::new();
+    for (op, _) in &bundle.commands {
+        if let Some(reason) = skip_reason(op.name()) {
+            info!("skipping op '{}': {}", op.name(), reason);
+            skipped.insert(op.name().to_string(), reason);
+        }
+    }
+
     // Reference pass (untimed, single-flight): capture each result's shape (cardinality +
     // order-independent value digest) for every **result-gated** command — the correctness oracle,
     // which also primes the plan cache. A result-N/A op's shapes are never verified or digested, so
@@ -204,6 +238,9 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     for (op, cyphers) in &bundle.commands {
         if cyphers.is_empty() {
             return Err(OtherError(format!("op '{}' has no recorded commands", op.name())));
+        }
+        if skipped.contains_key(op.name()) {
+            continue; // capability-skipped: never executed, not even the fail-fast probe
         }
         let entry = entry_for(op.name());
         let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);
@@ -234,6 +271,19 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     let uid_alloc = AtomicU64::new(0);
 
     let mut operations = BTreeMap::new();
+    // Skipped ops first: an empty-levels entry carrying the skip reason, so the report keeps the
+    // full recorded op set and the diff/regression guards can tell "skipped" from "not recorded".
+    for (name, reason) in skipped {
+        operations.insert(
+            name,
+            crate::synthetic::report::OperationReport {
+                levels: Vec::new(),
+                result_digest: None,
+                policy: None,
+                skipped: Some(reason),
+            },
+        );
+    }
     for (op, corpus, shapes) in &reference {
         let entry = entry_for(op.name());
         let is_gated = entry.result_gated;
@@ -290,10 +340,13 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         operations.insert(op.name().to_string(), op_report);
     }
 
-    // The corpus size is what the bundle actually recorded per op (not the compile-time constant).
-    let corpus_size = reference
+    // The corpus size is what the bundle actually recorded per op (not the compile-time constant) —
+    // over every recorded op, including capability-skipped ones (it describes the bundle, not the
+    // subset this engine could execute).
+    let corpus_size = bundle
+        .commands
         .iter()
-        .map(|(_, corpus, _)| corpus.len())
+        .map(|(_, cyphers)| cyphers.len())
         .max()
         .unwrap_or(0);
 
@@ -336,6 +389,49 @@ pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
 }
 
 /// Drop `graph`, execute the bundle's recorded load statements, and verify the node/edge counts.
+/// Ask the engine which procedures it registers (`dbms.procedures()`), returning their
+/// **lowercased** names — the capability probe (design Phase 6 §3.5). One query per replay,
+/// mirroring the A/B driver's `detect_algorithm_capabilities` (matching is case-insensitive so a
+/// registry spelling change can't fake a missing capability).
+async fn probe_procedures(
+    graph: &mut AsyncGraph,
+    server_timeout_ms: i64,
+    client_deadline: Duration,
+) -> BenchmarkResult<BTreeSet<String>> {
+    let cypher = "CALL dbms.procedures() YIELD name RETURN name";
+    let fut = async {
+        let query_result = graph
+            .ro_query(cypher)
+            .with_timeout(server_timeout_ms)
+            .execute()
+            .await
+            .map_err(|e| OtherError(format!("procedure registry query failed: {:?}", e)))?;
+        let mut names = BTreeSet::new();
+        let mut data = query_result.data;
+        while let Some(row) = data.next().await {
+            let row = row
+                .map_err(|e| OtherError(format!("procedure registry row decode error: {:?}", e)))?;
+            let name: String = row.try_get_at(0).map_err(|e| {
+                OtherError(format!(
+                    "procedure registry returned a non-string name: {:?}",
+                    e
+                ))
+            })?;
+            names.insert(name.to_lowercase());
+        }
+        Ok::<BTreeSet<String>, crate::error::BenchmarkError>(names)
+    };
+    tokio::time::timeout(client_deadline, fut)
+        .await
+        .map_err(|e| {
+            OtherError(format!(
+                "client deadline ({} ms) exceeded probing procedures: {}",
+                client_deadline.as_millis(),
+                e
+            ))
+        })?
+}
+
 async fn load_recorded_graph(
     graph: &mut AsyncGraph,
     bundle: &Bundle,

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -229,6 +229,12 @@ pub struct OperationReport {
     /// the diff/regression/baseline guards.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<OpPolicy>,
+    /// Why this op was **skipped** — recorded but never executed — or `None` for a measured op.
+    /// Set by the replay capability probe (design Phase 6 §3.5) when the engine lacks the
+    /// procedure the op's manifest entry requires. A skipped op has no levels, no digest and no
+    /// policy; the diff/regression guards treat it as **neither a pass nor a divergence**.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skipped: Option<String>,
 }
 
 impl OperationReport {
@@ -351,6 +357,10 @@ impl Report {
         }
         for (name, op) in &self.operations {
             out.push_str(&format!("\n{}\n", name));
+            if let Some(reason) = &op.skipped {
+                out.push_str(&format!("  skipped — {}\n", reason));
+                continue;
+            }
             render_op_levels(&mut out, op);
         }
         out
@@ -423,6 +433,10 @@ impl Report {
 
         for (name, op) in &self.operations {
             out.push_str(&format!("\n## `{}`\n", name));
+            if let Some(reason) = &op.skipped {
+                out.push_str(&format!("\n_⏭ skipped — {}_\n", md_cell(reason)));
+                continue;
+            }
             render_op_levels_markdown(&mut out, op);
         }
         out
@@ -685,6 +699,7 @@ mod tests {
                 ],
                 result_digest: None,
                 policy: None,
+                skipped: None,
             },
         );
         Report {
@@ -980,6 +995,7 @@ mod tests {
                 ],
                 result_digest: None,
                 policy: None,
+                skipped: None,
             },
         );
         ops.insert(
@@ -993,6 +1009,7 @@ mod tests {
                 }],
                 result_digest: None,
                 policy: None,
+                skipped: None,
             },
         );
         ops.insert(
@@ -1015,6 +1032,7 @@ mod tests {
                 ],
                 result_digest: None,
                 policy: None,
+                skipped: None,
             },
         );
         r.operations = ops;
@@ -1058,5 +1076,46 @@ mod tests {
     #[test]
     fn non_placeholder_version_not_flagged() {
         assert!(!sample_report().meta.server.is_placeholder());
+    }
+
+    #[test]
+    fn skipped_op_round_trips_renders_and_defaults_to_none() {
+        // A capability-skipped op (design Phase 6 §3.5) carries its reason through JSON…
+        let mut report = sample_report();
+        {
+            let op = report.operations.get_mut("return_const").unwrap();
+            op.levels = vec![];
+            op.result_digest = None;
+            op.skipped =
+                Some("engine lacks procedure 'algo.maxFlow' (capability probe)".to_string());
+        }
+        let json = report.to_json().unwrap();
+        assert!(json.contains("\"skipped\""));
+        let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.operations
+                .get("return_const")
+                .unwrap()
+                .skipped
+                .as_deref(),
+            Some("engine lacks procedure 'algo.maxFlow' (capability probe)")
+        );
+        // …renders in both the console and Markdown outputs…
+        let console = report.to_console();
+        assert!(
+            console.contains("skipped — engine lacks procedure 'algo.maxFlow'"),
+            "{console}"
+        );
+        let md = report.to_markdown();
+        assert!(
+            md.contains("_⏭ skipped — engine lacks procedure 'algo.maxFlow'"),
+            "{md}"
+        );
+        // …while a measured op (and any pre-Phase-6 report) omits the field and reads back None.
+        let plain = sample_report().to_json().unwrap();
+        assert!(!plain.contains("\"skipped\""));
+        let legacy: OperationReport = serde_json::from_str(r#"{"levels": []}"#).unwrap();
+        assert_eq!(legacy.skipped, None);
+        assert!(!sample_report().to_console().contains("skipped —"));
     }
 }

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -434,13 +434,21 @@ impl Report {
         for (name, op) in &self.operations {
             out.push_str(&format!("\n## `{}`\n", name));
             if let Some(reason) = &op.skipped {
-                out.push_str(&format!("\n_⏭ skipped — {}_\n", md_cell(reason)));
+                out.push_str(&format!("\n_⏭ skipped — {}_\n", md_cell(&html_escape(reason))));
                 continue;
             }
             render_op_levels_markdown(&mut out, op);
         }
         out
     }
+}
+
+/// Escape a string for safe embedding as **HTML text** (e.g. inside a `<code>`/`<summary>` or a
+/// report line): a crafted report or manifest could carry an op key or skip reason with `<`, `>`
+/// or `&` that would otherwise break the `<details>` markup or inject HTML into the PR comment.
+/// Order matters — `&` first.
+pub(crate) fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
 
 /// Escape a value for a GitHub-flavoured Markdown **table cell**: an unescaped `|` ends the cell
@@ -1117,5 +1125,20 @@ mod tests {
         let legacy: OperationReport = serde_json::from_str(r#"{"levels": []}"#).unwrap();
         assert_eq!(legacy.skipped, None);
         assert!(!sample_report().to_console().contains("skipped —"));
+    }
+
+    #[test]
+    fn skip_reason_is_html_escaped_in_the_markdown_report() {
+        // Skip reasons flow from manifest content — HTML-special chars must not inject markup.
+        let mut report = sample_report();
+        {
+            let op = report.operations.get_mut("return_const").unwrap();
+            op.levels = vec![];
+            op.result_digest = None;
+            op.skipped = Some("needs <engine&co> v2".to_string());
+        }
+        let md = report.to_markdown();
+        assert!(md.contains("_⏭ skipped — needs &lt;engine&amp;co&gt; v2_"), "{md}");
+        assert!(!md.contains("needs <engine&co> v2"), "raw HTML leaked: {md}");
     }
 }

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -434,7 +434,10 @@ impl Report {
         for (name, op) in &self.operations {
             out.push_str(&format!("\n## `{}`\n", name));
             if let Some(reason) = &op.skipped {
-                out.push_str(&format!("\n_⏭ skipped — {}_\n", md_cell(&html_escape(reason))));
+                out.push_str(&format!(
+                    "\n_⏭ skipped — {}_\n",
+                    md_cell(&md_inline(&html_escape(reason)))
+                ));
                 continue;
             }
             render_op_levels_markdown(&mut out, op);
@@ -456,6 +459,20 @@ pub(crate) fn html_escape(s: &str) -> String {
 /// to `<br>`. `\r` is dropped so a CRLF doesn't yield a doubled break.
 pub(crate) fn md_cell(s: &str) -> String {
     s.replace('|', "\\|").replace('\r', "").replace('\n', "<br>")
+}
+
+/// Escape Markdown inline-special characters so operator-supplied text (e.g. a skip reason from a
+/// manifest) can sit inside an emphasis span without terminating it or injecting inline syntax
+/// (emphasis, code spans, links). Backslash first so later escapes aren't doubled.
+pub(crate) fn md_inline(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '\\' | '`' | '*' | '_' | '[' | ']') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
 }
 
 /// A one-line client-host summary (` · `-joined, skipping unknown fields). With `with_hostname`,
@@ -1129,7 +1146,9 @@ mod tests {
 
     #[test]
     fn skip_reason_is_html_escaped_in_the_markdown_report() {
-        // Skip reasons flow from manifest content — HTML-special chars must not inject markup.
+        // Skip reasons flow from manifest content — HTML-special chars must not inject markup,
+        // and Markdown inline syntax must not terminate the `_…_` emphasis span or open a code
+        // span / link.
         let mut report = sample_report();
         {
             let op = report.operations.get_mut("return_const").unwrap();
@@ -1140,5 +1159,21 @@ mod tests {
         let md = report.to_markdown();
         assert!(md.contains("_⏭ skipped — needs &lt;engine&amp;co&gt; v2_"), "{md}");
         assert!(!md.contains("needs <engine&co> v2"), "raw HTML leaked: {md}");
+        report.operations.get_mut("return_const").unwrap().skipped =
+            Some("lacks `algo_x` (see [docs]) *and* _algo_y_".to_string());
+        let md = report.to_markdown();
+        assert!(
+            md.contains(
+                "_⏭ skipped — lacks \\`algo\\_x\\` (see \\[docs\\]) \\*and\\* \\_algo\\_y\\__"
+            ),
+            "markdown specials not escaped: {md}"
+        );
+    }
+
+    #[test]
+    fn md_inline_escapes_every_inline_special_and_backslash_first() {
+        assert_eq!(md_inline(r"a\_b"), r"a\\\_b");
+        assert_eq!(md_inline("`*_[]"), r"\`\*\_\[\]");
+        assert_eq!(md_inline("plain text, no specials!"), "plain text, no specials!");
     }
 }

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -66,11 +66,11 @@ impl ResultPolicy {
 /// The engine capability a fixture-dependent read requires beyond plain Cypher (design §3.4). The
 /// fulltext/vector smoke reads name the specific index procedure they exercise.
 ///
-/// Today this is **annotation only** — a stable, machine-readable label carried on the [`ShapeSpec`]
-/// so a future capability-gating pass (record-and-skip-as-N/A on an engine that lacks the capability)
-/// can key off it without a bundle-format change. It is not yet consulted at record or replay time
-/// (the per-PR A/B images are modern FalkorDB with all three capabilities). Non-fixture reads need
-/// nothing (`capability = None`).
+/// Recording persists [`Self::procedure`] on each shape's manifest entry
+/// ([`crate::synthetic::recording::OpEntry::capability`]), and replay probes the engine's
+/// procedure registry **before** the reference capture (design §3.5): an op whose required
+/// procedure is absent is *skipped* — reported, but never executed — instead of failing the whole
+/// replay. Non-fixture reads need nothing (`capability = None`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShapeCapability {
     /// `db.idx.vector.queryNodes` — a vector index over `:User(embedding)`.
@@ -87,6 +87,23 @@ pub enum ShapeCapability {
     AlgoMsf,
     /// `algo.HarmonicCentrality` — whole-graph harmonic centrality (Phase 6).
     AlgoHarmonic,
+}
+
+impl ShapeCapability {
+    /// The procedure name this capability requires, exactly as the engine's `dbms.procedures()`
+    /// registry spells it (matching is case-insensitive at probe time). Recorded on the shape's
+    /// manifest entry so replay can probe-and-skip on an engine that lacks the procedure.
+    pub fn procedure(self) -> &'static str {
+        match self {
+            ShapeCapability::VectorQueryNodes => "db.idx.vector.queryNodes",
+            ShapeCapability::FulltextQueryNodes => "db.idx.fulltext.queryNodes",
+            ShapeCapability::FulltextQueryRelationships => "db.idx.fulltext.queryRelationships",
+            ShapeCapability::AlgoPageRank => "algo.pageRank",
+            ShapeCapability::AlgoMaxFlow => "algo.maxFlow",
+            ShapeCapability::AlgoMsf => "algo.MSF",
+            ShapeCapability::AlgoHarmonic => "algo.HarmonicCentrality",
+        }
+    }
 }
 
 /// The **synthetic-only** coverage family a shape belongs to (design Phase 6 §3.3): which curated
@@ -638,6 +655,7 @@ fn render_shapes(
             key,
             result_gated: shape.result_policy.is_gated(),
             budget: shape.budget.into(),
+            capability: shape.capability.map(|c| c.procedure().to_string()),
             commands,
         });
     }
@@ -833,6 +851,58 @@ mod tests {
     }
 
     #[test]
+    fn capability_procedures_are_pinned() {
+        // The exact procedure names replay probes for (via `dbms.procedures()`). Renaming one
+        // changes which engines skip the shape — deliberate, so pin the full mapping.
+        let expected: &[(ShapeCapability, &str)] = &[
+            (
+                ShapeCapability::VectorQueryNodes,
+                "db.idx.vector.queryNodes",
+            ),
+            (
+                ShapeCapability::FulltextQueryNodes,
+                "db.idx.fulltext.queryNodes",
+            ),
+            (
+                ShapeCapability::FulltextQueryRelationships,
+                "db.idx.fulltext.queryRelationships",
+            ),
+            (ShapeCapability::AlgoPageRank, "algo.pageRank"),
+            (ShapeCapability::AlgoMaxFlow, "algo.maxFlow"),
+            (ShapeCapability::AlgoMsf, "algo.MSF"),
+            (ShapeCapability::AlgoHarmonic, "algo.HarmonicCentrality"),
+        ];
+        for (cap, procedure) in expected {
+            assert_eq!(cap.procedure(), *procedure);
+        }
+    }
+
+    #[test]
+    fn fixture_dependent_reads_record_their_index_capabilities() {
+        // The fulltext/vector fixture reads carry `db.idx.*` capability strings too — on an
+        // engine without those procedures they skip instead of erroring at the reference pass.
+        let ops = record_repo_reads(Tier::Full, 1000, 5000, 7).expect("record full reads");
+        let by_name: std::collections::BTreeMap<&str, Option<&str>> = ops
+            .iter()
+            .map(|op| (op.key.name(), op.capability.as_deref()))
+            .collect();
+        assert_eq!(
+            by_name["fulltext_query_nodes_smoke"],
+            Some("db.idx.fulltext.queryNodes")
+        );
+        assert_eq!(
+            by_name["vector_query_nodes_smoke"],
+            Some("db.idx.vector.queryNodes")
+        );
+        assert_eq!(
+            by_name["fulltext_query_relationships_smoke"],
+            Some("db.idx.fulltext.queryRelationships")
+        );
+        // Plain reads carry none — replay never probes for them.
+        assert_eq!(by_name["single_vertex_read"], None);
+    }
+
+    #[test]
     fn repo_read_shapes_exclude_algorithms_and_stay_exactly_todays_50_reads() {
         // Design §3.2: `repo_read_shapes()` / `--repo-reads full` remain EXACTLY today's 50
         // non-algorithm reads — algorithms are selected only by the orthogonal --repo-algorithms
@@ -879,6 +949,19 @@ mod tests {
                 op.key.name()
             );
         }
+        // Each op records its per-procedure capability string (design §3.5), so replay can
+        // probe-and-skip on an engine that lacks the procedure.
+        let capabilities: Vec<Option<&str>> =
+            ops.iter().map(|op| op.capability.as_deref()).collect();
+        assert_eq!(
+            capabilities,
+            vec![
+                Some("algo.pageRank"),
+                Some("algo.maxFlow"),
+                Some("algo.MSF"),
+                Some("algo.HarmonicCentrality"),
+            ]
+        );
         let corpora: Vec<usize> = ops.iter().map(|op| op.commands.len()).collect();
         assert_eq!(corpora, vec![1, MAX_FLOW_CORPUS_SIZE, 1, 1]);
         // The rendered Cypher exercises the real procedures…

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -63,14 +63,15 @@ impl ResultPolicy {
     }
 }
 
-/// The engine capability a fixture-dependent read requires beyond plain Cypher (design §3.5). The
-/// fulltext/vector smoke reads name the specific index procedure they exercise.
+/// The engine procedure a shape requires beyond plain Cypher (design §3.5): the fulltext/vector
+/// smoke reads name the index procedure they exercise, the algorithm shapes their `algo.*`
+/// procedure.
 ///
 /// Recording persists [`Self::procedure`] on each shape's manifest entry
 /// ([`crate::synthetic::recording::OpEntry::capability`]), and replay probes the engine's
 /// procedure registry **before** the reference capture (design §3.5): an op whose required
 /// procedure is absent is *skipped* — reported, but never executed — instead of failing the whole
-/// replay. Non-fixture reads need nothing (`capability = None`).
+/// replay. Capability-free shapes need nothing (`capability = None`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShapeCapability {
     /// `db.idx.vector.queryNodes` — a vector index over `:User(embedding)`.

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -63,7 +63,7 @@ impl ResultPolicy {
     }
 }
 
-/// The engine capability a fixture-dependent read requires beyond plain Cypher (design §3.4). The
+/// The engine capability a fixture-dependent read requires beyond plain Cypher (design §3.5). The
 /// fulltext/vector smoke reads name the specific index procedure they exercise.
 ///
 /// Recording persists [`Self::procedure`] on each shape's manifest entry

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -63,9 +63,11 @@ impl ResultPolicy {
     }
 }
 
-/// The engine procedure a shape requires beyond plain Cypher (design §3.5): the fulltext/vector
-/// smoke reads name the index procedure they exercise, the algorithm shapes their `algo.*`
-/// procedure.
+/// The engine procedure an **algorithm shape** requires beyond plain Cypher (design §3.5): each
+/// names its `algo.*` procedure. Read shapes — including the fulltext/vector fixture reads — are
+/// capability-free: their fixture DDL runs at graph-load time, **before** any probe could skip
+/// them, so annotating them would break the per-PR `--repo-reads full` gate on engines lacking the
+/// indexes rather than skip cleanly (capability-aware *loading* is future work, not built here).
 ///
 /// Recording persists [`Self::procedure`] on each shape's manifest entry
 /// ([`crate::synthetic::recording::OpEntry::capability`]), and replay probes the engine's
@@ -74,12 +76,6 @@ impl ResultPolicy {
 /// replay. Capability-free shapes need nothing (`capability = None`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShapeCapability {
-    /// `db.idx.vector.queryNodes` — a vector index over `:User(embedding)`.
-    VectorQueryNodes,
-    /// `db.idx.fulltext.queryNodes` — a fulltext index over `:User(ft_text)`.
-    FulltextQueryNodes,
-    /// `db.idx.fulltext.queryRelationships` — a fulltext index over `:Friend(ft_text)`.
-    FulltextQueryRelationships,
     /// `algo.pageRank` — whole-graph PageRank (Phase 6, per-procedure per design §3.5).
     AlgoPageRank,
     /// `algo.maxFlow` — single-pair max flow over `bench_capacity` (Phase 6).
@@ -96,9 +92,6 @@ impl ShapeCapability {
     /// manifest entry so replay can probe-and-skip on an engine that lacks the procedure.
     pub fn procedure(self) -> &'static str {
         match self {
-            ShapeCapability::VectorQueryNodes => "db.idx.vector.queryNodes",
-            ShapeCapability::FulltextQueryNodes => "db.idx.fulltext.queryNodes",
-            ShapeCapability::FulltextQueryRelationships => "db.idx.fulltext.queryRelationships",
             ShapeCapability::AlgoPageRank => "algo.pageRank",
             ShapeCapability::AlgoMaxFlow => "algo.maxFlow",
             ShapeCapability::AlgoMsf => "algo.MSF",
@@ -283,20 +276,17 @@ pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
 /// (record-once → replay-verbatim: every replay endpoint gets the identical fixture). They bind **no random
 /// params** (byte-identical renders), but their result set is **top-k** (ties/ordering are
 /// non-deterministic), so all three are result-**N/A** ([`ResultPolicy::NotApplicable`], Decision 4) —
-/// we do not add `ORDER BY` to force determinism. Each is annotated with the [`ShapeCapability`] it
-/// exercises (metadata for a future capability-gating pass — see [`ShapeCapability`]). All are
-/// [`Tier::Full`]: capability-gated shapes stay out of the always-on core subset.
+/// we do not add `ORDER BY` to force determinism. All are **capability-free** (`capability = None`,
+/// like every read shape — see [`ShapeCapability`]): their index DDL is part of the graph load,
+/// which runs before any probe, so the per-PR `--repo-reads full` gate must never probe. All are
+/// [`Tier::Full`]: fixture-dependent shapes stay out of the always-on core subset.
 ///
 /// Auto-discovered like the other sets: the drift-guard test asserts these names are **exactly** the
 /// reads the `FixtureDependent` profile adds over `ExtendedCore`.
 pub fn fixture_dependent_read_shapes() -> Vec<ShapeSpec> {
-    use ShapeCapability::{FulltextQueryNodes, FulltextQueryRelationships, VectorQueryNodes};
-    // Every row is a FixtureDependent, Full-tier, result-N/A read with a full corpus and an
-    // inherited (global) runtime budget; only the name + capability differ.
-    fn s(
-        name: &'static str,
-        capability: ShapeCapability,
-    ) -> ShapeSpec {
+    // Every row is a FixtureDependent, Full-tier, result-N/A, capability-free read with a full
+    // corpus and an inherited (global) runtime budget; only the name differs.
+    fn s(name: &'static str) -> ShapeSpec {
         ShapeSpec {
             name,
             family: CoverageFamily::Reads(QueryCoverageProfile::FixtureDependent),
@@ -304,15 +294,15 @@ pub fn fixture_dependent_read_shapes() -> Vec<ShapeSpec> {
             result_policy: ResultPolicy::NotApplicable(
                 "vector/fulltext top-k ordering is non-deterministic",
             ),
-            capability: Some(capability),
+            capability: None,
             corpus_size: CORPUS_SIZE,
             budget: OpBudget::INHERIT,
         }
     }
     vec![
-        s("vector_query_nodes_smoke", VectorQueryNodes),
-        s("fulltext_query_nodes_smoke", FulltextQueryNodes),
-        s("fulltext_query_relationships_smoke", FulltextQueryRelationships),
+        s("vector_query_nodes_smoke"),
+        s("fulltext_query_nodes_smoke"),
+        s("fulltext_query_relationships_smoke"),
     ]
 }
 
@@ -762,7 +752,9 @@ mod tests {
                 "fulltext_query_relationships_smoke",
             ])
         );
-        // Every fixture shape is FixtureDependent, Full-tier, result-N/A, and carries a capability.
+        // Every fixture shape is FixtureDependent, Full-tier, result-N/A, and capability-free —
+        // its index DDL loads with the graph, before any probe could skip it, so the per-PR
+        // `--repo-reads full` gate must never probe (see ShapeCapability).
         for shape in fixture_dependent_read_shapes() {
             assert_eq!(
                 shape.family,
@@ -770,19 +762,8 @@ mod tests {
             );
             assert_eq!(shape.tier, Tier::Full);
             assert!(!shape.result_policy.is_gated(), "top-k reads are result-N/A");
-            assert!(shape.capability.is_some(), "fixture reads carry a capability");
+            assert!(shape.capability.is_none(), "read shapes are capability-free");
         }
-        // The capabilities map 1:1 to the three index procedures.
-        let caps: Vec<Option<ShapeCapability>> =
-            fixture_dependent_read_shapes().iter().map(|s| s.capability).collect();
-        assert_eq!(
-            caps,
-            vec![
-                Some(ShapeCapability::VectorQueryNodes),
-                Some(ShapeCapability::FulltextQueryNodes),
-                Some(ShapeCapability::FulltextQueryRelationships),
-            ]
-        );
     }
 
     #[test]
@@ -856,18 +837,6 @@ mod tests {
         // The exact procedure names replay probes for (via `dbms.procedures()`). Renaming one
         // changes which engines skip the shape — deliberate, so pin the full mapping.
         let expected: &[(ShapeCapability, &str)] = &[
-            (
-                ShapeCapability::VectorQueryNodes,
-                "db.idx.vector.queryNodes",
-            ),
-            (
-                ShapeCapability::FulltextQueryNodes,
-                "db.idx.fulltext.queryNodes",
-            ),
-            (
-                ShapeCapability::FulltextQueryRelationships,
-                "db.idx.fulltext.queryRelationships",
-            ),
             (ShapeCapability::AlgoPageRank, "algo.pageRank"),
             (ShapeCapability::AlgoMaxFlow, "algo.maxFlow"),
             (ShapeCapability::AlgoMsf, "algo.MSF"),
@@ -876,31 +845,6 @@ mod tests {
         for (cap, procedure) in expected {
             assert_eq!(cap.procedure(), *procedure);
         }
-    }
-
-    #[test]
-    fn fixture_dependent_reads_record_their_index_capabilities() {
-        // The fulltext/vector fixture reads carry `db.idx.*` capability strings too — on an
-        // engine without those procedures they skip instead of erroring at the reference pass.
-        let ops = record_repo_reads(Tier::Full, 1000, 5000, 7).expect("record full reads");
-        let by_name: std::collections::BTreeMap<&str, Option<&str>> = ops
-            .iter()
-            .map(|op| (op.key.name(), op.capability.as_deref()))
-            .collect();
-        assert_eq!(
-            by_name["fulltext_query_nodes_smoke"],
-            Some("db.idx.fulltext.queryNodes")
-        );
-        assert_eq!(
-            by_name["vector_query_nodes_smoke"],
-            Some("db.idx.vector.queryNodes")
-        );
-        assert_eq!(
-            by_name["fulltext_query_relationships_smoke"],
-            Some("db.idx.fulltext.queryRelationships")
-        );
-        // Plain reads carry none — replay never probes for them.
-        assert_eq!(by_name["single_vertex_read"], None);
     }
 
     #[test]
@@ -1109,7 +1053,7 @@ mod tests {
             );
             assert_eq!(s.tier, Tier::Full);
             assert!(!s.result_policy.is_gated());
-            assert!(s.capability.is_some());
+            assert!(s.capability.is_none());
         }
     }
 
@@ -1171,6 +1115,36 @@ mod tests {
                 "fulltext_query_relationships_smoke",
             ]),
             "exactly the LIMIT-without-ORDER and top-k reads are result-N/A"
+        );
+    }
+
+    #[test]
+    fn repo_reads_replay_never_probes_because_no_read_records_a_capability() {
+        // The per-PR gate replays `--repo-reads full` bundles, and replay issues its one
+        // `dbms.procedures()` probe **only** when ≥1 recorded op carries a capability. Fixture
+        // (fulltext/vector) DDL loads with the graph, before any probe could skip its reads, so a
+        // capability there would fail the load on an engine lacking the index instead of skipping
+        // cleanly — reads must stay capability-free end-to-end (zero probes on the gate path).
+        for tier in [Tier::Core, Tier::Full] {
+            let ops = record_repo_reads(tier, 1000, 5000, 42).unwrap();
+            for op in &ops {
+                assert_eq!(
+                    op.capability,
+                    None,
+                    "read '{}' records a capability — the --repo-reads {tier:?} replay would probe",
+                    op.key.name()
+                );
+            }
+        }
+        // Drift guard for the annotation source: no read ShapeSpec carries a capability; the
+        // algorithm family (opt-in, never on the gate path) is the only annotated one.
+        assert!(
+            repo_read_shapes().iter().all(|s| s.capability.is_none()),
+            "read shapes must be capability-free"
+        );
+        assert!(
+            algorithm_read_shapes().iter().all(|s| s.capability.is_some()),
+            "algorithm shapes each name their procedure"
         );
     }
 

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1190,12 +1190,14 @@ async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
             key: OpKey::dynamic("budgeted_op", QueryType::Read),
             result_gated: true,
             budget: tight.clone(),
+            capability: None,
             commands: vec!["MATCH (u:User {id: 1}) RETURN u.id".to_string()],
         },
         RecordedOp {
             key: OpKey::dynamic("global_op", QueryType::Read),
             result_gated: true,
             budget: RecordedBudget::default(),
+            capability: None,
             commands: vec![
                 "MATCH (u:User {id: 2}) RETURN u.id".to_string(),
                 "MATCH (u:User {id: 3}) RETURN u.id".to_string(),
@@ -1205,6 +1207,7 @@ async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
             key: OpKey::dynamic("na_probe_op", QueryType::Read),
             result_gated: false,
             budget: tight.clone(),
+            capability: None,
             commands: vec![
                 "MATCH (u:User {id: 4}) RETURN u.id".to_string(),
                 "MATCH (u:User {id: 5}) RETURN u.id".to_string(),
@@ -1271,6 +1274,88 @@ async fn replay_honors_per_op_budgets_and_result_na_skips_reference_capture() {
     // The report's meta echoes the run's global knobs (budgets are per-op policy).
     assert_eq!(report.meta.concurrency, vec![1, 2]);
     assert_eq!(report.meta.samples, 3);
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Capability probe-before-capture (design Phase 6 §3.5): an op whose recorded `capability`
+/// procedure is absent from the engine's `dbms.procedures()` registry is **skipped** — never
+/// executed (its deliberately invalid command would fail the result-gated reference capture),
+/// reported with `skipped: Some(reason)` and no levels/digest/policy — while the capability-free
+/// op in the same bundle measures normally.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn replay_skips_ops_whose_capability_procedure_is_missing() {
+    use benchmark::synthetic::catalog::RecordedBudget;
+    use benchmark::synthetic::recording::RecordedOp;
+    use benchmark::synthetic::OpKey;
+
+    let graph = "syn_it_capskip";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-capskip");
+    let spec = DatasetSpec {
+        seed: 9,
+        nodes: 200,
+        edges: 400,
+    };
+    let ops = vec![
+        RecordedOp {
+            key: OpKey::dynamic("measured_op", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["MATCH (u:User {id: 1}) RETURN u.id".to_string()],
+        },
+        RecordedOp {
+            key: OpKey::dynamic("phantom_op", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: Some("algo.noSuchProcedureBench".to_string()),
+            // Invalid on purpose: result-gated ops get a full reference capture, so replay can
+            // only succeed by never executing this op at all.
+            commands: vec!["CALL algo.noSuchProcedureBench( RETURN oops".to_string()],
+        },
+    ];
+    recording::record_rendered(&spec, graph, &ops, spec.seed, 256, &dir).expect("record");
+
+    let out = dir.join("r.json").to_string_lossy().into_owned();
+    let mut config = replay_config(&dir, graph, &out, true);
+    config.samples = 3;
+    config.warmup = 1;
+    let report = replay::run(&config)
+        .await
+        .expect("replay must skip the phantom op");
+
+    let phantom = &report.operations["phantom_op"];
+    let reason = phantom
+        .skipped
+        .as_deref()
+        .expect("phantom_op must be marked skipped");
+    assert!(
+        reason.contains("algo.noSuchProcedureBench"),
+        "skip reason names the missing procedure: {reason}"
+    );
+    assert!(
+        phantom.levels.is_empty(),
+        "a skipped op has no measured levels"
+    );
+    assert!(
+        phantom.result_digest.is_none(),
+        "a skipped op has no digest"
+    );
+    assert!(
+        phantom.policy.is_none(),
+        "a skipped op has no resolved policy"
+    );
+
+    let measured = &report.operations["measured_op"];
+    assert!(
+        measured.skipped.is_none(),
+        "the capability-free op measures normally"
+    );
+    assert!(!measured.levels.is_empty());
+    assert!(measured.result_digest.is_some());
 
     std::fs::remove_dir_all(&dir).ok();
     drop_graph(graph).await;
@@ -1407,6 +1492,25 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
     .await
     .expect("record --repo-algorithms via run_command");
 
+    // The bundle's manifest annotates every algorithm op with its required procedure (§3.5).
+    let bundle = recording::load(&dir).expect("load the recorded bundle");
+    let caps: Vec<Option<&str>> = bundle
+        .manifest
+        .ops
+        .iter()
+        .map(|op| op.capability.as_deref())
+        .collect();
+    assert_eq!(
+        caps,
+        vec![
+            Some("algo.pageRank"),
+            Some("algo.maxFlow"),
+            Some("algo.MSF"),
+            Some("algo.HarmonicCentrality"),
+        ],
+        "recorded manifest must carry the per-procedure capabilities"
+    );
+
     let out = dir.join("algos.json").to_string_lossy().into_owned();
     let mut config = replay_config(&dir, graph, &out, true);
     // Global knobs the per-op budgets must override (sweep + cache) or inherit (nothing: the
@@ -1427,6 +1531,7 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
             .operations
             .get(name)
             .unwrap_or_else(|| panic!("{name} missing from the replay report"));
+        assert!(op.skipped.is_none(), "{name} must pass the capability probe on this server");
         let levels: Vec<usize> = op.levels.iter().map(|l| l.concurrency).collect();
         assert_eq!(levels, vec![1], "{name} must measure only its budgeted C=1 sweep");
         assert!(op.levels[0].cached.is_some(), "{name} measures cached");


### PR DESCRIPTION
## What

Phase 6 step 4 of [`docs/design/synthetic-cover-algorithms-phase6.md`](https://github.com/FalkorDB/benchmark/blob/master/docs/design/synthetic-cover-algorithms-phase6.md) (§3.5 + §8.5): **capability probe-before-capture** with a defined **skipped-op** representation across the whole reporting stack.

Every recorded op can now carry the **procedure it requires** (`capability` in the manifest — e.g. `algo.maxFlow`). At replay, one `CALL dbms.procedures()` probe (per run, case-insensitive) checks the engine's registry up front: an op whose procedure is missing is **skipped** — *never executed* — and reported as `skipped: <reason>` with no levels, no digest, no policy. Everything downstream (plain report, `report --diff --regression`, `--summary`, `--cells`, Criterion baseline guard) understands a skip as **neither a pass nor a divergence**.

## Why

Before this PR, replaying a bundle containing algorithm shapes against an engine that lacks a procedure (e.g. FalkorDB v4.0.7 has no `algo.maxFlow`/`algo.MSF`/`algo.HarmonicCentrality`) **failed the whole run** at the reference pass — `ResultPolicy::NotApplicable` only disables digest comparison, it never skipped execution (design §3.5). Worse, without guard changes a skipped op would read as a **config mismatch** (its absent per-op policy) *and* a **divergence** (its absent digest vs the measured side's) — both wrong for an expected engine limitation. This PR makes cross-version and cross-engine comparisons involving algorithm shapes degrade gracefully and *visibly* instead of erroring or lying.

## Worked example (real run)

Record the 4 algorithm shapes, then replay the same bundle against `falkordb:edge` (has all 4 procedures) and `falkordb:v4.0.7` (lacks 3 of them):

```bash
benchmark synthetic record --repo-algorithms --nodes 300 --edges 900 --seed 7 --out-dir rec
benchmark synthetic run --recording rec --endpoint falkor://127.0.0.1:16409 --graph p6 --label edge   --out edge.json
benchmark synthetic run --recording rec --endpoint falkor://127.0.0.1:16410 --graph p6 --label v4.0.7 --out old.json
benchmark synthetic report --diff edge.json old.json --regression --out diff.md --summary summary.json --cells cells.json
```

The v4.0.7 replay logs (and its report carries) the three skips instead of failing:

```
INFO … skipping op 'algo_max_flow_single_pair': engine lacks procedure 'algo.maxFlow' (capability probe)
INFO … skipping op 'algo_msf_summary': engine lacks procedure 'algo.MSF' (capability probe)
INFO … skipping op 'algo_harmonic_summary': engine lacks procedure 'algo.HarmonicCentrality' (capability probe)
```

The regression report's verdict line (a real excerpt from this run — the skips **annotate** a pass, they don't cap it):

> **v4.0.7 vs edge** — 🟢 no p50 regression beyond budget across 1 comparable cell(s); 3 op(s) skipped (engine lacks their required procedure)

Each skipped op keeps its section — collapsed summary row `⏭ algo_max_flow_single_pair — skipped (perf verdict N/A)` — showing the measured side's raw numbers as context, `—` for the skipped side, verdict `N/A`, plus:

> _⏭ skipped on v4.0.7 — engine lacks procedure 'algo.maxFlow' (capability probe); measured on edge only, so no cell is comparable_

and a one-line legend (`⏭ = skipped: …`) appears only when at least one op skipped.

## 🔊 Schema deltas (frozen contract — Part B consumers read this)

Skips are a **new outcome**: a v1/v2 consumer parsing outcomes exhaustively would reject `"skipped"`, so both machine schemas get a deliberate version bump (frozen-field-set tests updated accordingly):

| surface | before | after | delta |
|---|---|---|---|
| `--cells` (RegressionAnalysis JSON) | `schema_version: 1` | **`2`** | `op_outcome` enum gains `"skipped"`; `totals` gains a `skipped` bucket (now `{pass, regressed, diverged, skipped, not_applicable}`); per-op optional `skipped_baseline` / `skipped_candidate` (string reason, omitted when absent); skipped cells are always `perf_verdict: "not_applicable"`, `correctness: "not_gated"` |
| `--summary` | `schema_version: 2` | **`3`** | same `OutcomeCounts` extension in `totals` + `per_tier[].counts`; `headline` may carry the `; N op(s) skipped (engine lacks their required procedure)` suffix; summary Markdown tier table gains a ⏭ column; skipped algorithm ops are tallied in the `full` tier row (family-agnostic `shape_tier`, #261 review fix) |
| report JSON (`synthetic run`) | `schema_version: 2` | `2` (unchanged) | **additive optional** `skipped: "<reason>"` on an operation entry (omitted for measured ops; legacy reports deserialize with `None`); manifest `OpEntry` gains optional `capability` (omitted when absent; **excluded from `workload_hash`**) |
| Criterion baseline JSON | — | — | `BaselineKey` gains `skipped_ops` (omitted when empty ⇒ pre-existing baseline files byte-identical & loadable) |

`summary.json` from the run above (**complete**, schema v3):

```json
{
  "schema_version": 3,
  "baseline_label": "edge",
  "candidate_label": "v4.0.7",
  "slug": "synthetic-v4-0-7-vs-edge-9ab94eceb007",
  "budget_profile": "strict",
  "divergence_policy": "gate",
  "gated_metric": "total_ms.p50",
  "elapsed_secs": null,
  "overall_verdict": "pass",
  "headline": "no p50 regression beyond budget across 1 comparable cell(s); 3 op(s) skipped (engine lacks their required procedure)",
  "comparable_cells": 1,
  "regressed_cells": 0,
  "diverged_ops": [],
  "totals": {
    "pass": 1,
    "regressed": 0,
    "diverged": 0,
    "skipped": 3,
    "not_applicable": 0
  },
  "per_tier": [
    {
      "tier": "core",
      "counts": {
        "pass": 0,
        "regressed": 0,
        "diverged": 0,
        "skipped": 0,
        "not_applicable": 0
      }
    },
    {
      "tier": "full",
      "counts": {
        "pass": 0,
        "regressed": 0,
        "diverged": 0,
        "skipped": 3,
        "not_applicable": 0
      }
    }
  ],
  "worst_offenders": []
}
```

`cells.json` excerpt for the skipped op (schema v2; since the #261 review fix the shape→tier lookup is family-agnostic, so algorithm shapes carry `"tier": "full"` — **schema delta vs the first version of this exhibit**, which showed `tier` absent for algorithm ops):

```json
{
  "algo_max_flow_single_pair": {
    "tier": "full",
    "correctness": "not_gated",
    "op_outcome": "skipped",
    "skipped_candidate": "engine lacks procedure 'algo.maxFlow' (capability probe)",
    "cells": [
      {
        "concurrency": 1,
        "cache_mode": "cached",
        "baseline_p50_ms": 5.342958,
        "budget": {
          "metric": "p50",
          "budget_pct": 10.0,
          "floor_ms": 0.5
        },
        "perf_verdict": "not_applicable",
        "context": {
          "baseline": {
            "p90_ms": 5.9521332,
            "p95_ms": 6.0123999999999995,
            "p99_ms": 6.06475192,
            "throughput_ops_per_sec": 203.14811977964183
          }
        }
      }
    ]
  }
}
```

## Skip semantics (the §8.5 resolution, binding here)

A **skipped** op = recorded, but never executed on that side because the engine lacks its required procedure. Under **both** divergence policies (`gate` and `advisory`):

- **Neither a pass nor a divergence** — a new `OpOutcome::Skipped` (⏭), tallied in its own `skipped` bucket, **always** (even cell-less, mirroring the "every divergence counts" rule).
- **Perf cells are `N/A`** — the measured side's raw p50/context stays visible, but no latency claim is made.
- **Correctness is `not_gated`** — no result claim either (the op never ran).
- **Never gates, never an offender, never caps the verdict** below what the measured ops earn; **all-skipped** falls into the existing zero-comparable-cells rule ⇒ *Advisory*, never a green pass.
- **Exempt from both comparison guards** — the per-op policy gate (a skipped op's absent policy is "never ran", not a config mismatch) and the asymmetric-digest divergence rule, in `guard()` (Criterion baselines, via `BaselineKey.skipped_ops`) and `regression_guard()` (`report --diff`) both.
- A **probe failure** (server error/timeout on `dbms.procedures()`) is a **hard error** — fail loudly, never silently measure.

## Implementation notes

- `ShapeCapability::procedure()` pins the exact registry names (`algo.pageRank`, `algo.maxFlow`, `algo.MSF`, `algo.HarmonicCentrality`); a drift-guard test freezes the mapping.
- `RecordedOp`/`OpEntry.capability` follows the `budget` pattern exactly: serde-optional (omitted when absent ⇒ pre-existing bundles unchanged + legacy manifests load as `None`) and **outside the `workload_hash`** (replay policy, not workload content) — proven by a dedicated hash-invariance test; the `--repo-reads full` golden hash is untouched.
- **Retracted deviation (duck round 2):** an earlier revision of this PR also recorded `db.idx.*` capabilities on the fulltext/vector **fixture reads**. That broke the per-PR gate path: `synthetic-verify` records `--repo-reads full`, so replay would probe on the gate path — and the fixture's index DDL loads **before** the probe, so an engine lacking the index support fails at load and never reaches the skip. Capabilities are **algorithm-only** again; a regression test pins that a `--repo-reads full` recording carries zero capabilities (⇒ replay's probe set is structurally empty and never probes). Capability-aware *loading* is noted as future work in the phase-6 design doc.
- The probe runs **once per replay**, and **only if** ≥1 manifest op carries a capability — a bundle of plain reads never issues it (zero overhead for the per-PR `synthetic-verify` gate, whose byte-identical command-stream golden still passes).
- `corpus_size` in the report meta is computed from the bundle (skip-independent), so a skip never changes the meta echo.
- Docs: readme (record/replay/report sections + schema versions), cookbook (algorithm-shape story), design doc §7 item 4 marked ✅ with the resolution inlined at §8.5.

## Review fixes (duck round 2)

1. **Fixture capabilities retracted** (major): reads are capability-free again — see the retraction note under *Implementation notes*; readme + phase-6 design doc updated, zero-probe regression test added.
2. **Plain `report --diff` renders skips** (major): previously the strict guard exempted skipped ops but the plain diff rendered a bare heading (both-skipped) or dashes (one-sided) with no explanation. It now renders the same four-case ⏭ note as the regression report (HTML-escaped), e.g. `⏭ skipped on B — engine lacks procedure 'algo.maxFlow'; measured on A only`, with tests for both-skipped (same/different reasons), one-sided rendering, label fallbacks, and escaping.
3. **Schema rollout completed** (major): `just synthetic-sanity` now asserts summary **v3** and cells **v2** (it previously required v2 summaries and would have failed on this PR's own output); the Part B contract doc (`docs/design/synthetic-three-way-report.md`) gains an explicit versioned amendment (**§9**) documenting the cells v1→v2 and summary v2→v3 deltas (skipped outcome + buckets + per-op reasons + tier on algorithm cells + ⏭ column) with pointer notes at the amended §A1/§A5/§B4 — no silent edits of the frozen sketches.

## Design (verbatim, from master)

### §3.5

```text
### 3.5 One coarse capability is wrong, and N/A does not skip execution
FalkorDB capabilities are detected **per procedure** (`src/falkor/falkor_driver.rs:520-550`), and
Harmonic is independently optional (`src/main.rs:1171-1183`) — a single `GraphAlgorithms` label can't
represent a partially-supported engine. And `ResultPolicy::NotApplicable` only disables *digest
comparison*; it does **not** skip execution, so an engine lacking a procedure still runs (and fails)
the query. **Fix:** **per-procedure** capability variants (`PageRank`/`MaxFlow`/`Msf`/`Harmonic`),
**probe-before-capture**, and a defined representation for a **skipped** op in the report/diff.
```

### §7 (phasing — this PR is step 4)

```text
4. **Per-procedure capability** (§3.5) — probe-before-capture + skipped-op reporting.
```

### §8 (open question resolved by this PR)

```text
5. **Skipped-op semantics (§3.5)** — how a capability-absent op appears in `report --diff` needs
   defining so it neither reads as a pass nor a divergence.
```

## Tests

**Unit (24 new, 390 total lib):**
- `analysis`: skipped ⇒ neither pass nor divergence under both policies (incl. guard-divergence exemption); cell-less both-sides skip still tallied; all-skipped ⇒ Advisory never green; cells JSON field names + round-trip for skip reasons; frozen-field-set tests updated to schema v2 (op-level set + counts bucket set).
- `diff`: skip note rendering (asymmetric + both-sides same/different reasons), ⏭ summary-row emoji, legend only when skips exist, skipped bucket in summary totals + `full` and **all** tier rows, never an offender; frozen summary test updated to v3.
- `baseline`: `guard()` policy+digest exemption both directions; `regression_guard()` policy exemption + no-divergence for skips; `BaselineKey::from_report` collects `skipped_ops`; empty set omitted from JSON (pre-Phase-6 baselines byte-identical).
- `recording`: capability hash-invariance; manifest round-trip + omit-when-absent (`"capability"` key count == 1).
- `report`: skip round-trip + console/markdown rendering + legacy default `None`.
- `shapes`: `procedure()` mapping pinned; algorithm shapes record expected capability strings; **all** read shapes (incl. the fulltext/vector fixture reads) record none — plus a zero-probe regression test on a full `--repo-reads` recording.

**Live (2 new, 27 total, all green on `falkordb:edge`):**
- `replay_skips_ops_whose_capability_procedure_is_missing` — the skipped op carries a **deliberately invalid command**, so replay can only succeed by never executing it; the capability-free op in the same bundle measures normally.
- `record_and_replay_algorithm_shapes_end_to_end` extended: manifest carries the 4 `algo.*` capability strings; all 4 shapes pass the probe (no false skips).

## Validation

- `just ci` ✅ (build + clippy `-D warnings` + tests incl. the readme doctest)
- `just coverage` ✅ (390 lib + 27 live integration tests against a throwaway `falkordb:edge`) — **patch coverage 100%** (760/760 executable added lines vs master, incl. the duck-round-2 fixes)
- `just doc-links` ✅ · `just doc-shell` ✅
- `just synthetic-sanity` ✅ (throwaway Docker FalkorDB; now asserts summary v3 + cells v2)
- Cross-version smoke (above): edge measures all 4; v4.0.7 skips 3, measures `pageRank`; diff/summary/cells all render the skips per this body.

---

**Stacked on #261** (`barakb/phase6-algorithm-shapes`) — will be retargeted/rebased onto `master` once #261 merges. PR-5 (§7.5 byte-stability verification for `max_flow`/`msf` digest gating) follows.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replay now probes for required engine procedures and skips operations whose procedures are missing, without failing the run.
  * Skipped operations are clearly reported with reasons and are excluded from pass/divergence calculations.
  * Recording/replay now preserves required capability (procedure) metadata for algorithm operations; non-algorithm reads remain capability-free.
* **Documentation**
  * Updated recording, replay, and regression-report guidance to describe capability probing, skip behavior, and updated summary outputs.
* **Release/Schema Updates**
  * Updated analysis and summary schema versions to include dedicated skipped buckets and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
