### PR TITLE
feat(synthetic): write-capable record/replay — Phase 7 latency tier (all 10 write shapes)

### DIFF
--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -134,7 +134,8 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 4. ⛔ **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count
    `detach_delete_user`.
 5. ⛔ **Concurrency** — decide C>1 (per-worker id partitioning) or keep C=1 for correctness.
-6. ⛔ **Docs.**
+6. 🚧 **Docs** — folded into each phase's PR (doc sync is part of each phase's definition of
+   done): §6.1's readme + cookbook updates shipped with phase 1.
 
 ## 7. Risks & open questions
 1. **Reset cost / throughput accounting (§3.3)** — per-invocation restore is expensive and pollutes

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -125,16 +125,16 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
   gate or the A/B `--query-profile`.
 
 ## 6. Phasing (each its own PR)
-1. **Write-capable record/replay (latency-only):** versioned bundle with hashed write kind,
+1. ✅ **Write-capable record/replay (latency-only):** versioned bundle with hashed write kind,
    recorded-write worker, `GRAPH.QUERY` measure path, periodic base reset. Latency tier for all 10.
-2. **Generalized outcome model + full `MutationStats`** (`relationships_deleted`/`properties_removed`/
+2. ⛔ **Generalized outcome model + full `MutationStats`** (`relationships_deleted`/`properties_removed`/
    `labels_removed`); per-invocation restore primitive.
-3. **Online outcome oracle** at record time (capture per-command stats+result), C=1 correctness tier
+3. ⛔ **Online outcome oracle** at record time (capture per-command stats+result), C=1 correctness tier
    for the deterministic subset.
-4. **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count
+4. ⛔ **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count
    `detach_delete_user`.
-5. **Concurrency** — decide C>1 (per-worker id partitioning) or keep C=1 for correctness.
-6. **Docs.**
+5. ⛔ **Concurrency** — decide C>1 (per-worker id partitioning) or keep C=1 for correctness.
+6. ⛔ **Docs.**
 
 ## 7. Risks & open questions
 1. **Reset cost / throughput accounting (§3.3)** — per-invocation restore is expensive and pollutes

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -1,7 +1,10 @@
 # Design — cover the A/B benchmark's write shapes in the synthetic check (Phase 7)
 
-**Status:** proposal for review — **not implemented**. Draft for maintainer review before any code
-(per the workflow). **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+**Status:** §6.1 **implemented** (write-capable record/replay, latency tier for all 10 write
+shapes — recording format v2 with kind-bound `workload_hash`, `--repo-writes` selector,
+`GRAPH.QUERY` C=1 measure path with per-cell base reset + verified error-safe final restore);
+§6.2–§6.5 (outcome model, online oracle / correctness tier, prepared-state variants, concurrency)
+**not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
 merged in PRs #240–#250) and is the sibling of the algorithms design (Phase 6). The parent design

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -229,6 +229,26 @@ Algorithms never enter `--repo-reads full` or the per-PR `synthetic-verify` gate
 graph is already simple (no parallel `:Friend` edges) with `bench_capacity` on every edge, so the
 flow/MSF shapes need no extra fixture.
 
+**Variant — the opt-in write shapes.** `--repo-writes` records the A/B benchmark's 10 write shapes
+(`CREATE`/`SET`/`MERGE`/`DETACH DELETE`/`REMOVE`/`FOREACH`) as a **single-kind write bundle** —
+mutually exclusive with every read selector:
+
+```bash
+# The 10 write shapes as their own bundle (recording format v2 — the hash binds each op's kind):
+benchmark synthetic record --repo-writes --nodes 1000 --edges 5000 --seed 7 --out-dir rec-writes
+benchmark synthetic run --recording rec-writes --endpoint falkor://127.0.0.1:6379 --out writes.json
+```
+
+This is the **latency tier** of the writes design: replay measures each write shape via
+`GRAPH.QUERY` at its pinned **C=1 budget** (100 samples, warm-up 10), **resets the base graph
+before every measured cell** (op × cache mode) so mutation drift stays bounded, and asserts
+**nothing** about results or mutation counters (`result_digest` stays `null` — outcomes are state-
+and value-dependent). The replay finishes with an **error-safe final restore**: on success *and*
+failure the recorded base is reloaded and its node/edge **content digests** are verified against
+the pristine post-load capture, so the endpoint's graph is provably left exactly as recorded.
+`--no-load` is refused for write bundles. Writes never enter `--repo-reads`, any tier, or the
+per-PR `synthetic-verify` gate.
+
 ---
 
 <a id="story-4"></a>

--- a/readme.md
+++ b/readme.md
@@ -534,8 +534,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   about write results or counters (`result_digest` stays `null`; latency tier). The replay ends
   with an **error-safe final restore** — on success *and* failure the recorded base is reloaded
   and its node/edge **content digests** are verified against the pristine post-load capture, so a
-  write replay never leaves a mutated graph behind. `--no-load` is refused for write bundles, and
-  a bundle can never mix reads with writes.
+  write replay never silently leaves a mutated graph behind (a dual measurement+restore failure
+  surfaces **both** errors). `--no-load` is refused for write bundles, a bundle can never mix
+  reads with writes, and a write op can never be capability-gated (capabilities are unhashed, so
+  a crafted one could otherwise skip-shrink the ten-shape coverage).
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is

--- a/readme.md
+++ b/readme.md
@@ -492,6 +492,18 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   **never** part of `--repo-reads full` nor the per-PR `synthetic-verify` gate. They need no extra
   fixture — every generated graph is **simple** (no parallel `:Friend` edges, which `algo.maxFlow`
   rejects) and every `:Friend` edge carries the `bench_capacity` property the flow/MSF shapes use.
+  **`--repo-writes`** records the A/B benchmark's **10 write shapes** from `queries_repository`
+  (`CREATE`/`SET`/`MERGE`/`DETACH DELETE`/`REMOVE`/`FOREACH` — e.g. `single_vertex_write`,
+  `merge_friend_edge_upsert`, `detach_delete_user`) as a **single-kind write bundle** in
+  **recording format v2**, whose `workload_hash` additionally binds each op's read/write **kind**
+  (v1 read bundles hash byte-identically to before). Same render-once discipline and full
+  256-command corpora as the reads; no fixture. Every write shape pins a **C=1 budget**
+  (100 samples, warm-up 10) and is **result-N/A by design** — this is the **latency tier** of the
+  writes design: mutation outcomes (result stats/counters) are state- and value-dependent, so
+  nothing is asserted about them. Write bundles are single-kind, so `--repo-writes` is mutually
+  exclusive with **every** read selector (`--op`/`--all-reads`/`--tier`/`--repo-reads`/
+  `--repo-algorithms`); writes never enter `--repo-reads`, any tier, or the per-PR
+  `synthetic-verify` gate.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result
@@ -514,6 +526,16 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   for a load-once / run-many flow (still count-verifying first). `just synthetic-replay <name>
   <endpoint>` wraps this. Pass **`--label <name>`** (e.g. `pr`/`main`) to name the run — the label
   becomes the column header in `report --diff`/`--regression`.
+  A **write bundle** (recorded with `--repo-writes`) replays through `GRAPH.QUERY` (writes are
+  rejected by the read path's `GRAPH.RO_QUERY`) at **C=1 only** — the guard refuses any other
+  effective sweep, since budgets sit outside the `workload_hash` and could otherwise be tampered
+  wider — and the base graph is **reset (drop + reload + count-verify) before every measured
+  cell** (op × cache mode), bounding mutation drift to one cell's invocations. Nothing is asserted
+  about write results or counters (`result_digest` stays `null`; latency tier). The replay ends
+  with an **error-safe final restore** — on success *and* failure the recorded base is reloaded
+  and its node/edge **content digests** are verified against the pristine post-load capture, so a
+  write replay never leaves a mutated graph behind. `--no-load` is refused for write bundles, and
+  a bundle can never mix reads with writes.
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -547,6 +547,12 @@ pub enum SyntheticCommands {
         )]
         repo_algorithms: bool,
         #[arg(
+            long = "repo-writes",
+            conflicts_with_all = ["ops", "all_reads", "tier", "repo_reads", "repo_algorithms"],
+            help = "record the A/B benchmark's 10 WRITE shapes from queries_repository (CREATE/SET/MERGE/DELETE/REMOVE/FOREACH) as a write bundle (recording format v2; the workload_hash binds each op's read/write kind). Replay measures them via GRAPH.QUERY at C=1 only, resetting the base graph before every measured cell and restoring + content-verifying it afterwards; results/counters are NOT asserted (latency tier). Write bundles are single-kind: mutually exclusive with every read selector."
+        )]
+        repo_writes: bool,
+        #[arg(
             long,
             help = "seed for the dataset and the per-operation corpora (same seed + same tool build ⇒ identical bundle; default 0)"
         )]

--- a/src/queries_repository.rs
+++ b/src/queries_repository.rs
@@ -296,6 +296,12 @@ impl QueriesRepository {
         &self.algorithm_read_query_names
     }
 
+    /// The write shape names, in definition order — the mutation shapes the synthetic check
+    /// records via [`Self::render_write_with_rng`] (Phase 7 §1, selected by `--repo-writes`).
+    pub fn write_names(&self) -> &[String] {
+        &self.write_query_names
+    }
+
     /// Render the read shape `name` from a caller-supplied RNG, so a fixed seed yields a
     /// byte-identical Cypher+params corpus (design §4.1 — the seedable entry the record-once /
     /// replay-verbatim synthetic path renders each shape's corpus with). Returns `None` if `name`
@@ -332,6 +338,25 @@ impl QueriesRepository {
             name.to_string(),
             generator.query_type,
             generator.generate_with_path(rng, path),
+        ))
+    }
+
+    /// Render the write shape `name` from a caller-supplied RNG — [`Self::render_read_with_rng`]
+    /// for the write pool (Phase 7 §3.1: the seedable entry the record-once / replay-verbatim
+    /// synthetic path renders each write shape's corpus with). Returns `None` if `name` is not a
+    /// known write shape.
+    pub fn render_write_with_rng(
+        &self,
+        name: &str,
+        rng: &mut dyn Rng,
+    ) -> Option<PreparedQuery> {
+        let generator = self.write_queries.get(name)?;
+        let q_id = *self.name_to_id.get(name)?;
+        Some(PreparedQuery::new(
+            q_id,
+            name.to_string(),
+            generator.query_type,
+            generator.generate_with_rng(rng),
         ))
     }
 
@@ -426,6 +451,12 @@ impl UsersQueriesRepository {
         self.queries_repository.algorithm_read_names()
     }
 
+    /// The write shape names, in definition order (Phase 7 §1) — the 10 mutation shapes the
+    /// synthetic check records via [`Self::render_write_with_rng`].
+    pub fn write_names(&self) -> &[String] {
+        self.queries_repository.write_names()
+    }
+
     /// Render the read shape `name` from a caller-supplied RNG (record-once determinism, §4.1).
     /// Returns `None` if `name` is not a known read shape.
     pub fn render_read_with_rng(
@@ -445,6 +476,16 @@ impl UsersQueriesRepository {
         path: (i32, i32),
     ) -> Option<PreparedQuery> {
         self.queries_repository.render_read_with_path(name, rng, path)
+    }
+
+    /// Render the write shape `name` from a caller-supplied RNG (Phase 7 §3.1 — record-once
+    /// determinism for the write corpus). Returns `None` if `name` is not a known write shape.
+    pub fn render_write_with_rng(
+        &self,
+        name: &str,
+        rng: &mut dyn Rng,
+    ) -> Option<PreparedQuery> {
+        self.queries_repository.render_write_with_rng(name, rng)
     }
 
     pub fn random_queries(
@@ -1507,5 +1548,82 @@ mod tests {
         assert!(repo.render_read_with_rng("no_such_shape", &mut rand::rng()).is_none());
         // A write shape is not a read and must not render through the read seam.
         assert!(repo.render_read_with_rng("single_vertex_write", &mut rand::rng()).is_none());
+    }
+
+    #[test]
+    fn write_names_are_the_ten_write_shapes_in_definition_order() {
+        let repo = UsersQueriesRepository::new(
+            100,
+            1000,
+            Flavour::FalkorDB,
+            AlgorithmQuerySelection::default(),
+            QueryCoverageProfile::Baseline,
+        );
+        // The write pool is profile-independent (registered unconditionally), so the Baseline
+        // profile sees all 10 writes — in definition order (Phase 7 §1).
+        let names: Vec<&str> = repo.write_names().iter().map(String::as_str).collect();
+        assert_eq!(
+            names,
+            vec![
+                "single_vertex_write",
+                "single_vertex_update",
+                "single_edge_update",
+                "single_edge_write",
+                "merge_user_insert_path",
+                "merge_user_upsert_existing",
+                "merge_friend_edge_upsert",
+                "detach_delete_user",
+                "remove_user_property_and_label",
+                "foreach_loop_mutation",
+            ]
+        );
+        // Every name resolves to a Write shape through the write render seam.
+        for name in &names {
+            let prepared = repo
+                .render_write_with_rng(name, &mut rand::rng())
+                .unwrap_or_else(|| panic!("write shape '{name}' must be renderable"));
+            assert_eq!(prepared.q_type, QueryType::Write, "'{name}' must render as a write");
+        }
+    }
+
+    #[test]
+    fn render_write_with_rng_is_byte_identical_for_a_fixed_seed() {
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+
+        let repo = UsersQueriesRepository::new(
+            1000,
+            5000,
+            Flavour::FalkorDB,
+            AlgorithmQuerySelection::default(),
+            QueryCoverageProfile::Baseline,
+        );
+        // Same record-once / replay-verbatim property as the read seam, for a randomised write.
+        let corpus = |seed: u64| -> Vec<String> {
+            let mut rng = StdRng::seed_from_u64(seed);
+            (0..64)
+                .map(|_| {
+                    repo.render_write_with_rng("merge_friend_edge_upsert", &mut rng)
+                        .expect("shape present")
+                        .cypher
+                })
+                .collect()
+        };
+        assert_eq!(corpus(0xA11CE), corpus(0xA11CE));
+        assert_ne!(corpus(0xA11CE), corpus(0xB0B));
+    }
+
+    #[test]
+    fn render_write_with_rng_rejects_unknown_and_non_write_shapes() {
+        let repo = UsersQueriesRepository::new(
+            100,
+            1000,
+            Flavour::FalkorDB,
+            AlgorithmQuerySelection::default(),
+            QueryCoverageProfile::Baseline,
+        );
+        assert!(repo.render_write_with_rng("no_such_shape", &mut rand::rng()).is_none());
+        // A read shape is not a write and must not render through the write seam.
+        assert!(repo.render_write_with_rng("single_vertex_read", &mut rand::rng()).is_none());
     }
 }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1472,6 +1472,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             tier,
             repo_reads,
             repo_algorithms,
+            repo_writes,
             seed,
             nodes,
             edges,
@@ -1481,14 +1482,14 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let ops = crate::cli::expand_op_selectors(&ops);
             // Reuse the run-config resolution (with generate=true) to validate + resolve the
             // dataset knobs, graph and read-op selection, then record OFFLINE (no server).
-            // `--repo-reads`/`--repo-algorithms` select repo SHAPES implicitly (not catalog ops),
-            // so they force `all_reads` only to satisfy op resolution; the resolved ops are
-            // ignored below.
+            // `--repo-reads`/`--repo-algorithms`/`--repo-writes` select repo SHAPES implicitly
+            // (not catalog ops), so they force `all_reads` only to satisfy op resolution; the
+            // resolved ops are ignored below.
             let overrides = config::CliOverrides {
                 endpoint: None,
                 graph,
                 ops,
-                all_reads: all_reads || repo_reads.is_some() || repo_algorithms,
+                all_reads: all_reads || repo_reads.is_some() || repo_algorithms || repo_writes,
                 tier,
                 samples: None,
                 warmup: None,
@@ -1510,7 +1511,26 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let spec = resolved.dataset.ok_or_else(|| {
                 OtherError("record requires --nodes/--edges (or a config) to generate a dataset".to_string())
             })?;
-            let manifest = if repo_reads.is_some() || repo_algorithms {
+            let manifest = if repo_writes {
+                // Phase 7: record the 10 opt-in write shapes as a single-kind write bundle
+                // (recording format v2 — the workload_hash binds each op's kind). Same
+                // render-once discipline as the read shapes; no fixture (writes address the plain
+                // generated dataset). `--repo-writes` conflicts with every read selector, so a
+                // bundle is never mixed.
+                let recorded = crate::synthetic::shapes::record_repo_writes(
+                    spec.nodes as i32,
+                    spec.edges as i32,
+                    resolved.seed,
+                )?;
+                recording::record_rendered(
+                    &spec,
+                    &resolved.graph,
+                    &recorded,
+                    resolved.seed,
+                    DATASET_LOAD_BATCH,
+                    std::path::Path::new(&out_dir),
+                )?
+            } else if repo_reads.is_some() || repo_algorithms {
                 // Phase 3/4/5: record the queries_repository read shapes (Baseline reads +
                 // ExtendedCore `temporal_spatial_roundtrip` + the FixtureDependent fulltext/vector
                 // reads); Phase 6: optionally append the 4 opt-in algorithm shapes
@@ -2351,6 +2371,7 @@ mod tests {
             tier: Some(Tier::Core),
             repo_reads: None,
             repo_algorithms: false,
+            repo_writes: false,
             seed: Some(3),
             nodes: Some(200),
             edges: Some(600),
@@ -2390,6 +2411,7 @@ mod tests {
             tier: None,
             repo_reads: Some(Tier::Core),
             repo_algorithms: false,
+            repo_writes: false,
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
@@ -2436,6 +2458,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_command_record_offline_records_repo_write_shapes_and_replay_guards_hold() {
+        // `synthetic record --repo-writes` runs OFFLINE (no server): it writes a format-v2 write
+        // bundle containing exactly the 10 write shapes (Phase 7 §3.1), each kind=Write, un-gated,
+        // budgeted C=[1]. Then the replay guards are exercised through the REAL `replay::run` path
+        // against that bundle — both fail offline, before any connection (bogus endpoint).
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let out_dir = std::env::temp_dir().join(format!(
+            "syn-rec-repowrites-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let command = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: Some("grepowrites".to_string()),
+            ops: vec![],
+            all_reads: false,
+            tier: None,
+            repo_reads: None,
+            repo_algorithms: false,
+            repo_writes: true,
+            seed: Some(7),
+            nodes: Some(300),
+            edges: Some(900),
+            out_dir: out_dir.to_string_lossy().into_owned(),
+        };
+        run_command(command)
+            .await
+            .expect("offline repo-writes record succeeds without a server");
+        let manifest_path = out_dir.join("manifest.json");
+        let bundle = recording::load(&out_dir).expect("write bundle loads");
+        assert_eq!(bundle.manifest.format_version, 2, "write bundles are format v2");
+        let expected: Vec<&str> =
+            crate::synthetic::shapes::write_shapes().iter().map(|s| s.name).collect();
+        let recorded: Vec<&str> = bundle.manifest.ops.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(recorded, expected, "exactly the 10 write shapes, in definition order");
+        for entry in &bundle.manifest.ops {
+            assert_eq!(entry.kind, QueryType::Write, "{}", entry.name);
+            assert!(!entry.result_gated, "{} is latency-tier (§4.1)", entry.name);
+            assert_eq!(
+                entry.budget.concurrency.as_deref(),
+                Some(&[1][..]),
+                "{} must pin C=[1]",
+                entry.name
+            );
+        }
+        // Guard 1 through the real path: --no-load is forbidden for a write bundle…
+        let mut replay_cfg = crate::synthetic::replay::ReplayConfig {
+            recording_dir: out_dir.clone(),
+            endpoint: "falkor://127.0.0.1:1".to_string(),
+            graph: None,
+            load: false,
+            samples: 2,
+            warmup: 0,
+            concurrency: vec![1],
+            cache: CacheSelection::Cached,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: out_dir.join("unused.json").to_string_lossy().into_owned(),
+            server_image: None,
+            label: None,
+        };
+        let err = crate::synthetic::replay::run(&replay_cfg).await.unwrap_err();
+        assert!(
+            format!("{err}").contains("--no-load is not supported for a write bundle"),
+            "got: {err}"
+        );
+        // …guard 2: a tampered budget sweep (budgets are OUTSIDE workload_hash, so the load hash
+        // gate passes) is refused by the C=1 check, still offline.
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        manifest["ops"][0]["budget"]["concurrency"] = serde_json::json!([8]);
+        std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+        replay_cfg.load = true;
+        let err = crate::synthetic::replay::run(&replay_cfg).await.unwrap_err();
+        assert!(format!("{err}").contains("write replay is C=1 only"), "got: {err}");
+        std::fs::remove_dir_all(&out_dir).ok();
+    }
+
+    #[tokio::test]
     async fn run_command_record_offline_repo_reads_full_bakes_the_fixture() {
         // `synthetic record --repo-reads full` runs OFFLINE: it records the FixtureDependent
         // fulltext/vector reads (Phase 5) as non-gated (result-N/A) ops AND bakes the fulltext/vector
@@ -2456,6 +2558,7 @@ mod tests {
             tier: None,
             repo_reads: Some(Tier::Full),
             repo_algorithms: false,
+            repo_writes: false,
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
@@ -2523,6 +2626,7 @@ mod tests {
             tier: None,
             repo_reads: Some(Tier::Full),
             repo_algorithms: false,
+            repo_writes: false,
             seed: Some(7),
             nodes: Some(1000),
             edges: Some(5000),
@@ -2561,6 +2665,7 @@ mod tests {
             tier: None,
             repo_reads: None,
             repo_algorithms: true,
+            repo_writes: false,
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
@@ -2626,6 +2731,7 @@ mod tests {
             tier: None,
             repo_reads: Some(Tier::Full),
             repo_algorithms: true,
+            repo_writes: false,
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -38,8 +38,19 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// On-disk bundle format version. Bumped when the bundle layout changes incompatibly.
+/// On-disk bundle format version for **read-only** bundles — the original format, kept
+/// byte-identical (including [`Manifest::workload_hash`]) so existing read bundles and their
+/// goldens never change (Phase 7 §7.5).
 pub const RECORDING_FORMAT_VERSION: u32 = 1;
+
+/// On-disk bundle format version for bundles containing **write** ops (Phase 7 §3.1): the op
+/// **kind** is folded into the `workload_hash` (a v1 hash never covered kind — every v1 op is a
+/// read), so a bundle's read/write nature cannot be silently flipped. The version is
+/// content-determined at record time: any write op ⇒ v2, all-reads ⇒ v1.
+pub const RECORDING_FORMAT_VERSION_WRITES: u32 = 2;
+
+/// The newest bundle format this build can [`load`].
+const RECORDING_FORMAT_VERSION_MAX: u32 = RECORDING_FORMAT_VERSION_WRITES;
 
 /// The dataset knobs a bundle was recorded from (mirrors [`DatasetSpec`], but owned + serde).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -65,15 +76,17 @@ pub struct OpEntry {
     pub name: String,
     /// The op's read/write kind, so [`load`] can rebuild its [`OpKey`] — a built-in [`OpName`] or a
     /// string-keyed dynamic op. Defaults to `Read` for bundles written before this field existed
-    /// (v1 records reads only), and is **not** folded into the [`Manifest::workload_hash`].
+    /// (v1 records reads only). Under format v2+ (write bundles, Phase 7 §3.1) the kind **is**
+    /// folded into the [`Manifest::workload_hash`], so a bundle's read/write nature can't be
+    /// silently flipped; v1 (read-only) hashes never covered it and stay byte-identical.
     #[serde(default = "default_op_kind")]
     pub kind: QueryType,
     /// Whether this op's result is compared across the A/B (record-once / replay-verbatim) gate.
     /// `true` (the default, and the value for every built-in catalog op) means replay computes and
     /// gates a `result_digest`; `false` marks the op **result-N/A** — still recorded and timed, but
     /// its result is *not* gated, for shapes whose result set isn't byte-stable (LIMIT-without-
-    /// ORDER, top-k, float scores — design §3.2 / Decision 4). Like [`Self::kind`] it is **not**
-    /// folded into the [`Manifest::workload_hash`] (it's replay-gating policy, not workload content)
+    /// ORDER, top-k, float scores — design §3.2 / Decision 4). It is **not** folded into the
+    /// [`Manifest::workload_hash`] (it's replay-gating policy, not workload content)
     /// and defaults to `true` for bundles written before this field existed.
     #[serde(default = "default_result_gated")]
     pub result_gated: bool,
@@ -81,7 +94,7 @@ pub struct OpEntry {
     /// §3.4), so a heavy recorded shape (e.g. a whole-graph algorithm) can dial its own
     /// samples/warmup/concurrency/cache/timeouts down without perturbing the rest of the bundle.
     /// Defaults to full inheritance — the value for every op recorded before this field existed —
-    /// and an inherit budget is omitted when serializing. Like [`Self::kind`]/[`Self::result_gated`]
+    /// and an inherit budget is omitted when serializing. Like [`Self::result_gated`]
     /// it is **not** folded into the [`Manifest::workload_hash`] (replay policy, not workload
     /// content).
     #[serde(default, skip_serializing_if = "RecordedBudget::is_inherit")]
@@ -182,8 +195,9 @@ pub struct Bundle {
 /// Length-framed workload hasher. Every part is prefixed with its byte length (u64 LE) before the
 /// bytes, so no concatenation of parts can collide with a different split (e.g. `["ab","c"]` and
 /// `["a","bc"]` hash differently). Record (streaming) and [`load`] (from memory) feed it in the
-/// same order, so they agree iff the content matches.
-struct WorkloadHasher(Sha256);
+/// same order, so they agree iff the content matches. Under format v2+ each op header also feeds
+/// the op's read/write **kind** (v1 hashes stay byte-identical: every v1 op is a read).
+struct WorkloadHasher(Sha256, u32);
 
 impl WorkloadHasher {
     /// Start a hasher seeded with the bundle header (everything but the graph/command bodies).
@@ -194,7 +208,7 @@ impl WorkloadHasher {
         graph: &str,
         corpus_seed: u64,
     ) -> Self {
-        let mut h = WorkloadHasher(Sha256::new());
+        let mut h = WorkloadHasher(Sha256::new(), format_version);
         h.part(b"synthbench-recording");
         h.part(&format_version.to_le_bytes());
         h.part(generator_version.as_bytes());
@@ -226,15 +240,21 @@ impl WorkloadHasher {
         self.part(cypher.as_bytes());
     }
 
-    /// Feed one operation header (name + command count, tagged `O`).
+    /// Feed one operation header (name + command count, tagged `O`). Under format v2+ the op's
+    /// read/write `kind` follows (tagged `K`) — absent from v1 hashes, whose ops are all reads.
     fn op_header(
         &mut self,
         name: &str,
         count: usize,
+        kind: QueryType,
     ) {
         self.part(b"O");
         self.part(name.as_bytes());
         self.part(&(count as u64).to_le_bytes());
+        if self.1 >= RECORDING_FORMAT_VERSION_WRITES {
+            self.part(b"K");
+            self.part(command_kind(kind).as_bytes());
+        }
     }
 
     /// Feed one measured command (tagged `C`).
@@ -248,6 +268,14 @@ impl WorkloadHasher {
 
     fn finalize(self) -> String {
         format!("sha256:{:x}", self.0.finalize())
+    }
+}
+
+/// The `kind` string a [`CommandRecord`] (and the v2 hash) carries for the given [`QueryType`].
+fn command_kind(kind: QueryType) -> &'static str {
+    match kind {
+        QueryType::Read => "read",
+        QueryType::Write => "write",
     }
 }
 
@@ -294,7 +322,10 @@ pub fn render_commands(
 
 /// Record a workload bundle to `out_dir` (created if absent) for the given built-in catalog read
 /// `ops`. **Offline** — no server is contacted. Renders each op's corpus via [`render_commands`]
-/// then delegates to [`record_rendered`]; **write ops are rejected** (v1 records read ops only).
+/// then delegates to [`record_rendered`]; **catalog write ops are rejected** — their semantics
+/// depend on live scratch state ([`WritePlan`](crate::synthetic::catalog::OperationSpec) hooks),
+/// so they cannot be replayed verbatim. Recordable writes are the repo write *shapes*
+/// (`--repo-writes`, Phase 7 §1).
 pub fn record(
     dataset: &DatasetSpec,
     graph: &str,
@@ -303,11 +334,12 @@ pub fn record(
     batch_size: usize,
     out_dir: &Path,
 ) -> BenchmarkResult<Manifest> {
-    // Reject writes up-front — before rendering — so we never build a write op's corpus (v1 records
-    // reads only). [`record_rendered`] re-checks by kind for string-keyed callers.
+    // Reject catalog writes up-front — before rendering — so we never build a corpus whose
+    // semantics depend on the live write worker's scratch/reset hooks.
     if let Some(op) = ops.iter().find(|op| spec(**op).kind == QueryType::Write) {
         return Err(OtherError(format!(
-            "recording write op '{}' is not supported yet (v1 records read ops only)",
+            "catalog write op '{}' cannot be recorded (its scratch/reset hooks don't replay \
+             verbatim) — record the repo write shapes with --repo-writes instead",
             op.as_str()
         )));
     }
@@ -334,7 +366,10 @@ pub fn record(
 ///
 /// Writes `graph.jsonl` (the [`load_statements`] for `dataset`), `commands/<op>.jsonl` for each op,
 /// and `manifest.json` with the [`Manifest::workload_hash`]. `ops` are de-duplicated by name (first
-/// occurrence wins); **write ops are rejected** (v1 records read ops only). Returns the manifest.
+/// occurrence wins). Write ops are supported (Phase 7 §3.1) but **not mixed with reads** — replay
+/// has one global concurrency sweep, so a mixed bundle cannot express C=1 writes alongside swept
+/// reads (design §4); an all-write bundle is stamped format v2 (kind folded into the hash), an
+/// all-read bundle stays byte-identical v1. Returns the manifest.
 pub fn record_rendered(
     dataset: &DatasetSpec,
     graph: &str,
@@ -382,17 +417,29 @@ fn record_rendered_impl(
     if batch_size == 0 {
         return Err(OtherError("record batch_size must be greater than 0".to_string()));
     }
-    // Reject writes on the *original* ops (before dedup) so a duplicate-name write can't be dropped
-    // by dedup and slip through, and validate every name up-front (a name becomes a file stem).
+    // Validate every name up-front (a name becomes a file stem), and reject a mixed read+write
+    // bundle on the *original* ops (before dedup) so a duplicate name can't hide a kind. Replay
+    // has one global concurrency sweep — a mixed bundle cannot express C=1 writes alongside swept
+    // reads (Phase 7 §4), so read and write recordings stay separate bundles.
     for op in ops {
         validate_op_name(op.key.name())?;
-        if op.key.kind() == QueryType::Write {
-            return Err(OtherError(format!(
-                "recording write op '{}' is not supported yet (v1 records read ops only)",
-                op.key.name()
-            )));
-        }
     }
+    let has_writes = ops.iter().any(|op| op.key.kind() == QueryType::Write);
+    let has_reads = ops.iter().any(|op| op.key.kind() == QueryType::Read);
+    if has_writes && has_reads {
+        return Err(OtherError(
+            "cannot record a mixed read+write bundle — record writes (--repo-writes) separately \
+             from reads (replay measures the two under different policies)"
+            .to_string(),
+        ));
+    }
+    // Content-determined format version: any write op ⇒ v2 (kind folded into the workload hash);
+    // an all-read bundle stays v1, byte-identical to every bundle recorded before writes existed.
+    let format_version = if has_writes {
+        RECORDING_FORMAT_VERSION_WRITES
+    } else {
+        RECORDING_FORMAT_VERSION
+    };
     let ops = dedup_recorded(ops);
     if ops.is_empty() {
         return Err(OtherError(
@@ -410,7 +457,7 @@ fn record_rendered_impl(
         .map_err(|e| OtherError(format!("creating {}: {}", commands_dir.display(), e)))?;
 
     let mut hasher = WorkloadHasher::new(
-        RECORDING_FORMAT_VERSION,
+        format_version,
         GENERATOR_VERSION,
         &knobs,
         graph,
@@ -450,14 +497,14 @@ fn record_rendered_impl(
         if cyphers.is_empty() {
             return Err(OtherError(format!("operation '{}' produced an empty corpus", name)));
         }
-        hasher.op_header(name, cyphers.len());
+        hasher.op_header(name, cyphers.len(), op.key.kind());
         let path = commands_dir.join(format!("{}.jsonl", name));
         let mut w = BufWriter::new(create_file(&path)?);
         for (seq, cypher) in cyphers.iter().enumerate() {
             hasher.command(cypher);
             let rec = CommandRecord {
                 seq,
-                kind: "read".to_string(),
+                kind: command_kind(op.key.kind()).to_string(),
                 cypher: cypher.clone(),
             };
             write_jsonl(&mut w, &path, &rec)?;
@@ -475,7 +522,7 @@ fn record_rendered_impl(
     }
 
     let manifest = Manifest {
-        format_version: RECORDING_FORMAT_VERSION,
+        format_version,
         generator_version: GENERATOR_VERSION.to_string(),
         tool_version: env!("CARGO_PKG_VERSION").to_string(),
         dataset: knobs,
@@ -509,11 +556,25 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
         serde_json::from_slice(&bytes)
             .map_err(|e| OtherError(format!("parsing {}: {}", path.display(), e)))?
     };
-    if manifest.format_version != RECORDING_FORMAT_VERSION {
+    if manifest.format_version < RECORDING_FORMAT_VERSION
+        || manifest.format_version > RECORDING_FORMAT_VERSION_MAX
+    {
         return Err(OtherError(format!(
-            "unsupported recording format_version {} (this build expects {})",
-            manifest.format_version, RECORDING_FORMAT_VERSION
+            "unsupported recording format_version {} (this build supports {}..={})",
+            manifest.format_version, RECORDING_FORMAT_VERSION, RECORDING_FORMAT_VERSION_MAX
         )));
+    }
+    // A v1 bundle predates write support: every v1 op is a read and v1 hashes never covered kind,
+    // so a v1 manifest naming a write op is crafted/corrupt — reject it before the (kind-blind)
+    // v1 hash recompute could pass it.
+    if manifest.format_version < RECORDING_FORMAT_VERSION_WRITES {
+        if let Some(entry) = manifest.ops.iter().find(|e| e.kind == QueryType::Write) {
+            return Err(OtherError(format!(
+                "format_version {} bundle names write op '{}' — v1 bundles are read-only \
+                 (write bundles are format_version {}+)",
+                manifest.format_version, entry.name, RECORDING_FORMAT_VERSION_WRITES
+            )));
+        }
     }
 
     // graph.jsonl → ordered (phase, cypher).
@@ -576,7 +637,7 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
         hasher.graph_record(phase.tag(), cypher);
     }
     for ((_, cyphers), entry) in commands.iter().zip(&manifest.ops) {
-        hasher.op_header(&entry.name, cyphers.len());
+        hasher.op_header(&entry.name, cyphers.len(), entry.kind);
         for cypher in cyphers {
             hasher.command(cypher);
         }
@@ -756,7 +817,8 @@ mod tests {
             edges: 20,
         };
         let err = record(&spec, "g", &[OpName::CreateNode], 1, 8, &dir).unwrap_err();
-        assert!(format!("{}", err).contains("write op"), "got: {err}");
+        assert!(format!("{}", err).contains("catalog write op"), "got: {err}");
+        assert!(format!("{}", err).contains("--repo-writes"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -891,7 +953,9 @@ mod tests {
     }
 
     #[test]
-    fn record_rendered_rejects_write_kind_ops() {
+    fn record_rendered_writes_a_format_v2_write_bundle_that_round_trips() {
+        // A write-only bundle is stamped format v2 (Phase 7 §3.1): the op kind lands in the
+        // manifest, in every CommandRecord, and in the workload hash; `load` verifies it intact.
         let dir = temp_bundle_dir("synthrec-dynwrite");
         let spec = DatasetSpec {
             seed: 1,
@@ -900,13 +964,87 @@ mod tests {
         };
         let ops = vec![RecordedOp {
             key: OpKey::dynamic("bulk_insert", QueryType::Write),
-            result_gated: true,
+            result_gated: false,
             budget: RecordedBudget::default(),
             capability: None,
             commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
         }];
-        let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
-        assert!(format!("{}", err).contains("write op"), "got: {err}");
+        let manifest = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_WRITES);
+        assert_eq!(manifest.ops[0].kind, QueryType::Write);
+        // The on-disk command record carries the write kind.
+        let raw = std::fs::read_to_string(dir.join("commands").join("bulk_insert.jsonl")).unwrap();
+        let rec: CommandRecord = serde_json::from_str(raw.lines().next().unwrap()).unwrap();
+        assert_eq!(rec.kind, "write");
+        // And the bundle loads back with the kind preserved + the integrity gate green.
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.commands.len(), 1);
+        assert_eq!(bundle.commands[0].0.kind(), QueryType::Write);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn write_bundle_workload_hash_binds_the_op_kind() {
+        // Flipping a v2 bundle's op kind in the manifest must fail the hash recompute on `load` —
+        // the kind is hashed (v2), so a bundle's read/write nature can't be silently flipped.
+        let dir = temp_bundle_dir("synthrec-kindflip");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("w", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["CYPHER  CREATE (n)".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        let path = dir.join("manifest.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        manifest["ops"][0]["kind"] = serde_json::json!("Read");
+        std::fs::write(&path, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{err}").contains("workload_hash mismatch"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_v1_bundle_naming_a_write_op() {
+        // A v1 manifest naming a write op is crafted/corrupt (v1 predates writes, and its hash
+        // never covered kind) — rejected explicitly, before the kind-blind v1 hash recompute.
+        let dir = temp_bundle_dir("synthrec-v1write");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("w", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["CYPHER  CREATE (n)".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        let path = dir.join("manifest.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        manifest["format_version"] = serde_json::json!(1);
+        std::fs::write(&path, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{err}").contains("v1 bundles are read-only"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_bundles_stay_format_v1() {
+        // The format version is content-determined: an all-read bundle must keep writing v1 so
+        // every pre-Phase-7 read bundle, hash and golden stays byte-identical (§7.5).
+        let (dir, manifest) = record_to_temp(17);
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION);
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -992,9 +1130,10 @@ mod tests {
     }
 
     #[test]
-    fn record_rendered_rejects_a_write_hidden_behind_a_duplicate_read() {
-        // The write check runs on the original ops (before dedup), so a later same-named write is
-        // caught rather than dropped by first-occurrence dedup.
+    fn record_rendered_rejects_a_mixed_read_write_bundle() {
+        // The kind check runs on the original ops (before dedup), so a same-named write behind a
+        // read is caught rather than dropped by first-occurrence dedup. Mixed bundles are rejected
+        // outright: replay measures reads and writes under different policies (Phase 7 §4).
         let dir = temp_bundle_dir("synthrec-dupwrite");
         let spec = DatasetSpec {
             seed: 1,
@@ -1018,7 +1157,7 @@ mod tests {
             },
         ];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
-        assert!(format!("{err}").contains("write op"), "got: {err}");
+        assert!(format!("{err}").contains("mixed read+write bundle"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -1303,13 +1442,32 @@ mod tests {
     #[test]
     fn workload_hash_is_length_framed() {
         // ["ab","c"] and ["a","bc"] must not collide — the length prefix disambiguates.
-        let mut h1 = WorkloadHasher(Sha256::new());
+        let mut h1 = WorkloadHasher(Sha256::new(), RECORDING_FORMAT_VERSION);
         h1.part(b"ab");
         h1.part(b"c");
-        let mut h2 = WorkloadHasher(Sha256::new());
+        let mut h2 = WorkloadHasher(Sha256::new(), RECORDING_FORMAT_VERSION);
         h2.part(b"a");
         h2.part(b"bc");
         assert_ne!(h1.finalize(), h2.finalize());
+    }
+
+    #[test]
+    fn op_header_hashes_the_kind_only_under_v2() {
+        // v1 op headers are kind-blind (byte-compat with every pre-Phase-7 bundle); v2 headers
+        // fold the kind in, so read- and write-kinded ops hash differently under v2 only.
+        let hash = |version: u32, kind: QueryType| {
+            let mut h = WorkloadHasher(Sha256::new(), version);
+            h.op_header("op", 1, kind);
+            h.finalize()
+        };
+        assert_eq!(
+            hash(RECORDING_FORMAT_VERSION, QueryType::Read),
+            hash(RECORDING_FORMAT_VERSION, QueryType::Write)
+        );
+        assert_ne!(
+            hash(RECORDING_FORMAT_VERSION_WRITES, QueryType::Read),
+            hash(RECORDING_FORMAT_VERSION_WRITES, QueryType::Write)
+        );
     }
 
     #[test]

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -439,6 +439,17 @@ fn record_rendered_impl(
             .to_string(),
         ));
     }
+    // The write latency tier asserts nothing (Phase 7 §4.1), so a result-gated write op could be
+    // recorded but never replayed (replay hard-rejects it) — fail early here instead.
+    if let Some(op) =
+        ops.iter().find(|op| op.key.kind() == QueryType::Write && op.result_gated)
+    {
+        return Err(OtherError(format!(
+            "write op '{}' is marked result-gated — the write latency tier asserts nothing \
+             (Phase 7 §4.1), so a result-gated write bundle could never be replayed",
+            op.key.name()
+        )));
+    }
     // The write latency tier is algorithm-free plain Cypher (Phase 7 §4.1): no engine procedure to
     // probe for, so a capability on a write op is meaningless — and `capability` is outside the
     // workload hash, so replay independently re-rejects it (a capability-skip would silently
@@ -1270,6 +1281,32 @@ mod tests {
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
         assert!(format!("{err}").contains("never capability-gated"), "got: {err}");
         assert!(format!("{err}").contains("algo.maxFlow"), "must name the capability: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_rejects_a_result_gated_write_op() {
+        // Phase 7 §4.1: the write latency tier asserts nothing, and replay hard-rejects a
+        // result-gated write — so recording one would produce a bundle that can never be
+        // replayed. Fail early, naming the op.
+        let dir = temp_bundle_dir("synthrec-writegated");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("w_gated", QueryType::Write),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["CREATE (n)".to_string()],
+        }];
+        let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("could never be replayed"), "got: {msg}");
+        assert!(msg.contains("w_gated"), "must name the op: {msg}");
+        assert!(!dir.join("manifest.json").exists(), "nothing may be written");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -180,6 +180,9 @@ pub struct GraphRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommandRecord {
     pub seq: usize,
+    /// The op's read/write kind tag (`"read"`/`"write"`). Informational on disk and **not** part
+    /// of the workload hash, so [`load`] validates it against the op's declared kind instead — a
+    /// contradicting tag means a hand-edited/corrupt bundle.
     pub kind: String,
     pub cypher: String,
 }
@@ -653,6 +656,20 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
                 entry.count
             )));
         }
+        // The per-command `kind` tag is informational and unhashed, so a hand-edited tag would
+        // survive the workload-hash gate below — validate it against the op's declared kind here
+        // to keep the bundle self-consistent.
+        if let Some(rec) = recs.iter().find(|r| r.kind != command_kind(entry.kind)) {
+            return Err(OtherError(format!(
+                "{}: command seq {} declares kind '{}' but op '{}' is a {} op — the bundle is \
+                 corrupted or was edited",
+                path.display(),
+                rec.seq,
+                rec.kind,
+                entry.name,
+                command_kind(entry.kind)
+            )));
+        }
         commands.push((op, recs.into_iter().map(|r| r.cypher).collect::<Vec<_>>()));
     }
 
@@ -1016,8 +1033,9 @@ mod tests {
 
     #[test]
     fn write_bundle_workload_hash_binds_the_op_kind() {
-        // Flipping a v2 bundle's op kind in the manifest must fail the hash recompute on `load` —
-        // the kind is hashed (v2), so a bundle's read/write nature can't be silently flipped.
+        // Flipping a v2 bundle's op kind must fail the hash recompute on `load` — the kind is
+        // hashed (v2), so a bundle's read/write nature can't be silently flipped even by a
+        // self-consistent edit that also flips every unhashed per-command kind tag.
         let dir = temp_bundle_dir("synthrec-kindflip");
         let spec = DatasetSpec {
             seed: 1,
@@ -1037,8 +1055,48 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         manifest["ops"][0]["kind"] = serde_json::json!("Read");
         std::fs::write(&path, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+        let cmd_path = dir.join("commands").join("w.jsonl");
+        let retagged: String = std::fs::read_to_string(&cmd_path)
+            .unwrap()
+            .lines()
+            .map(|line| {
+                let mut rec: CommandRecord = serde_json::from_str(line).unwrap();
+                rec.kind = "read".to_string();
+                serde_json::to_string(&rec).unwrap() + "\n"
+            })
+            .collect();
+        std::fs::write(&cmd_path, retagged).unwrap();
         let err = load(&dir).unwrap_err();
         assert!(format!("{err}").contains("workload_hash mismatch"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_command_record_with_a_contradicting_kind() {
+        // The per-command `kind` tag is informational and unhashed, so flipping it on disk keeps
+        // the workload hash valid — `load` must still reject the contradiction against the op's
+        // declared kind (and via the kind gate, not the hash gate).
+        let (dir, manifest) = record_to_temp(19);
+        let name = manifest.ops[0].name.clone();
+        let path = dir.join("commands").join(format!("{name}.jsonl"));
+        let flipped: String = std::fs::read_to_string(&path)
+            .unwrap()
+            .lines()
+            .map(|line| {
+                let mut rec: CommandRecord = serde_json::from_str(line).unwrap();
+                rec.kind = "write".to_string();
+                serde_json::to_string(&rec).unwrap() + "\n"
+            })
+            .collect();
+        std::fs::write(&path, flipped).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("declares kind 'write'"), "got: {msg}");
+        assert!(msg.contains(&format!("op '{name}' is a read op")), "got: {msg}");
+        assert!(
+            !msg.contains("workload_hash"),
+            "the unhashed tag must be caught by the kind gate, not the hash gate: {msg}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -78,7 +78,10 @@ pub struct OpEntry {
     /// string-keyed dynamic op. Defaults to `Read` for bundles written before this field existed
     /// (v1 records reads only). Under format v2+ (write bundles, Phase 7 §3.1) the kind **is**
     /// folded into the [`Manifest::workload_hash`], so a bundle's read/write nature can't be
-    /// silently flipped; v1 (read-only) hashes never covered it and stay byte-identical.
+    /// silently flipped; v1 (read-only) hashes never covered it and stay byte-identical. In both
+    /// formats [`load`] also rejects an entry whose declared kind contradicts its built-in name's
+    /// catalog kind — the hash is computable by anyone, so a crafted-but-hash-valid manifest must
+    /// not reinterpret a built-in op (e.g. declare the write `create_node` as a read).
     #[serde(default = "default_op_kind")]
     pub kind: QueryType,
     /// Whether this op's result is compared across the A/B (record-once / replay-verbatim) gate.
@@ -433,6 +436,20 @@ fn record_rendered_impl(
             .to_string(),
         ));
     }
+    // The write latency tier is algorithm-free plain Cypher (Phase 7 §4.1): no engine procedure to
+    // probe for, so a capability on a write op is meaningless — and `capability` is outside the
+    // workload hash, so replay independently re-rejects it (a capability-skip would silently
+    // shrink the all-ten write coverage).
+    if let Some(op) =
+        ops.iter().find(|op| op.key.kind() == QueryType::Write && op.capability.is_some())
+    {
+        return Err(OtherError(format!(
+            "write op '{}' declares capability '{}' — write ops are plain Cypher and never \
+             capability-gated (Phase 7 §4.1)",
+            op.key.name(),
+            op.capability.as_deref().unwrap_or_default()
+        )));
+    }
     // Content-determined format version: any write op ⇒ v2 (kind folded into the workload hash);
     // an all-read bundle stays v1, byte-identical to every bundle recorded before writes existed.
     let format_version = if has_writes {
@@ -612,6 +629,20 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
         // name back to its `OpName` (keeping the built-in salt/kind); a name with no `OpName`
         // becomes a string-keyed dynamic op. Either way the bundle round-trips by name.
         let op = OpKey::dynamic(entry.name.clone(), entry.kind);
+        // …but that canonicalization IGNORES the manifest kind for a built-in name, so a crafted
+        // manifest declaring a built-in under the wrong kind (e.g. the write op `create_node` as a
+        // `read`) would be silently reinterpreted with the catalog kind — sidestepping the v1
+        // read-only gate above and, under v1's kind-blind hash, the integrity check too. Reject
+        // the mismatch instead of reinterpreting it.
+        if op.kind() != entry.kind {
+            return Err(OtherError(format!(
+                "manifest declares op '{}' as kind '{}', but that name is the built-in '{}' op — \
+                 a bundle cannot reinterpret a built-in op's kind (crafted/corrupt manifest)",
+                entry.name,
+                command_kind(entry.kind),
+                command_kind(op.kind()),
+            )));
+        }
         let path = dir.join("commands").join(format!("{}.jsonl", entry.name));
         let recs: Vec<CommandRecord> = read_jsonl(&path)?;
         if recs.len() != entry.count {
@@ -1158,6 +1189,150 @@ mod tests {
         ];
         let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
         assert!(format!("{err}").contains("mixed read+write bundle"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn record_rendered_rejects_a_capability_on_a_write_op() {
+        // Phase 7 §4.1: the write latency tier is algorithm-free plain Cypher — a capability on a
+        // write op is meaningless at record time (and unhashed, so replay re-rejects it too).
+        let dir = temp_bundle_dir("synthrec-writecap");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("w_cap", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: Some("algo.maxFlow".to_string()),
+            commands: vec!["CREATE (n)".to_string()],
+        }];
+        let err = record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap_err();
+        assert!(format!("{err}").contains("never capability-gated"), "got: {err}");
+        assert!(format!("{err}").contains("algo.maxFlow"), "must name the capability: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Rewrite the bundle's single op to `new_name`/`new_kind` (renaming its commands file to
+    /// match) and **recompute a valid `workload_hash`** over the tampered content — modeling an
+    /// attacker who can rewrite the whole bundle (the hash is computable by anyone; it is an
+    /// integrity check, not a MAC) but cannot change what a built-in op name *means*.
+    fn tamper_op_identity_with_valid_hash(
+        dir: &Path,
+        new_name: &str,
+        new_kind: QueryType,
+    ) {
+        let manifest_path = dir.join("manifest.json");
+        let mut manifest: Manifest =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        let old_name = manifest.ops[0].name.clone();
+        manifest.ops[0].name = new_name.to_string();
+        manifest.ops[0].kind = new_kind;
+        if old_name != new_name {
+            std::fs::rename(
+                dir.join("commands").join(format!("{old_name}.jsonl")),
+                dir.join("commands").join(format!("{new_name}.jsonl")),
+            )
+            .unwrap();
+        }
+        let graph_records: Vec<GraphRecord> = read_jsonl(&dir.join("graph.jsonl")).unwrap();
+        let mut hasher = WorkloadHasher::new(
+            manifest.format_version,
+            &manifest.generator_version,
+            &manifest.dataset,
+            &manifest.graph,
+            manifest.corpus_seed,
+        );
+        for rec in &graph_records {
+            hasher.graph_record(&rec.phase, &rec.cypher);
+        }
+        for entry in &manifest.ops {
+            let recs: Vec<CommandRecord> =
+                read_jsonl(&dir.join("commands").join(format!("{}.jsonl", entry.name))).unwrap();
+            hasher.op_header(&entry.name, recs.len(), entry.kind);
+            for rec in &recs {
+                hasher.command(&rec.cypher);
+            }
+        }
+        manifest.workload_hash = hasher.finalize();
+        std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn load_rejects_a_v1_bundle_reinterpreting_a_builtin_write_as_read() {
+        // The reinterpretation attack, v1 flavor: every v1 entry claims kind read (passing the
+        // v1 read-only gate) and the v1 hash is kind-blind — but `OpKey::dynamic` canonicalizes
+        // 'create_node' to the built-in WRITE op, ignoring the manifest kind. Before the kind
+        // guard, this hash-valid bundle silently became a write workload.
+        let dir = temp_bundle_dir("synthrec-kindv1");
+        let spec = DatasetSpec {
+            seed: 3,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("plain_read", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["RETURN 1".to_string()],
+        }];
+        let manifest = record_rendered(&spec, "g", &ops, 3, 8, &dir).unwrap();
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION, "reads record as v1");
+
+        tamper_op_identity_with_valid_hash(&dir, "create_node", QueryType::Read);
+        let err = load(&dir).unwrap_err();
+        assert!(
+            format!("{err}").contains("cannot reinterpret a built-in op's kind"),
+            "got: {err}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_v2_bundle_reinterpreting_a_builtin_kind() {
+        // The v2 flavor: v2 hashes the kind, but the hash is computable by anyone — a crafted
+        // bundle can declare the built-in write 'create_node' as a read with a perfectly valid
+        // recomputed hash. The kind guard, not the hash gate, must reject it.
+        let dir = temp_bundle_dir("synthrec-kindv2");
+        let spec = DatasetSpec {
+            seed: 3,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("w_op", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["CREATE (n:X)".to_string()],
+        }];
+        let manifest = record_rendered(&spec, "g", &ops, 3, 8, &dir).unwrap();
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_WRITES, "writes are v2");
+
+        // Sanity: renaming to the built-in with the CORRECT kind loads fine — proving the
+        // tamper helper produces hash-valid bundles, so the rejection below is the kind guard
+        // alone, not the hash gate.
+        tamper_op_identity_with_valid_hash(&dir, "create_node", QueryType::Write);
+        load(&dir).expect("correct-kind rename with a recomputed hash must load");
+
+        // The attack: same built-in name, kind flipped to read (hash recomputed over 'read').
+        tamper_op_identity_with_valid_hash(&dir, "create_node", QueryType::Read);
+        let err = load(&dir).unwrap_err();
+        assert!(
+            format!("{err}").contains("cannot reinterpret a built-in op's kind"),
+            "got: {err}"
+        );
+
+        // The reverse direction is equally rejected: a built-in READ name declared as a write.
+        tamper_op_identity_with_valid_hash(&dir, "match_by_index", QueryType::Write);
+        let err = load(&dir).unwrap_err();
+        assert!(
+            format!("{err}").contains("cannot reinterpret a built-in op's kind"),
+            "got: {err}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -238,58 +238,6 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         }
     }
 
-    // Reference pass (untimed, single-flight): capture each result's shape (cardinality +
-    // order-independent value digest) for every **result-gated** command — the correctness oracle,
-    // which also primes the plan cache. A result-N/A op's shapes are never verified or digested, so
-    // it skips the full capture (a heavy shape would pay corpus × per-call latency for nothing —
-    // design §3.4) and only its first command runs once, to fail fast on a broken recorded command.
-    // Captures run under the op's budgeted timeouts so a budgeted heavy op can't trip the global
-    // deadline before measurement starts. Reads return scalars, so a single connection is safe.
-    let mut reference: Vec<(OpKey, Arc<Vec<String>>, Vec<ResultShape>)> =
-        Vec::with_capacity(bundle.commands.len());
-    for (op, cyphers) in &bundle.commands {
-        if cyphers.is_empty() {
-            return Err(OtherError(format!("op '{}' has no recorded commands", op.name())));
-        }
-        if skipped.contains_key(op.name()) {
-            continue; // capability-skipped: never executed, not even the fail-fast probe
-        }
-        let entry = entry_for(op.name());
-        let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);
-        let op_deadline = entry
-            .budget
-            .client_deadline_ms
-            .map(Duration::from_millis)
-            .unwrap_or(client_deadline);
-        if op.kind() == QueryType::Write {
-            // Fail-fast probe for a write op, via GRAPH.QUERY (`RO_QUERY` rejects writes
-            // server-side): run the first recorded command once, untimed, so a broken command
-            // fails here instead of mid-measurement. Its mutation is erased by the first
-            // measured cell's base reset. No shapes: the latency tier asserts nothing (§4.1).
-            run_and_drain(&mut graph, QueryType::Write, &cyphers[0], op_st, op_deadline)
-                .await
-                .map_err(|e| OtherError(format!("probing write '{}': {}", op.name(), e)))?;
-            reference.push((op.clone(), Arc::new(cyphers.clone()), Vec::new()));
-            continue;
-        }
-        let to_capture: &[String] = if entry.result_gated { cyphers } else { &cyphers[..1] };
-        let mut shapes = Vec::with_capacity(to_capture.len());
-        for c in to_capture {
-            shapes.push(
-                capture_result(&mut graph, c, op_st, op_deadline)
-                    .await
-                    .map_err(|e| OtherError(format!("capturing '{}': {}", op.name(), e)))?,
-            );
-        }
-        if !entry.result_gated {
-            // The probe shape is discarded: downstream code treats a shapeless op as result-N/A.
-            shapes.clear();
-        }
-        reference.push((op.clone(), Arc::new(cyphers.clone()), shapes));
-    }
-    // Setup connection done; drop it so it isn't an idle extra connection during the sweep.
-    drop(graph);
-
     let run_token = rand::random_range(0..=u64::MAX);
     let uid_alloc = AtomicU64::new(0);
 
@@ -297,20 +245,74 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // Skipped ops get an empty-levels entry carrying the skip reason (BTreeMap renders by key),
     // so the report keeps the full recorded op set and the diff/regression guards can tell
     // "skipped" from "not recorded".
-    for (name, reason) in skipped {
+    for (name, reason) in &skipped {
         operations.insert(
-            name,
+            name.clone(),
             crate::synthetic::report::OperationReport {
                 levels: Vec::new(),
                 result_digest: None,
                 policy: None,
-                skipped: Some(reason),
+                skipped: Some(reason.clone()),
             },
         );
     }
-    // The measurement loop runs inside an immediately-awaited block so a write replay can run its
-    // error-safe final restore on success AND failure (§3.5) before any error propagates.
+    // The reference pass and the measurement loop both run inside an immediately-awaited block so
+    // a write replay can run its error-safe final restore on success AND failure (§3.5) before any
+    // error propagates — including a failed write fail-fast probe, where earlier ops' probes (or
+    // the failing command's own partial execution) may already have mutated the graph.
     let measured: BenchmarkResult<()> = async {
+        // Reference pass (untimed, single-flight): capture each result's shape (cardinality +
+        // order-independent value digest) for every **result-gated** command — the correctness oracle,
+        // which also primes the plan cache. A result-N/A op's shapes are never verified or digested, so
+        // it skips the full capture (a heavy shape would pay corpus × per-call latency for nothing —
+        // design §3.4) and only its first command runs once, to fail fast on a broken recorded command.
+        // Captures run under the op's budgeted timeouts so a budgeted heavy op can't trip the global
+        // deadline before measurement starts. Reads return scalars, so a single connection is safe.
+        let mut reference: Vec<(OpKey, Arc<Vec<String>>, Vec<ResultShape>)> =
+            Vec::with_capacity(bundle.commands.len());
+        for (op, cyphers) in &bundle.commands {
+            if cyphers.is_empty() {
+                return Err(OtherError(format!("op '{}' has no recorded commands", op.name())));
+            }
+            if skipped.contains_key(op.name()) {
+                continue; // capability-skipped: never executed, not even the fail-fast probe
+            }
+            let entry = entry_for(op.name());
+            let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);
+            let op_deadline = entry
+                .budget
+                .client_deadline_ms
+                .map(Duration::from_millis)
+                .unwrap_or(client_deadline);
+            if op.kind() == QueryType::Write {
+                // Fail-fast probe for a write op, via GRAPH.QUERY (`RO_QUERY` rejects writes
+                // server-side): run the first recorded command once, untimed, so a broken command
+                // fails here instead of mid-measurement. Its mutation is erased by the first
+                // measured cell's base reset. No shapes: the latency tier asserts nothing (§4.1).
+                run_and_drain(&mut graph, QueryType::Write, &cyphers[0], op_st, op_deadline)
+                    .await
+                    .map_err(|e| OtherError(format!("probing write '{}': {}", op.name(), e)))?;
+                reference.push((op.clone(), Arc::new(cyphers.clone()), Vec::new()));
+                continue;
+            }
+            let to_capture: &[String] = if entry.result_gated { cyphers } else { &cyphers[..1] };
+            let mut shapes = Vec::with_capacity(to_capture.len());
+            for c in to_capture {
+                shapes.push(
+                    capture_result(&mut graph, c, op_st, op_deadline)
+                        .await
+                        .map_err(|e| OtherError(format!("capturing '{}': {}", op.name(), e)))?,
+                );
+            }
+            if !entry.result_gated {
+                // The probe shape is discarded: downstream code treats a shapeless op as result-N/A.
+                shapes.clear();
+            }
+            reference.push((op.clone(), Arc::new(cyphers.clone()), shapes));
+        }
+        // Setup connection done; drop it so it isn't an idle extra connection during the sweep.
+        drop(graph);
+
         for (op, corpus, shapes) in &reference {
             let entry = entry_for(op.name());
             let is_gated = entry.result_gated;
@@ -559,6 +561,7 @@ async fn measure_write_op(
         let level = cell_report.levels.into_iter().next().ok_or_else(|| {
             OtherError(format!("write op '{}' produced no level report", op.name()))
         })?;
+        debug_assert_eq!(level.concurrency, 1, "write replay is C=1 only (validate_write_replay)");
         match mode {
             CacheMode::Cached => cached = level.cached,
             CacheMode::Uncached => uncached = level.uncached,
@@ -570,15 +573,18 @@ async fn measure_write_op(
     };
     Ok(OperationReport {
         levels: vec![LevelReport {
-            concurrency: 1,
+            // The op's effective sweep — `[1]` today, enforced by `validate_write_replay`, and
+            // derived (not hardcoded) so the report stays honest if §5's C>1 decision ever lands.
+            concurrency: op_concurrency.first().copied().unwrap_or(1),
             cached,
             uncached,
             compilation_ms_median,
         }],
         // The latency tier asserts nothing about results (§4.1): no digest, ever.
         result_digest: None,
-        // WRITE_BUDGET always overrides the global sweep, so the effective per-op policy is
-        // always persisted — the diff/baseline guards then refuse cross-policy comparisons.
+        // The effective per-op policy is persisted unconditionally — whether WRITE_BUDGET
+        // overrode the globals or an inherit budget ran under a global C=1 sweep — so the
+        // diff/baseline guards always refuse cross-policy comparisons of write cells.
         policy: Some(op_config.resolved_policy(op_concurrency)),
         skipped: None,
     })
@@ -587,7 +593,10 @@ async fn measure_write_op(
 /// The whole-graph content queries backing the write replay's restore verification: the node and
 /// edge multisets, canonicalized value-by-value by [`capture_result`] (order-independent digest;
 /// node/edge canonicalization includes entity ids, which are deterministic across identical fresh
-/// loads because the recorded statements replay in recorded order onto an empty graph).
+/// loads because the recorded statements replay in recorded order onto an empty graph). Both scans
+/// materialize the graph client-side, so they price the verification at the recorded base's size —
+/// fine for the fixture-scale bases `synthetic record` emits (10³–10⁴ entities, ≈0.1 s), by design
+/// not a path for arbitrarily large graphs.
 const CONTENT_QUERIES: [&str; 2] =
     ["MATCH (n) RETURN n", "MATCH (a)-[r]->(b) RETURN ID(a), r, ID(b)"];
 

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -16,6 +16,16 @@
 //! integrity (the bundle's `workload_hash` is verified on load), graph fidelity (drop + load +
 //! count-verify), and result correctness (a per-op result-**value** digest + the concurrency check),
 //! leaving latency to be compared advisorily by the [`crate::synthetic::baseline`] guard.
+//!
+//! **Write bundles** (recording format v2, Phase 7 §4.1 latency tier): a bundle whose ops are
+//! writes is measured via `GRAPH.QUERY` at **C=1 only**, with the base graph **reset (drop + load
+//! + count-verify) before every measured cell** (op × cache mode) so mutation drift stays bounded
+//! to one cell's invocations. Nothing is asserted about results or mutation counters — outcomes
+//! are state/value-dependent (§10), so the latency tier records `result_digest: None` and leaves
+//! correctness to the deferred oracle tier. The replay ends with an **error-safe final restore**:
+//! the recorded base is reloaded (on success *and* failure) and its node/edge content digests are
+//! verified against the pristine post-load capture, so a write replay can never leave a mutated
+//! graph behind on the endpoint.
 
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
@@ -23,12 +33,14 @@ use crate::falkor::falkor_endpoint_to_redis_url;
 use crate::queries_repository::QueryType;
 use crate::synthetic::catalog::DEFAULT_RESET_EVERY;
 use crate::synthetic::dataset::{self, DatasetSpec};
-use crate::synthetic::op_runner::{capture_result, ResultShape};
+use crate::synthetic::op_runner::{capture_result, run_and_drain, ResultShape};
 use crate::synthetic::recording::{self, Bundle};
-use crate::synthetic::report::{DatasetInfo, Meta, Report, ServerInfo, SCHEMA_VERSION};
+use crate::synthetic::report::{
+    DatasetInfo, LevelReport, Meta, OperationReport, Report, ServerInfo, SCHEMA_VERSION,
+};
 use crate::synthetic::{
     measure_op, normalize_concurrency, open_graph, provenance, redact_endpoint,
-    validate_op_config, write_report, CacheSelection, Config, MeasureTarget, OpKey,
+    validate_op_config, write_report, CacheMode, CacheSelection, Config, MeasureTarget, OpKey,
 };
 use falkordb::AsyncGraph;
 use futures::StreamExt;
@@ -74,25 +86,20 @@ pub struct ReplayConfig {
 
 /// Replay `config`'s bundle: load the recorded graph, then measure the recorded commands through the
 /// closed-loop engine across the concurrency sweep + cache modes, verifying results are unchanged by
-/// concurrency. Builds the [`Report`].
+/// concurrency (reads) or resetting the base graph per measured cell (writes — see the module docs).
+/// Builds the [`Report`].
 pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     if config.samples == 0 {
         return Err(OtherError("run --recording --samples must be greater than 0".to_string()));
     }
     let concurrency = normalize_concurrency(&config.concurrency)?;
     let bundle = recording::load(&config.recording_dir)?;
-    // Fail closed on a write op: v1 recording is read-only, and the measurement path uses RO_QUERY.
-    // A hand-crafted bundle naming a write op would otherwise be run as a read.
-    if let Some((op, _)) = bundle
-        .commands
-        .iter()
-        .find(|(op, _)| op.kind() == QueryType::Write)
-    {
-        return Err(OtherError(format!(
-            "recorded op '{}' is a write op — replaying writes is not supported (v1 records reads \
-             only)",
-            op.name()
-        )));
+    // A bundle is single-kind: reads replay through RO_QUERY exactly as before; a write bundle
+    // (format v2) takes the Phase 7 write path. Its invariants — no mixed kinds, no --no-load,
+    // C=1 only, nothing result-gated — are guarded up front, offline, before any connection.
+    let has_writes = bundle.commands.iter().any(|(op, _)| op.kind() == QueryType::Write);
+    if has_writes {
+        validate_write_replay(&bundle, config, &concurrency)?;
     }
     let dataset_spec = bundle.spec();
     let graph_name = config
@@ -135,6 +142,15 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             })?;
     }
 
+    // Phase 7 §3.5: capture the pristine base-graph content (node + edge digests) right after the
+    // initial load, so the error-safe final restore below can verify the graph it leaves behind is
+    // EXACTLY the recorded base — content-verified, not just count-verified.
+    let pristine = if has_writes {
+        Some(capture_graph_content(&mut graph, config).await?)
+    } else {
+        None
+    };
+
     // Per-op replay policy from the recorded manifest (keyed by the op's unique name):
     // `result_gated` + the per-op `budget` (design §3.4). A result-N/A op — a shape whose result
     // set isn't byte-stable (LIMIT-without-ORDER, top-k, float scores — design §3.2 / Decision 4)
@@ -164,7 +180,9 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             .expect("every replayed op name was validated against the manifest above")
     };
 
-    // Engine config for the recorded workload (writes/reset are irrelevant — recorded ops are reads).
+    // Engine config for the recorded workload (`reset_every` only frames catalog write scratch,
+    // which recorded ops never use — recorded writes measure with `write: None`, resetting via
+    // whole-graph reloads instead).
     let engine_config = Config {
         endpoint: config.endpoint.clone(),
         graph: graph_name.clone(),
@@ -243,6 +261,17 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             .client_deadline_ms
             .map(Duration::from_millis)
             .unwrap_or(client_deadline);
+        if op.kind() == QueryType::Write {
+            // Fail-fast probe for a write op, via GRAPH.QUERY (`RO_QUERY` rejects writes
+            // server-side): run the first recorded command once, untimed, so a broken command
+            // fails here instead of mid-measurement. Its mutation is erased by the first
+            // measured cell's base reset. No shapes: the latency tier asserts nothing (§4.1).
+            run_and_drain(&mut graph, QueryType::Write, &cyphers[0], op_st, op_deadline)
+                .await
+                .map_err(|e| OtherError(format!("probing write '{}': {}", op.name(), e)))?;
+            reference.push((op.clone(), Arc::new(cyphers.clone()), Vec::new()));
+            continue;
+        }
         let to_capture: &[String] = if entry.result_gated { cyphers } else { &cyphers[..1] };
         let mut shapes = Vec::with_capacity(to_capture.len());
         for c in to_capture {
@@ -279,61 +308,102 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             },
         );
     }
-    for (op, corpus, shapes) in &reference {
-        let entry = entry_for(op.name());
-        let is_gated = entry.result_gated;
-        // Overlay this op's recorded budget on the run's global config (the same per-op overlay a
-        // generated run applies from the catalog spec) — already validated before the reference
-        // pass, so the resolved knobs are known-good here.
-        let op_config = engine_config.with_recorded_budget(&entry.budget);
-        let op_concurrency = normalize_concurrency(&op_config.concurrency)?;
-        let op_deadline = Duration::from_millis(op_config.client_deadline_ms);
-        let op_max_c = op_concurrency.iter().copied().max().unwrap_or(1);
-        // Verify results are IDENTICAL at the op's highest concurrency (untimed) before trusting
-        // the measured latencies — a concurrent path that returns different/wrong results is a
-        // hard fail. Skipped for result-N/A ops, whose results aren't required to be stable.
-        if op_max_c > 1 && is_gated {
-            verify_concurrent(
-                &config.endpoint,
-                &graph_name,
-                corpus,
-                shapes,
-                op_max_c,
-                op_config.server_timeout_ms,
+    // The measurement loop runs inside an immediately-awaited block so a write replay can run its
+    // error-safe final restore on success AND failure (§3.5) before any error propagates.
+    let measured: BenchmarkResult<()> = async {
+        for (op, corpus, shapes) in &reference {
+            let entry = entry_for(op.name());
+            let is_gated = entry.result_gated;
+            // Overlay this op's recorded budget on the run's global config (the same per-op
+            // overlay a generated run applies from the catalog spec) — already validated before
+            // the reference pass, so the resolved knobs are known-good here.
+            let op_config = engine_config.with_recorded_budget(&entry.budget);
+            let op_concurrency = normalize_concurrency(&op_config.concurrency)?;
+            let op_deadline = Duration::from_millis(op_config.client_deadline_ms);
+            if op.kind() == QueryType::Write {
+                let op_report = measure_write_op(
+                    config,
+                    &bundle,
+                    &graph_name,
+                    &dataset_spec,
+                    op,
+                    &op_config,
+                    &op_concurrency,
+                    Arc::clone(corpus),
+                    run_token,
+                    &uid_alloc,
+                    op_deadline,
+                )
+                .await?;
+                operations.insert(op.name().to_string(), op_report);
+                continue;
+            }
+            let op_max_c = op_concurrency.iter().copied().max().unwrap_or(1);
+            // Verify results are IDENTICAL at the op's highest concurrency (untimed) before
+            // trusting the measured latencies — a concurrent path that returns different/wrong
+            // results is a hard fail. Skipped for result-N/A ops, whose results aren't required
+            // to be stable.
+            if op_max_c > 1 && is_gated {
+                verify_concurrent(
+                    &config.endpoint,
+                    &graph_name,
+                    corpus,
+                    shapes,
+                    op_max_c,
+                    op_config.server_timeout_ms,
+                    op_deadline,
+                )
+                .await
+                .map_err(|e| {
+                    OtherError(format!(
+                        "op '{}' returned different results at concurrency {}: {}",
+                        op.name(),
+                        op_max_c,
+                        e
+                    ))
+                })?;
+            }
+            let mut op_report = measure_op(
+                &op_config,
+                &op_concurrency,
+                MeasureTarget::read(),
+                Arc::clone(corpus),
+                run_token,
+                &uid_alloc,
                 op_deadline,
             )
-            .await
-            .map_err(|e| {
-                OtherError(format!(
-                    "op '{}' returned different results at concurrency {}: {}",
-                    op.name(),
-                    op_max_c,
-                    e
-                ))
-            })?;
+            .await?;
+            // Gate the result only for byte-stable shapes; a result-N/A op reports `None` so the
+            // diff guard renders it N/A instead of comparing a non-deterministic digest.
+            op_report.result_digest =
+                is_gated.then(|| op_result_digest(op.name(), shapes));
+            // Persist the op's effective measurement policy when its recorded budget overrode any
+            // global knob (design §3.4): budgets are deliberately outside the workload_hash, so
+            // this block is what lets the diff/regression/baseline guards refuse to compare two
+            // runs that measured the same workload under different per-op conditions.
+            op_report.policy =
+                (!entry.budget.is_inherit()).then(|| op_config.resolved_policy(&op_concurrency));
+            operations.insert(op.name().to_string(), op_report);
         }
-        let mut op_report = measure_op(
-            &op_config,
-            &op_concurrency,
-            MeasureTarget::read(),
-            Arc::clone(corpus),
-            run_token,
-            &uid_alloc,
-            op_deadline,
-        )
-        .await?;
-        // Gate the result only for byte-stable shapes; a result-N/A op reports `None` so the diff
-        // guard renders it N/A instead of comparing a non-deterministic digest.
-        op_report.result_digest =
-            is_gated.then(|| op_result_digest(op.name(), shapes));
-        // Persist the op's effective measurement policy when its recorded budget overrode any
-        // global knob (design §3.4): budgets are deliberately outside the workload_hash, so this
-        // block is what lets the diff/regression/baseline guards refuse to compare two runs that
-        // measured the same workload under different per-op conditions.
-        op_report.policy =
-            (!entry.budget.is_inherit()).then(|| op_config.resolved_policy(&op_concurrency));
-        operations.insert(op.name().to_string(), op_report);
+        Ok(())
     }
+    .await;
+
+    // Phase 7 §3.5: a write replay must leave the endpoint's graph exactly as recorded — final
+    // restore + content verification on success AND failure. On the failure path the restore is
+    // best-effort (logged, never masking the measurement error).
+    if let Some(pristine) = &pristine {
+        let restored = restore_and_verify(&bundle, &graph_name, &dataset_spec, config, pristine).await;
+        match (&measured, restored) {
+            (Ok(()), Err(e)) => return Err(e),
+            (Err(original), Err(e)) => warn!(
+                "final restore after failed write replay also failed: {} (measurement error: {})",
+                e, original
+            ),
+            _ => {}
+        }
+    }
+    measured?;
 
     // The corpus size is what the bundle actually recorded per op (not the compile-time constant) —
     // over every recorded op, including capability-skipped ones (it describes the bundle, not the
@@ -381,6 +451,188 @@ pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
     let report = run(config).await?;
     println!("{}", report.to_console());
     write_report(&report, &config.out).await
+}
+
+/// Guard the Phase 7 write-replay invariants for a bundle containing write ops — **offline**,
+/// before any connection is attempted, so a bad bundle/flag combination fails closed:
+///
+/// - **single-kind**: recorded bundles never mix reads and writes (one global sweep can't express
+///   swept reads + C=1 writes — design §4); the record path enforces this, but budgets and flags
+///   are outside `workload_hash`, so replay re-checks everything hand-editable;
+/// - **`--no-load` forbidden**: write measurement is defined from the recorded base graph
+///   (per-cell resets reload it — §3.3);
+/// - **C=1 only**: every write op's *effective* sweep (its recorded budget's, else the run's)
+///   must be exactly `[1]` (§5 defers concurrent writes);
+/// - **never result-gated**: the latency tier asserts nothing (§4.1) — a gated write would imply
+///   a correctness capture the write path deliberately skips.
+fn validate_write_replay(
+    bundle: &Bundle,
+    config: &ReplayConfig,
+    global_concurrency: &[usize],
+) -> BenchmarkResult<()> {
+    if let Some((op, _)) = bundle.commands.iter().find(|(op, _)| op.kind() != QueryType::Write) {
+        return Err(OtherError(format!(
+            "recorded bundle mixes write ops with read op '{}' — a bundle must be single-kind \
+             (record reads and writes as separate bundles)",
+            op.name()
+        )));
+    }
+    if !config.load {
+        return Err(OtherError(
+            "--no-load is not supported for a write bundle: write replay must start from the \
+             recorded base graph, which its per-cell resets reload (design §3.3/§3.5)"
+                .to_string(),
+        ));
+    }
+    for (op, _) in &bundle.commands {
+        let entry = bundle.manifest.ops.iter().find(|e| e.name == op.name());
+        let sweep: &[usize] = entry
+            .and_then(|e| e.budget.concurrency.as_deref())
+            .unwrap_or(global_concurrency);
+        if sweep != [1] {
+            return Err(OtherError(format!(
+                "write op '{}' resolves to concurrency sweep {:?} — write replay is C=1 only \
+                 (design §5; budgets are outside workload_hash, so this is enforced at replay)",
+                op.name(),
+                sweep
+            )));
+        }
+        if entry.is_some_and(|e| e.result_gated) {
+            return Err(OtherError(format!(
+                "write op '{}' is marked result-gated — the write latency tier asserts nothing \
+                 (design §4.1), so a write op can never gate on a result digest",
+                op.name()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Measure one recorded **write** op (Phase 7 §4.1): the base graph is **reset (drop + reload +
+/// count-verify) before every measured cell** (one cell per requested cache mode; C=1 enforced by
+/// [`validate_write_replay`]), bounding mutation drift to a single cell's invocations. Each cell
+/// runs [`measure_op`] with the op's config narrowed to that one cache mode, and the per-mode
+/// single-level results are merged into one C=1 [`LevelReport`] (cached + uncached + the derived
+/// compilation cost) so a write op's report shape matches a read op's.
+#[allow(clippy::too_many_arguments)]
+async fn measure_write_op(
+    config: &ReplayConfig,
+    bundle: &Bundle,
+    graph_name: &str,
+    dataset_spec: &DatasetSpec,
+    op: &OpKey,
+    op_config: &Config,
+    op_concurrency: &[usize],
+    corpus: Arc<Vec<String>>,
+    run_token: u64,
+    uid_alloc: &AtomicU64,
+    op_deadline: Duration,
+) -> BenchmarkResult<OperationReport> {
+    let mut cached = None;
+    let mut uncached = None;
+    for &mode in op_config.cache.modes() {
+        // Per-cell base reset, on its own short-lived connection (the measurement workers open
+        // their own).
+        let mut reset_conn = open_graph(&config.endpoint, graph_name).await?;
+        load_recorded_graph(&mut reset_conn, bundle, graph_name, dataset_spec, config).await?;
+        drop(reset_conn);
+        let cell_config = Config {
+            cache: match mode {
+                CacheMode::Cached => CacheSelection::Cached,
+                CacheMode::Uncached => CacheSelection::Uncached,
+            },
+            ..op_config.clone()
+        };
+        let cell_report = measure_op(
+            &cell_config,
+            op_concurrency,
+            MeasureTarget {
+                kind: QueryType::Write,
+                write: None,
+            },
+            Arc::clone(&corpus),
+            run_token,
+            uid_alloc,
+            op_deadline,
+        )
+        .await?;
+        let level = cell_report.levels.into_iter().next().ok_or_else(|| {
+            OtherError(format!("write op '{}' produced no level report", op.name()))
+        })?;
+        match mode {
+            CacheMode::Cached => cached = level.cached,
+            CacheMode::Uncached => uncached = level.uncached,
+        }
+    }
+    let compilation_ms_median = match (&cached, &uncached) {
+        (Some(cm), Some(um)) => Some(um.metrics.server_ms.median - cm.metrics.server_ms.median),
+        _ => None,
+    };
+    Ok(OperationReport {
+        levels: vec![LevelReport {
+            concurrency: 1,
+            cached,
+            uncached,
+            compilation_ms_median,
+        }],
+        // The latency tier asserts nothing about results (§4.1): no digest, ever.
+        result_digest: None,
+        // WRITE_BUDGET always overrides the global sweep, so the effective per-op policy is
+        // always persisted — the diff/baseline guards then refuse cross-policy comparisons.
+        policy: Some(op_config.resolved_policy(op_concurrency)),
+        skipped: None,
+    })
+}
+
+/// The whole-graph content queries backing the write replay's restore verification: the node and
+/// edge multisets, canonicalized value-by-value by [`capture_result`] (order-independent digest;
+/// node/edge canonicalization includes entity ids, which are deterministic across identical fresh
+/// loads because the recorded statements replay in recorded order onto an empty graph).
+const CONTENT_QUERIES: [&str; 2] =
+    ["MATCH (n) RETURN n", "MATCH (a)-[r]->(b) RETURN ID(a), r, ID(b)"];
+
+/// Capture the graph's full content shape ([`CONTENT_QUERIES`]) under load-scale timeouts.
+async fn capture_graph_content(
+    graph: &mut AsyncGraph,
+    config: &ReplayConfig,
+) -> BenchmarkResult<Vec<ResultShape>> {
+    // Whole-graph scans do real work — give them the same generous deadline as a bulk load.
+    let deadline = Duration::from_millis(config.client_deadline_ms.max(60_000));
+    let server_timeout_ms = config
+        .server_timeout_ms
+        .max(i64::try_from(deadline.as_millis()).unwrap_or(i64::MAX));
+    let mut shapes = Vec::with_capacity(CONTENT_QUERIES.len());
+    for cypher in CONTENT_QUERIES {
+        shapes.push(
+            capture_result(graph, cypher, server_timeout_ms, deadline)
+                .await
+                .map_err(|e| OtherError(format!("capturing graph content ({cypher}): {e}")))?,
+        );
+    }
+    Ok(shapes)
+}
+
+/// The write replay's final restore (§3.5): reload the recorded base graph, then verify its
+/// **content** — not just its counts — matches the pristine post-load capture, so the replay
+/// provably leaves the endpoint's graph exactly as recorded.
+async fn restore_and_verify(
+    bundle: &Bundle,
+    graph_name: &str,
+    dataset_spec: &DatasetSpec,
+    config: &ReplayConfig,
+    pristine: &[ResultShape],
+) -> BenchmarkResult<()> {
+    let mut graph = open_graph(&config.endpoint, graph_name).await?;
+    load_recorded_graph(&mut graph, bundle, graph_name, dataset_spec, config).await?;
+    let restored = capture_graph_content(&mut graph, config).await?;
+    if restored != pristine {
+        return Err(OtherError(format!(
+            "final restore left graph '{}' content-diverged from the recorded base (node/edge \
+             digests differ) — the recorded dataset did not reload reproducibly",
+            graph_name
+        )));
+    }
+    Ok(())
 }
 
 /// Ask the engine which procedures it registers (`dbms.procedures()`), returning their
@@ -526,11 +778,84 @@ fn op_result_digest(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::synthetic::catalog::RecordedBudget;
+    use crate::synthetic::recording::{DatasetKnobs, Manifest, OpEntry};
 
     fn shape(rows: usize, digest: &str) -> ResultShape {
         ResultShape {
             rows,
             value_digest: format!("sha256:{digest}"),
+        }
+    }
+
+    fn replay_config(load: bool, concurrency: Vec<usize>) -> ReplayConfig {
+        ReplayConfig {
+            recording_dir: PathBuf::from("/nonexistent/recording"),
+            // Nothing should ever connect in these tests — a guard regression that reaches the
+            // network fails loudly on this closed port instead of hanging.
+            endpoint: "falkor://127.0.0.1:1".to_string(),
+            graph: None,
+            load,
+            samples: 5,
+            warmup: 0,
+            concurrency,
+            cache: CacheSelection::Cached,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: "unused.json".to_string(),
+            server_image: None,
+            label: None,
+        }
+    }
+
+    /// A minimal in-memory bundle: one op per `(name, kind, result_gated, budget)` row, each with
+    /// a single recorded command. (The workload hash is never checked here — these bundles feed
+    /// [`validate_write_replay`] directly, mimicking what a hand-crafted-but-hash-valid bundle
+    /// could smuggle past `recording::load`.)
+    fn bundle_of(rows: Vec<(&str, QueryType, bool, RecordedBudget)>) -> Bundle {
+        let ops = rows
+            .iter()
+            .map(|(name, kind, gated, budget)| OpEntry {
+                name: name.to_string(),
+                kind: *kind,
+                result_gated: *gated,
+                budget: budget.clone(),
+                capability: None,
+                count: 1,
+            })
+            .collect();
+        let commands = rows
+            .iter()
+            .map(|(name, kind, _, _)| {
+                (OpKey::dynamic(name.to_string(), *kind), vec!["CREATE (n)".to_string()])
+            })
+            .collect();
+        Bundle {
+            manifest: Manifest {
+                format_version: 2,
+                generator_version: "synthbench/v5".to_string(),
+                tool_version: "test".to_string(),
+                dataset: DatasetKnobs {
+                    seed: 7,
+                    nodes: 10,
+                    edges: 20,
+                },
+                graph: "g".to_string(),
+                corpus_seed: 7,
+                batch_size: 8,
+                ops,
+                workload_hash: "sha256:unchecked".to_string(),
+                created_at_epoch_secs: 0,
+            },
+            graph_statements: Vec::new(),
+            commands,
+        }
+    }
+
+    fn write_budget() -> RecordedBudget {
+        RecordedBudget {
+            concurrency: Some(vec![1]),
+            ..RecordedBudget::default()
         }
     }
 
@@ -551,22 +876,72 @@ mod tests {
     #[tokio::test]
     async fn run_rejects_zero_samples() {
         // Guarded before any disk/server access, so this stays hermetic.
-        let config = ReplayConfig {
-            recording_dir: PathBuf::from("/nonexistent/recording"),
-            endpoint: "falkor://127.0.0.1:6379".to_string(),
-            graph: None,
-            load: true,
-            samples: 0,
-            warmup: 0,
-            concurrency: vec![1],
-            cache: CacheSelection::Cached,
-            server_timeout_ms: 5_000,
-            client_deadline_ms: 6_000,
-            out: "unused.json".to_string(),
-            server_image: None,
-            label: None,
-        };
+        let mut config = replay_config(true, vec![1]);
+        config.samples = 0;
         let err = run(&config).await.unwrap_err();
         assert!(format!("{err}").contains("samples must be greater than 0"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_write_replay_rejects_a_mixed_bundle() {
+        // Single-kind invariant (§4): the record path already refuses mixed bundles, but the
+        // replay re-checks because a hand-crafted manifest with a correct v2 hash can mix kinds.
+        let bundle = bundle_of(vec![
+            ("w", QueryType::Write, false, write_budget()),
+            ("r", QueryType::Read, true, RecordedBudget::default()),
+        ]);
+        let err = validate_write_replay(&bundle, &replay_config(true, vec![1]), &[1]).unwrap_err();
+        assert!(format!("{err}").contains("mixes write ops with read op 'r'"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_write_replay_rejects_no_load() {
+        // §3.3/§3.5: write measurement is defined from the recorded base graph.
+        let bundle = bundle_of(vec![("w", QueryType::Write, false, write_budget())]);
+        let err = validate_write_replay(&bundle, &replay_config(false, vec![1]), &[1]).unwrap_err();
+        assert!(
+            format!("{err}").contains("--no-load is not supported for a write bundle"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_write_replay_rejects_a_non_c1_sweep() {
+        // §5: C=1 only — budgets are outside workload_hash, so a tampered budget passes the load
+        // hash gate and MUST be caught here, whether the sweep comes from the budget…
+        let tampered = RecordedBudget {
+            concurrency: Some(vec![8]),
+            ..RecordedBudget::default()
+        };
+        let bundle = bundle_of(vec![("w", QueryType::Write, false, tampered)]);
+        let err = validate_write_replay(&bundle, &replay_config(true, vec![1]), &[1]).unwrap_err();
+        assert!(format!("{err}").contains("write replay is C=1 only"), "got: {err}");
+        assert!(format!("{err}").contains("[8]"), "must name the offending sweep: {err}");
+
+        // …or from the run's global sweep via an inherit budget.
+        let bundle = bundle_of(vec![("w", QueryType::Write, false, RecordedBudget::default())]);
+        let err = validate_write_replay(&bundle, &replay_config(true, vec![1, 8]), &[1, 8])
+            .unwrap_err();
+        assert!(format!("{err}").contains("write replay is C=1 only"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_write_replay_rejects_a_result_gated_write() {
+        // §4.1: the latency tier asserts nothing — result_gated isn't hashed, so a tampered
+        // manifest could otherwise send a write down the RO_QUERY capture path.
+        let bundle = bundle_of(vec![("w", QueryType::Write, true, write_budget())]);
+        let err = validate_write_replay(&bundle, &replay_config(true, vec![1]), &[1]).unwrap_err();
+        assert!(format!("{err}").contains("marked result-gated"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_write_replay_accepts_a_c1_write_bundle() {
+        // The recorded WRITE_BUDGET pins C=[1]; an inherit budget under a C=1 global sweep is
+        // equally valid.
+        let bundle = bundle_of(vec![
+            ("w1", QueryType::Write, false, write_budget()),
+            ("w2", QueryType::Write, false, RecordedBudget::default()),
+        ]);
+        validate_write_replay(&bundle, &replay_config(true, vec![1]), &[1]).unwrap();
     }
 }

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -24,8 +24,9 @@
 //! outcomes are state/value-dependent (§10), so the latency tier records `result_digest: None`
 //! and leaves correctness to the deferred oracle tier. The replay ends with an **error-safe final
 //! restore**: the recorded base is reloaded (on success *and* failure) and its node/edge content
-//! digests are verified against the pristine post-load capture, so a write replay can never leave
-//! a mutated graph behind on the endpoint.
+//! digests are verified against the pristine post-load capture, so a write replay never silently
+//! leaves a mutated graph behind — if the restore itself fails, that failure is surfaced
+//! (combined with the measurement error when both fail).
 
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
@@ -96,7 +97,8 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     let bundle = recording::load(&config.recording_dir)?;
     // A bundle is single-kind: reads replay through RO_QUERY exactly as before; a write bundle
     // (format v2) takes the Phase 7 write path. Its invariants — no mixed kinds, no --no-load,
-    // C=1 only, nothing result-gated — are guarded up front, offline, before any connection.
+    // C=1 only, nothing result-gated, nothing capability-gated — are guarded up front, offline,
+    // before any connection.
     let has_writes = bundle.commands.iter().any(|(op, _)| op.kind() == QueryType::Write);
     if has_writes {
         validate_write_replay(&bundle, config, &concurrency)?;
@@ -392,19 +394,14 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     .await;
 
     // Phase 7 §3.5: a write replay must leave the endpoint's graph exactly as recorded — final
-    // restore + content verification on success AND failure. On the failure path the restore is
-    // best-effort (logged, never masking the measurement error).
-    if let Some(pristine) = &pristine {
-        let restored = restore_and_verify(&bundle, &graph_name, &dataset_spec, config, pristine).await;
-        match (&measured, restored) {
-            (Ok(()), Err(e)) => return Err(e),
-            (Err(original), Err(e)) => warn!(
-                "final restore after failed write replay also failed: {} (measurement error: {})",
-                e, original
-            ),
-            _ => {}
-        }
-    }
+    // restore + content verification on success AND failure.
+    let measured = if let Some(pristine) = &pristine {
+        let restored =
+            restore_and_verify(&bundle, &graph_name, &dataset_spec, config, pristine).await;
+        reconcile_measure_and_restore(measured, restored, &graph_name)
+    } else {
+        measured
+    };
     measured?;
 
     // The corpus size is what the bundle actually recorded per op (not the compile-time constant) —
@@ -466,7 +463,10 @@ pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
 /// - **C=1 only**: every write op's *effective* sweep (its recorded budget's, else the run's)
 ///   must be exactly `[1]` (§5 defers concurrent writes);
 /// - **never result-gated**: the latency tier asserts nothing (§4.1) — a gated write would imply
-///   a correctness capture the write path deliberately skips.
+///   a correctness capture the write path deliberately skips;
+/// - **never capability-gated**: write shapes are algorithm-free plain Cypher (§4.1), and
+///   `capability` is outside `workload_hash` — a crafted capability would otherwise let the probe
+///   silently skip an op, shrinking the all-ten coverage while the replay still "succeeds".
 fn validate_write_replay(
     bundle: &Bundle,
     config: &ReplayConfig,
@@ -504,6 +504,15 @@ fn validate_write_replay(
                 "write op '{}' is marked result-gated — the write latency tier asserts nothing \
                  (design §4.1), so a write op can never gate on a result digest",
                 op.name()
+            )));
+        }
+        if let Some(capability) = entry.and_then(|e| e.capability.as_deref()) {
+            return Err(OtherError(format!(
+                "write op '{}' declares capability '{}' — write ops are plain Cypher and never \
+                 capability-gated (design §4.1; capability is outside workload_hash, so this is \
+                 enforced at replay: a crafted capability must not skip-shrink the write coverage)",
+                op.name(),
+                capability
             )));
         }
     }
@@ -619,6 +628,27 @@ async fn capture_graph_content(
         );
     }
     Ok(shapes)
+}
+
+/// Reconcile a write replay's measurement outcome with its §3.5 final-restore outcome. A restore
+/// failure surfaces even when the measurement succeeded, and a **dual** failure returns a
+/// combined error naming both — the caller must learn that the endpoint's graph may be left
+/// polluted, not just that the measurement failed.
+fn reconcile_measure_and_restore(
+    measured: BenchmarkResult<()>,
+    restored: BenchmarkResult<()>,
+    graph_name: &str,
+) -> BenchmarkResult<()> {
+    match (measured, restored) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Err(restore)) => Err(restore),
+        (Err(original), Ok(())) => Err(original),
+        (Err(original), Err(restore)) => Err(OtherError(format!(
+            "write replay failed AND its final restore failed — graph '{}' may be left polluted \
+             (measurement error: {}; restore error: {})",
+            graph_name, original, restore
+        ))),
+    }
 }
 
 /// The write replay's final restore (§3.5): reload the recorded base graph, then verify its
@@ -952,5 +982,95 @@ mod tests {
             ("w2", QueryType::Write, false, RecordedBudget::default()),
         ]);
         validate_write_replay(&bundle, &replay_config(true, vec![1]), &[1]).unwrap();
+    }
+
+    #[test]
+    fn validate_write_replay_rejects_a_capability_on_a_write_op() {
+        // §4.1: writes are plain Cypher — and `capability` is outside workload_hash, so a crafted
+        // capability naming a procedure the engine lacks would otherwise make the probe skip the
+        // op, silently shrinking the all-ten coverage while the replay still "succeeds".
+        let mut bundle = bundle_of(vec![("w", QueryType::Write, false, write_budget())]);
+        bundle.manifest.ops[0].capability = Some("algo.nonexistent".to_string());
+        let err = validate_write_replay(&bundle, &replay_config(true, vec![1]), &[1]).unwrap_err();
+        assert!(format!("{err}").contains("never capability-gated"), "got: {err}");
+        assert!(format!("{err}").contains("algo.nonexistent"), "must name the capability: {err}");
+    }
+
+    #[tokio::test]
+    async fn run_rejects_a_tampered_capability_on_a_write_bundle() {
+        // The full disk-level attack: `capability` is not folded into workload_hash, so adding a
+        // nonexistent capability to a recorded write bundle survives `recording::load`'s hash
+        // gate. The offline write guard must then fail the replay closed — before this guard the
+        // replay "succeeded" with the op capability-skipped.
+        use crate::synthetic::recording::{record_rendered, temp_bundle_dir, RecordedOp};
+
+        let dir = temp_bundle_dir("replay-cap-tamper");
+        let spec = DatasetSpec {
+            seed: 7,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("w_op", QueryType::Write),
+            result_gated: false,
+            budget: write_budget(),
+            capability: None,
+            commands: vec!["CREATE (n:X)".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 7, 64, &dir).expect("record a legit write bundle");
+
+        let manifest_path = dir.join("manifest.json");
+        let mut manifest: Manifest =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        manifest.ops[0].capability = Some("algo.nonexistent".to_string());
+        std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+        recording::load(&dir)
+            .expect("capability is unhashed, so the tamper must survive the load hash gate");
+
+        let mut config = replay_config(true, vec![1]);
+        config.recording_dir = dir.clone();
+        let err = run(&config).await.unwrap_err();
+        assert!(format!("{err}").contains("never capability-gated"), "got: {err}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn reconcile_measure_and_restore_combines_a_dual_failure() {
+        // §3.5: when the measurement AND the final restore both fail, the caller must see both —
+        // the restore failure means the endpoint's graph may be left polluted, which the
+        // measurement error alone would hide.
+        let err = reconcile_measure_and_restore(
+            Err(OtherError("probe exploded".to_string())),
+            Err(OtherError("content diverged".to_string())),
+            "g7",
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("may be left polluted"), "got: {msg}");
+        assert!(msg.contains("g7"), "must name the graph: {msg}");
+        assert!(msg.contains("probe exploded"), "must surface the measurement error: {msg}");
+        assert!(msg.contains("content diverged"), "must surface the restore error: {msg}");
+    }
+
+    #[test]
+    fn reconcile_measure_and_restore_passes_single_outcomes_through() {
+        assert!(reconcile_measure_and_restore(Ok(()), Ok(()), "g").is_ok());
+        let err = reconcile_measure_and_restore(
+            Ok(()),
+            Err(OtherError("restore only".to_string())),
+            "g",
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("restore only"), "got: {err}");
+        let err = reconcile_measure_and_restore(
+            Err(OtherError("measure only".to_string())),
+            Ok(()),
+            "g",
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("measure only"), "got: {msg}");
+        assert!(!msg.contains("polluted"), "a successful restore is not a dual failure: {msg}");
     }
 }

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -338,7 +338,10 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                     &uid_alloc,
                     op_deadline,
                 )
-                .await?;
+                .await
+                .map_err(|e| {
+                    OtherError(format!("measuring write op '{}': {}", op.name(), e))
+                })?;
                 operations.insert(op.name().to_string(), op_report);
                 continue;
             }
@@ -376,7 +379,8 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                 &uid_alloc,
                 op_deadline,
             )
-            .await?;
+            .await
+            .map_err(|e| OtherError(format!("measuring op '{}': {}", op.name(), e)))?;
             // Gate the result only for byte-stable shapes; a result-N/A op reports `None` so the
             // diff guard renders it N/A instead of comparing a non-deterministic digest.
             op_report.result_digest =

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -18,14 +18,14 @@
 //! leaving latency to be compared advisorily by the [`crate::synthetic::baseline`] guard.
 //!
 //! **Write bundles** (recording format v2, Phase 7 §4.1 latency tier): a bundle whose ops are
-//! writes is measured via `GRAPH.QUERY` at **C=1 only**, with the base graph **reset (drop + load
-//! + count-verify) before every measured cell** (op × cache mode) so mutation drift stays bounded
-//! to one cell's invocations. Nothing is asserted about results or mutation counters — outcomes
-//! are state/value-dependent (§10), so the latency tier records `result_digest: None` and leaves
-//! correctness to the deferred oracle tier. The replay ends with an **error-safe final restore**:
-//! the recorded base is reloaded (on success *and* failure) and its node/edge content digests are
-//! verified against the pristine post-load capture, so a write replay can never leave a mutated
-//! graph behind on the endpoint.
+//! writes is measured via `GRAPH.QUERY` at **C=1 only**, with the base graph **reset (drop +
+//! load + count-verify) before every measured cell** (op × cache mode) so mutation drift stays
+//! bounded to one cell's invocations. Nothing is asserted about results or mutation counters —
+//! outcomes are state/value-dependent (§10), so the latency tier records `result_digest: None`
+//! and leaves correctness to the deferred oracle tier. The replay ends with an **error-safe final
+//! restore**: the recorded base is reloaded (on success *and* failure) and its node/edge content
+//! digests are verified against the pristine post-load capture, so a write replay can never leave
+//! a mutated graph behind on the endpoint.
 
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -717,15 +717,14 @@ fn render_shapes(
         }
         // The op's key kind follows its family: Write-family shapes render through the repo's
         // write seam and record as write ops (format v2, kind hashed); everything else is a read.
-        let (key_kind, render): (QueryType, &dyn Fn(&mut StdRng) -> Option<crate::queries_repository::PreparedQuery>) =
-            match shape.family {
-                CoverageFamily::Write => (QueryType::Write, &|rng: &mut StdRng| {
-                    repo.render_write_with_rng(shape.name, rng)
-                }),
-                _ => (QueryType::Read, &|rng: &mut StdRng| {
-                    repo.render_read_with_rng(shape.name, rng)
-                }),
-            };
+        let key_kind = match shape.family {
+            CoverageFamily::Write => QueryType::Write,
+            _ => QueryType::Read,
+        };
+        let render = |rng: &mut StdRng| match shape.family {
+            CoverageFamily::Write => repo.render_write_with_rng(shape.name, rng),
+            _ => repo.render_read_with_rng(shape.name, rng),
+        };
         let key = OpKey::dynamic(shape.name.to_string(), key_kind);
         let mut rng = StdRng::seed_from_u64(corpus_seed ^ key.salt());
         let mut commands = Vec::with_capacity(shape.corpus_size);

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -117,6 +117,10 @@ pub enum CoverageFamily {
     /// never by `--repo-reads`/tier, never in the per-PR gate, and absent from the A/B
     /// `--query-profile`.
     Algorithm,
+    /// An opt-in mutation shape (Phase 7 §1) — selected **only** by `--repo-writes`, never by
+    /// `--repo-reads`/tier, never in the per-PR gate. Latency tier: measured via `GRAPH.QUERY`
+    /// with periodic base-graph resets, result + counters untracked (design §4.1).
+    Write,
 }
 
 /// One repo read shape's synthetic metadata: its stable [`queries_repository`] name, coverage
@@ -317,12 +321,14 @@ pub fn repo_read_shapes() -> Vec<ShapeSpec> {
 }
 
 /// The coverage [`Tier`] of the recorded shape named `name` — **family-agnostic**: repo read
-/// shapes and the Phase 6 algorithm shapes alike — or `None` when no shape has that name. Lets
-/// string-keyed consumers (thresholds validation, report tier rollups) resolve a dynamic recorded
-/// op exactly like a static catalog op. Selection stays per-family ([`record_repo_reads`] /
-/// [`record_algorithm_reads`]) — this is a lookup, not a selector.
+/// shapes, the Phase 6 algorithm shapes and the Phase 7 write shapes alike — or `None` when no
+/// shape has that name. Lets string-keyed consumers (thresholds validation, report tier rollups)
+/// resolve a dynamic recorded op exactly like a static catalog op. Selection stays per-family
+/// ([`record_repo_reads`] / [`record_algorithm_reads`] / [`record_repo_writes`]) — this is a
+/// lookup, not a selector.
 pub fn shape_tier(name: &str) -> Option<Tier> {
-    // Chain the component lists (same order as `repo_read_shapes`, then the algorithm family)
+    // Chain the component lists (same order as `repo_read_shapes`, then the algorithm family,
+    // then the write family)
     // instead of materializing the combined Vec on every lookup;
     // `shape_tier_covers_every_shape` guards drift.
     baseline_read_shapes()
@@ -330,6 +336,7 @@ pub fn shape_tier(name: &str) -> Option<Tier> {
         .chain(extended_core_read_shapes())
         .chain(fixture_dependent_read_shapes())
         .chain(algorithm_read_shapes())
+        .chain(write_shapes())
         .find(|shape| shape.name == name)
         .map(|shape| shape.tier)
 }
@@ -447,6 +454,102 @@ pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {
     ]
 }
 
+/// The per-op replay budget every write shape records (Phase 7 §4.1): **C=1 only** — concurrent
+/// writes are explicitly deferred (design §5; interleaved mutations change what each invocation
+/// does, so a C>1 latency number would not be comparable across versions) — with a modest
+/// samples/warmup so the drift a cell accumulates between base resets stays small (~110
+/// invocations/cell). Cache modes + timeouts inherit the run's global knobs: the write shapes are
+/// single-entity point mutations, as cheap as the point reads, and their uncached-vs-cached
+/// compilation split is as meaningful as for reads. Recorded into the bundle ([`RecordedBudget`])
+/// and overlaid at replay; the resolved effective policy is persisted per op and guarded by
+/// `report --diff`.
+///
+/// [`RecordedBudget`]: crate::synthetic::catalog::RecordedBudget
+const WRITE_SWEEP: [usize; 1] = [1];
+const WRITE_BUDGET: OpBudget = OpBudget {
+    samples: Some(100),
+    warmup: Some(10),
+    concurrency: Some(&WRITE_SWEEP),
+    cache: None,
+    server_timeout_ms: None,
+    client_deadline_ms: None,
+};
+
+/// The curated annotation for the **10 opt-in write shapes** (Phase 7 §1), in `queries_repository`
+/// definition order. Selected **only** by `--repo-writes` — never by `--repo-reads`/tier, never in
+/// the per-PR gate ([`repo_read_shapes`] stays exactly the 50 non-algorithm reads).
+///
+/// The op *set* is auto-discovered: the drift-guard test asserts this table's names are **exactly**
+/// [`UsersQueriesRepository::write_names`], so adding/removing a write shape there fails the build
+/// until this table is updated.
+///
+/// Every shape is **latency-tier** (design §4.1): replayed via `GRAPH.QUERY` with periodic
+/// base-graph resets, and `ResultPolicy::NotApplicable` — mutation outcomes are state- and
+/// value-dependent (MERGE create-vs-match, SET-same-value counting 0, DETACH DELETE no-ops on
+/// repeat — §2/§10.1), `timestamp()`/`date()`/`rand()` values are non-reproducible (§3.4), and the
+/// correctness tier (an online per-command outcome oracle with per-invocation restore) is
+/// deliberately deferred to later Phase 7 PRs (§6.2–6.3). No capability: all plain Cypher.
+pub fn write_shapes() -> Vec<ShapeSpec> {
+    // Every row is a Write-family, Full-tier, result-N/A shape with the write budget and a full
+    // corpus; only the name and the N/A reason vary.
+    fn s(
+        name: &'static str,
+        why_na: &'static str,
+    ) -> ShapeSpec {
+        ShapeSpec {
+            name,
+            family: CoverageFamily::Write,
+            tier: Tier::Full,
+            result_policy: ResultPolicy::NotApplicable(why_na),
+            capability: None,
+            corpus_size: CORPUS_SIZE,
+            budget: WRITE_BUDGET,
+        }
+    }
+    vec![
+        s(
+            "single_vertex_write",
+            "latency tier — plain CREATE grows the graph (duplicate ids); outcome untracked",
+        ),
+        s(
+            "single_vertex_update",
+            "latency tier — SET counters are value-dependent (1↔0 on repeated value, §10.1)",
+        ),
+        s(
+            "single_edge_update",
+            "latency tier — server rand() picks the target edge; never correctness-verifiable (§3.4)",
+        ),
+        s(
+            "single_edge_write",
+            "latency tier — MERGE create-vs-match depends on accumulated state; date() non-reproducible",
+        ),
+        s(
+            "merge_user_insert_path",
+            "latency tier — create-once-then-match ordering; timestamp() non-reproducible (§10.2)",
+        ),
+        s(
+            "merge_user_upsert_existing",
+            "latency tier — ON MATCH SET counters value-dependent; timestamp() non-reproducible",
+        ),
+        s(
+            "merge_friend_edge_upsert",
+            "latency tier — MERGE create-vs-match depends on accumulated state; date() non-reproducible",
+        ),
+        s(
+            "detach_delete_user",
+            "latency tier — deletes are state-dependent (no-op on repeat) with variable counts",
+        ),
+        s(
+            "remove_user_property_and_label",
+            "latency tier — REMOVE needs prepared state; deferred to the correctness tier (§4.2)",
+        ),
+        s(
+            "foreach_loop_mutation",
+            "latency tier — SET counters value-dependent on repeat against the same User",
+        ),
+    ]
+}
+
 /// The algorithm selection [`record_algorithm_reads`] uses: **all four** enabled, so the
 /// repository registers every `algo_*` read and the drift-guard sees the complete set.
 fn all_algorithms() -> AlgorithmQuerySelection {
@@ -557,11 +660,37 @@ pub fn record_algorithm_reads(
     )
 }
 
+/// Render the 10 opt-in write shapes ([`write_shapes`]) into [`RecordedOp`]s — **offline**, no
+/// server (Phase 7 §3.1, selected by `--repo-writes`).
+///
+/// The write pool is profile-independent (registered unconditionally in `queries_repository`), so
+/// a plain Baseline repository sees all 10; the annotation table is validated against
+/// [`UsersQueriesRepository::write_names`] (annotation drift fails loudly). The rendered corpora
+/// address the plain generated dataset — seeded ids within `1..=vertices` (plus the disjoint
+/// `vertices + id` insert band `merge_user_insert_path` uses), no fixture. Replay measures them
+/// via `GRAPH.QUERY` with periodic base resets (latency tier, design §4.1).
+pub fn record_repo_writes(
+    vertices: i32,
+    edges: i32,
+    corpus_seed: u64,
+) -> BenchmarkResult<Vec<RecordedOp>> {
+    let repo = UsersQueriesRepository::new(
+        vertices,
+        edges,
+        Flavour::FalkorDB,
+        AlgorithmQuerySelection::default(),
+        QueryCoverageProfile::Baseline,
+    );
+    let available: BTreeSet<&str> = repo.write_names().iter().map(String::as_str).collect();
+    render_shapes(&repo, &available, "write", &write_shapes(), vertices, corpus_seed)
+}
+
 /// Render each of `shapes` into a [`RecordedOp`] from `repo`, seeding every shape's corpus with
 /// `corpus_seed ^ salt` (the op's [`OpKey::salt`]) so a given seed yields a byte-identical corpus
 /// (record-once → replay-verbatim). `available` is the repository's auto-discovered name set for
 /// the family being rendered; `kind` names it in the annotation-drift error. Shared by
-/// [`record_selected_shapes`] (non-algorithm reads) and [`record_algorithm_reads`] (Phase 6).
+/// [`record_selected_shapes`] (non-algorithm reads), [`record_algorithm_reads`] (Phase 6) and
+/// [`record_repo_writes`] (Phase 7 — rendered through the repo's write seam, keyed `Write`).
 fn render_shapes(
     repo: &UsersQueriesRepository,
     available: &BTreeSet<&str>,
@@ -586,21 +715,32 @@ fn render_shapes(
                 shape.name
             )));
         }
-        let key = OpKey::dynamic(shape.name.to_string(), QueryType::Read);
+        // The op's key kind follows its family: Write-family shapes render through the repo's
+        // write seam and record as write ops (format v2, kind hashed); everything else is a read.
+        let (key_kind, render): (QueryType, &dyn Fn(&mut StdRng) -> Option<crate::queries_repository::PreparedQuery>) =
+            match shape.family {
+                CoverageFamily::Write => (QueryType::Write, &|rng: &mut StdRng| {
+                    repo.render_write_with_rng(shape.name, rng)
+                }),
+                _ => (QueryType::Read, &|rng: &mut StdRng| {
+                    repo.render_read_with_rng(shape.name, rng)
+                }),
+            };
+        let key = OpKey::dynamic(shape.name.to_string(), key_kind);
         let mut rng = StdRng::seed_from_u64(corpus_seed ^ key.salt());
         let mut commands = Vec::with_capacity(shape.corpus_size);
         // An Algorithm-family multi-command corpus is a seeded set of DISTINCT commands (the
         // maxFlow pair set — measuring the same pair twice adds runtime without coverage), so
         // duplicate draws re-render, bounded and deterministically (same seed ⇒ same skips ⇒ same
-        // corpus). Read corpora keep plain sequential draws: duplicates there are legitimate
-        // (a parameterless read renders CORPUS_SIZE identical commands by design).
+        // corpus). Read and write corpora keep plain sequential draws: duplicates there are
+        // legitimate (a parameterless read renders CORPUS_SIZE identical commands by design).
         let need_distinct = shape.family == CoverageFamily::Algorithm && shape.corpus_size > 1;
         let mut seen = BTreeSet::new();
         let max_attempts = shape.corpus_size * 16;
         let mut attempts = 0usize;
         while commands.len() < shape.corpus_size && attempts < max_attempts {
             attempts += 1;
-            let prepared = repo.render_read_with_rng(shape.name, &mut rng).ok_or_else(|| {
+            let prepared = render(&mut rng).ok_or_else(|| {
                 OtherError(format!("shape '{}' failed to render", shape.name))
             })?;
             if need_distinct && !seen.insert(prepared.cypher.clone()) {
@@ -680,7 +820,11 @@ mod tests {
     fn shape_tier_covers_every_shape() {
         // Drift guard for the chained lookup: every shape in every family registry must resolve
         // to its own tier, so a new component list can't silently escape `shape_tier`.
-        for shape in repo_read_shapes().into_iter().chain(algorithm_read_shapes()) {
+        for shape in repo_read_shapes()
+            .into_iter()
+            .chain(algorithm_read_shapes())
+            .chain(write_shapes())
+        {
             assert_eq!(shape_tier(shape.name), Some(shape.tier), "{}", shape.name);
         }
     }
@@ -802,6 +946,58 @@ mod tests {
         // is reachable only through record_algorithm_reads.
         let reads_repo = read_shapes_repository(QueryCoverageProfile::FixtureDependent, 1000, 5000);
         assert!(reads_repo.algorithm_read_names().is_empty());
+    }
+
+    #[test]
+    fn write_shapes_match_exactly_the_repo_write_names() {
+        // Derive-with-annotation for Phase 7 (§8 acceptance): the annotation table must be EXACTLY
+        // the 10 writes the repository auto-discovers, in definition order (the record order that
+        // feeds workload_hash). If `queries_repository` adds/renames/removes/reorders a write,
+        // this fails until `write_shapes()` is realigned.
+        let repo = UsersQueriesRepository::new(
+            1000,
+            5000,
+            Flavour::FalkorDB,
+            AlgorithmQuerySelection::default(),
+            QueryCoverageProfile::Baseline,
+        );
+        let discovered: Vec<&str> = repo.write_names().iter().map(String::as_str).collect();
+        let annotated: Vec<&str> = write_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(annotated.len(), 10, "Phase 7 §1 defines exactly 10 write shapes");
+        assert_eq!(annotated, discovered, "write shapes drifted from repo write names");
+    }
+
+    #[test]
+    fn write_shapes_are_uniformly_latency_tier_annotated() {
+        // Phase 7 §4.1 (latency tier): every write shape is Write-family, Full-tier (never in the
+        // per-PR Core gate), result-N/A (mutation outcomes are state/value-dependent — §2/§10),
+        // plain Cypher (no capability), full corpus, and pinned to the C=1 write budget (§5 defers
+        // concurrent writes).
+        for shape in write_shapes() {
+            assert_eq!(shape.family, CoverageFamily::Write, "{}", shape.name);
+            assert_eq!(shape.tier, Tier::Full, "{}", shape.name);
+            assert!(
+                matches!(shape.result_policy, ResultPolicy::NotApplicable(_)),
+                "'{}' must be result-N/A in the latency tier",
+                shape.name
+            );
+            assert!(shape.capability.is_none(), "{}", shape.name);
+            assert_eq!(shape.corpus_size, CORPUS_SIZE, "{}", shape.name);
+            assert_eq!(shape.budget, WRITE_BUDGET, "{}", shape.name);
+        }
+        assert_eq!(WRITE_BUDGET.concurrency, Some(&WRITE_SWEEP[..]), "write replay is C=1 (§5)");
+    }
+
+    #[test]
+    fn repo_read_selection_is_unchanged_by_the_write_family() {
+        // --repo-reads must keep selecting EXACTLY the 50 non-algorithm reads: the write family is
+        // reachable only through record_repo_writes (its own selector), never via tier selection.
+        let selected = selected_shapes(Tier::Full);
+        assert_eq!(selected.len(), 50);
+        assert!(
+            selected.iter().all(|s| !matches!(s.family, CoverageFamily::Write | CoverageFamily::Algorithm)),
+            "tier selection must never pull in write or algorithm shapes"
+        );
     }
 
     #[test]
@@ -939,6 +1135,37 @@ mod tests {
         assert_eq!(unique_pairs.len(), MAX_FLOW_CORPUS_SIZE, "seeded pairs must differ");
         // …and the same seed reproduces the identical corpus (record-once → replay-verbatim).
         let again = record_algorithm_reads(1000, 5000, 7).expect("re-record");
+        for (a, b) in ops.iter().zip(&again) {
+            assert_eq!(a.commands, b.commands, "'{}' corpus must be seed-stable", a.key.name());
+        }
+    }
+
+    #[test]
+    fn record_repo_writes_renders_seeded_write_corpora() {
+        // The Phase 7 record path end-to-end (offline): 10 write ops in definition order, each
+        // keyed Write (kind feeds the format-v2 workload_hash), un-gated, budgeted C=1, with a
+        // full seed-stable corpus.
+        let ops = record_repo_writes(1000, 5000, 7).expect("record repo writes");
+        let names: Vec<&str> = ops.iter().map(|op| op.key.name()).collect();
+        let annotated: Vec<&str> = write_shapes().iter().map(|s| s.name).collect();
+        assert_eq!(names, annotated, "record order must be the annotation (definition) order");
+        for op in &ops {
+            assert_eq!(op.key.kind(), QueryType::Write, "{}", op.key.name());
+            assert!(!op.result_gated, "'{}' is latency-tier (result-N/A)", op.key.name());
+            assert!(op.capability.is_none(), "{}", op.key.name());
+            assert_eq!(
+                op.budget,
+                RecordedBudget::from(WRITE_BUDGET),
+                "'{}' must record the write budget",
+                op.key.name()
+            );
+            assert_eq!(op.commands.len(), CORPUS_SIZE, "{}", op.key.name());
+        }
+        // Spot-check rendered Cypher mutates (CREATE/SET/MERGE/DELETE/REMOVE/FOREACH)…
+        assert!(ops[0].commands[0].contains("CREATE"), "{}", ops[0].commands[0]);
+        assert!(ops[1].commands[0].contains("SET"), "{}", ops[1].commands[0]);
+        // …and the same seed reproduces the identical corpora (record-once → replay-verbatim).
+        let again = record_repo_writes(1000, 5000, 7).expect("re-record");
         for (a, b) in ops.iter().zip(&again) {
             assert_eq!(a.commands, b.commands, "'{}' corpus must be seed-stable", a.key.name());
         }

--- a/src/synthetic/thresholds.rs
+++ b/src/synthetic/thresholds.rs
@@ -647,6 +647,18 @@ concurrency = { 32 = 40.0 }
     }
 
     #[test]
+    fn accepts_write_shape_op_key() {
+        // Phase 7: a write shape name is a valid `[op.*]` key — `shape_tier` chains the write
+        // family, so per-op budgets can be tuned for recorded writes like any other dynamic op.
+        let cfg = "[op.merge_friend_edge_upsert]\nbudget_pct = 45.0\nfloor_ms = 1.0\n";
+        let t = Thresholds::from_toml_str(cfg).unwrap();
+        assert!(OpName::from_tag("merge_friend_edge_upsert").is_none(), "must be dynamic");
+        let r = t.resolve_by_name("merge_friend_edge_upsert", 1);
+        assert_eq!(r.budget_pct, 45.0);
+        assert_eq!(r.floor_ms, 1.0);
+    }
+
+    #[test]
     fn rejects_invalid_budget_and_floor_and_metric() {
         assert!(Thresholds::from_toml_str("[default]\nbudget_pct = -1.0\n")
             .unwrap_err()

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1609,7 +1609,7 @@ async fn record_and_replay_write_shapes_end_to_end() {
     use benchmark::cli::SyntheticCommands;
     use benchmark::synthetic::run_command;
 
-    let graph = "syn_it_writes";
+    let graph = "syn_it_repo_writes";
     drop_graph(graph).await;
     let dir = temp_bundle_dir("syn-it-writes");
     let out_dir = dir.to_string_lossy().into_owned();

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1697,6 +1697,80 @@ async fn record_and_replay_write_shapes_end_to_end() {
     drop_graph(graph).await;
 }
 
+/// Phase 7 §3.5 — a write replay that fails **during the reference pass** (a broken recorded
+/// command caught by the write fail-fast probe) must still run the error-safe final restore: an
+/// earlier op's probe has already mutated the graph by then, so skipping the restore would leave
+/// the endpoint polluted for the next recording/replay.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn failed_write_probe_still_restores_the_recorded_base() {
+    use benchmark::synthetic::catalog::RecordedBudget;
+    use benchmark::synthetic::recording::RecordedOp;
+    use benchmark::synthetic::OpKey;
+
+    let graph = "syn_it_write_probe_fail";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-probe-fail");
+    let spec = DatasetSpec {
+        seed: 7,
+        nodes: 50,
+        edges: 100,
+    };
+    // Op order matters: the first op's probe mutates the graph, then the second op's broken
+    // command fails its probe mid-reference-pass.
+    let ops = vec![
+        RecordedOp {
+            key: OpKey::dynamic("w_marker", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget {
+                concurrency: Some(vec![1]),
+                ..RecordedBudget::default()
+            },
+            capability: None,
+            commands: vec!["CREATE (:ProbeMarker)".to_string()],
+        },
+        RecordedOp {
+            key: OpKey::dynamic("w_broken", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget {
+                concurrency: Some(vec![1]),
+                ..RecordedBudget::default()
+            },
+            capability: None,
+            commands: vec!["CREAT (:Broken)".to_string()],
+        },
+    ];
+    recording::record_rendered(&spec, graph, &ops, spec.seed, 256, &dir).expect("record");
+
+    let out = dir.join("r.json").to_string_lossy().into_owned();
+    let config = replay_config(&dir, graph, &out, true);
+    let err = replay::run(&config)
+        .await
+        .expect_err("a broken write command must fail the replay at its probe");
+    assert!(
+        format!("{err:?}").contains("probing write 'w_broken'"),
+        "error should name the failing probe, got: {err:?}"
+    );
+
+    // The final restore ran despite the reference-pass failure: the marker probe's mutation is
+    // gone and the graph is exactly the recorded base again.
+    let mut g = open_graph(&endpoint(), graph).await.expect("open restored graph");
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH (m:ProbeMarker) RETURN count(m)").await,
+        0,
+        "probe mutation must be erased by the final restore"
+    );
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await,
+        50,
+        "restored graph must be the recorded base"
+    );
+    drop(g);
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
 #[tokio::test]
 #[ignore = "requires a running FalkorDB server"]
 async fn replay_concurrency_sweep_verifies_results_and_reports_levels() {

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1413,6 +1413,7 @@ async fn record_and_replay_via_run_command() {
         tier: None,
         repo_reads: None,
         repo_algorithms: false,
+        repo_writes: false,
         seed: Some(11),
         nodes: Some(400),
         edges: Some(1200),
@@ -1486,6 +1487,7 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
         tier: None,
         repo_reads: None,
         repo_algorithms: true,
+        repo_writes: false,
         seed: Some(7),
         nodes: Some(300),
         edges: Some(900),
@@ -1589,6 +1591,107 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
             "{name} digest must be byte-stable across independent replays"
         );
     }
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.1 acceptance: `record --repo-writes` (offline, via the CLI arm) then a live replay
+/// measures all 10 write shapes end-to-end via `GRAPH.QUERY` (empirics E1: `RO_QUERY` rejects
+/// writes) at the budgeted C=1, under BOTH cache modes with a base reset before every measured
+/// cell (§3.3 latency tier), asserting nothing about results (`result_digest: None`) while
+/// persisting each op's effective policy. The replay's error-safe final restore (§3.5) must leave
+/// the endpoint's graph content-identical to the recorded base — re-verified here by raw counts
+/// and by a second full replay of the same bundle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn record_and_replay_write_shapes_end_to_end() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::run_command;
+
+    let graph = "syn_it_writes";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-writes");
+    let out_dir = dir.to_string_lossy().into_owned();
+
+    run_command(SyntheticCommands::Record {
+        config: None,
+        graph: Some(graph.to_string()),
+        ops: vec![],
+        all_reads: false,
+        tier: None,
+        repo_reads: None,
+        repo_algorithms: false,
+        repo_writes: true,
+        seed: Some(7),
+        nodes: Some(300),
+        edges: Some(900),
+        out_dir: out_dir.clone(),
+    })
+    .await
+    .expect("record --repo-writes via run_command");
+
+    let bundle = recording::load(&dir).expect("load the recorded write bundle");
+    assert_eq!(bundle.manifest.format_version, 2, "write bundles are recording format v2");
+
+    let out = dir.join("writes.json").to_string_lossy().into_owned();
+    let mut config = replay_config(&dir, graph, &out, true);
+    // Global knobs the per-op write budget must override (samples/warmup/sweep) or inherit
+    // (cache: WRITE_BUDGET leaves it None, so the global Both applies — two cells per op).
+    config.samples = 3;
+    config.warmup = 1;
+    config.concurrency = vec![1, 2];
+    config.cache = benchmark::synthetic::CacheSelection::Both;
+    let report = replay::run(&config).await.expect("replay the 10 write shapes");
+
+    let expected: Vec<String> = bundle.manifest.ops.iter().map(|e| e.name.clone()).collect();
+    assert_eq!(expected.len(), 10, "the write family is exactly 10 shapes");
+    assert_eq!(
+        report.operations.len(),
+        10,
+        "every write shape must be measured: {:?}",
+        report.operations.keys().collect::<Vec<_>>()
+    );
+    for name in &expected {
+        let op = report
+            .operations
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} missing from the replay report"));
+        assert!(op.skipped.is_none(), "{name} is plain Cypher — never capability-skipped");
+        let level = only_level(op);
+        assert_eq!(level.concurrency, 1, "{name} must measure only the budgeted C=1");
+        assert!(level.cached.is_some(), "{name} measures the cached cell");
+        assert!(level.uncached.is_some(), "{name} measures the uncached cell (inherited Both)");
+        assert!(
+            level.compilation_ms_median.is_some(),
+            "{name} derives compilation cost from the merged cells"
+        );
+        assert!(
+            op.result_digest.is_none(),
+            "{name} is latency-tier: nothing asserted about results (§4.1)"
+        );
+        let policy = op.policy.as_ref().unwrap_or_else(|| panic!("{name} must persist policy"));
+        assert_eq!(policy.samples, 100, "{name} budgeted samples");
+        assert_eq!(policy.warmup, 10, "{name} budgeted warmup");
+        assert_eq!(policy.concurrency, vec![1], "{name} budgeted sweep");
+    }
+
+    // §3.5 error-safe final restore: the replay's own content verification passed (or run()
+    // would have failed); double-check from a fresh connection that the graph is EXACTLY the
+    // 300-node / 900-edge recorded base — no residue from ~2200 measured mutations.
+    let mut g = open_graph(&endpoint(), graph).await.expect("open restored graph");
+    assert_eq!(scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await, 300);
+    assert_eq!(scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await, 900);
+    drop(g);
+
+    // A second full replay of the same bundle proves the restored graph state is reusable
+    // end-to-end (fresh load, fresh resets, same invariants).
+    let out2 = dir.join("writes2.json").to_string_lossy().into_owned();
+    let mut config2 = replay_config(&dir, graph, &out2, true);
+    config2.samples = 3;
+    config2.warmup = 1;
+    let report2 = replay::run(&config2).await.expect("second write replay");
+    assert_eq!(report2.operations.len(), 10);
 
     std::fs::remove_dir_all(&dir).ok();
     drop_graph(graph).await;


### PR DESCRIPTION
Phase 7 PR-1: implements **§6.1 of the binding design** [`docs/design/synthetic-cover-writes-phase7.md`](https://github.com/FalkorDB/benchmark/blob/master/docs/design/synthetic-cover-writes-phase7.md) — the **latency tier** for all 10 A/B write shapes: a write-capable record/replay path that measures write latency/throughput and **asserts no correctness** (results + mutation counters untracked, per the design's corrected §2/§10 thesis that mutation counters are state/value/order-dependent and have no cheap deterministic oracle).

## What this adds

1. **Recording format v2 with a kind-bound `workload_hash`** (`recording.rs`). A bundle containing any write op is stamped `format_version: 2`, and under v2 each op's header feeds its `kind` (`read`/`write`) into the workload hash — a bundle's read/write nature can't be silently flipped (test: flipping the manifest kind fails the load-time hash recompute). **v1 read bundles hash byte-identically to before** (goldens `repo_reads_full_workload_hash_golden_is_pinned` and `read_bundles_stay_format_v1` pin this); `load()` accepts v1 and v2, and rejects a v1 manifest naming a write op *before* the hash recompute ("v1 bundles are read-only"). Mixed read+write bundles are rejected at record time (checked pre-dedup, so a same-named write can't hide) *and* re-checked at replay (a hand-crafted manifest with a correct v2 hash could still mix kinds).
2. **The write shape family** (`shapes.rs`): `CoverageFamily::Write` + a 10-row `write_shapes()` table — every write `queries_repository` auto-discovers, in definition order, drift-guarded by test against `write_names()` exactly like the Phase 6 algorithm family. All 10 are `Tier::Full`, **result-N/A**, capability-free, full 256-command corpus, and pin `WRITE_BUDGET`: **C=[1]** (§5 defers concurrent writes), samples 100, warmup 10, cache/timeouts inherited. `shape_tier` chains the family, so summary tier rollups and `[op.<name>]` threshold overrides resolve write op names (the #261 lesson, covered by test). `record_repo_writes()` renders through the repo's new `render_write_with_rng()` seam and keys ops `QueryType::Write`.
3. **`synthetic record --repo-writes`** (`cli.rs`, `mod.rs`): records the 10-shape write family as a single-kind write bundle. Mutually exclusive with **every** read selector (`--op`/`--all-reads`/`--tier`/`--repo-reads`/`--repo-algorithms`) per design §4: replay has one global sweep, so a mixed bundle can't express C=1 writes alongside swept reads.
4. **Write-bundle replay** (`replay.rs`):
   - **Offline fail-closed guards**, before any connection: single-kind bundle; `--no-load` refused; every write op's *effective* sweep (its recorded budget's, else the run's) must be exactly `[1]` — budgets sit **outside** `workload_hash`, so a tampered budget passes the load hash gate and must be caught here (proved by test: manifest edited to `concurrency: [8]` loads fine and is refused by the C=1 check); result-gated writes refused (§4.1: the latency tier asserts nothing).
   - **Fail-fast probe** via `GRAPH.QUERY` (first command, once, untimed — `RO_QUERY` rejects writes server-side, empirics E1); its mutation is erased by the first cell reset.
   - **Per-cell base reset (§3.3 "periodic reset", see interpretation note 1)**: before **every measured cell** (op × cache mode) the recorded graph is dropped + reloaded + count-verified. Each cell runs the shared closed-loop engine (`measure_op`) narrowed to one cache mode with `MeasureTarget { kind: Write, write: None }` — the existing worker already routes `Write` → `GRAPH.QUERY` — and the per-mode single-level results merge into one C=1 `LevelReport` (cached + uncached + derived compilation), so a write op's report shape matches a read op's. `result_digest` stays `None`; the effective per-op policy is always persisted (so `report --diff` / baseline guards refuse cross-policy comparisons, as shipped in #260).
   - **Error-safe final restore (§3.5)**: on success **and** failure the recorded base is reloaded and its **content** — not just counts — is verified: node + edge multiset digests (`MATCH (n) RETURN n`, `MATCH (a)-[r]->(b) RETURN ID(a), r, ID(b)` through the existing order-independent `capture_result` canonicalization) captured pristine right after the initial load must match after the final reload. On the failure path the restore still runs; if it fails too, the replay returns a combined error surfacing both the measurement and restore failures and warning the graph may be left polluted (`reconcile_measure_and_restore`).

## Worked example (run against the pinned image below)

```bash
benchmark synthetic record --repo-writes --nodes 1000 --edges 5000 --seed 7 --out-dir rec-writes
# recorded 10 op(s) into rec-writes (workload_hash sha256:25e211abfa99c668d1d0be73f17778d0c30614de7b7575f650822d985cd4210d)

benchmark synthetic run --recording rec-writes --endpoint falkor://127.0.0.1:16409 --out writes.json
```

The full 10-op replay (10 ops × cached+uncached × (100+10) invocations + 20 base resets on the 1000/5000 graph) took **8.9 s** wall. Excerpt:

```text
single_vertex_write
  [cached — plan reused, execution only]
    C    throughput(ops/s)   server p50/p90/p95/p99             total p50/p90/p95/p99              miss%
    1              2347     0.022 / 0.026 / 0.028 / 0.030     0.418 / 0.453 / 0.467 / 0.481     0.0  <- knee
  [uncached — plan-cache miss each run, execution + compilation]
    1              1672     0.049 / 0.069 / 0.088 / 0.101     0.552 / 0.727 / 0.773 / 0.801   100.0  <- knee
  compilation_ms (median uncached-cached server time) by level:
    C=1    0.026
```

Per-op report entry (every write op): `result_digest` **absent** (nothing asserted), and

```json
"policy": {"samples": 100, "warmup": 10, "concurrency": [1], "cache": "both", "server_timeout_ms": 5000, "client_deadline_ms": 6000}
```

After the run, the endpoint's graph is exactly the recorded base again: `MATCH (n) RETURN count(n)` → **1000**, `MATCH ()-[r]->() RETURN count(r)` → **5000** (content-digest-verified internally by the replay itself).

## Empirical evidence (design-mandated checks, run before implementation)

All on **`falkordb/falkordb:edge` pinned `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`** (same digest as the Phase 6 evidence).

| # | Claim (design §) | Result |
|---|---|---|
| E1 | Replay is read-only by construction (§3.1) | `GRAPH.RO_QUERY w7 "CREATE …"` → error `graph.RO_QUERY is to be executed only on read-only queries` — writes **must** go through `GRAPH.QUERY`, so the write path can't reuse the reference-capture (`RO_QUERY`) machinery. |
| E3 | Counters are value-change-dependent (§2/§10.1) | `SET n.x = 42` twice: first reply `Properties set: 1`, second reply emits **no** properties-set stat (0) — a constant expected-counter model is wrong. |
| E4 | Outcomes are order/state-dependent (§2/§10.2) | `MERGE` same id twice: `Nodes created: 1, Properties set: 2, Labels added: 1` then **no stats**; `DETACH DELETE` twice: `Nodes deleted: 1` then nothing — create-once-then-match / delete-then-no-op accumulation confirmed. |
| E5 | Reset affordability (§3.3) | Full replay of a 1-op bundle on the seed-7 1000/5000 graph: 0.420 s with load vs 0.161 s `--no-load` ⇒ drop+reload+verify ≈ **0.26 s**. Per-cell reset ⇒ 10 ops × 2 modes ≈ **+5.2 s/run** — affordable (measured: full 10-op replay 8.9 s). |
| e2e | Live acceptance | `record_and_replay_write_shapes_end_to_end` (seed 7, 300/900, bundle `workload_hash sha256:160db9317b717a40bfa2b548191b567244918247b3f4a22a15cbf925b4653888`): records via the CLI arm, replays all 10 shapes (C=1 only, both cache cells, digest `None`, policy persisted), then proves the restore by raw counts **and** a second full replay. |

## Interpretation notes (design ambiguities, resolved here — flagged per house rules)

1. **"Periodic base reset" (§3.3/§4.1) ⇒ per-cell.** The design fixes per-*invocation* restore to the correctness tier and says the latency tier "uses a cheaper periodic reset and asserts nothing", without pinning the period. I implemented the reset per **measured cell** (op × cache mode): E5 makes that ≈ 5 s/run, and it bounds drift to one cell's ≤ 110 invocations while keeping every cell's starting state identical (fair cross-version comparison). A coarser period (per-op / per-run) would be cheaper but let drift leak across cache modes/ops.
2. **`WRITE_BUDGET` values are my choice**: samples 100 / warmup 10 (vs the global 200/30 read defaults) keeps a cell ≈ 110 invocations — enough for stable p50/p90 on sub-ms writes, small enough to bound drift; cache + timeouts inherit the run's globals. C=[1] is the design's (§5).
3. **Content verification method (§3.5)**: node + edge multiset digests via the existing `capture_result` canonicalization, which includes entity ids — deterministic across identical fresh loads because the recorded statements replay in recorded order onto an empty graph (the same property the Phase 6 digest byte-stability evidence rests on).
4. **Corpus size 256 for writes** (uniformity with reads); only ~110 of each corpus is consumed per cell.
5. **C=1 is a hard replay-side check**, not just a recorded budget: budgets are deliberately outside `workload_hash`, so the guard re-derives each write op's effective sweep and refuses anything but `[1]`.
6. **Catalog write ops stay un-recordable** (`recording::record` still rejects them, now pointing at `--repo-writes`): their scratch/reset hooks don't replay verbatim; the recorded write family is the repo shapes.

## Design sections (verbatim)

> **§6.1** — Write-capable record/replay (latency-only): versioned bundle with hashed write kind, recorded-write worker, `GRAPH.QUERY` measure path, periodic base reset. Latency tier for all 10.

> **§4 Approach — two tiers, latency-first**
> 1. **Latency tier (achievable, primary goal):** a write-capable record/replay path (`GRAPH.QUERY`, recorded-write worker, versioned bundle) that **measures write latency/throughput** with periodic base-graph reset to bound drift, and **asserts no correctness** (result + counters both untracked). This alone delivers per-op **trend** coverage for all 10 write shapes — the A/B trend goal.
> 2. **Correctness tier (harder, partial, deferred):** an **online-recorded per-command outcome oracle** … for the **deterministic subset only** …
>
> Selection is an **orthogonal** `--repo-writes` axis (like Phase 6's `--repo-algorithms`), initially **mutually exclusive** with `--repo-reads` (replay has one global concurrency sweep, so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).

> **§3.5 Restore safety & verification are load-bearing** — `--no-load` verifies only node/edge **counts**, missing property/label corruption; a failed write run must **restore on both success and failure**; `workload_hash` hashes bundle files, not live state. **Fix:** error-safe final restore, forbid `--no-load` for writes, and verify graph **content** (not just counts) after a write run so a later read recording is not silently polluted.

> **§8 Acceptance (latency tier)** — opt-in record + replay of all 10 write shapes on the FalkorDB per-PR image with periodic base reset, off the per-PR read gate, no correctness assertion. … A drift-guard binds the shape table to `queries_repository`'s 10 write names.

## Part B / schema deltas

**None.** Summary stays **v3**, cells stay **v2** — no regression/report schema change in this PR. Recording **format v2** is bundle-internal (manifest `format_version` + per-command `kind` + the kind-aware hash); it never crosses the report/summary/cells surface the next-gen consumers read. The per-PR `synthetic-verify` gate is untouched and still reads-only (§9): proven by the pinned `--repo-reads full` workload-hash golden and a green `just synthetic-verify` run.

## Validation

- `just ci` — green (411 unit tests + integration + doctests; clippy denies warnings).
- `just coverage` vs the pinned-image container (`FALKORDB_HOST=127.0.0.1 FALKORDB_PORT=16409`) — green, all 28 `synthetic_probe` tests incl. the new live write e2e. **Patch coverage 97.35 %** (699/718 executable added lines; the only misses are fault-injection error arms: restore-after-measurement-failure logging, defensive empty-level guards).
- `just doc-links` + `just doc-shell` — green.
- `just synthetic-sanity` — green, **unchanged**.
- `just synthetic-verify` — green, **unchanged** (reads-only per-PR gate unaffected).
- Docs synced: `readme.md` (`--repo-writes` + write-replay semantics), `docs/synthetic-benchmark-cookbook.md` (write-shapes variant with worked example), design doc status marker (§6.1 implemented).

## Deviations from the design

None functional. §3.1's "recorded-write worker" is realized *without* a new worker type: the existing closed-loop worker already routes `kind: Write` → `GRAPH.QUERY`, so recorded writes reuse the read worker's corpus source with the write kind (`MeasureTarget { kind: Write, write: None }`) — same measured path, no scratch hooks. The design's §6.2–§6.5 (outcome model, online oracle, prepared-state variants, C>1 decision) are intentionally not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--repo-writes` mode to record and replay dedicated write benchmark bundles (10 operations).
  * Write bundles use a fixed concurrency of 1, enforce write-only semantics, and report latency-style results without requiring result/mutation assertions.
  * Write replay now resets the base graph per measured cell and performs error-safe final restoration.

* **Bug Fixes**
  * Improved validation to reject invalid/tampered write bundles and unsupported replay options (e.g., `--no-load`, mixed read/write, non-C1).

* **Documentation**
  * Updated the README, cookbook, and design docs with `--repo-writes` usage, bundle rules, and replay guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
