### PR TITLE
feat(synthetic): gate the deterministic algorithm digests (max_flow, msf) (Phase 6, PR-5)

### DIFF
--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -143,15 +143,16 @@ curated metadata in `shapes.rs`), but on a **separate axis** from reads:
 Floats are digested by `f64::to_bits()` (exact), so the question is **value** stability run-to-run on
 the same image:
 
-| Shape | Proposed `result_policy` | Why |
+| Shape | `result_policy` (final) | Why |
 | --- | --- | --- |
 | `algo_pagerank_summary` | **N/A** | `RETURN score LIMIT 1` (no `ORDER BY`) — arbitrary single float. |
-| `algo_harmonic_summary` | **N/A** (pending) | `avg`/`max` over all nodes; iterative/aggregation value stability unproven. |
-| `algo_max_flow_single_pair` | **Gated (candidate)** | Max-flow of a fixed simple graph + capacities + seeded pair is a unique integral value coerced to exact `f64`. |
-| `algo_msf_summary` | **Gated (candidate)** | `edge_count` and MSF `total_weight` are unique (tie-breaking cannot change the minimum total). |
+| `algo_harmonic_summary` | **N/A** | `avg`/`max` over all nodes; iterative/aggregation value stability unproven. |
+| `algo_max_flow_single_pair` | **Gated** | Max-flow of a fixed simple graph + capacities + seeded pair is a unique integral value coerced to exact `f64`; digests verified byte-stable (§7 step 5). |
+| `algo_msf_summary` | **Gated** | `edge_count` and MSF `total_weight` are unique (tie-breaking cannot change the minimum total); digests verified byte-stable (§7 step 5). |
 
-Default **all four to N/A**; promote `max_flow`/`msf` to `Gated` **only after** confirming byte-stable
-digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synthetic-only `ORDER BY`.
+All four defaulted to N/A until the promotion bar was met: promote `max_flow`/`msf` to `Gated`
+**only after** confirming byte-stable digests across ≥2 runs on the per-PR image (the reads' bar).
+Never add a synthetic-only `ORDER BY`.
 *(Resolved — see §7 step 5: verified byte-stable, `max_flow`/`msf` promoted; `pagerank`/`harmonic`
 stay N/A per this table.)*
 

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -193,7 +193,9 @@ stay N/A per this table.)*
    on a pre-load probe) is future work if a later phase needs fixture reads to skip.
 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable. ✅
    implemented: digests verified byte-identical across **3 independent replays** on the same
-   `falkordb/falkordb:edge` image — two from the same server process and one after a full server restart —
+   `falkordb/falkordb:edge` image (pinned:
+   `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`) —
+   two from the same server process and one after a full server restart —
    for all four shapes; per the §6 table only `max_flow`/`msf` are promoted (`pagerank`/`harmonic`
    stay N/A — arbitrary/iterative floats even if empirically stable on the small fixture). The
    algorithm e2e integration test now replays every bundle **twice** and asserts the gated digests
@@ -206,7 +208,8 @@ stay N/A per this table.)*
    deduped simple graph keeps `workload_hash`/digests deterministic.
 2. **Float/iteration value stability (§6)** — whether `max_flow`/`msf` digests are byte-stable
    run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`. ✅ resolved:
-   byte-stable across 3 independent replays (incl. a server restart) on `falkordb/falkordb:edge`; both
+   byte-stable across 3 independent replays (incl. a server restart) on `falkordb/falkordb:edge`
+   (pinned: `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`); both
    promoted to Gated, with the two-replay digest-equality assertion in the algorithm e2e test
    guarding against future instability.
 3. **Value of N/A-only coverage** — N/A shapes add latency/trend coverage + exercise the `algo.*`

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -197,7 +197,9 @@ stay N/A per this table.)*
    `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`) —
    two from the same server process and one after a full server restart —
    for all four shapes; per the §6 table only `max_flow`/`msf` are promoted (`pagerank`/`harmonic`
-   stay N/A — arbitrary/iterative floats even if empirically stable on the small fixture). The
+   stay N/A — arbitrary/iterative floats even if empirically stable on the small fixture). Digest
+   *values* are engine-build- and workload-specific; the promotion claim is **stability on one
+   image**, not any particular bytes. The
    algorithm e2e integration test now replays every bundle **twice** and asserts the gated digests
    match, so byte-stability is re-verified continuously (including on the CI image/arch). A future
    instability would surface as a loud divergence, and the shape can be demoted back to N/A.
@@ -209,7 +211,8 @@ stay N/A per this table.)*
 2. **Float/iteration value stability (§6)** — whether `max_flow`/`msf` digests are byte-stable
    run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`. ✅ resolved:
    byte-stable across 3 independent replays (incl. a server restart) on `falkordb/falkordb:edge`
-   (pinned: `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`); both
+   (pinned: `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`);
+   digest values themselves are engine-build- and workload-specific (only stability is claimed); both
    promoted to Gated, with the two-replay digest-equality assertion in the algorithm e2e test
    guarding against future instability.
 3. **Value of N/A-only coverage** — N/A shapes add latency/trend coverage + exercise the `algo.*`

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -152,6 +152,8 @@ the same image:
 
 Default **all four to N/A**; promote `max_flow`/`msf` to `Gated` **only after** confirming byte-stable
 digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synthetic-only `ORDER BY`.
+*(Resolved — see §7 step 5: verified byte-stable, `max_flow`/`msf` promoted; `pagerank`/`harmonic`
+stay N/A per this table.)*
 
 ## 7. Phasing (prerequisites first, each its own PR)
 1. ✅ **Simple-graph algorithm fixture** (§3.1) — deterministic, no parallel `:Friend` edges + tests.
@@ -188,14 +190,24 @@ digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synth
    them — annotating them would fail the per-PR `--repo-reads full` gate at load on an engine
    lacking the indexes instead of skipping cleanly. Capability-aware *loading* (fixture DDL gated
    on a pre-load probe) is future work if a later phase needs fixture reads to skip.
-5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable.
+5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable. ✅
+   implemented: digests verified byte-identical across **3 independent replays** on the same
+   `falkordb:edge` image — two from the same server process and one after a full server restart —
+   for all four shapes; per the §6 table only `max_flow`/`msf` are promoted (`pagerank`/`harmonic`
+   stay N/A — arbitrary/iterative floats even if empirically stable on the small fixture). The
+   algorithm e2e integration test now replays every bundle **twice** and asserts the gated digests
+   match, so byte-stability is re-verified continuously (including on the CI image/arch). A future
+   instability would surface as a loud divergence, and the shape can be demoted back to N/A.
 6. **Docs:** cookbook + readme.
 
 ## 8. Risks & open questions
 1. **maxFlow topology (§3.1)** — biggest: confirm the dup-pair count + tensors error, and that a
    deduped simple graph keeps `workload_hash`/digests deterministic.
 2. **Float/iteration value stability (§6)** — whether `max_flow`/`msf` digests are byte-stable
-   run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`.
+   run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`. ✅ resolved:
+   byte-stable across 3 independent replays (incl. a server restart) on `falkordb:edge`; both
+   promoted to Gated, with the two-replay digest-equality assertion in the algorithm e2e test
+   guarding against future instability.
 3. **Value of N/A-only coverage** — N/A shapes add latency/trend coverage + exercise the `algo.*`
    paths but nothing to the divergence gate; acceptable because algorithms are opt-in, not per-PR.
 4. **Budget/corpus plumbing is real work (§3.4)**, not annotation — it is a prerequisite, and it also

--- a/docs/design/synthetic-cover-algorithms-phase6.md
+++ b/docs/design/synthetic-cover-algorithms-phase6.md
@@ -192,7 +192,7 @@ stay N/A per this table.)*
    on a pre-load probe) is future work if a later phase needs fixture reads to skip.
 5. **Promote deterministic shapes:** flip `max_flow`/`msf` to `Gated` once verified byte-stable. ✅
    implemented: digests verified byte-identical across **3 independent replays** on the same
-   `falkordb:edge` image — two from the same server process and one after a full server restart —
+   `falkordb/falkordb:edge` image — two from the same server process and one after a full server restart —
    for all four shapes; per the §6 table only `max_flow`/`msf` are promoted (`pagerank`/`harmonic`
    stay N/A — arbitrary/iterative floats even if empirically stable on the small fixture). The
    algorithm e2e integration test now replays every bundle **twice** and asserts the gated digests
@@ -205,7 +205,7 @@ stay N/A per this table.)*
    deduped simple graph keeps `workload_hash`/digests deterministic.
 2. **Float/iteration value stability (§6)** — whether `max_flow`/`msf` digests are byte-stable
    run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`. ✅ resolved:
-   byte-stable across 3 independent replays (incl. a server restart) on `falkordb:edge`; both
+   byte-stable across 3 independent replays (incl. a server restart) on `falkordb/falkordb:edge`; both
    promoted to Gated, with the two-replay digest-equality assertion in the algorithm e2e test
    guarding against future instability.
 3. **Value of N/A-only coverage** — N/A shapes add latency/trend coverage + exercise the `algo.*`

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -218,8 +218,9 @@ benchmark synthetic record --repo-algorithms --nodes 1000 --edges 5000 --seed 7 
 
 Each algorithm shape records a tight per-op `budget` (25 samples, warm-up 2, C=1, cached-only,
 60 s server timeout) and a reduced corpus (1 command each; a small seeded set of distinct
-`(source, target)` pairs for maxFlow), and starts **result-N/A** — latency/trend coverage, not
-divergence gating.
+`(source, target)` pairs for maxFlow). The deterministic pair (`max_flow`/`msf` — unique values,
+byte-stable digests verified across independent replays) is **digest-gated**; `pagerank`/`harmonic`
+stay **result-N/A** (arbitrary/iterative floats) — latency/trend coverage, not divergence gating.
 Each also records its required procedure as a `capability` (replay policy like `budget`, outside
 the `workload_hash`): at replay, one `CALL dbms.procedures()` probe **skips** any op whose
 procedure the engine lacks — reported as `skipped: <reason>` (⏭ in the diff, its own `skipped`

--- a/readme.md
+++ b/readme.md
@@ -477,9 +477,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   (`algo.pageRank` / `algo.maxFlow` / `algo.MSF` / `algo.HarmonicCentrality`), each with a tight
   per-op budget (25 samples, warm-up 2, C=1, cached-only, 60 s server timeout) and a reduced corpus
   (1 command for the parameterless shapes; a small seeded set of distinct `(source, target)` pairs for maxFlow).
-  All four start **result-N/A** (their values aren't verified byte-stable yet — `max_flow`/`msf`
-  are gating candidates pending that verification), so they add latency/trend coverage without
-  joining the divergence gate. Each shape also records its required procedure (`capability` in the
+  `algo_max_flow_single_pair` and `algo_msf_summary` are **digest-gated** — their values are unique
+  for the fixed graph and verified byte-stable across independent replays — while
+  `algo_pagerank_summary`/`algo_harmonic_summary` stay **result-N/A** (arbitrary/iterative floats),
+  adding latency/trend coverage without joining the divergence gate. Each shape also records its
+  required procedure (`capability` in the
   manifest — replay policy like `budget`, not folded into the `workload_hash`): at replay a single
   `CALL dbms.procedures()` probe **skips** any op whose procedure the engine lacks (reported, never
   executed) instead of failing the run. Only algorithm shapes carry a capability — read shapes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -543,7 +543,7 @@ pub enum SyntheticCommands {
         #[arg(
             long = "repo-algorithms",
             conflicts_with_all = ["ops", "all_reads", "tier"],
-            help = "additionally record the 4 opt-in whole-graph algorithm read shapes (algo.pageRank / algo.maxFlow / algo.MSF / algo.HarmonicCentrality) — all result-N/A, each with a tight per-op budget (C=1, cached, 25 samples) and a small corpus. Orthogonal to --repo-reads (combinable with it or usable alone); never part of --repo-reads or the per-PR gate. Mutually exclusive with --op/--all-reads/--tier."
+            help = "additionally record the 4 opt-in whole-graph algorithm read shapes (algo.pageRank / algo.maxFlow / algo.MSF / algo.HarmonicCentrality) — algo.maxFlow/algo.MSF result-gated (byte-stable digests), algo.pageRank/algo.HarmonicCentrality result-N/A (arbitrary/iterative floats, design §6); each with a tight per-op budget (C=1, cached, 25 samples) and a small corpus. Orthogonal to --repo-reads (combinable with it or usable alone); never part of --repo-reads or the per-PR gate. Mutually exclusive with --op/--all-reads/--tier."
         )]
         repo_algorithms: bool,
         #[arg(

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -2581,7 +2581,13 @@ mod tests {
             "exactly the 4 algorithm shapes, in definition order"
         );
         for entry in &bundle.manifest.ops {
-            assert!(!entry.result_gated, "{} must start result-N/A (design §6)", entry.name);
+            let expect_gated =
+                matches!(entry.name.as_str(), "algo_max_flow_single_pair" | "algo_msf_summary");
+            assert_eq!(
+                entry.result_gated, expect_gated,
+                "{} gating must follow the §6 determinism table",
+                entry.name
+            );
             assert!(
                 !entry.budget.is_inherit(),
                 "{} must carry its recorded per-op budget",

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -2541,7 +2541,8 @@ mod tests {
     #[tokio::test]
     async fn run_command_record_offline_records_algorithm_shapes() {
         // `synthetic record --repo-algorithms` runs OFFLINE (Phase 6 §7.3): it writes a bundle
-        // containing exactly the 4 opt-in algorithm shapes — each result-N/A with its recorded
+        // containing exactly the 4 opt-in algorithm shapes — max_flow/msf result-gated,
+        // pagerank/harmonic result-N/A (design §6), each with its recorded
         // per-op budget — and, without --repo-reads, no read shape and no fulltext/vector fixture
         // (the algorithm shapes run on the plain simple graph). Exercises the Record handler's
         // `repo_algorithms` plumbing end-to-end (shapes::record_algorithm_reads → record_rendered).

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -393,9 +393,10 @@ const ALGORITHM_BUDGET: OpBudget = OpBudget {
 /// Result policies follow the design's §6 determinism table: `max_flow`/`msf` are **Gated** —
 /// their values are unique (a max-flow of a fixed simple graph + capacities + seeded pair; an
 /// MSF's `edge_count`/minimum `total_weight`, which tie-breaking cannot change) and their digests
-/// verified byte-stable across ≥2 independent replays on the same image, including across a
-/// server restart (design §7.5; `record_and_replay_algorithm_shapes_end_to_end` re-verifies on
-/// every coverage run). `pagerank`/`harmonic` stay **N/A** — arbitrary/iterative float values.
+/// were verified byte-stable across 3 independent replays on the same image, including across a
+/// server restart (the design §7.5 evidence); `record_and_replay_algorithm_shapes_end_to_end`
+/// re-verifies two-replay digest stability (same server process) on every coverage run.
+/// `pagerank`/`harmonic` stay **N/A** — arbitrary/iterative float values.
 /// Never force determinism with a synthetic-only `ORDER BY`. Each shape carries the
 /// per-procedure [`ShapeCapability`] replay probes before capture (design §3.5).
 pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -390,27 +390,30 @@ const ALGORITHM_BUDGET: OpBudget = OpBudget {
 /// [`UsersQueriesRepository::algorithm_read_names`] of an all-algorithms-enabled repository, so
 /// adding/removing an algorithm read there fails the build until this table is updated.
 ///
-/// All four start [`ResultPolicy::NotApplicable`] per the design's §6 determinism table;
-/// `max_flow`/`msf` are gating **candidates**, promoted only after byte-stability across ≥2
-/// independent record runs on the same image is verified (design §7.5). Never force determinism
-/// with a synthetic-only `ORDER BY`. Each carries the per-procedure [`ShapeCapability`] it
-/// exercises (annotation in this phase; probe-before-capture is design §3.5).
+/// Result policies follow the design's §6 determinism table: `max_flow`/`msf` are **Gated** —
+/// their values are unique (a max-flow of a fixed simple graph + capacities + seeded pair; an
+/// MSF's `edge_count`/minimum `total_weight`, which tie-breaking cannot change) and their digests
+/// verified byte-stable across ≥2 independent replays on the same image, including across a
+/// server restart (design §7.5; `record_and_replay_algorithm_shapes_end_to_end` re-verifies on
+/// every coverage run). `pagerank`/`harmonic` stay **N/A** — arbitrary/iterative float values.
+/// Never force determinism with a synthetic-only `ORDER BY`. Each shape carries the
+/// per-procedure [`ShapeCapability`] replay probes before capture (design §3.5).
 pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {
     use ShapeCapability::{AlgoHarmonic, AlgoMaxFlow, AlgoMsf, AlgoPageRank};
     // Every row is an Algorithm-family, Full-tier shape with the algorithm budget; only the
     // corpus size (1 for parameterless shapes, a small seeded pair set for maxFlow), capability
-    // and N/A reason vary.
+    // and result policy vary.
     fn s(
         name: &'static str,
         capability: ShapeCapability,
         corpus_size: usize,
-        not_applicable_reason: &'static str,
+        result_policy: ResultPolicy,
     ) -> ShapeSpec {
         ShapeSpec {
             name,
             family: CoverageFamily::Algorithm,
             tier: Tier::Full,
-            result_policy: ResultPolicy::NotApplicable(not_applicable_reason),
+            result_policy,
             capability: Some(capability),
             corpus_size,
             budget: ALGORITHM_BUDGET,
@@ -421,25 +424,24 @@ pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {
             "algo_pagerank_summary",
             AlgoPageRank,
             1,
-            "RETURN score LIMIT 1 without ORDER BY — arbitrary single float",
+            ResultPolicy::NotApplicable(
+                "RETURN score LIMIT 1 without ORDER BY — arbitrary single float",
+            ),
         ),
         s(
             "algo_max_flow_single_pair",
             AlgoMaxFlow,
             MAX_FLOW_CORPUS_SIZE,
-            "gating candidate — pending byte-stable digests across >=2 record runs (design §7.5)",
+            ResultPolicy::Gated,
         ),
-        s(
-            "algo_msf_summary",
-            AlgoMsf,
-            1,
-            "gating candidate — pending byte-stable digests across >=2 record runs (design §7.5)",
-        ),
+        s("algo_msf_summary", AlgoMsf, 1, ResultPolicy::Gated),
         s(
             "algo_harmonic_summary",
             AlgoHarmonic,
             1,
-            "avg/max over all nodes — iterative float value stability unproven",
+            ResultPolicy::NotApplicable(
+                "avg/max over all nodes — iterative float value stability unproven",
+            ),
         ),
     ]
 }
@@ -802,18 +804,30 @@ mod tests {
     }
 
     #[test]
-    fn algorithm_shapes_are_all_result_na_full_tier_with_per_procedure_capabilities() {
-        // Design §6: all four start result-N/A (max_flow/msf promote only after §7.5 byte-stability
-        // verification); §3.5: each carries its per-procedure capability; §3.4: each records a
-        // reduced corpus (1, or the small seeded maxFlow pair set) under the algorithm budget.
+    fn algorithm_shapes_gate_only_the_deterministic_pair() {
+        // Design §6 determinism table + §7.5 promotion: max_flow/msf are Gated (byte-stability
+        // verified across independent replays — the e2e live test re-verifies it continuously);
+        // pagerank/harmonic stay result-N/A (arbitrary/iterative floats). §3.5: each carries its
+        // per-procedure capability; §3.4: each records a reduced corpus (1, or the small seeded
+        // maxFlow pair set) under the algorithm budget.
         let shapes = algorithm_read_shapes();
         assert_eq!(shapes.len(), 4);
         for shape in &shapes {
             assert_eq!(shape.family, CoverageFamily::Algorithm, "'{}'", shape.name);
             assert_eq!(shape.tier, Tier::Full, "'{}'", shape.name);
-            assert!(!shape.result_policy.is_gated(), "'{}' must start result-N/A", shape.name);
             assert_eq!(shape.budget, ALGORITHM_BUDGET, "'{}'", shape.name);
         }
+        let gated: Vec<(&str, bool)> =
+            shapes.iter().map(|s| (s.name, s.result_policy.is_gated())).collect();
+        assert_eq!(
+            gated,
+            vec![
+                ("algo_pagerank_summary", false),
+                ("algo_max_flow_single_pair", true),
+                ("algo_msf_summary", true),
+                ("algo_harmonic_summary", false),
+            ]
+        );
         let caps: Vec<Option<ShapeCapability>> = shapes.iter().map(|s| s.capability).collect();
         assert_eq!(
             caps,
@@ -886,7 +900,6 @@ mod tests {
             ]
         );
         for op in &ops {
-            assert!(!op.result_gated, "'{}' starts result-N/A (design §6)", op.key.name());
             assert_eq!(
                 op.budget,
                 RecordedBudget::from(ALGORITHM_BUDGET),
@@ -894,6 +907,9 @@ mod tests {
                 op.key.name()
             );
         }
+        // Gating mirrors the shape table (§6): the deterministic pair is digest-gated.
+        let gated: Vec<bool> = ops.iter().map(|op| op.result_gated).collect();
+        assert_eq!(gated, vec![false, true, true, false]);
         // Each op records its per-procedure capability string (design §3.5), so replay can
         // probe-and-skip on an engine that lacks the procedure.
         let capabilities: Vec<Option<&str>> =

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1546,16 +1546,18 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
     // Digest gating per the §6 determinism table: the deterministic pair is gated, the float
     // shapes are N/A.
     for name in ["algo_max_flow_single_pair", "algo_msf_summary"] {
-        assert!(
-            report.operations[name].result_digest.is_some(),
-            "{name} is digest-gated (design §6/§7.5)"
-        );
+        let op = report
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} missing from the replay report"));
+        assert!(op.result_digest.is_some(), "{name} is digest-gated (design §6/§7.5)");
     }
     for name in ["algo_pagerank_summary", "algo_harmonic_summary"] {
-        assert!(
-            report.operations[name].result_digest.is_none(),
-            "{name} stays result-N/A (design §6)"
-        );
+        let op = report
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} missing from the replay report"));
+        assert!(op.result_digest.is_none(), "{name} stays result-N/A (design §6)");
     }
 
     // §7.5 byte-stability, verified continuously: an independent second replay of the same bundle
@@ -1577,8 +1579,12 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
             .result_digest
             .as_ref()
             .unwrap_or_else(|| panic!("{name} must stay digest-gated on the second replay"));
+        let first = report
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} missing from the first replay report"));
         assert_eq!(
-            report.operations[name].result_digest.as_ref(),
+            first.result_digest.as_ref(),
             Some(d2),
             "{name} digest must be byte-stable across independent replays"
         );

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1566,8 +1566,21 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
     config2.warmup = 1;
     let report2 = replay::run(&config2).await.expect("second independent replay");
     for name in ["algo_max_flow_single_pair", "algo_msf_summary"] {
+        let second = report2
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} must be measured by the second replay"));
+        assert!(
+            second.skipped.is_none(),
+            "{name} must pass the capability probe on the second replay"
+        );
+        let d2 = second
+            .result_digest
+            .as_ref()
+            .unwrap_or_else(|| panic!("{name} must stay digest-gated on the second replay"));
         assert_eq!(
-            report.operations[name].result_digest, report2.operations[name].result_digest,
+            report.operations[name].result_digest.as_ref(),
+            Some(d2),
             "{name} digest must be byte-stable across independent replays"
         );
     }

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1560,10 +1560,9 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
 
     // §7.5 byte-stability, verified continuously: an independent second replay of the same bundle
     // must reproduce the gated digests byte-identically (this is what keeps max_flow/msf gated).
+    // The recorded per-op algorithm budget pins samples/warmup — the helper's globals are inert.
     let out2 = dir.join("algos2.json").to_string_lossy().into_owned();
-    let mut config2 = replay_config(&dir, graph, &out2, true);
-    config2.samples = 3;
-    config2.warmup = 1;
+    let config2 = replay_config(&dir, graph, &out2, true);
     let report2 = replay::run(&config2).await.expect("second independent replay");
     for name in ["algo_max_flow_single_pair", "algo_msf_summary"] {
         let second = report2

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1463,8 +1463,10 @@ async fn record_and_replay_via_run_command() {
 /// Phase 6 §7.3 acceptance: `record --repo-algorithms` (offline, via the CLI arm) then a live
 /// replay measures all 4 whole-graph algorithm shapes end-to-end on the generated **simple** graph
 /// (synthbench/v5 — `algo.maxFlow` rejects parallel edges, so this passing proves the guarantee).
-/// Each op must obey its recorded per-op budget (C=1, cached-only), stay result-N/A (no digest),
-/// and persist its resolved effective policy.
+/// Each op must obey its recorded per-op budget (C=1, cached-only) and persist its resolved
+/// effective policy; the §6 determinism table gates `max_flow`/`msf` digests (byte-stability
+/// re-verified here across two independent replays — §7.5) while `pagerank`/`harmonic` stay
+/// result-N/A.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
 async fn record_and_replay_algorithm_shapes_end_to_end() {
@@ -1536,11 +1538,38 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
         assert_eq!(levels, vec![1], "{name} must measure only its budgeted C=1 sweep");
         assert!(op.levels[0].cached.is_some(), "{name} measures cached");
         assert!(op.levels[0].uncached.is_none(), "{name} skips uncached (budget)");
-        assert!(op.result_digest.is_none(), "{name} starts result-N/A (design §6)");
         let policy = op.policy.as_ref().unwrap_or_else(|| panic!("{name} must persist policy"));
         assert_eq!(policy.samples, 25, "{name} budgeted samples");
         assert_eq!(policy.concurrency, vec![1], "{name} budgeted sweep");
         assert_eq!(policy.server_timeout_ms, 60_000, "{name} budgeted server timeout");
+    }
+    // Digest gating per the §6 determinism table: the deterministic pair is gated, the float
+    // shapes are N/A.
+    for name in ["algo_max_flow_single_pair", "algo_msf_summary"] {
+        assert!(
+            report.operations[name].result_digest.is_some(),
+            "{name} is digest-gated (design §6/§7.5)"
+        );
+    }
+    for name in ["algo_pagerank_summary", "algo_harmonic_summary"] {
+        assert!(
+            report.operations[name].result_digest.is_none(),
+            "{name} stays result-N/A (design §6)"
+        );
+    }
+
+    // §7.5 byte-stability, verified continuously: an independent second replay of the same bundle
+    // must reproduce the gated digests byte-identically (this is what keeps max_flow/msf gated).
+    let out2 = dir.join("algos2.json").to_string_lossy().into_owned();
+    let mut config2 = replay_config(&dir, graph, &out2, true);
+    config2.samples = 3;
+    config2.warmup = 1;
+    let report2 = replay::run(&config2).await.expect("second independent replay");
+    for name in ["algo_max_flow_single_pair", "algo_msf_summary"] {
+        assert_eq!(
+            report.operations[name].result_digest, report2.operations[name].result_digest,
+            "{name} digest must be byte-stable across independent replays"
+        );
     }
 
     std::fs::remove_dir_all(&dir).ok();


### PR DESCRIPTION
## What

Phase 6, step 5 of 6 (final code step) — the **§7.5 promotion decision**: after empirically verifying byte-stability, `algo_max_flow_single_pair` and `algo_msf_summary` flip from `ResultPolicy::NotApplicable` to **`ResultPolicy::Gated`**, so their digests now participate in the divergence gate whenever the algorithm shapes are recorded/replayed. `algo_pagerank_summary` and `algo_harmonic_summary` **stay result-N/A** per the design's §6 determinism table.

Stacked on #262 (PR-4, capability probe) → #261 (PR-3, algorithm shapes) → master. Retargets to master as the chain merges.

## Why

PR-3 landed all four whole-graph algorithm shapes deliberately **all result-N/A** — latency/trend coverage only — because the design (§6) requires promotion "**only after** confirming byte-stable digests across ≥2 runs on the per-PR image (the reads' bar)". This PR performs that verification, records the evidence, and promotes exactly the pair the design marked *Gated (candidate)*. With their digests gated, a cross-version replay that produces a different max-flow value or MSF total weight is now a **loud divergence** instead of silently invisible.

## Empirical evidence (the §7.5 verification)

Bundle: `record --repo-algorithms` on the seed=7 1000/5000 simple-graph fixture, all four ops digest-gated for the experiment (safe: `result_gated` is replay policy, excluded from `workload_hash`), `workload_hash sha256:57b4265bc81c62f3f254cd40732c56f4f8770bdd7ac5589ff4ff7ca6570de5f3`.

Three independent replays on the **same `falkordb/falkordb:edge` image** (pinned: `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`, also cited in the design's §6/§7 evidence notes): runs 1–2 against the same server process, run 3 **after a full `docker restart`** (fresh process, fresh caches). All four digests byte-identical across all three runs (evidence re-captured at head `d52def0` — the earlier draft of this table was measured on a smaller 300-node/900-edge fixture (workload_hash `9ab94ece…`); the head bundle records the standard 1000/5000 fixture (workload_hash `57b4265b…`), a different workload and hence different digest values (#261's seed-7 pair fix itself preserved bytes); digest *values* are engine-build- and workload-specific — the promotion claim is **stability**, not any particular bytes):

| Shape | Digest (identical in runs 1, 2 and 3) |
| --- | --- |
| `algo_pagerank_summary` | `sha256:8e5de513af9468c7133221b93fd37cb33a3ade5c0c0cc6bf977a68cba64deeb5` |
| `algo_max_flow_single_pair` | `sha256:cdb8cf8c4fded53911c662c0e8a98de34c637c8be1b88d81e72dfa7f52640397` |
| `algo_msf_summary` | `sha256:3ed681b8b04bc0326b08a12b2badacced211388fc5d5cf424ea0229f23cf3f07` |
| `algo_harmonic_summary` | `sha256:7fda092c2426b42e309ae3f373ac1598d3b9b371d7548b0259bc03abd55a401b` |

Two decisions that follow from the design, not from the data:

- **`pagerank`/`harmonic` stay N/A even though they were empirically stable here.** The §6 table pins their policy on *structural* grounds (`LIMIT` without `ORDER BY` ⇒ arbitrary row; iterative float aggregation) — stability observed on one small fixture is not a determinism guarantee, and the design's table is explicit. No synthetic-only `ORDER BY` was added (§6 forbids it).
- **Interpretation flag (read this):** the design's promotion bar (§6) reads: "promote `max_flow`/`msf` to `Gated` **only after** confirming byte-stable digests across ≥2 runs on the per-PR image (the reads' bar)"; §7 step 5: "flip `max_flow`/`msf` to `Gated` once verified byte-stable." The doc does not pin down what a "run" is. A *record* run cannot be it: `record` for generated shapes is offline and deterministic, so two record runs trivially produce byte-identical bundles (same `workload_hash`, no server involved) and verify nothing about *value* stability. **Deviation/interpretation:** I read "≥2 runs" as **≥2 independent replays on the same image** — digests are produced at replay reference-capture, which is the property the gate actually depends on. The 3-replay × server-restart experiment above is that verification. If a different reading was intended, say so and I'll extend the experiment.

## Continuous re-verification (cross-arch residual risk)

The experiment ran on an ARM Mac; CI runs linux-x86. To keep the promotion honest on the image/arch that matters, the algorithm e2e integration test (`record_and_replay_algorithm_shapes_end_to_end`, runs under `just coverage` on CI) now:

1. asserts `max_flow`/`msf` carry `Some(result_digest)` and `pagerank`/`harmonic` carry `None`, and
2. **replays the same bundle a second time and asserts the gated digests are byte-identical across the two replays.**

If any FalkorDB build ever produces unstable max-flow/MSF values, that test — and every recorded diff — fails loudly, and the shape can be demoted back to N/A with a one-line change (the §8 risk-2 fallback).

## Worked example

```bash
benchmark synthetic record --out-dir rec/algos --nodes 1000 --edges 5000 --seed 7 \
  --repo-algorithms
benchmark synthetic run --recording rec/algos --graph algos --out run-a.json
benchmark synthetic run --recording rec/algos --graph algos --out run-b.json
benchmark synthetic report --diff run-a.json run-b.json --regression
```

Where the report previously showed `results: not gated (N/A)` for every algorithm op, `max_flow`/`msf` now show `results: ✅ digests match` — and a genuine value change renders the standard `🔴 diverged` outcome with both digests, exactly like the repository read shapes.

## Design (verbatim, from `docs/design/synthetic-cover-algorithms-phase6.md` @ master)

## 6. Determinism per shape
Floats are digested by `f64::to_bits()` (exact), so the question is **value** stability run-to-run on
the same image:

| Shape | Proposed `result_policy` | Why |
| --- | --- | --- |
| `algo_pagerank_summary` | **N/A** | `RETURN score LIMIT 1` (no `ORDER BY`) — arbitrary single float. |
| `algo_harmonic_summary` | **N/A** (pending) | `avg`/`max` over all nodes; iterative/aggregation value stability unproven. |
| `algo_max_flow_single_pair` | **Gated (candidate)** | Max-flow of a fixed simple graph + capacities + seeded pair is a unique integral value coerced to exact `f64`. |
| `algo_msf_summary` | **Gated (candidate)** | `edge_count` and MSF `total_weight` are unique (tie-breaking cannot change the minimum total). |

Default **all four to N/A**; promote `max_flow`/`msf` to `Gated` **only after** confirming byte-stable
digests across ≥2 runs on the per-PR image (the reads' bar). Never add a synthetic-only `ORDER BY`.

> **§7 step 5:** Promote deterministic shapes: flip `max_flow`/`msf` to `Gated` once verified byte-stable.

> **§8 risk 2:** **Float/iteration value stability (§6)** — whether `max_flow`/`msf` digests are byte-stable run-to-run; if not they stay N/A (latency-only), like `pagerank`/`harmonic`.

## Implementation notes

- `shapes.rs::algorithm_read_shapes()`: the shape constructor now takes the `ResultPolicy` directly; `max_flow`/`msf` pass `Gated`, `pagerank`/`harmonic` keep their N/A reasons verbatim. Doc comment rewritten to describe the resolved state.
- No schema changes: `result_gated` already flows through manifest → replay → report → diff (PR-2/PR-3 plumbing). Summary stays v3, cells v2, recording format v1 — **no delta for Part B**.
- Docs: readme + cookbook now describe the gated pair; the design doc marks §6, §7 step 5, §8 risk 2 resolved with the evidence inline.

## Tests

- `shapes::algorithm_shapes_gate_only_the_deterministic_pair` (renamed) — pins per-shape gating `[false, true, true, false]` in definition order.
- `shapes::record_algorithm_reads_renders_seeded_budgeted_corpora` — gating assertion updated to the pair.
- `synthetic::tests::run_command_record_offline_records_algorithm_shapes` — per-op `result_gated` must follow the §6 table (was: all-false).
- `record_and_replay_algorithm_shapes_end_to_end` (live) — per-op digest presence + the two-replay byte-equality assertion (continuous §7.5).

## Validation

- `just ci` ✅ (build + clippy -D warnings + 382 lib tests + doctests)
- `just coverage` against a live FalkorDB ✅ — 382 lib + **27 integration tests** (incl. the extended algorithm e2e with the double replay)
- Patch coverage vs PR-4 head: **24/24 = 100%**
- `just doc-links` ✅, `just doc-shell` ✅

Release note: no release/tag here — versioning follows merge, per the repo flow.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Algorithm benchmark replay now distinguishes digest-gated operations from result-not-applicable operations.
  * Max-flow and minimum-spanning-forest results are validated for byte-identical output across repeated replays.
  * Replay verification now confirms recorded sampling, concurrency, and timeout settings.

* **Documentation**
  * Updated CLI help, README, and benchmark guidance to explain algorithm result policies and reproducibility expectations.
  * Documented validation across independent replays, including server restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
