### PR TITLE
feat(synthetic): generalized write outcome model, full MutationStats, restore primitive (Phase 7 §6.2)

### DIFF
--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -3,8 +3,9 @@
 **Status:** §6.1 **implemented** (write-capable record/replay, latency tier for all 10 write
 shapes — recording format v2 with kind-bound `workload_hash`, `--repo-writes` selector,
 `GRAPH.QUERY` C=1 measure path with per-cell base reset + verified error-safe final restore);
-§6.2–§6.5 (outcome model, online oracle / correctness tier, prepared-state variants, concurrency)
-**not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+§6.2 **implemented** (generalized `ExpectedOutcome` model, full 7-counter `MutationStats`,
+`restore_base` per-invocation restore primitive); §6.3–§6.5 (online oracle / correctness tier,
+prepared-state variants, concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
 merged in PRs #240–#250) and is the sibling of the algorithms design (Phase 6). The parent design
@@ -127,8 +128,8 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 ## 6. Phasing (each its own PR)
 1. ✅ **Write-capable record/replay (latency-only):** versioned bundle with hashed write kind,
    recorded-write worker, `GRAPH.QUERY` measure path, periodic base reset. Latency tier for all 10.
-2. ⛔ **Generalized outcome model + full `MutationStats`** (`relationships_deleted`/`properties_removed`/
-   `labels_removed`); per-invocation restore primitive.
+2. ✅ **Generalized outcome model + full `MutationStats`** (`relationships_deleted`/`properties_removed`/
+   `labels_removed`); per-invocation restore primitive (`replay::restore_base`).
 3. ⛔ **Online outcome oracle** at record time (capture per-command stats+result), C=1 correctness tier
    for the deterministic subset.
 4. ⛔ **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -44,12 +44,14 @@ first draft listed 8 and mis-described several:
 The synthetic **live** path benchmarks *synthetic-owned* writes with isolation
 (`src/synthetic/writes.rs`, `src/synthetic/catalog.rs:272-370`), but the primitives **do not** transfer cleanly:
 
-- **`ExpectedMutation`** is **5 rigid unit variants** and **`MutationStats` has only 4 counters**
-  (`src/synthetic/writes.rs:221-287`): `nodes_created`/`nodes_deleted`/`relationships_created`/`properties_set` —
+- **`ExpectedMutation`** *was* **5 rigid unit variants** and **`MutationStats` had only 4 counters**:
+  `nodes_created`/`nodes_deleted`/`relationships_created`/`properties_set` —
   **no** `relationships_deleted`, `properties_removed`, or `labels_removed` (the client exposes them,
   `vendor/falkordb-rs/src/response/mod.rs:109-156`). So `detach_delete_user` and
-  `remove_user_property_and_label` are **unrepresentable** today, and `NodeMatched` (which requires
-  `properties_set == 0`) cannot model an upsert that matches *and* updates.
+  `remove_user_property_and_label` were **unrepresentable**, and `NodeMatched` (which required
+  `properties_set == 0`) could not model an upsert that matches *and* updates. *Resolved by §6.2
+  (phasing item 2): `MutationStats` now carries all 7 counters and the generalized `ExpectedOutcome`
+  (`src/synthetic/writes.rs`) replaces the variants with per-counter `Exactly(n)`/`Any` expectations.*
 - **`verify_mutation` is value-dependent, not value-independent** — FalkorDB counts *actual* changes,
   so `single_vertex_update`/`merge_user_upsert_existing`/`single_edge_update` flap between
   `properties_set` 1 and 0 when a repeated value is already set (observed even at C=1).
@@ -121,7 +123,8 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 - **In (correctness tier, staged):** the deterministic fixed-outcome subset (the two plain
   create/update, the create-once MERGEs, `foreach_loop_mutation`) via the online oracle at C=1.
 - **Deferred:** `single_edge_update` (server `rand()`), `remove_user_property_and_label` (prepared
-  state), `detach_delete_user`'s variable counts until `relationships_deleted` is added; C>1 writes.
+  state), `detach_delete_user`'s variable counts until the §6.3 online oracle records per-invocation
+  expected values (the `relationships_deleted` counter itself landed with §6.2); C>1 writes.
 - **Out:** Neo4j/Memgraph variants; any digest gating of write results; any change to the per-PR read
   gate or the A/B `--query-profile`.
 

--- a/src/synthetic/catalog.rs
+++ b/src/synthetic/catalog.rs
@@ -12,7 +12,7 @@ use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::query::{Query, QueryBuilder};
-use crate::synthetic::writes::{ExpectedMutation, WritePlan, WriteScratch};
+use crate::synthetic::writes::{ExpectedOutcome, WritePlan, WriteScratch};
 use crate::synthetic::{CacheSelection, OpName, Tier};
 use rand::{Rng, RngExt};
 use serde::{Deserialize, Serialize};
@@ -327,7 +327,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
-                expected: ExpectedMutation::NodeCreated,
+                expected: ExpectedOutcome::node_created(),
                 plan_tag: "create_node.v1",
                 default_reset_every: DEFAULT_RESET_EVERY,
                 setup: write_clear_band,
@@ -345,7 +345,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
-                expected: ExpectedMutation::NodeCreated,
+                expected: ExpectedOutcome::node_created(),
                 plan_tag: "merge_miss.v1",
                 default_reset_every: DEFAULT_RESET_EVERY,
                 setup: write_clear_band,
@@ -363,7 +363,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
-                expected: ExpectedMutation::RelationshipCreated,
+                expected: ExpectedOutcome::relationship_created(),
                 plan_tag: "create_edge.v1",
                 default_reset_every: DEFAULT_RESET_EVERY,
                 setup: write_reset_populated,
@@ -381,7 +381,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
-                expected: ExpectedMutation::PropertySet,
+                expected: ExpectedOutcome::property_set(),
                 plan_tag: "set_property.v1",
                 default_reset_every: DEFAULT_RESET_EVERY,
                 setup: write_reset_populated,
@@ -399,7 +399,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
-                expected: ExpectedMutation::NodeDeleted,
+                expected: ExpectedOutcome::node_deleted(),
                 plan_tag: "delete_node.v1",
                 default_reset_every: DEFAULT_RESET_EVERY,
                 setup: write_reset_populated,
@@ -417,7 +417,7 @@ pub fn spec(op: OpName) -> OperationSpec {
             budget: OpBudget::INHERIT,
             corpus: write_corpus_stub,
             write: Some(WritePlan {
-                expected: ExpectedMutation::NodeMatched,
+                expected: ExpectedOutcome::node_matched(),
                 plan_tag: "merge_hit.v1",
                 default_reset_every: DEFAULT_RESET_EVERY,
                 setup: write_reset_populated,
@@ -879,20 +879,19 @@ mod tests {
 
     #[test]
     fn write_ops_carry_a_write_plan_and_write_kind() {
-        use ExpectedMutation::*;
         let expected = [
-            (OpName::CreateNode, NodeCreated),
-            (OpName::MergeMiss, NodeCreated),
-            (OpName::CreateEdge, RelationshipCreated),
-            (OpName::SetProperty, PropertySet),
-            (OpName::DeleteNode, NodeDeleted),
-            (OpName::MergeHit, NodeMatched),
+            (OpName::CreateNode, ExpectedOutcome::node_created()),
+            (OpName::MergeMiss, ExpectedOutcome::node_created()),
+            (OpName::CreateEdge, ExpectedOutcome::relationship_created()),
+            (OpName::SetProperty, ExpectedOutcome::property_set()),
+            (OpName::DeleteNode, ExpectedOutcome::node_deleted()),
+            (OpName::MergeHit, ExpectedOutcome::node_matched()),
         ];
-        for (op, mutation) in expected {
+        for (op, outcome) in expected {
             let s = spec(op);
             assert_eq!(s.kind, QueryType::Write, "{} is a write op", op.as_str());
             let plan = s.write.expect("write op carries a WritePlan");
-            assert_eq!(plan.expected, mutation, "{} expected mutation", op.as_str());
+            assert_eq!(plan.expected, outcome, "{} expected outcome", op.as_str());
             assert_eq!(plan.default_reset_every, DEFAULT_RESET_EVERY);
         }
         // Every catalog op agrees on kind vs. the presence of a write plan.

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -69,13 +69,16 @@ pub async fn run_and_drain(
         .map_err(|e| OtherError(format!("query '{}' failed: {:?}", cypher, e)))?;
 
         let cached = query_result.get_cached_execution();
-        // Read the mutation counters (absent ⇒ 0, e.g. for reads) before draining the stream, so a
-        // write worker can verify the sample actually did what the operation intends.
+        // Read the full mutation-counter set (absent ⇒ 0, e.g. for reads) before draining the
+        // stream, so a write worker can verify the sample actually did what the operation intends.
         let mutations = MutationStats {
             nodes_created: query_result.get_nodes_created().unwrap_or(0),
             nodes_deleted: query_result.get_nodes_deleted().unwrap_or(0),
             relationships_created: query_result.get_relationship_created().unwrap_or(0),
+            relationships_deleted: query_result.get_relationship_deleted().unwrap_or(0),
             properties_set: query_result.get_properties_set().unwrap_or(0),
+            properties_removed: query_result.get_properties_removed().unwrap_or(0),
+            labels_removed: query_result.get_labels_removed().unwrap_or(0),
         };
         // A missing server-time stat is a hard error — never fold it into the numbers as NaN/0.
         let server_ms = validate_server_ms(query_result.get_internal_execution_time(), cypher)?;

--- a/src/synthetic/op_runner.rs
+++ b/src/synthetic/op_runner.rs
@@ -69,7 +69,7 @@ pub async fn run_and_drain(
         .map_err(|e| OtherError(format!("query '{}' failed: {:?}", cypher, e)))?;
 
         let cached = query_result.get_cached_execution();
-        // Read the full mutation-counter set (absent ⇒ 0, e.g. for reads) before draining the
+        // Read every MutationStats counter (absent ⇒ 0, e.g. for reads) before draining the
         // stream, so a write worker can verify the sample actually did what the operation intends.
         let mutations = MutationStats {
             nodes_created: query_result.get_nodes_created().unwrap_or(0),

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -611,7 +611,10 @@ const CONTENT_QUERIES: [&str; 2] =
     ["MATCH (n) RETURN n", "MATCH (a)-[r]->(b) RETURN ID(a), r, ID(b)"];
 
 /// Capture the graph's full content shape ([`CONTENT_QUERIES`]) under load-scale timeouts.
-async fn capture_graph_content(
+/// `pub` as [`restore_base`]'s verification counterpart: the §3.5 final restore compares against
+/// it, the restore-primitive integration test proves restores content-identical (not merely
+/// count-identical) with it, and §6.3's correctness tier captures the pristine base through it.
+pub async fn capture_graph_content(
     graph: &mut AsyncGraph,
     config: &ReplayConfig,
 ) -> BenchmarkResult<Vec<ResultShape>> {

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -546,11 +546,8 @@ async fn measure_write_op(
     let mut cached = None;
     let mut uncached = None;
     for &mode in op_config.cache.modes() {
-        // Per-cell base reset, on its own short-lived connection (the measurement workers open
-        // their own).
-        let mut reset_conn = open_graph(&config.endpoint, graph_name).await?;
-        load_recorded_graph(&mut reset_conn, bundle, graph_name, dataset_spec, config).await?;
-        drop(reset_conn);
+        // Per-cell base reset (§4.1's periodic reset — one restore per measured cell).
+        restore_base(config, bundle, graph_name, dataset_spec).await?;
         let cell_config = Config {
             cache: match mode {
                 CacheMode::Cached => CacheSelection::Cached,
@@ -719,6 +716,26 @@ async fn probe_procedures(
                 e
             ))
         })?
+}
+
+/// Restore the recorded pristine base into `graph_name` — drop + reload the bundle's recorded
+/// statements + verify counts (the exact `--generate` load path), on a fresh short-lived
+/// connection (the measurement workers hold their own).
+///
+/// This is the Phase 7 §3.3 **restore primitive**: the §4.1 latency tier calls it once per
+/// measured cell (a periodic reset bounding mutation drift to one cell's invocations), and the
+/// §6.3 correctness tier will call it **before each measured invocation** (per-invocation pristine
+/// state at C=1, so accumulated-state effects — MERGE create-vs-match, delete no-ops — can't skew
+/// the recorded outcome). Restores always run *between* invocations/cells, never inside a timed
+/// sample, so their cost lands in wall-clock only — sample latencies stay clean.
+pub async fn restore_base(
+    config: &ReplayConfig,
+    bundle: &Bundle,
+    graph_name: &str,
+    spec: &DatasetSpec,
+) -> BenchmarkResult<()> {
+    let mut conn = open_graph(&config.endpoint, graph_name).await?;
+    load_recorded_graph(&mut conn, bundle, graph_name, spec, config).await
 }
 
 /// Drop `graph`, execute the bundle's recorded load statements, and verify the node/edge counts.

--- a/src/synthetic/writes.rs
+++ b/src/synthetic/writes.rs
@@ -14,7 +14,7 @@
 //!    sequence (warm-up included), bounding accumulation to one sawtooth window.
 //! 3. **Silent no-ops** — a `delete` with no target, or a `merge` that hit when it should have
 //!    missed, would benchmark the wrong thing. [`verify_mutation`] checks FalkorDB's reported
-//!    mutation counters against the operation's [`ExpectedMutation`] on every sample.
+//!    mutation counters against the operation's [`ExpectedOutcome`] on every sample.
 //!
 //! These primitives are deliberately pure (no I/O), so the tricky invariants — reset cadence, key
 //! disjointness, mutation checks — are unit-tested in isolation before being wired into the engine.
@@ -196,7 +196,7 @@ impl WriteScratch {
 pub struct WritePlan {
     /// What each invocation must mutate, checked against the response counters via
     /// [`verify_mutation`].
-    pub expected: ExpectedMutation,
+    pub expected: ExpectedOutcome,
     /// A stable identifier for this operation's query shape, folded into the workload hash so a
     /// change to the write bodies makes old and new runs incomparable. Bump the suffix when the
     /// cypher changes (e.g. `"create_node.v1"`).
@@ -216,84 +216,177 @@ pub struct WritePlan {
 }
 
 /// The mutation counters FalkorDB reports for a query, used to verify a write actually did what the
-/// operation intends (rather than silently matching nothing).
+/// operation intends (rather than silently matching nothing). Covers the full counter set a write
+/// can move (Phase 7 §6.2): absent counters read as 0 (FalkorDB omits untouched statistics).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct MutationStats {
     pub nodes_created: i64,
     pub nodes_deleted: i64,
     pub relationships_created: i64,
+    pub relationships_deleted: i64,
     pub properties_set: i64,
+    pub properties_removed: i64,
+    pub labels_removed: i64,
 }
 
-/// What a write operation must effect on **each** invocation, checked against the response's
-/// [`MutationStats`] so a no-op (a delete with no target, a merge that hit instead of missed) is a
-/// hard error rather than a fast, misleading sample.
+/// One mutation counter's per-invocation expectation: pinned to an exact value, or explicitly
+/// unconstrained (for counters that legitimately vary, like a create's inline `properties_set`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExpectedMutation {
-    /// Exactly one node created (`create_node`, `merge_miss`).
-    NodeCreated,
-    /// Exactly one node deleted (`delete_node`).
-    NodeDeleted,
-    /// Exactly one relationship created (`create_edge`).
-    RelationshipCreated,
-    /// Exactly one property set (`set_property`).
-    PropertySet,
-    /// A merge that matched an existing node — **no** node created (`merge_hit`).
-    NodeMatched,
+pub enum CounterExpectation {
+    /// The counter must equal exactly this value.
+    Exactly(i64),
+    /// The counter is legitimately variable — not checked.
+    Any,
 }
 
-/// Verify a sample's [`MutationStats`] match the operation's [`ExpectedMutation`], returning a clear
-/// error naming the mismatch so an operation that silently benchmarks the wrong thing fails loudly.
+impl CounterExpectation {
+    /// Whether `reported` satisfies this expectation.
+    fn accepts(
+        self,
+        reported: i64,
+    ) -> bool {
+        match self {
+            CounterExpectation::Exactly(want) => reported == want,
+            CounterExpectation::Any => true,
+        }
+    }
+}
+
+/// What a write operation must effect on **each** invocation — one [`CounterExpectation`] per
+/// [`MutationStats`] counter, checked by [`verify_mutation`] so a no-op (a delete with no target, a
+/// merge that hit instead of missed) is a hard error rather than a fast, misleading sample.
 ///
-/// Each variant asserts its **primary** counter *and* that no **conflicting structural** mutation
-/// happened (a `create_node` that also deleted a node or created a relationship is rejected, not
-/// just one that created zero nodes). `properties_set` is deliberately left unconstrained for the
-/// create/edge variants because inline properties (`{id: $id}`, `{eid: $eid}`) legitimately count
-/// toward it, and FalkorDB's exact accounting for inline-vs-`SET` properties is pinned per operation
-/// against a live server in the Part 5b integration tests; the non-create variants, which set no
-/// inline properties, do assert `properties_set == 0`.
+/// This is the generalized per-invocation outcome model of Phase 7 §6.2 (replacing five rigid
+/// unit variants that could not express `DETACH DELETE`'s `relationships_deleted` or `REMOVE`'s
+/// `properties_removed`/`labels_removed`): the catalog's fixed-shape writes use the named
+/// constructors below, and the §6.3 online oracle pins a recorded per-command outcome with
+/// [`ExpectedOutcome::exactly`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExpectedOutcome {
+    pub nodes_created: CounterExpectation,
+    pub nodes_deleted: CounterExpectation,
+    pub relationships_created: CounterExpectation,
+    pub relationships_deleted: CounterExpectation,
+    pub properties_set: CounterExpectation,
+    pub properties_removed: CounterExpectation,
+    pub labels_removed: CounterExpectation,
+}
+
+impl ExpectedOutcome {
+    /// Every counter pinned to 0 — the base the named constructors override, and exactly what a
+    /// pure match (`merge_hit`) must report.
+    const ZERO: Self = Self {
+        nodes_created: CounterExpectation::Exactly(0),
+        nodes_deleted: CounterExpectation::Exactly(0),
+        relationships_created: CounterExpectation::Exactly(0),
+        relationships_deleted: CounterExpectation::Exactly(0),
+        properties_set: CounterExpectation::Exactly(0),
+        properties_removed: CounterExpectation::Exactly(0),
+        labels_removed: CounterExpectation::Exactly(0),
+    };
+
+    /// Pin every counter to the given stats — the §6.3 oracle mode, where record captured the
+    /// command's *actual* outcome and replay must reproduce it exactly.
+    pub fn exactly(stats: MutationStats) -> Self {
+        Self {
+            nodes_created: CounterExpectation::Exactly(stats.nodes_created),
+            nodes_deleted: CounterExpectation::Exactly(stats.nodes_deleted),
+            relationships_created: CounterExpectation::Exactly(stats.relationships_created),
+            relationships_deleted: CounterExpectation::Exactly(stats.relationships_deleted),
+            properties_set: CounterExpectation::Exactly(stats.properties_set),
+            properties_removed: CounterExpectation::Exactly(stats.properties_removed),
+            labels_removed: CounterExpectation::Exactly(stats.labels_removed),
+        }
+    }
+
+    /// Exactly one node created (`create_node`, `merge_miss`). `properties_set` is unconstrained:
+    /// the shape's inline property (`{id: $id}`) legitimately counts toward it.
+    pub fn node_created() -> Self {
+        Self {
+            nodes_created: CounterExpectation::Exactly(1),
+            properties_set: CounterExpectation::Any,
+            ..Self::ZERO
+        }
+    }
+
+    /// Exactly one node deleted (`delete_node`), nothing else — the scratch target is edgeless, so
+    /// even `relationships_deleted` must stay 0.
+    pub fn node_deleted() -> Self {
+        Self {
+            nodes_deleted: CounterExpectation::Exactly(1),
+            ..Self::ZERO
+        }
+    }
+
+    /// Exactly one relationship created (`create_edge`). `properties_set` is unconstrained for the
+    /// same inline-property reason as [`ExpectedOutcome::node_created`].
+    pub fn relationship_created() -> Self {
+        Self {
+            relationships_created: CounterExpectation::Exactly(1),
+            properties_set: CounterExpectation::Any,
+            ..Self::ZERO
+        }
+    }
+
+    /// Exactly one property set (`set_property`), nothing else.
+    pub fn property_set() -> Self {
+        Self {
+            properties_set: CounterExpectation::Exactly(1),
+            ..Self::ZERO
+        }
+    }
+
+    /// A merge that matched an existing node (`merge_hit`) — every counter must be 0.
+    pub fn node_matched() -> Self {
+        Self::ZERO
+    }
+}
+
+/// Verify a sample's [`MutationStats`] satisfy the operation's [`ExpectedOutcome`], returning a
+/// clear error naming every mismatching counter so an operation that silently benchmarks the wrong
+/// thing fails loudly.
 pub fn verify_mutation(
-    expected: ExpectedMutation,
+    expected: ExpectedOutcome,
     stats: &MutationStats,
 ) -> BenchmarkResult<()> {
-    let ok = match expected {
-        ExpectedMutation::NodeCreated => {
-            stats.nodes_created == 1
-                && stats.nodes_deleted == 0
-                && stats.relationships_created == 0
-        }
-        ExpectedMutation::NodeDeleted => {
-            stats.nodes_deleted == 1
-                && stats.nodes_created == 0
-                && stats.relationships_created == 0
-                && stats.properties_set == 0
-        }
-        ExpectedMutation::RelationshipCreated => {
-            stats.relationships_created == 1
-                && stats.nodes_created == 0
-                && stats.nodes_deleted == 0
-        }
-        ExpectedMutation::PropertySet => {
-            stats.properties_set == 1
-                && stats.nodes_created == 0
-                && stats.nodes_deleted == 0
-                && stats.relationships_created == 0
-        }
-        ExpectedMutation::NodeMatched => {
-            stats.nodes_created == 0
-                && stats.nodes_deleted == 0
-                && stats.relationships_created == 0
-                && stats.properties_set == 0
-        }
-    };
-    if ok {
+    // (counter name, expectation, reported) — one row per MutationStats counter, so a new counter
+    // can't be silently skipped here (the exhaustive destructuring below fails to compile).
+    let MutationStats {
+        nodes_created,
+        nodes_deleted,
+        relationships_created,
+        relationships_deleted,
+        properties_set,
+        properties_removed,
+        labels_removed,
+    } = *stats;
+    let checks = [
+        ("nodes_created", expected.nodes_created, nodes_created),
+        ("nodes_deleted", expected.nodes_deleted, nodes_deleted),
+        ("relationships_created", expected.relationships_created, relationships_created),
+        ("relationships_deleted", expected.relationships_deleted, relationships_deleted),
+        ("properties_set", expected.properties_set, properties_set),
+        ("properties_removed", expected.properties_removed, properties_removed),
+        ("labels_removed", expected.labels_removed, labels_removed),
+    ];
+    let mismatches: Vec<String> = checks
+        .iter()
+        .filter(|(_, want, got)| !want.accepts(*got))
+        .map(|(name, want, got)| match want {
+            CounterExpectation::Exactly(want) => {
+                format!("{name}: expected exactly {want}, server reported {got}")
+            }
+            CounterExpectation::Any => unreachable!("Any accepts every value"),
+        })
+        .collect();
+    if mismatches.is_empty() {
         Ok(())
     } else {
         Err(OtherError(format!(
-            "write operation expected {:?} but the server reported {:?} — the operation is not \
-             doing what it should (e.g. a delete matched nothing, a merge hit instead of missed, or \
-             a create also mutated something it shouldn't have)",
-            expected, stats
+            "write outcome mismatch ({}) — the operation is not doing what it should (e.g. a \
+             delete matched nothing, a merge hit instead of missed, or a write also mutated \
+             something it shouldn't have)",
+            mismatches.join("; ")
         )))
     }
 }
@@ -405,7 +498,7 @@ mod tests {
     #[test]
     fn verify_mutation_accepts_the_expected_effect() {
         assert!(verify_mutation(
-            ExpectedMutation::NodeCreated,
+            ExpectedOutcome::node_created(),
             &MutationStats {
                 nodes_created: 1,
                 ..Default::default()
@@ -413,7 +506,7 @@ mod tests {
         )
         .is_ok());
         assert!(verify_mutation(
-            ExpectedMutation::NodeDeleted,
+            ExpectedOutcome::node_deleted(),
             &MutationStats {
                 nodes_deleted: 1,
                 ..Default::default()
@@ -421,7 +514,7 @@ mod tests {
         )
         .is_ok());
         assert!(verify_mutation(
-            ExpectedMutation::RelationshipCreated,
+            ExpectedOutcome::relationship_created(),
             &MutationStats {
                 relationships_created: 1,
                 ..Default::default()
@@ -429,7 +522,7 @@ mod tests {
         )
         .is_ok());
         assert!(verify_mutation(
-            ExpectedMutation::PropertySet,
+            ExpectedOutcome::property_set(),
             &MutationStats {
                 properties_set: 1,
                 ..Default::default()
@@ -437,11 +530,11 @@ mod tests {
         )
         .is_ok());
         // merge_hit: a match, so nothing created.
-        assert!(verify_mutation(ExpectedMutation::NodeMatched, &MutationStats::default()).is_ok());
+        assert!(verify_mutation(ExpectedOutcome::node_matched(), &MutationStats::default()).is_ok());
         // A create's inline property (`{id: $id}`) legitimately bumps properties_set, so it is not
         // constrained for the create/edge variants.
         assert!(verify_mutation(
-            ExpectedMutation::NodeCreated,
+            ExpectedOutcome::node_created(),
             &MutationStats {
                 nodes_created: 1,
                 properties_set: 1,
@@ -450,7 +543,7 @@ mod tests {
         )
         .is_ok());
         assert!(verify_mutation(
-            ExpectedMutation::RelationshipCreated,
+            ExpectedOutcome::relationship_created(),
             &MutationStats {
                 relationships_created: 1,
                 properties_set: 1,
@@ -463,12 +556,12 @@ mod tests {
     #[test]
     fn verify_mutation_rejects_a_silent_no_op() {
         // A delete that matched nothing.
-        assert!(verify_mutation(ExpectedMutation::NodeDeleted, &MutationStats::default()).is_err());
+        assert!(verify_mutation(ExpectedOutcome::node_deleted(), &MutationStats::default()).is_err());
         // A merge that HIT when it should have MISSED (created 0, expected 1).
-        assert!(verify_mutation(ExpectedMutation::NodeCreated, &MutationStats::default()).is_err());
+        assert!(verify_mutation(ExpectedOutcome::node_created(), &MutationStats::default()).is_err());
         // A merge that MISSED when it should have HIT (created 1, expected 0).
         assert!(verify_mutation(
-            ExpectedMutation::NodeMatched,
+            ExpectedOutcome::node_matched(),
             &MutationStats {
                 nodes_created: 1,
                 ..Default::default()
@@ -482,7 +575,7 @@ mod tests {
         // A create that ALSO deleted a node — a conflicting structural mutation, not just a
         // wrong-count no-op — must be rejected even though it created one node.
         assert!(verify_mutation(
-            ExpectedMutation::NodeCreated,
+            ExpectedOutcome::node_created(),
             &MutationStats {
                 nodes_created: 1,
                 nodes_deleted: 1,
@@ -492,7 +585,7 @@ mod tests {
         .is_err());
         // A create that also created a relationship.
         assert!(verify_mutation(
-            ExpectedMutation::NodeCreated,
+            ExpectedOutcome::node_created(),
             &MutationStats {
                 nodes_created: 1,
                 relationships_created: 1,
@@ -502,7 +595,7 @@ mod tests {
         .is_err());
         // A delete that also created a node.
         assert!(verify_mutation(
-            ExpectedMutation::NodeDeleted,
+            ExpectedOutcome::node_deleted(),
             &MutationStats {
                 nodes_deleted: 1,
                 nodes_created: 1,
@@ -512,7 +605,7 @@ mod tests {
         .is_err());
         // A set_property that also created a node.
         assert!(verify_mutation(
-            ExpectedMutation::PropertySet,
+            ExpectedOutcome::property_set(),
             &MutationStats {
                 properties_set: 1,
                 nodes_created: 1,
@@ -522,12 +615,128 @@ mod tests {
         .is_err());
         // A merge_hit that unexpectedly set a property.
         assert!(verify_mutation(
-            ExpectedMutation::NodeMatched,
+            ExpectedOutcome::node_matched(),
             &MutationStats {
                 properties_set: 1,
                 ..Default::default()
             }
         )
         .is_err());
+        // A delete that also silently dropped edges — the new counters are pinned to 0 for the
+        // catalog shapes (an edgeless scratch target must not report relationship deletions).
+        assert!(verify_mutation(
+            ExpectedOutcome::node_deleted(),
+            &MutationStats {
+                nodes_deleted: 1,
+                relationships_deleted: 2,
+                ..Default::default()
+            }
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn exactly_pins_every_counter() {
+        // The §6.3 oracle mode: an outcome built from recorded stats accepts exactly those stats…
+        let recorded = MutationStats {
+            nodes_created: 1,
+            nodes_deleted: 2,
+            relationships_created: 3,
+            relationships_deleted: 4,
+            properties_set: 5,
+            properties_removed: 6,
+            labels_removed: 7,
+        };
+        let expected = ExpectedOutcome::exactly(recorded);
+        assert!(verify_mutation(expected, &recorded).is_ok());
+        // …and rejects a deviation in ANY single counter (each counter is independently pinned).
+        for i in 0..7 {
+            let mut off = recorded;
+            match i {
+                0 => off.nodes_created += 1,
+                1 => off.nodes_deleted += 1,
+                2 => off.relationships_created += 1,
+                3 => off.relationships_deleted += 1,
+                4 => off.properties_set += 1,
+                5 => off.properties_removed += 1,
+                _ => off.labels_removed += 1,
+            }
+            assert!(verify_mutation(expected, &off).is_err(), "counter {i} not pinned");
+        }
+    }
+
+    #[test]
+    fn generalized_outcomes_express_detach_delete_and_remove() {
+        // The outcomes the 5 rigid variants could not represent (design §2/§10.4), pinned to the
+        // live-verified counter behavior: DETACH DELETE reports the deleted node AND its degree…
+        let detach_delete = ExpectedOutcome::exactly(MutationStats {
+            nodes_deleted: 1,
+            relationships_deleted: 3,
+            ..Default::default()
+        });
+        assert!(verify_mutation(
+            detach_delete,
+            &MutationStats {
+                nodes_deleted: 1,
+                relationships_deleted: 3,
+                ..Default::default()
+            }
+        )
+        .is_ok());
+        // …a wrong degree is a mismatch, not a pass…
+        assert!(verify_mutation(
+            detach_delete,
+            &MutationStats {
+                nodes_deleted: 1,
+                relationships_deleted: 2,
+                ..Default::default()
+            }
+        )
+        .is_err());
+        // …and REMOVE prop/label reports the removal counters.
+        let remove = ExpectedOutcome::exactly(MutationStats {
+            properties_removed: 1,
+            labels_removed: 1,
+            ..Default::default()
+        });
+        assert!(verify_mutation(
+            remove,
+            &MutationStats {
+                properties_removed: 1,
+                labels_removed: 1,
+                ..Default::default()
+            }
+        )
+        .is_ok());
+        // A REMOVE that silently no-opped (unprepared state) is a hard error.
+        assert!(verify_mutation(remove, &MutationStats::default()).is_err());
+    }
+
+    #[test]
+    fn verify_mutation_names_every_mismatching_counter() {
+        let err = verify_mutation(
+            ExpectedOutcome::node_deleted(),
+            &MutationStats {
+                nodes_created: 1,
+                properties_removed: 2,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        // All three deviations named, with expected vs reported values.
+        assert!(msg.contains("nodes_created: expected exactly 0, server reported 1"), "{msg}");
+        assert!(msg.contains("nodes_deleted: expected exactly 1, server reported 0"), "{msg}");
+        assert!(msg.contains("properties_removed: expected exactly 0, server reported 2"), "{msg}");
+        // Unconstrained counters never appear: node_created() leaves properties_set free.
+        let ok = verify_mutation(
+            ExpectedOutcome::node_created(),
+            &MutationStats {
+                nodes_created: 1,
+                properties_set: 40,
+                ..Default::default()
+            },
+        );
+        assert!(ok.is_ok());
     }
 }

--- a/src/synthetic/writes.rs
+++ b/src/synthetic/writes.rs
@@ -216,8 +216,10 @@ pub struct WritePlan {
 }
 
 /// The mutation counters FalkorDB reports for a query, used to verify a write actually did what the
-/// operation intends (rather than silently matching nothing). Covers the full counter set a write
-/// can move (Phase 7 §6.2): absent counters read as 0 (FalkorDB omits untouched statistics).
+/// operation intends (rather than silently matching nothing). Covers the seven counters the write
+/// plans verify (Phase 7 §6.2) — a deliberate subset of the server's statistics (e.g. `labels_added`
+/// and index counters are not tracked): absent counters read as 0 (FalkorDB omits untouched
+/// statistics).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct MutationStats {
     pub nodes_created: i64,

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -702,7 +702,7 @@ async fn write_scratch_reset_reuses_its_band_without_duplicates() {
     // Pin the isolation model against the server directly: within a window every MERGE misses
     // (unique keys), a band-scoped reset clears exactly this worker's rows, and the next window
     // reuses the very same keys — still all misses, with no duplicate accumulation.
-    use benchmark::synthetic::writes::{verify_mutation, ExpectedMutation, WriteScratch};
+    use benchmark::synthetic::writes::{verify_mutation, ExpectedOutcome, WriteScratch};
 
     let graph = "syn_it_write_reset";
     drop_graph(graph).await;
@@ -722,7 +722,7 @@ async fn write_scratch_reset_reuses_its_band_without_duplicates() {
         let s = run_and_drain(&mut g, QueryType::Write, &cypher, 5_000, Duration::from_secs(5))
             .await
             .expect("window-1 merge");
-        verify_mutation(ExpectedMutation::NodeCreated, &s.mutations).expect("window-1 must miss");
+        verify_mutation(ExpectedOutcome::node_created(), &s.mutations).expect("window-1 must miss");
     }
     assert_eq!(
         scalar_i64(&mut g, &count_cypher).await,
@@ -756,12 +756,93 @@ async fn write_scratch_reset_reuses_its_band_without_duplicates() {
         let s = run_and_drain(&mut g, QueryType::Write, &cypher, 5_000, Duration::from_secs(5))
             .await
             .expect("window-2 merge");
-        verify_mutation(ExpectedMutation::NodeCreated, &s.mutations).expect("window-2 must miss");
+        verify_mutation(ExpectedOutcome::node_created(), &s.mutations).expect("window-2 must miss");
     }
     assert_eq!(
         scalar_i64(&mut g, &count_cypher).await,
         reset_every as i64,
         "the reused band holds exactly one node per key — no duplicate accumulation"
+    );
+
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.2 — pin the full mutation-counter set end-to-end against the server: DETACH DELETE
+/// reports `relationships_deleted` = the victim's degree, REMOVE reports `properties_removed` +
+/// `labels_removed`, and a repeated (no-op) mutation reports all-zero (absent counters read as 0)
+/// — exactly the outcomes the generalized [`ExpectedOutcome`] model pins via `exactly`.
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn full_mutation_counters_are_read_from_the_server() {
+    use benchmark::synthetic::writes::{verify_mutation, ExpectedOutcome, MutationStats};
+
+    let graph = "syn_it_full_counters";
+    drop_graph(graph).await;
+    let mut g = open_graph(&endpoint(), graph).await.expect("open graph");
+    let deadline = Duration::from_secs(5);
+
+    // A hub (id 1) with 3 edges, and a labeled + flagged node (id 2) to strip.
+    for cypher in [
+        "CREATE (a:User {id:1}), (b:User {id:2}), (c:User {id:3}), (d:User {id:4}), \
+         (a)-[:Friend]->(b), (a)-[:Friend]->(c), (d)-[:Friend]->(a)",
+        "MATCH (u:User {id:2}) SET u:Temp, u.flag = 1",
+    ] {
+        run_and_drain(&mut g, QueryType::Write, cypher, 5_000, deadline)
+            .await
+            .expect("setup");
+    }
+
+    // DETACH DELETE the hub: 1 node + its full degree of edges, nothing else.
+    let s = run_and_drain(
+        &mut g,
+        QueryType::Write,
+        "MATCH (u:User {id:1}) DETACH DELETE u",
+        5_000,
+        deadline,
+    )
+    .await
+    .expect("detach delete");
+    let detach = MutationStats {
+        nodes_deleted: 1,
+        relationships_deleted: 3,
+        ..Default::default()
+    };
+    assert_eq!(s.mutations, detach, "DETACH DELETE counters");
+    verify_mutation(ExpectedOutcome::exactly(detach), &s.mutations).expect("detach outcome");
+
+    // REMOVE a property + a label: only the removal counters move.
+    let s = run_and_drain(
+        &mut g,
+        QueryType::Write,
+        "MATCH (u:User {id:2}) REMOVE u.flag, u:Temp",
+        5_000,
+        deadline,
+    )
+    .await
+    .expect("remove");
+    let removed = MutationStats {
+        properties_removed: 1,
+        labels_removed: 1,
+        ..Default::default()
+    };
+    assert_eq!(s.mutations, removed, "REMOVE counters");
+    verify_mutation(ExpectedOutcome::exactly(removed), &s.mutations).expect("remove outcome");
+
+    // Repeating the REMOVE is a silent no-op: the server omits every counter, all must read 0.
+    let s = run_and_drain(
+        &mut g,
+        QueryType::Write,
+        "MATCH (u:User {id:2}) REMOVE u.flag",
+        5_000,
+        deadline,
+    )
+    .await
+    .expect("no-op remove");
+    assert_eq!(s.mutations, MutationStats::default(), "no-op reports all-zero");
+    // …which the generalized model surfaces as a hard error when an outcome was expected.
+    assert!(
+        verify_mutation(ExpectedOutcome::exactly(removed), &s.mutations).is_err(),
+        "a silent no-op must not satisfy a removal outcome"
     );
 
     drop_graph(graph).await;
@@ -1765,6 +1846,95 @@ async fn failed_write_probe_still_restores_the_recorded_base() {
         50,
         "restored graph must be the recorded base"
     );
+    drop(g);
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.2 — [`replay::restore_base`] is a *per-invocation* restore primitive: calling it
+/// back-to-back after arbitrary pollution (marker nodes, deleted users) must return the endpoint
+/// to the recorded base every single time — the property the §6.3 correctness tier will lean on
+/// between oracle invocations. The pristine shape is captured after the first restore (no fixture
+/// assumptions) and re-asserted after each subsequent one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn restore_base_returns_the_recorded_base_per_invocation() {
+    let graph = "syn_it_restore_base";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-restore");
+    let spec = DatasetSpec {
+        seed: 7,
+        nodes: 120,
+        edges: 360,
+    };
+    recording::record(&spec, graph, &[OpName::MatchByIndex], spec.seed, 16, &dir)
+        .expect("record a small bundle");
+    let bundle = recording::load(&dir).expect("load the bundle");
+    let out = dir.join("unused.json").to_string_lossy().into_owned();
+    let config = replay_config(&dir, graph, &out, true);
+
+    replay::restore_base(&config, &bundle, graph, &spec)
+        .await
+        .expect("initial restore");
+    let mut g = open_graph(&endpoint(), graph).await.expect("open graph");
+    let pristine_nodes = scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await;
+    let pristine_edges = scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await;
+
+    let deadline = Duration::from_secs(5);
+    for round in 0..3_i64 {
+        // Pollute: add a marker node and detach-delete one recorded user.
+        run_and_drain(
+            &mut g,
+            QueryType::Write,
+            &format!("CREATE (:RestoreMarker {{round: {round}}})"),
+            5_000,
+            deadline,
+        )
+        .await
+        .expect("marker");
+        run_and_drain(
+            &mut g,
+            QueryType::Write,
+            "MATCH (u:User)-[]->() WITH u LIMIT 1 DETACH DELETE u",
+            5_000,
+            deadline,
+        )
+        .await
+        .expect("delete a user");
+        assert_eq!(
+            scalar_i64(&mut g, "MATCH (m:RestoreMarker) RETURN count(m)").await,
+            1,
+            "round {round}: pollution must actually change the graph"
+        );
+        assert_ne!(
+            scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await,
+            pristine_edges,
+            "round {round}: the detach-delete must remove edges"
+        );
+        drop(g);
+
+        replay::restore_base(&config, &bundle, graph, &spec)
+            .await
+            .unwrap_or_else(|e| panic!("round {round}: restore_base failed: {e}"));
+
+        g = open_graph(&endpoint(), graph).await.expect("reopen graph");
+        assert_eq!(
+            scalar_i64(&mut g, "MATCH (m:RestoreMarker) RETURN count(m)").await,
+            0,
+            "round {round}: the marker must be erased"
+        );
+        assert_eq!(
+            scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await,
+            pristine_nodes,
+            "round {round}: node count must match the recorded base"
+        );
+        assert_eq!(
+            scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await,
+            pristine_edges,
+            "round {round}: edge count must match the recorded base"
+        );
+    }
     drop(g);
 
     std::fs::remove_dir_all(&dir).ok();

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1928,8 +1928,9 @@ async fn restore_base_returns_the_recorded_base_per_invocation() {
             );
         } else {
             // Count-changing pollution: add a marker node and detach-delete a connected user.
+            let marker = format!("CREATE (:RestoreMarker {{round: {round}}})");
             for cypher in [
-                &format!("CREATE (:RestoreMarker {{round: {round}}})") as &str,
+                marker.as_str(),
                 "MATCH (u:User)-[]->() WITH u LIMIT 1 DETACH DELETE u",
             ] {
                 run_and_drain(&mut g, QueryType::Write, cypher, 5_000, deadline)

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -769,8 +769,9 @@ async fn write_scratch_reset_reuses_its_band_without_duplicates() {
 
 /// Phase 7 §6.2 — pin the full mutation-counter set end-to-end against the server: DETACH DELETE
 /// reports `relationships_deleted` = the victim's degree, REMOVE reports `properties_removed` +
-/// `labels_removed`, and a repeated (no-op) mutation reports all-zero (absent counters read as 0)
-/// — exactly the outcomes the generalized [`ExpectedOutcome`] model pins via `exactly`.
+/// `labels_removed`, and repeated (no-op) runs of **both** mutations report all-zero (absent
+/// counters read as 0) — exactly the outcomes the generalized [`ExpectedOutcome`] model pins via
+/// `exactly`.
 #[tokio::test]
 #[ignore = "requires a running FalkorDB server"]
 async fn full_mutation_counters_are_read_from_the_server() {
@@ -828,17 +829,33 @@ async fn full_mutation_counters_are_read_from_the_server() {
     assert_eq!(s.mutations, removed, "REMOVE counters");
     verify_mutation(ExpectedOutcome::exactly(removed), &s.mutations).expect("remove outcome");
 
-    // Repeating the REMOVE is a silent no-op: the server omits every counter, all must read 0.
+    // Repeating both mutations is a silent no-op (E1c): the DETACH DELETE target is gone and the
+    // property + label are already removed — the server omits every counter, all must read 0.
     let s = run_and_drain(
         &mut g,
         QueryType::Write,
-        "MATCH (u:User {id:2}) REMOVE u.flag",
+        "MATCH (u:User {id:1}) DETACH DELETE u",
+        5_000,
+        deadline,
+    )
+    .await
+    .expect("no-op detach delete");
+    assert_eq!(s.mutations, MutationStats::default(), "no-op DETACH DELETE reports all-zero");
+    assert!(
+        verify_mutation(ExpectedOutcome::exactly(detach), &s.mutations).is_err(),
+        "a silent no-op must not satisfy the deletion outcome"
+    );
+
+    let s = run_and_drain(
+        &mut g,
+        QueryType::Write,
+        "MATCH (u:User {id:2}) REMOVE u.flag, u:Temp",
         5_000,
         deadline,
     )
     .await
     .expect("no-op remove");
-    assert_eq!(s.mutations, MutationStats::default(), "no-op reports all-zero");
+    assert_eq!(s.mutations, MutationStats::default(), "no-op REMOVE reports all-zero");
     // …which the generalized model surfaces as a hard error when an outcome was expected.
     assert!(
         verify_mutation(ExpectedOutcome::exactly(removed), &s.mutations).is_err(),
@@ -1853,10 +1870,12 @@ async fn failed_write_probe_still_restores_the_recorded_base() {
 }
 
 /// Phase 7 §6.2 — [`replay::restore_base`] is a *per-invocation* restore primitive: calling it
-/// back-to-back after arbitrary pollution (marker nodes, deleted users) must return the endpoint
-/// to the recorded base every single time — the property the §6.3 correctness tier will lean on
-/// between oracle invocations. The pristine shape is captured after the first restore (no fixture
-/// assumptions) and re-asserted after each subsequent one.
+/// back-to-back after arbitrary pollution must return the endpoint to the recorded base every
+/// single time — the property the §6.3 correctness tier will lean on between oracle invocations.
+/// "Returns the base" is asserted on **content digests** ([`replay::capture_graph_content`]), not
+/// just counts: the count-preserving rounds mutate node/edge *properties* (invisible to counts,
+/// asserted so) and only the digest can catch them; the count-changing round proves the reload
+/// path. The pristine shape is captured after the first restore (no fixture assumptions).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
 async fn restore_base_returns_the_recorded_base_per_invocation() {
@@ -1880,37 +1899,50 @@ async fn restore_base_returns_the_recorded_base_per_invocation() {
     let mut g = open_graph(&endpoint(), graph).await.expect("open graph");
     let pristine_nodes = scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await;
     let pristine_edges = scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await;
+    let pristine = replay::capture_graph_content(&mut g, &config)
+        .await
+        .expect("capture the pristine content digest");
 
     let deadline = Duration::from_secs(5);
     for round in 0..3_i64 {
-        // Pollute: add a marker node and detach-delete one recorded user.
-        run_and_drain(
-            &mut g,
-            QueryType::Write,
-            &format!("CREATE (:RestoreMarker {{round: {round}}})"),
-            5_000,
-            deadline,
-        )
-        .await
-        .expect("marker");
-        run_and_drain(
-            &mut g,
-            QueryType::Write,
-            "MATCH (u:User)-[]->() WITH u LIMIT 1 DETACH DELETE u",
-            5_000,
-            deadline,
-        )
-        .await
-        .expect("delete a user");
-        assert_eq!(
-            scalar_i64(&mut g, "MATCH (m:RestoreMarker) RETURN count(m)").await,
-            1,
-            "round {round}: pollution must actually change the graph"
-        );
+        if round % 2 == 0 {
+            // Count-preserving pollution: corrupt a node property and an edge property. Node and
+            // edge counts stay pristine — only the content digest can detect this class.
+            for cypher in [
+                "MATCH (u:User) WITH u ORDER BY u.id LIMIT 1 SET u.polluted = true",
+                "MATCH ()-[r:Friend]->() WITH r LIMIT 1 SET r.polluted = true",
+            ] {
+                run_and_drain(&mut g, QueryType::Write, cypher, 5_000, deadline)
+                    .await
+                    .expect("property pollution");
+            }
+            assert_eq!(
+                scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await,
+                pristine_nodes,
+                "round {round}: property pollution must preserve the node count"
+            );
+            assert_eq!(
+                scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await,
+                pristine_edges,
+                "round {round}: property pollution must preserve the edge count"
+            );
+        } else {
+            // Count-changing pollution: add a marker node and detach-delete a connected user.
+            for cypher in [
+                &format!("CREATE (:RestoreMarker {{round: {round}}})") as &str,
+                "MATCH (u:User)-[]->() WITH u LIMIT 1 DETACH DELETE u",
+            ] {
+                run_and_drain(&mut g, QueryType::Write, cypher, 5_000, deadline)
+                    .await
+                    .expect("structural pollution");
+            }
+        }
+        let polluted = replay::capture_graph_content(&mut g, &config)
+            .await
+            .expect("capture the polluted content digest");
         assert_ne!(
-            scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await,
-            pristine_edges,
-            "round {round}: the detach-delete must remove edges"
+            polluted, pristine,
+            "round {round}: pollution must be visible to the content digest"
         );
         drop(g);
 
@@ -1933,6 +1965,13 @@ async fn restore_base_returns_the_recorded_base_per_invocation() {
             scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await,
             pristine_edges,
             "round {round}: edge count must match the recorded base"
+        );
+        let restored = replay::capture_graph_content(&mut g, &config)
+            .await
+            .expect("capture the restored content digest");
+        assert_eq!(
+            restored, pristine,
+            "round {round}: restored content must digest-match the recorded base"
         );
     }
     drop(g);


### PR DESCRIPTION
Phase 7, PR 2 of the writes-coverage design ([docs/design/synthetic-cover-writes-phase7.md](https://github.com/FalkorDB/benchmark/blob/master/docs/design/synthetic-cover-writes-phase7.md)) — implements **§6 phasing item 2**:

> 2. **Generalized outcome model + full `MutationStats`** (`relationships_deleted`/`properties_removed`/`labels_removed`); per-invocation restore primitive.

Follows #265 (§6.1 write-capable record/replay). No CLI surface changes; no report/summary/cells schema changes — **no Part B delta**.

## What changed

### 1. Full `MutationStats` (4 → 7 counters)

`MutationStats` gains `relationships_deleted`, `properties_removed`, `labels_removed` alongside the existing 4, and `run_and_drain` populates them from the vendored client getters (`get_relationship_deleted` / `get_properties_removed` / `get_labels_removed`). FalkorDB omits untouched counters from the response entirely, so all getters keep the `unwrap_or(0)` absent-⇒-zero semantics (empirics E1c below).

### 2. Generalized `ExpectedOutcome` (replaces `ExpectedMutation`)

Per design §4.2, the 5 rigid unit variants are replaced by a per-counter expectation model:

```rust
pub enum CounterExpectation { Exactly(i64), Any }
pub struct ExpectedOutcome { /* one CounterExpectation per MutationStats counter */ }
```

- `ExpectedOutcome::exactly(stats)` pins **every** counter — the oracle mode §6.3 will record per-command (e.g. `DETACH DELETE` with `relationships_deleted: Exactly(3)` for a degree-3 victim).
- Legacy-shaped constructors (`node_created()`, `node_deleted()`, `relationship_created()`, `property_set()`, `node_matched()`) keep the six catalog write plans expressible. **Interpretation note:** these are *strictly stronger* than the old variants — the three new counters are pinned to `Exactly(0)`, where the old model never looked at them. Verified safe empirically (E2): none of the six catalog write shapes moves any of the three new counters. `properties_set` stays `Any` on the create constructors, exactly matching the old variants' blind spot for inline `{id: $id}` properties.
- `verify_mutation` destructures `MutationStats` exhaustively (adding an 8th counter without wiring it into the checks is a compile error) and its error names **every** mismatching counter, not just the first.

The live write worker call site (`verify_mutation(plan.expected, &sample.mutations)`) is shape-unchanged.

### 3. `replay::restore_base` — the §3.3 per-invocation restore primitive

The per-cell write reset previously inlined "open a fresh connection, drop + reload + count-verify". That is now the standalone `pub async fn restore_base(config, bundle, graph_name, spec)`; the per-cell reset routes through it, and §6.3's correctness tier will invoke it between oracle invocations. **Interpretation note:** shipped as a function (not a struct/engine seam) — the correctness tier per the design is a bespoke C=1 loop in `replay.rs` like the reference pass, so a function is the whole requirement; no serde on `ExpectedOutcome` yet either, since §6.3 (PR 3) owns the bundle-format serialization.

## Empirical basis

All against `falkordb/falkordb:edge` pinned at `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c` (same image as the #265 evidence):

| # | Probe | Result |
|---|---|---|
| E1a | `DETACH DELETE` a degree-3 node | `Nodes deleted: 1`, `Relationships deleted: 3` — exact vendored stat-string match |
| E1b | `REMOVE u.flag, u:Temp` | `Properties removed: 1`, `Labels removed: 1` |
| E1c | Re-run E1a/E1b as no-ops | **all counters absent** from the response ⇒ `unwrap_or(0)` reads 0 |
| E2 | All 6 catalog write shapes | none reports any of the 3 new counters (plain `DELETE` of an edgeless node reports only `Nodes deleted: 1`) ⇒ pinning them `Exactly(0)` in the constructors is safe |
| E3 | Same-value `SET` | no `Properties set` reported — confirms the design's §10.4 value-change-counting correction |

E1a–E1c are now pinned permanently by the live test `full_mutation_counters_are_read_from_the_server`; `restore_base` per-invocation semantics by `restore_base_returns_the_recorded_base_per_invocation` (3 pollute→restore cycles, pristine shape re-asserted each time). Both run under `just coverage` (`--include-ignored`).

## Validation

- `just ci` ✅ (build, clippy `-D warnings`, tests incl. doc examples)
- `just coverage` vs the pinned container ✅ — patch coverage **99.53%** (214/215; the one uncovered line is the `unreachable!` arm for `CounterExpectation::Any` in the mismatch formatter)
- `just doc-links` ✅, `just synthetic-sanity` ✅, `just synthetic-verify` ✅
- Design doc §6 item 2 flipped ⛔ → ✅, Status header updated.

## Not in this PR (per phasing)

- §6.3 online outcome oracle (record-time per-command stats capture, C=1 correctness tier) — PR 3.
- §6.4 prepared-state / removal shapes, §6.5 concurrency decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved write-operation verification with detailed mutation outcomes, including node, relationship, property, and label changes.
  * Added reliable per-invocation restoration of recorded graph data for replay workflows.
* **Bug Fixes**
  * Detects silent no-ops and incorrect mutation results more accurately.
  * Expanded reporting captures additional deletion and removal counters.
* **Documentation**
  * Updated Phase 7 write-coverage documentation to reflect the implemented verification and restoration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->