### PR TITLE
fix(synthetic): render op headings inert; document the single registry probe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -391,7 +391,7 @@ synthetic-verify:
     # sticky comment is compact. The workflow publishes recordings/verify-report.md to the job
     # summary AND upserts it as a sticky PR comment; the raw bundle is then dropped (on failure the
     # trap leaves it to inspect).
-    awk '/^## `/{p=1} {print > ("recordings/_verify/" (p ? "detail" : "hdr") ".md")}' recordings/_verify/diff.md
+    awk '/^## <code>/{p=1} {print > ("recordings/_verify/" (p ? "detail" : "hdr") ".md")}' recordings/_verify/diff.md
     {
         echo '<!-- synthetic-verify -->'
         echo "> 🔁 **Synthetic non-divergence — same-machine A/B.** The recorded workload (every A/B read shape via \`--repo-reads full\`) ran **twice** against the same FalkorDB, back-to-back on one machine, across concurrency \`$sweep\` × uncached. The gate fails only if a per-op result digest or the \`workload_hash\` differs — so the latency deltas below are same-machine noise, not a regression."

--- a/docs/design/synthetic-three-way-report.md
+++ b/docs/design/synthetic-three-way-report.md
@@ -446,9 +446,11 @@ Each PR: design-first (this doc), ≥90% patch coverage on Rust changes, `just c
 
 The algorithm-coverage work
 ([`synthetic-cover-algorithms-phase6.md`](synthetic-cover-algorithms-phase6.md)) introduced
-**capability-skipped ops**: before capture/measure, the replayer probes the engine for each
-op's required procedure (algorithm shapes only) and records ops the engine cannot run as
-*skipped* instead of failing. A skip is **neither a pass nor a divergence** and is never an
+**capability-skipped ops**: before capture/measure, the replayer probes the engine's procedure
+registry **once per run** (`CALL dbms.procedures()`, and only when ≥1 manifest op names a
+required procedure — algorithm shapes only), then evaluates every op locally against that
+snapshot and records ops the engine cannot run as *skipped* instead of failing. A skip is
+**neither a pass nor a divergence** and is never an
 offender. This extends the two machine schemas this document froze; the deltas below are the
 new contract (original sketches in §A1/§A5 left intact for history):
 

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -83,7 +83,7 @@ benchmark synthetic report --diff runA.json runB.json --out diff.md
 
 > ⚠ server image changed: falkordb/falkordb:v4.2.0 → falkordb/falkordb:v4.2.1
 
-## `aggregate_count`
+## <code>aggregate\_count</code>
 
 _cached (plan reused — execution only)_
 

--- a/docs/synthetic/sample-diff.md
+++ b/docs/synthetic/sample-diff.md
@@ -12,7 +12,7 @@ _Δ is 100·(B−A)/A. **Latency: lower is better** (a positive Δ = slower / re
 
 > ⚠ baseline and candidate ran the same FalkorDB module version (4.20.1) — there is no version delta to measure
 
-## `aggregate_count`
+## <code>aggregate\_count</code>
 
 _cached (plan reused — execution only)_
 
@@ -28,7 +28,7 @@ _uncached (forced plan-cache miss — execution + compilation)_
 | 1 | 0.409 / 0.464 / 0.491 / 0.538 | 0.425 / 0.487 / 0.519 / 0.571 | +4.1% | 2337 | 2261 | -3.3% |
 | 4 | 0.541 / 0.645 / 0.676 / 0.746 | 0.560 / 0.689 / 0.732 / 0.860 | +3.5% | 7190 | 6690 | -6.9% |
 
-## `expand_1_hop`
+## <code>expand\_1\_hop</code>
 
 _cached (plan reused — execution only)_
 
@@ -44,7 +44,7 @@ _uncached (forced plan-cache miss — execution + compilation)_
 | 1 | 0.457 / 0.543 / 0.571 / 0.648 | 0.562 / 0.786 / 0.855 / 1.007 | +22.9% | 2115 | 1588 | -24.9% |
 | 4 | 0.581 / 0.741 / 0.813 / 0.964 | 0.572 / 0.694 / 0.742 / 0.830 | -1.6% | 6115 | 6721 | +9.9% |
 
-## `match_by_index`
+## <code>match\_by\_index</code>
 
 _cached (plan reused — execution only)_
 

--- a/docs/synthetic/sample-replay-report.md
+++ b/docs/synthetic/sample-replay-report.md
@@ -15,7 +15,7 @@
 | dataset | seed 42 · 1000 nodes · 5000 edges |
 | workload_hash | `sha256:57ec47dffa81b5be2d39fba9b634ea93e79020e2a0ba9f578692d72b351c7606` |
 
-## `aggregate_count`
+## <code>aggregate\_count</code>
 
 _cached — plan reused, execution only_
 
@@ -38,7 +38,7 @@ compilation_ms (median uncached − cached server time):
 | 1 | 0.053 |
 | 4 | 0.071 |
 
-## `expand_1_hop`
+## <code>expand\_1\_hop</code>
 
 _cached — plan reused, execution only_
 
@@ -61,7 +61,7 @@ compilation_ms (median uncached − cached server time):
 | 1 | 0.049 |
 | 4 | 0.075 |
 
-## `match_by_index`
+## <code>match\_by\_index</code>
 
 _cached — plan reused, execution only_
 

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -102,7 +102,10 @@ pub fn diff_markdown(
         .collect();
     let (la, lb) = (col_label(baseline, "A"), col_label(candidate, "B"));
     for op in ops {
-        out.push_str(&format!("\n## `{op}`\n"));
+        // Op names are report content in an inline-Markdown context (unlike the regression
+        // renderer's raw-HTML <summary>, Markdown stays active here) — a backtick or newline in a
+        // name could terminate the span or the heading, so render <code> with the full chain.
+        out.push_str(&format!("\n## <code>{}</code>\n", md_cell(&md_inline(&html_escape(op)))));
         // A capability-skipped op has no levels, so its tables render empty — say why instead
         // (design Phase 6 §3.5), per side; reasons are manifest content, hence HTML-escaped.
         if let Some(note) = diff_skip_note(baseline, candidate, op, &la, &lb) {
@@ -872,7 +875,7 @@ mod tests {
         let md = diff_markdown(&a, &b, &["server image changed: x → y".to_string()]);
         assert!(md.contains("Synthetic benchmark diff"));
         assert!(md.contains("4.20.1") && md.contains("4.20.2"));
-        assert!(md.contains("## `match_by_index`"));
+        assert!(md.contains("## <code>match\\_by\\_index</code>"));
         assert!(md.contains("cached (plan reused"));
         // p50 delta +10.0%, throughput delta -10.0%.
         assert!(md.contains("+10.0%"), "expected latency +10%: {md}");
@@ -899,7 +902,7 @@ mod tests {
         // Drop B's only op so A-only ops render with "—".
         b.operations.clear();
         let md = diff_markdown(&a, &b, &[]);
-        assert!(md.contains("## `match_by_index`"));
+        assert!(md.contains("## <code>match\\_by\\_index</code>"));
         assert!(md.contains("| 1 | 1.000"), "A cell present");
         assert!(md.contains("| — |") || md.contains(" — "), "B cell missing marker: {md}");
     }
@@ -924,7 +927,7 @@ mod tests {
             o.skipped = Some("engine lacks procedure 'algo.maxFlow' <v2&up>".to_string());
         }
         let md = diff_markdown(&a, &b, &[]);
-        assert!(md.contains("## `match_by_index`"));
+        assert!(md.contains("## <code>match\\_by\\_index</code>"));
         assert!(
             md.contains(
                 "⏭ skipped on both sides — engine lacks procedure 'algo.maxFlow' &lt;v2&amp;up&gt;"
@@ -982,6 +985,20 @@ mod tests {
             Some("lacks `algo_x` *v2*".to_string());
         let md = diff_markdown(&a2, &b2, &[]);
         assert!(md.contains(r"lacks \`algo\_x\` \*v2\*"), "markdown specials not escaped: {md}");
+    }
+
+    #[test]
+    fn diff_op_headings_render_hostile_names_inert() {
+        // Op names are report content: a backtick or newline in a name must not terminate the
+        // heading's code styling or inject Markdown/HTML into the diff.
+        let a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        let hostile = "evil`op\nx*<b>&y";
+        let op = b.operations.remove("match_by_index").unwrap();
+        b.operations.insert(hostile.to_string(), op);
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("## <code>evil\\`op<br>x\\*&lt;b&gt;&amp;y</code>"), "{md}");
+        assert!(!md.contains(hostile), "raw hostile name leaked: {md}");
     }
 
     #[test]

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -432,7 +432,12 @@ impl Report {
         }
 
         for (name, op) in &self.operations {
-            out.push_str(&format!("\n## `{}`\n", name));
+            // Same escaping as the plain diff's op headings: names are report content and the
+            // heading is an inline-Markdown context, so backticks/newlines must render inert.
+            out.push_str(&format!(
+                "\n## <code>{}</code>\n",
+                md_cell(&md_inline(&html_escape(name)))
+            ));
             if let Some(reason) = &op.skipped {
                 out.push_str(&format!(
                     "\n_⏭ skipped — {}_\n",
@@ -881,7 +886,7 @@ mod tests {
             "hostname must stay out of the markdown"
         );
         // Per-op section, markdown table header, both cache modes, knee, and compilation table.
-        assert!(md.contains("## `return_const`"));
+        assert!(md.contains("## <code>return\\_const</code>"));
         assert!(md.contains("| C | throughput (ops/s) |"));
         assert!(md.contains("cached — plan reused"));
         assert!(md.contains("uncached — plan-cache miss"));
@@ -892,14 +897,16 @@ mod tests {
     #[test]
     fn markdown_and_console_agree_on_numbers() {
         // The shared row model means a level's throughput renders identically in both surfaces.
+        // Op names differ by design: the Markdown heading escapes inline specials (e.g. `_`), so
+        // it is asserted in its escaped form.
         let r = sample_report();
         let (console, md) = (r.to_console(), r.to_markdown());
-        for needle in ["2950", "return_const"] {
-            assert!(
-                console.contains(needle) && md.contains(needle),
-                "both surfaces must render {needle}"
-            );
-        }
+        assert!(
+            console.contains("2950") && md.contains("2950"),
+            "both surfaces must render 2950"
+        );
+        assert!(console.contains("return_const"), "console renders the raw op name");
+        assert!(md.contains("return\\_const"), "markdown renders the escaped op name");
     }
 
     #[test]
@@ -1142,6 +1149,18 @@ mod tests {
         let legacy: OperationReport = serde_json::from_str(r#"{"levels": []}"#).unwrap();
         assert_eq!(legacy.skipped, None);
         assert!(!sample_report().to_console().contains("skipped —"));
+    }
+
+    #[test]
+    fn op_headings_render_hostile_names_inert_in_the_markdown_report() {
+        // Op names are report content: a backtick or newline in a name must not terminate the
+        // heading's code styling or inject Markdown/HTML into the report.
+        let mut report = sample_report();
+        let op = report.operations.remove("return_const").unwrap();
+        report.operations.insert("evil`op\nx*<b>&y".to_string(), op);
+        let md = report.to_markdown();
+        assert!(md.contains("## <code>evil\\`op<br>x\\*&lt;b&gt;&amp;y</code>"), "{md}");
+        assert!(!md.contains("evil`op\nx*<b>&y"), "raw hostile name leaked: {md}");
     }
 
     #[test]


### PR DESCRIPTION
## What

Two post-merge CodeRabbit findings from #262 (they raced the merge — threads linked below), landed as a focused follow-up.

### 1. Op headings render report content inert (major)

`report --diff` and the replay report interpolated op names into a Markdown ATX heading code span:

```text
## `{op}`
```

Op names are report content, and an ATX heading is an **inline-Markdown context** — unlike the regression renderer's `<summary>`, whose raw-HTML span keeps Markdown inert. A backtick in a name terminates the code span; a CR/LF terminates the heading and injects a fresh Markdown block into the PR comment. Both surfaces now render the heading through the same chain the skip notes use (`html_escape` → `md_inline` → `md_cell`, from the #262 escaping work), as HTML `<code>`:

```text
## <code>match\_by\_index</code>
```

which GitHub renders identically to the old form for sane names. A hostile name like ``evil`op\nx*<b>&y`` now renders inert as:

```text
## <code>evil\`op<br>x\*&lt;b&gt;&amp;y</code>
```

Tests pin both surfaces (`diff_op_headings_render_hostile_names_inert`, `op_headings_render_hostile_names_inert_in_the_markdown_report`). Two consumers of the old heading shape are updated in the same commit: the `synthetic-verify` awk header/detail split (`/^## <code>/` — verified end-to-end locally, see Validation) and the cookbook's sample diff excerpt.

### 2. §9.1 documents the single registry probe (minor)

The Phase 6 amendment in `docs/design/synthetic-three-way-report.md` said the replayer probes the engine "for each op's required procedure". The implementation issues **one** `CALL dbms.procedures()` registry probe per run — and only when ≥1 manifest op names a capability — then evaluates every op locally against that snapshot (`src/synthetic/replay.rs`). The doc now states exactly that.

## Validation

- `just ci` ✅ (build + clippy `-D warnings` + 393 lib tests + doctests)
- `just coverage` ✅ (393 lib + 27 live against a throwaway `falkordb:edge`) — **patch coverage 100%** (31/31 executable added lines)
- `just doc-links` ✅ · `just doc-shell` ✅
- `just synthetic-verify` ✅ (full local run: record → 2× replay → diff → report assembly; the new awk split produces the same hdr/detail layout — metadata table before `<details>`, all 50 op sections inside)

## Review threads

- https://github.com/FalkorDB/benchmark/pull/262#discussion_r3651077790 (docs)
- https://github.com/FalkorDB/benchmark/pull/262#discussion_r3651077792 (headings)
