### PR TITLE
feat(synthetic): online write outcome oracle + C=1 correctness tier (§6.3)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -207,7 +207,8 @@ synthetic-record name *args:
 # Measure a recorded bundle against an endpoint via `run --recording`: load the recorded graph +
 # measure the recorded commands across the concurrency sweep + cache modes, writing
 # recordings/<name>/report.json. Extra flags forward to `synthetic run`
-# (e.g. --concurrency, --cache, --no-load, --samples, --out).
+# (e.g. --concurrency, --cache, --no-load, --samples, --out, and --require-oracle for a write
+# bundle expected to carry the §6.3 outcome oracle).
 synthetic-replay name endpoint *args:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -11,7 +11,9 @@ into **recording format v3** with the outcomes bound into the `workload_hash`; a
 carry the oracle for **exactly** the eligible set, full corpus per op — enforced at load, attach
 and replay — and the replay report attests the verified coverage (`meta.oracle_verified`); replay
 re-verifies every recorded outcome against the engine as an untimed C=1 correctness pass and
-hard-fails on divergence; **stats only** — write result *values* stay un-captured per §3.4/§5-Out);
+hard-fails on divergence, `--require-oracle` refuses oracle-less write bundles (v3→v2 downgrade
+guard) and the diff/regression guards treat a one-sided or differing attestation as
+not-comparable; **stats only** — write result *values* stay un-captured per §3.4/§5-Out);
 §6.4–§6.5 (prepared-state variants, concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
@@ -147,7 +149,16 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
    outcomes, no sampling), and a v3 bundle must carry the oracle for **exactly** the eligible
    set — full corpus per op, none anywhere else — enforced at load, attach and replay, with the
    replay report attesting verified coverage (`meta.oracle_verified`), so oracle coverage can
-   never silently shrink. Capture is a record-time-only cost (~13½ min for the two full passes
+   never silently shrink. A re-hashed **v3→v2 downgrade** is byte-indistinguishable from a
+   legitimate latency-tier v2 bundle (v2 hashes never covered oracle data), so it is refused by
+   operator expectation instead: `run --recording --require-oracle` rejects (offline) any write
+   bundle without an oracle, and the comparison side guards the attestation — `report --diff`
+   (strict and `--regression`) treats a one-sided or differing `meta.oracle_verified` as
+   not-comparable, renders the per-side attestation as an "outcome oracle" header row, and
+   prominently warns when two un-attested runs measured oracle-eligible write ops. Capture is
+   error-safe end to end: the *initial* setup load failure triggers one recovery restore (a
+   combined error when that fails too), and the final restore is content-verified against the
+   pristine digests. Capture is a record-time-only cost (~13½ min for the two full passes
    over the 1 000/5 000 repo-writes bundle on the pinned dev image). *Deviation from the sketch
    above:* per-command **result values** are **not** captured — §5-Out rules out digest-gating
    write results and §3.4 makes returned values irreproducible (`rand()`, engine-internal ids),

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -156,7 +156,7 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
    (strict and `--regression`) treats a one-sided or differing `meta.oracle_verified` as
    not-comparable, renders the per-side attestation as an "outcome oracle" header row, and
    prominently warns when two un-attested runs measured oracle-eligible write ops. Capture is
-   error-safe end to end: the *initial* setup load failure triggers one recovery restore (a
+   error-safe end-to-end: the *initial* setup load failure triggers one recovery restore (a
    combined error when that fails too), and the final restore is content-verified against the
    pristine digests. Capture is a record-time-only cost (~13½ min for the two full passes
    over the 1 000/5 000 repo-writes bundle on the pinned dev image). *Deviation from the sketch

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -5,11 +5,13 @@ shapes — recording format v2 with kind-bound `workload_hash`, `--repo-writes` 
 `GRAPH.QUERY` C=1 measure path with per-cell base reset + verified error-safe final restore);
 §6.2 **implemented** (generalized `ExpectedOutcome` model, full 7-counter `MutationStats`,
 `restore_base` per-invocation restore primitive); §6.3 **implemented** (online outcome oracle:
-`record --oracle <endpoint> [--oracle-samples K]` captures per-command `MutationStats` for the
-deterministic subset — twice, determinism proven at record time — into **recording format v3**
-with the outcomes bound into the `workload_hash`; replay re-verifies every recorded outcome
-against the engine as an untimed C=1 correctness pass and hard-fails on divergence; **stats
-only** — write result *values* stay un-captured per §3.4/§5-Out);
+`record --oracle <endpoint>` captures per-command `MutationStats` for the deterministic subset
+over each eligible op's **complete command corpus** — twice, determinism proven at record time —
+into **recording format v3** with the outcomes bound into the `workload_hash`; a v3 bundle must
+carry the oracle for **exactly** the eligible set, full corpus per op — enforced at load, attach
+and replay — and the replay report attests the verified coverage (`meta.oracle_verified`); replay
+re-verifies every recorded outcome against the engine as an untimed C=1 correctness pass and
+hard-fails on divergence; **stats only** — write result *values* stay un-captured per §3.4/§5-Out);
 §6.4–§6.5 (prepared-state variants, concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
@@ -141,10 +143,15 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 3. ✅ **Online outcome oracle** at record time (capture per-command stats), C=1 correctness tier
    for the deterministic subset — 7 of the 10 shapes eligible; `single_edge_update` excluded
    (server `rand()`, §3.4), `detach_delete_user` + `remove_user_property_and_label` excluded
-   until §6.4. *Deviation from the sketch above:* per-command **result values** are **not**
-   captured — §5-Out rules out digest-gating write results and §3.4 makes returned values
-   irreproducible (`rand()`, engine-internal ids), so the oracle records the `MutationStats`
-   counters only.
+   until §6.4. The capture covers each eligible op's **complete command corpus** (per-command
+   outcomes, no sampling), and a v3 bundle must carry the oracle for **exactly** the eligible
+   set — full corpus per op, none anywhere else — enforced at load, attach and replay, with the
+   replay report attesting verified coverage (`meta.oracle_verified`), so oracle coverage can
+   never silently shrink. Capture is a record-time-only cost (~13½ min for the two full passes
+   over the 1 000/5 000 repo-writes bundle on the pinned dev image). *Deviation from the sketch
+   above:* per-command **result values** are **not** captured — §5-Out rules out digest-gating
+   write results and §3.4 makes returned values irreproducible (`rand()`, engine-internal ids),
+   so the oracle records the `MutationStats` counters only.
 4. ⛔ **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count
    `detach_delete_user`.
 5. ⛔ **Concurrency** — decide C>1 (per-worker id partitioning) or keep C=1 for correctness.

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -4,8 +4,13 @@
 shapes — recording format v2 with kind-bound `workload_hash`, `--repo-writes` selector,
 `GRAPH.QUERY` C=1 measure path with per-cell base reset + verified error-safe final restore);
 §6.2 **implemented** (generalized `ExpectedOutcome` model, full 7-counter `MutationStats`,
-`restore_base` per-invocation restore primitive); §6.3–§6.5 (online oracle / correctness tier,
-prepared-state variants, concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+`restore_base` per-invocation restore primitive); §6.3 **implemented** (online outcome oracle:
+`record --oracle <endpoint> [--oracle-samples K]` captures per-command `MutationStats` for the
+deterministic subset — twice, determinism proven at record time — into **recording format v3**
+with the outcomes bound into the `workload_hash`; replay re-verifies every recorded outcome
+against the engine as an untimed C=1 correctness pass and hard-fails on divergence; **stats
+only** — write result *values* stay un-captured per §3.4/§5-Out);
+§6.4–§6.5 (prepared-state variants, concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
 merged in PRs #240–#250) and is the sibling of the algorithms design (Phase 6). The parent design
@@ -122,9 +127,9 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 - **In (latency tier):** all 10 shapes, latency/throughput, periodic reset, opt-in nightly.
 - **In (correctness tier, staged):** the deterministic fixed-outcome subset (the two plain
   create/update, the create-once MERGEs, `foreach_loop_mutation`) via the online oracle at C=1.
-- **Deferred:** `single_edge_update` (server `rand()`), `remove_user_property_and_label` (prepared
-  state), `detach_delete_user`'s variable counts until the §6.3 online oracle records per-invocation
-  expected values (the `relationships_deleted` counter itself landed with §6.2); C>1 writes.
+- **Deferred:** `single_edge_update` (server `rand()`, §3.4 — outside any oracle),
+  `remove_user_property_and_label` (prepared state — from the pristine base the removal is a
+  degenerate no-op) and `detach_delete_user`'s variable counts (both §6.4); C>1 writes.
 - **Out:** Neo4j/Memgraph variants; any digest gating of write results; any change to the per-PR read
   gate or the A/B `--query-profile`.
 
@@ -133,8 +138,13 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
    recorded-write worker, `GRAPH.QUERY` measure path, periodic base reset. Latency tier for all 10.
 2. ✅ **Generalized outcome model + full `MutationStats`** (`relationships_deleted`/`properties_removed`/
    `labels_removed`); per-invocation restore primitive (`replay::restore_base`).
-3. ⛔ **Online outcome oracle** at record time (capture per-command stats+result), C=1 correctness tier
-   for the deterministic subset.
+3. ✅ **Online outcome oracle** at record time (capture per-command stats), C=1 correctness tier
+   for the deterministic subset — 7 of the 10 shapes eligible; `single_edge_update` excluded
+   (server `rand()`, §3.4), `detach_delete_user` + `remove_user_property_and_label` excluded
+   until §6.4. *Deviation from the sketch above:* per-command **result values** are **not**
+   captured — §5-Out rules out digest-gating write results and §3.4 makes returned values
+   irreproducible (`rand()`, engine-internal ids), so the oracle records the `MutationStats`
+   counters only.
 4. ⛔ **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count
    `detach_delete_user`.
 5. ⛔ **Concurrency** — decide C>1 (per-worker id partitioning) or keep C=1 for correctness.

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -255,18 +255,22 @@ to also capture what each write **does** — not just how fast it is:
 ```bash
 # Record + capture the outcome oracle on a live FalkorDB (format v3; hash binds the outcomes):
 benchmark synthetic record --repo-writes --nodes 1000 --edges 5000 --seed 7 \
-  --oracle falkor://127.0.0.1:6379 --oracle-samples 8 --out-dir rec-writes-v3
+  --oracle falkor://127.0.0.1:6379 --out-dir rec-writes-v3
 benchmark synthetic run --recording rec-writes-v3 --endpoint falkor://127.0.0.1:6379 --out writes.json
 ```
 
-Record-time capture runs each **oracle-eligible** command (the deterministic subset — 7 of the
+Record-time capture runs every **oracle-eligible** command (the deterministic subset — 7 of the
 10 shapes; `single_edge_update` is excluded for server `rand()`, the two §6.4 prepared-state
 shapes stay latency-only) once against the freshly restored pristine base and records the
-engine's mutation counters, then a **second pass** must reproduce every outcome exactly. Replay
-of a v3 bundle re-verifies each recorded outcome the same way (untimed, C=1, restore before
-every invocation) **before** measuring latency and **hard-fails on any divergence** — an engine
-that no longer creates/updates what was recorded is doing different work, so its latency would
-be meaningless. `--oracle-samples <K>` (default 8) caps the per-op sample count.
+engine's mutation counters, then a **second pass** must reproduce every outcome exactly. The
+capture covers each eligible op's **complete command corpus**, and a v3 bundle must carry an
+oracle for **exactly** the eligible set (full corpus per op, none anywhere else — enforced at
+load, attach and replay), so coverage can never silently shrink. Capture is a record-time-only
+cost: the two full passes over this 1 000/5 000 bundle take ~13½ min. Replay of a v3 bundle
+re-verifies each recorded outcome the same way (untimed, C=1, restore before every invocation)
+**before** measuring latency and **hard-fails on any divergence** — an engine that no longer
+creates/updates what was recorded is doing different work, so its latency would be meaningless —
+and the report's `meta.oracle_verified` attests the verified coverage.
 
 ---
 

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -249,6 +249,25 @@ the pristine post-load capture, so the endpoint's graph is provably left exactly
 `--no-load` is refused for write bundles. Writes never enter `--repo-reads`, any tier, or the
 per-PR `synthetic-verify` gate.
 
+**Variant — the §6.3 outcome oracle (correctness tier).** Add `--oracle <endpoint>` to the record
+to also capture what each write **does** — not just how fast it is:
+
+```bash
+# Record + capture the outcome oracle on a live FalkorDB (format v3; hash binds the outcomes):
+benchmark synthetic record --repo-writes --nodes 1000 --edges 5000 --seed 7 \
+  --oracle falkor://127.0.0.1:6379 --oracle-samples 8 --out-dir rec-writes-v3
+benchmark synthetic run --recording rec-writes-v3 --endpoint falkor://127.0.0.1:6379 --out writes.json
+```
+
+Record-time capture runs each **oracle-eligible** command (the deterministic subset — 7 of the
+10 shapes; `single_edge_update` is excluded for server `rand()`, the two §6.4 prepared-state
+shapes stay latency-only) once against the freshly restored pristine base and records the
+engine's mutation counters, then a **second pass** must reproduce every outcome exactly. Replay
+of a v3 bundle re-verifies each recorded outcome the same way (untimed, C=1, restore before
+every invocation) **before** measuring latency and **hard-fails on any divergence** — an engine
+that no longer creates/updates what was recorded is doing different work, so its latency would
+be meaningless. `--oracle-samples <K>` (default 8) caps the per-op sample count.
+
 ---
 
 <a id="story-4"></a>

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -256,7 +256,8 @@ to also capture what each write **does** — not just how fast it is:
 # Record + capture the outcome oracle on a live FalkorDB (format v3; hash binds the outcomes):
 benchmark synthetic record --repo-writes --nodes 1000 --edges 5000 --seed 7 \
   --oracle falkor://127.0.0.1:6379 --out-dir rec-writes-v3
-benchmark synthetic run --recording rec-writes-v3 --endpoint falkor://127.0.0.1:6379 --out writes.json
+benchmark synthetic run --recording rec-writes-v3 --require-oracle \
+  --endpoint falkor://127.0.0.1:6379 --out writes.json
 ```
 
 Record-time capture runs every **oracle-eligible** command (the deterministic subset — 7 of the
@@ -270,7 +271,12 @@ cost: the two full passes over this 1 000/5 000 bundle take ~13½ min. Replay of
 re-verifies each recorded outcome the same way (untimed, C=1, restore before every invocation)
 **before** measuring latency and **hard-fails on any divergence** — an engine that no longer
 creates/updates what was recorded is doing different work, so its latency would be meaningless —
-and the report's `meta.oracle_verified` attests the verified coverage.
+and the report's `meta.oracle_verified` attests the verified coverage. Pass **`--require-oracle`**
+on the replay whenever the bundle is *expected* to carry the correctness tier (as above): a
+re-hashed v3→v2 strip is byte-indistinguishable from a legitimate latency-tier recording, so only
+your stated expectation can refuse the downgrade — and on the comparison side, `report --diff`
+aborts on a one-sided or differing `meta.oracle_verified` and prominently warns when two
+un-attested runs measured oracle-eligible write ops.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -504,6 +504,17 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   exclusive with **every** read selector (`--op`/`--all-reads`/`--tier`/`--repo-reads`/
   `--repo-algorithms`); writes never enter `--repo-reads`, any tier, or the per-PR
   `synthetic-verify` gate.
+  Adding **`--oracle <endpoint>`** (write bundles only) additionally captures the **§6.3 outcome
+  oracle**: each **oracle-eligible** write command (the deterministic subset — 7 of the 10 shapes;
+  excluded: `single_edge_update` (server `rand()`), `detach_delete_user` and
+  `remove_user_property_and_label` (deferred)) runs once against the recorded **pristine base** on
+  that live FalkorDB endpoint — restored before every invocation — recording the mutation counters
+  it reports; a **second full pass** must reproduce every outcome exactly (determinism is proven at
+  record time, or the record fails naming the op/seq). The outcomes are folded into the bundle as
+  **recording format v3** with the oracle records **bound into the `workload_hash`**, and the
+  endpoint's graph is left restored (on failure too; a dual capture+restore failure surfaces both
+  errors). `--oracle-samples <K>` (default 8) bounds how many leading commands per eligible op are
+  captured. Plain (oracle-free) v1/v2 bundles stay byte-identical.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result
@@ -537,7 +548,14 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   write replay never silently leaves a mutated graph behind (a dual measurement+restore failure
   surfaces **both** errors). `--no-load` is refused for write bundles, a bundle can never mix
   reads with writes, and a write op can never be capability-gated (capabilities are unhashed, so
-  a crafted one could otherwise skip-shrink the ten-shape coverage).
+  a crafted one could otherwise skip-shrink the ten-shape coverage). When the bundle carries a
+  **§6.3 outcome oracle** (format v3, recorded with `--oracle`), replay first runs an untimed
+  **correctness pass**: every recorded outcome is re-verified — pristine base restored before
+  each invocation, command run once, engine counters required to **equal** the recorded stats —
+  and any divergence **hard-fails the replay** naming the op/seq/command (an engine that no
+  longer effects the recorded outcome is doing *different work*, so measuring its latency would
+  poison the A/B trend silently). Only then are latencies measured, exactly as for a plain write
+  bundle.
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is

--- a/readme.md
+++ b/readme.md
@@ -505,16 +505,20 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   `--repo-algorithms`); writes never enter `--repo-reads`, any tier, or the per-PR
   `synthetic-verify` gate.
   Adding **`--oracle <endpoint>`** (write bundles only) additionally captures the **§6.3 outcome
-  oracle**: each **oracle-eligible** write command (the deterministic subset — 7 of the 10 shapes;
+  oracle**: every **oracle-eligible** write command (the deterministic subset — 7 of the 10 shapes;
   excluded: `single_edge_update` (server `rand()`), `detach_delete_user` and
   `remove_user_property_and_label` (deferred)) runs once against the recorded **pristine base** on
   that live FalkorDB endpoint — restored before every invocation — recording the mutation counters
   it reports; a **second full pass** must reproduce every outcome exactly (determinism is proven at
-  record time, or the record fails naming the op/seq). The outcomes are folded into the bundle as
-  **recording format v3** with the oracle records **bound into the `workload_hash`**, and the
-  endpoint's graph is left restored (on failure too; a dual capture+restore failure surfaces both
-  errors). `--oracle-samples <K>` (default 8) bounds how many leading commands per eligible op are
-  captured. Plain (oracle-free) v1/v2 bundles stay byte-identical.
+  record time, or the record fails naming the op/seq). The capture covers each eligible op's
+  **complete command corpus** (per-command outcomes, no sampling), and the resulting **format v3**
+  bundle must carry an oracle for **exactly** the eligible set — full corpus per op, none anywhere
+  else — enforced at load, attach and replay, so oracle coverage can never silently shrink. The
+  outcomes are **bound into the `workload_hash`**, and the endpoint's graph is left restored — on
+  failure too, with the restored **content** verified against the pristine post-load digests (a
+  dual capture+restore failure surfaces both errors). Capture is a record-time-only cost (the two
+  full passes over the 1 000-node/5 000-edge repo-writes bundle take ~13½ min); plain (oracle-free)
+  v1/v2 bundles stay byte-identical.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result
@@ -554,8 +558,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   each invocation, command run once, engine counters required to **equal** the recorded stats —
   and any divergence **hard-fails the replay** naming the op/seq/command (an engine that no
   longer effects the recorded outcome is doing *different work*, so measuring its latency would
-  poison the A/B trend silently). Only then are latencies measured, exactly as for a plain write
-  bundle.
+  poison the A/B trend silently). The pass re-checks the exact-set rule (every eligible op, full
+  corpus) and the report's `meta.oracle_verified` attests the verified coverage (op → outcome
+  count) — absent for oracle-less runs — so a v3→v2 downgrade is visible when comparing runs.
+  Only then are latencies measured, exactly as for a plain write bundle.
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is

--- a/readme.md
+++ b/readme.md
@@ -516,7 +516,9 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   else — enforced at load, attach and replay, so oracle coverage can never silently shrink. The
   outcomes are **bound into the `workload_hash`**, and the endpoint's graph is left restored — on
   failure too, with the restored **content** verified against the pristine post-load digests (a
-  dual capture+restore failure surfaces both errors). Capture is a record-time-only cost (the two
+  dual capture+restore failure surfaces both errors; the *initial* setup load is under the same
+  discipline — a mid-load failure triggers one recovery restore and a combined error when that
+  fails too). Capture is a record-time-only cost (the two
   full passes over the 1 000-node/5 000-edge repo-writes bundle take ~13½ min); plain (oracle-free)
   v1/v2 bundles stay byte-identical.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
@@ -561,13 +563,21 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   poison the A/B trend silently). The pass re-checks the exact-set rule (every eligible op, full
   corpus) and the report's `meta.oracle_verified` attests the verified coverage (op → outcome
   count) — absent for oracle-less runs — so a v3→v2 downgrade is visible when comparing runs.
-  Only then are latencies measured, exactly as for a plain write bundle.
+  Only then are latencies measured, exactly as for a plain write bundle. Because a re-hashed
+  v3→v2 strip is byte-indistinguishable from a legitimate latency-tier recording (v2 hashes never
+  covered oracle data), pass **`--require-oracle`** whenever the bundle is *expected* to carry
+  the correctness tier: the replay then refuses (offline, before any connection) a write bundle
+  without an oracle, and errors on a read bundle (reads have none).
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is
   expected and recorded), then writes a **Markdown diff** across every op × cache-mode × concurrency
-  level (throughput + total-latency p50/p90/p95/p99 with deltas). `just synthetic-compare-versions`
-  runs `run --recording` against both endpoints then `report --diff`.
+  level (throughput + total-latency p50/p90/p95/p99 with deltas). The §6.3 **oracle attestation** is
+  guarded the same way: a one-sided or differing `meta.oracle_verified` aborts (the runs did not run
+  the same correctness tier — a re-hashed v3→v2 downgrade looks exactly like this), the per-side
+  attestation renders as an **outcome oracle** header row, and a pair of *un*-attested runs over
+  oracle-eligible write ops gets a prominent latency-tier-only warning. `just
+  synthetic-compare-versions` runs `run --recording` against both endpoints then `report --diff`.
 - **`benchmark synthetic report --diff <A.json> <B.json> --regression [--thresholds t.toml]`** is a
   **non-fatal, colored** variant for a per-PR regression report: each op × cache-mode × concurrency
   cell gets a **🟢 / 🔴 / N/A** verdict on **p50** — 🟢 if the candidate (B) is faster or slower
@@ -593,7 +603,12 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   counts) ▸ **regressed** (≥1 cell over budget, or a divergence under the `gate` policy) ▸
   **advisory** (⚠ — a divergence under the `advisory` policy, or **zero comparable cells**, which is
   never a green pass) ▸ **pass** (≥1 comparable cell, nothing wrong). Version/image mismatches are
-  advisory *warnings*, never comparability guards. An op **skipped** on either side (capability
+  advisory *warnings*, never comparability guards. A **one-sided or differing §6.3 oracle
+  attestation** (`meta.oracle_verified`) *is* a comparability guard — the runs did not run the same
+  correctness tier, so the pair renders **not comparable** — while two *un*-attested runs over
+  oracle-eligible write ops stay comparable with a prominent latency-tier-only warning (both rules
+  shared with the strict `--diff` guard, which also renders the per-side **outcome oracle** header
+  row). An op **skipped** on either side (capability
   probe — the engine lacks its required procedure) is **neither a pass nor a divergence** under
   both policies: its perf cells are N/A, it never gates or caps the verdict, it is tallied in its
   own **`skipped`** bucket (⏭ in the reports) and exempt from the per-op policy/digest guards —
@@ -605,7 +620,8 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
     offenders, `budget_profile`, `divergence_policy`, `gated_metric`, `elapsed_secs`, and a stable
     `slug` for linking the externally-hosted full report) — small enough for a PR comment.
   - **`--cells <file>`** writes the **full analysis model** as JSON (schema v2): the meta block
-    (labels, module versions, images, `workload_hash`, samples/warmup, thresholds echo) plus every
+    (labels, module versions, images, `workload_hash`, samples/warmup, per-side `oracle_verified`
+    attestation when present, thresholds echo) plus every
     op × cache-mode × concurrency cell with baseline/candidate p50, `delta_pct`/`delta_ms`, the
     resolved budget and the per-cell verdict — source material for an interactive report page.
     Skipped ops carry their reason in `skipped_baseline`/`skipped_candidate` (omitted otherwise).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -565,16 +565,9 @@ pub enum SyntheticCommands {
             long,
             requires = "repo_writes",
             value_name = "ENDPOINT",
-            help = "capture the write outcome ORACLE while recording (write bundles only): run each oracle-eligible write command (the deterministic subset — 7 of the 10 shapes) once against the recorded pristine base on this live FalkorDB endpoint (falkor://host:port), per-invocation restore, capture its mutation counters, prove determinism with a second full pass, and fold the outcomes into the bundle (format v3; hash-bound). Replay then re-verifies every recorded outcome at C=1 before measuring latency; any divergence is a hard replay error naming the op/seq/command."
+            help = "capture the write outcome ORACLE while recording (write bundles only): run EVERY command of each oracle-eligible write shape (the deterministic subset — 7 of the 10 shapes, complete corpus) once against the recorded pristine base on this live FalkorDB endpoint (falkor://host:port), per-invocation restore, capture its mutation counters, prove determinism with a second full pass, and fold the outcomes into the bundle (format v3; hash-bound; the oracle must cover every eligible op exactly — no subset). Replay then re-verifies every recorded outcome at C=1 before measuring latency; any divergence is a hard replay error naming the op/seq/command."
         )]
         oracle: Option<String>,
-        #[arg(
-            long = "oracle-samples",
-            requires = "oracle",
-            value_name = "K",
-            help = "with --oracle: how many leading commands per eligible op to capture and re-verify (default 8, capped at the op's corpus size; each sample costs a full base restore at capture and at every replay)"
-        )]
-        oracle_samples: Option<usize>,
         #[arg(
             long = "out-dir",
             help = "directory to write the recording bundle into (manifest.json + graph.jsonl + commands/)"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -549,7 +549,7 @@ pub enum SyntheticCommands {
         #[arg(
             long = "repo-writes",
             conflicts_with_all = ["ops", "all_reads", "tier", "repo_reads", "repo_algorithms"],
-            help = "record the A/B benchmark's 10 WRITE shapes from queries_repository (CREATE/SET/MERGE/DELETE/REMOVE/FOREACH) as a write bundle (recording format v2; the workload_hash binds each op's read/write kind). Replay measures them via GRAPH.QUERY at C=1 only, resetting the base graph before every measured cell and restoring + content-verifying it afterwards; results/counters are NOT asserted (latency tier). Write bundles are single-kind: mutually exclusive with every read selector."
+            help = "record the A/B benchmark's 10 WRITE shapes from queries_repository (CREATE/SET/MERGE/DELETE/REMOVE/FOREACH) as a write bundle (recording format v2; the workload_hash binds each op's read/write kind). Replay measures them via GRAPH.QUERY at C=1 only, resetting the base graph before every measured cell and restoring + content-verifying it afterwards; results/counters are NOT asserted (latency tier) unless the bundle carries the --oracle outcomes. Write bundles are single-kind: mutually exclusive with every read selector."
         )]
         repo_writes: bool,
         #[arg(
@@ -561,6 +561,20 @@ pub enum SyntheticCommands {
         nodes: Option<usize>,
         #[arg(long, help = "dataset edge count, must be >= nodes")]
         edges: Option<usize>,
+        #[arg(
+            long,
+            requires = "repo_writes",
+            value_name = "ENDPOINT",
+            help = "capture the write outcome ORACLE while recording (write bundles only): run each oracle-eligible write command (the deterministic subset — 7 of the 10 shapes) once against the recorded pristine base on this live FalkorDB endpoint (falkor://host:port), per-invocation restore, capture its mutation counters, prove determinism with a second full pass, and fold the outcomes into the bundle (format v3; hash-bound). Replay then re-verifies every recorded outcome at C=1 before measuring latency; any divergence is a hard replay error naming the op/seq/command."
+        )]
+        oracle: Option<String>,
+        #[arg(
+            long = "oracle-samples",
+            requires = "oracle",
+            value_name = "K",
+            help = "with --oracle: how many leading commands per eligible op to capture and re-verify (default 8, capped at the op's corpus size; each sample costs a full base restore at capture and at every replay)"
+        )]
+        oracle_samples: Option<usize>,
         #[arg(
             long = "out-dir",
             help = "directory to write the recording bundle into (manifest.json + graph.jsonl + commands/)"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -498,6 +498,12 @@ pub enum SyntheticCommands {
             help = "with --recording: skip loading the recorded graph, only count-verify the already-loaded graph (load-once / run-many)."
         )]
         no_load: bool,
+        #[arg(
+            long = "require-oracle",
+            requires = "recording",
+            help = "with --recording: refuse to measure a write bundle that carries no outcome oracle (recording format < v3). Guards against re-hashed v3-to-v2 downgrades; errors on read bundles (reads have no oracle)."
+        )]
+        require_oracle: bool,
     },
     #[command(about = "list the available operations")]
     ListOps,
@@ -866,6 +872,21 @@ mod tests {
         // `--repo-reads` is record-only (not a `run` flag).
         assert!(Cli::try_parse_from([
             "benchmark", "synthetic", "run", "--repo-reads", "core",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn cli_require_oracle_needs_recording() {
+        use clap::Parser;
+        // `--require-oracle` rides on `--recording` (like `--no-load`)…
+        assert!(Cli::try_parse_from([
+            "benchmark", "synthetic", "run", "--recording", "rec", "--require-oracle",
+        ])
+        .is_ok());
+        // …and is rejected without it.
+        assert!(Cli::try_parse_from([
+            "benchmark", "synthetic", "run", "--require-oracle",
         ])
         .is_err());
     }

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -853,6 +853,7 @@ mod tests {
                     workload_hash: "sha256:abc".to_string(),
                 }),
                 label: Some(label.to_string()),
+                oracle_verified: None,
             },
             operations,
         }

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -246,6 +246,11 @@ pub struct SideMeta {
     pub warmup: usize,
     /// The concurrency sweep this side measured.
     pub concurrency: Vec<usize>,
+    /// §6.3 oracle attestation this side's report carries (`meta.oracle_verified`): op → number
+    /// of recorded write outcomes the replay re-verified before measuring. `None` for read runs
+    /// and latency-tier-only write runs. Additive optional field — absent from pre-§6.3 models.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oracle_verified: Option<std::collections::BTreeMap<String, usize>>,
 }
 
 /// Header/config metadata the renderers need: both sides plus the threshold settings that were
@@ -442,6 +447,7 @@ fn side_meta(r: &Report) -> SideMeta {
         samples: r.meta.samples,
         warmup: r.meta.warmup,
         concurrency: r.meta.concurrency.clone(),
+        oracle_verified: r.meta.oracle_verified.clone(),
     }
 }
 
@@ -1322,6 +1328,30 @@ mod tests {
         assert_eq!(an.divergence_policy, DivergencePolicy::Gate);
         // The thresholds echo carries the resolved default budget.
         assert!((an.meta.thresholds.default_budget_pct - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn analysis_meta_carries_oracle_attestation_additively() {
+        // §6.3 attestation is an additive optional SideMeta field: the key is absent (not null)
+        // for un-attested runs — pre-oracle cells consumers never see it — and a plain copy of
+        // `meta.oracle_verified` when the replay re-verified a write outcome oracle.
+        let mut a = rpt("main", 42001, &[("match_by_index", 1.0, Some("d1"))]);
+        let mut b = rpt("pr", 42002, &[("match_by_index", 1.0, Some("d1"))]);
+        let un_attested = gate(&a, &b);
+        let value: serde_json::Value =
+            serde_json::from_str(&un_attested.to_json().unwrap()).unwrap();
+        assert!(value["meta"]["baseline"].get("oracle_verified").is_none(), "{value}");
+
+        let attestation: std::collections::BTreeMap<String, usize> =
+            [("single_vertex_write".to_string(), 256)].into();
+        a.meta.oracle_verified = Some(attestation.clone());
+        b.meta.oracle_verified = Some(attestation.clone());
+        let attested = gate(&a, &b);
+        assert_eq!(attested.meta.baseline.oracle_verified, Some(attestation.clone()));
+        assert_eq!(attested.meta.candidate.oracle_verified, Some(attestation));
+        let value: serde_json::Value =
+            serde_json::from_str(&attested.to_json().unwrap()).unwrap();
+        assert_eq!(value["meta"]["candidate"]["oracle_verified"]["single_vertex_write"], 256);
     }
 
     #[test]

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -760,6 +760,7 @@ mod regression_guard_tests {
                     workload_hash: hash.to_string(),
                 }),
                 label: None,
+                oracle_verified: None,
             },
             operations,
         }

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -40,6 +40,18 @@ pub struct BaselineKey {
     /// as neither a pass nor a divergence. Empty for pre-Phase-6 reports.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub skipped_ops: BTreeSet<String>,
+    /// §6.3 oracle attestation (`meta.oracle_verified`): op → number of recorded write outcomes
+    /// the replay **re-verified** before measuring. `None` for a latency-tier-only run. Compared
+    /// across sides so a run that dropped the correctness tier can't silently pair with one that
+    /// kept it. Absent from pre-§6.3 baselines.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oracle_verified: Option<BTreeMap<String, usize>>,
+    /// The **oracle-eligible** write ops (the §6.3 deterministic subset) this run measured. Lets
+    /// the guards flag a pair that measured eligible writes with *no* oracle on either side —
+    /// legitimate for a v2 latency-tier bundle, but exactly what a two-sided v3→v2 downgrade
+    /// looks like, so it warrants a prominent warning. Empty for read runs and older baselines.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub eligible_write_ops: BTreeSet<String>,
 }
 
 impl BaselineKey {
@@ -65,7 +77,75 @@ impl BaselineKey {
                 .filter(|(_, op)| op.skipped.is_some())
                 .map(|(name, _)| name.clone())
                 .collect(),
+            oracle_verified: report.meta.oracle_verified.clone(),
+            eligible_write_ops: eligible_write_ops(report),
         }
+    }
+}
+
+/// The oracle-eligible write ops (§6.3 deterministic subset) present in a report's op set.
+fn eligible_write_ops(report: &Report) -> BTreeSet<String> {
+    let eligible = crate::synthetic::shapes::oracle_eligible_names();
+    report
+        .operations
+        .keys()
+        .filter(|name| eligible.contains(name.as_str()))
+        .cloned()
+        .collect()
+}
+
+/// Compact human summary of an oracle attestation map: `"7 op(s), 1792 outcome(s)"`.
+fn attestation_summary(m: &BTreeMap<String, usize>) -> String {
+    format!("{} op(s), {} outcome(s)", m.len(), m.values().sum::<usize>())
+}
+
+/// §6.3 oracle-attestation comparability between two runs.
+///
+/// `Err(reason)` is a **fatal** mismatch — the runs re-verified different outcome coverage
+/// (one-sided or differing attestations), so their correctness tiers are not the same check and
+/// the comparison must refuse, exactly like a workload mismatch. Unreachable through the real
+/// pipeline (a v3 bundle's oracle is hash-bound, so hash-equal replays attest identically) — this
+/// arm defends hand-edited or mixed-provenance reports.
+///
+/// `Ok(warnings)` may carry the **downgrade-visibility** warning: both sides measured
+/// oracle-eligible write ops with no attestation at all. That pair is legitimate (a v2
+/// latency-tier bundle) but indistinguishable from a two-sided re-hashed v3→v2 strip, so it is
+/// surfaced prominently rather than silently passed (§6.3 — duck's downgrade finding).
+fn oracle_attestation_check(
+    baseline: Option<&BTreeMap<String, usize>>,
+    candidate: Option<&BTreeMap<String, usize>>,
+    eligible_ops: &BTreeSet<String>,
+) -> Result<Vec<String>, String> {
+    match (baseline, candidate) {
+        (Some(b), Some(c)) if b == c => Ok(Vec::new()),
+        (Some(b), Some(c)) => Err(format!(
+            "oracle attestation differs — baseline re-verified {} but candidate re-verified {}: \
+             the runs verified different write-outcome coverage, so their correctness tiers are \
+             not comparable",
+            attestation_summary(b),
+            attestation_summary(c)
+        )),
+        (Some(b), None) => Err(format!(
+            "oracle attestation is one-sided — baseline re-verified the write outcome oracle \
+             ({}) but candidate carries no attestation (latency tier only): a re-hashed v3→v2 \
+             downgrade looks exactly like this. Re-run the candidate against the oracle-bearing \
+             (v3) bundle, with `--require-oracle` to refuse the downgrade",
+            attestation_summary(b)
+        )),
+        (None, Some(c)) => Err(format!(
+            "oracle attestation is one-sided — candidate re-verified the write outcome oracle \
+             ({}) but baseline carries no attestation (latency tier only): a re-hashed v3→v2 \
+             downgrade looks exactly like this. Re-run the baseline against the oracle-bearing \
+             (v3) bundle, with `--require-oracle` to refuse the downgrade",
+            attestation_summary(c)
+        )),
+        (None, None) if !eligible_ops.is_empty() => Ok(vec![format!(
+            "both runs measured oracle-eligible write op(s) ({}) with no outcome oracle — \
+             latencies were compared WITHOUT the §6.3 correctness tier. Re-record with --oracle \
+             and replay with --require-oracle to enforce it",
+            eligible_ops.iter().cloned().collect::<Vec<_>>().join(", ")
+        )]),
+        (None, None) => Ok(Vec::new()),
     }
 }
 
@@ -159,6 +239,22 @@ pub fn guard(
         return GuardOutcome::Abort { reason };
     }
 
+    // §6.3 oracle-attestation gate: one-sided or differing attestation means the two runs did not
+    // run the same correctness tier — refuse, like a workload mismatch. Both-absent over
+    // oracle-eligible write ops is legitimate (latency tier) but downgrade-shaped ⇒ warning below.
+    let attestation_warnings = match oracle_attestation_check(
+        baseline.oracle_verified.as_ref(),
+        candidate.oracle_verified.as_ref(),
+        &baseline
+            .eligible_write_ops
+            .union(&candidate.eligible_write_ops)
+            .cloned()
+            .collect(),
+    ) {
+        Ok(warnings) => warnings,
+        Err(reason) => return GuardOutcome::Abort { reason },
+    };
+
     // Result-correctness gate: for every op the baseline recorded a result digest for, the
     // candidate must record the *same* digest — otherwise a version returning wrong or empty
     // results faster could masquerade as an improvement. A candidate that is missing a digest the
@@ -194,7 +290,7 @@ pub fn guard(
         }
     }
 
-    let mut warnings = Vec::new();
+    let mut warnings = attestation_warnings;
     // Only warn "same version" when both versions are actually *known* and equal — two unknown
     // (`None`) versions are not a known match, so don't claim there's no delta to measure. The
     // dev placeholder is excluded too: two edge/RC images both reporting the placeholder are NOT
@@ -353,6 +449,20 @@ pub fn regression_guard(
     {
         return RegressionGuard::NotComparable { reason };
     }
+    // §6.3 oracle-attestation gate — same rule as the strict [`guard`]: one-sided or differing
+    // attestation ⇒ the correctness tiers differ ⇒ NotComparable; both-absent over eligible
+    // write ops ⇒ the prominent latency-tier-only warning (merged into the advisory set below).
+    let attestation_warnings = match oracle_attestation_check(
+        baseline.meta.oracle_verified.as_ref(),
+        candidate.meta.oracle_verified.as_ref(),
+        &eligible_write_ops(baseline)
+            .union(&eligible_write_ops(candidate))
+            .cloned()
+            .collect(),
+    ) {
+        Ok(warnings) => warnings,
+        Err(reason) => return RegressionGuard::NotComparable { reason },
+    };
 
     // 2. Per-op result divergence — reported, never fatal. Over the *union* of ops: two present
     //    digests that differ, or an asymmetric one-side-only digest, is diverged (we can't verify
@@ -383,7 +493,11 @@ pub fn regression_guard(
 
     RegressionGuard::Comparable {
         diverged_ops,
-        warnings: advisory_warnings(baseline, candidate),
+        warnings: {
+            let mut warnings = attestation_warnings;
+            warnings.extend(advisory_warnings(baseline, candidate));
+            warnings
+        },
     }
 }
 
@@ -455,6 +569,8 @@ mod tests {
             result_digests: BTreeMap::new(),
             op_policies: BTreeMap::new(),
             skipped_ops: BTreeSet::new(),
+            oracle_verified: None,
+            eligible_write_ops: BTreeSet::new(),
         }
     }
 
@@ -472,6 +588,8 @@ mod tests {
                 .collect(),
             op_policies: BTreeMap::new(),
             skipped_ops: BTreeSet::new(),
+            oracle_verified: None,
+            eligible_write_ops: BTreeSet::new(),
         }
     }
 
@@ -510,6 +628,8 @@ mod tests {
                 .map(|(k, p)| (k.to_string(), p.clone()))
                 .collect(),
             skipped_ops: BTreeSet::new(),
+            oracle_verified: None,
+            eligible_write_ops: BTreeSet::new(),
         }
     }
 
@@ -685,6 +805,8 @@ mod tests {
             result_digests: BTreeMap::new(),
             op_policies: BTreeMap::new(),
             skipped_ops: BTreeSet::new(),
+            oracle_verified: None,
+            eligible_write_ops: BTreeSet::new(),
         };
         let cand = BaselineKey {
             workload_hash: Some("sha256:abc".to_string()),
@@ -693,6 +815,8 @@ mod tests {
             result_digests: BTreeMap::new(),
             op_policies: BTreeMap::new(),
             skipped_ops: BTreeSet::new(),
+            oracle_verified: None,
+            eligible_write_ops: BTreeSet::new(),
         };
         match guard(&base, &cand) {
             GuardOutcome::Proceed { warnings } => {
@@ -700,6 +824,99 @@ mod tests {
             }
             other => panic!("expected Proceed, got {other:?}"),
         }
+    }
+
+    fn attested(entries: &[(&str, usize)]) -> BTreeMap<String, usize> {
+        entries.iter().map(|(op, n)| (op.to_string(), *n)).collect()
+    }
+
+    #[test]
+    fn attestation_check_covers_every_arm() {
+        let full = attested(&[("single_vertex_write", 256), ("foreach_loop_mutation", 256)]);
+        let subset = attested(&[("single_vertex_write", 256)]);
+        let eligible: BTreeSet<String> = ["single_vertex_write".to_string()].into();
+        // Matching attestations: clean pass.
+        assert_eq!(oracle_attestation_check(Some(&full), Some(&full), &eligible), Ok(Vec::new()));
+        // Differing attestations: fatal.
+        let err = oracle_attestation_check(Some(&full), Some(&subset), &eligible).unwrap_err();
+        assert!(err.contains("oracle attestation differs"), "{err}");
+        assert!(err.contains("2 op(s), 512 outcome(s)"), "{err}");
+        assert!(err.contains("1 op(s), 256 outcome(s)"), "{err}");
+        // One-sided (either way): fatal, naming the downgrade and the flag.
+        for (b, c, side) in
+            [(Some(&full), None, "candidate"), (None, Some(&full), "baseline")]
+        {
+            let err = oracle_attestation_check(b, c, &eligible).unwrap_err();
+            assert!(err.contains("one-sided"), "{err}");
+            assert!(err.contains(&format!("Re-run the {side}")), "{err}");
+            assert!(err.contains("--require-oracle"), "{err}");
+            assert!(err.contains("v3→v2"), "{err}");
+        }
+        // Both absent over eligible write ops: legitimate but downgrade-shaped ⇒ warning.
+        let warnings = oracle_attestation_check(None, None, &eligible).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("WITHOUT"), "{}", warnings[0]);
+        assert!(warnings[0].contains("single_vertex_write"), "{}", warnings[0]);
+        assert!(warnings[0].contains("--require-oracle"), "{}", warnings[0]);
+        // Both absent, nothing eligible (read runs): silent.
+        assert_eq!(oracle_attestation_check(None, None, &BTreeSet::new()), Ok(Vec::new()));
+    }
+
+    #[test]
+    fn guard_aborts_on_one_sided_or_differing_attestation() {
+        let mut base = key(Some("sha256:abc"), Some(42001));
+        let mut cand = key(Some("sha256:abc"), Some(42002));
+        base.oracle_verified = Some(attested(&[("single_vertex_write", 256)]));
+        match guard(&base, &cand) {
+            GuardOutcome::Abort { reason } => assert!(reason.contains("one-sided"), "{reason}"),
+            other => panic!("expected Abort, got {other:?}"),
+        }
+        cand.oracle_verified = Some(attested(&[("single_vertex_write", 8)]));
+        match guard(&base, &cand) {
+            GuardOutcome::Abort { reason } => {
+                assert!(reason.contains("attestation differs"), "{reason}");
+            }
+            other => panic!("expected Abort, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn guard_warns_on_downgrade_shaped_pair_and_passes_matching_attestation() {
+        // Both sides measured an oracle-eligible write op with no attestation: comparable, but
+        // the latency-tier-only warning must surface (the two-sided-downgrade blind spot).
+        let mut base = key(Some("sha256:abc"), Some(42001));
+        let mut cand = key(Some("sha256:abc"), Some(42002));
+        base.eligible_write_ops = ["single_vertex_write".to_string()].into();
+        cand.eligible_write_ops = base.eligible_write_ops.clone();
+        match guard(&base, &cand) {
+            GuardOutcome::Proceed { warnings } => {
+                assert!(warnings.iter().any(|w| w.contains("no outcome oracle")), "{warnings:?}");
+            }
+            other => panic!("expected Proceed, got {other:?}"),
+        }
+        // Matching attestations: no oracle warning at all.
+        base.oracle_verified = Some(attested(&[("single_vertex_write", 256)]));
+        cand.oracle_verified = base.oracle_verified.clone();
+        match guard(&base, &cand) {
+            GuardOutcome::Proceed { warnings } => {
+                assert!(!warnings.iter().any(|w| w.contains("oracle")), "{warnings:?}");
+            }
+            other => panic!("expected Proceed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn baseline_key_serde_defaults_for_pre_oracle_json() {
+        // A pre-§6.3 baseline JSON (no oracle fields) must load with the defaults…
+        let old = r#"{"workload_hash":"sha256:abc","module_graph_ver":42001,"result_digests":{}}"#;
+        let key: BaselineKey = serde_json::from_str(old).unwrap();
+        assert_eq!(key.oracle_verified, None);
+        assert!(key.eligible_write_ops.is_empty());
+        // …and a key without attestation serializes without the new fields (read baselines stay
+        // byte-identical to pre-§6.3 output).
+        let json = serde_json::to_string(&key).unwrap();
+        assert!(!json.contains("oracle_verified"), "{json}");
+        assert!(!json.contains("eligible_write_ops"), "{json}");
     }
 }
 
@@ -1080,5 +1297,93 @@ mod regression_guard_tests {
         assert!(clean_key.skipped_ops.is_empty());
         let json = serde_json::to_string(&clean_key).unwrap();
         assert!(!json.contains("skipped_ops"), "{json}");
+    }
+
+    fn oracle_map(entries: &[(&str, usize)]) -> BTreeMap<String, usize> {
+        entries.iter().map(|(op, n)| (op.to_string(), *n)).collect()
+    }
+
+    #[test]
+    fn regression_guard_not_comparable_on_one_sided_or_differing_attestation() {
+        // Baseline replayed the v3 bundle (attested); candidate replayed a stripped/downgraded
+        // v2 twin — hash-equal, so only the attestation gate can catch it.
+        let mut a =
+            rep("h", 100, 50, vec![1], None, None, &[("single_vertex_write", Some("d1"))]);
+        let mut b =
+            rep("h", 100, 50, vec![1], None, None, &[("single_vertex_write", Some("d1"))]);
+        a.meta.oracle_verified = Some(oracle_map(&[("single_vertex_write", 256)]));
+        match regression_guard(&a, &b) {
+            RegressionGuard::NotComparable { reason } => {
+                assert!(reason.contains("one-sided"), "{reason}");
+                assert!(reason.contains("--require-oracle"), "{reason}");
+            }
+            other => panic!("expected NotComparable, got {other:?}"),
+        }
+        // Differing attestations are just as fatal.
+        b.meta.oracle_verified = Some(oracle_map(&[("single_vertex_write", 8)]));
+        assert!(matches!(regression_guard(&a, &b), RegressionGuard::NotComparable { .. }));
+    }
+
+    #[test]
+    fn regression_guard_warns_on_unattested_eligible_write_ops_only() {
+        // Two latency-tier (v2) write replays: comparable, but prominently flagged.
+        let a = rep("h", 100, 50, vec![1], None, None, &[("single_vertex_write", Some("d1"))]);
+        let b = rep("h", 100, 50, vec![1], None, None, &[("single_vertex_write", Some("d1"))]);
+        match regression_guard(&a, &b) {
+            RegressionGuard::Comparable { warnings, .. } => {
+                assert!(
+                    warnings.iter().any(|w| w.contains("no outcome oracle")),
+                    "{warnings:?}"
+                );
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+        // A read-only pair carries no oracle-eligible ops ⇒ no oracle warning.
+        let ra = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", Some("d1"))]);
+        let rb = rep("h", 100, 50, vec![1], None, None, &[("match_by_index", Some("d1"))]);
+        match regression_guard(&ra, &rb) {
+            RegressionGuard::Comparable { warnings, .. } => {
+                assert!(!warnings.iter().any(|w| w.contains("oracle")), "{warnings:?}");
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn regression_guard_passes_matching_attestation_without_warning() {
+        let mut a =
+            rep("h", 100, 50, vec![1], None, None, &[("single_vertex_write", Some("d1"))]);
+        let mut b =
+            rep("h", 100, 50, vec![1], None, None, &[("single_vertex_write", Some("d1"))]);
+        a.meta.oracle_verified = Some(oracle_map(&[("single_vertex_write", 256)]));
+        b.meta.oracle_verified = a.meta.oracle_verified.clone();
+        match regression_guard(&a, &b) {
+            RegressionGuard::Comparable { diverged_ops, warnings } => {
+                assert!(diverged_ops.is_empty());
+                assert!(!warnings.iter().any(|w| w.contains("oracle")), "{warnings:?}");
+            }
+            other => panic!("expected Comparable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn baseline_key_collects_oracle_attestation_and_eligible_write_ops() {
+        let mut r = rep(
+            "h",
+            100,
+            50,
+            vec![1],
+            None,
+            None,
+            &[("single_vertex_write", Some("d1")), ("match_by_index", Some("d2"))],
+        );
+        r.meta.oracle_verified = Some(oracle_map(&[("single_vertex_write", 256)]));
+        let key = BaselineKey::from_report(&r);
+        assert_eq!(key.oracle_verified, r.meta.oracle_verified);
+        // Only the oracle-eligible write op is collected — reads never carry oracles.
+        assert_eq!(
+            key.eligible_write_ops,
+            ["single_vertex_write".to_string()].into()
+        );
     }
 }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -85,6 +85,14 @@ pub fn diff_markdown(
         &format!("{} / {}", baseline.meta.samples, baseline.meta.warmup),
         &format!("{} / {}", candidate.meta.samples, candidate.meta.warmup),
     );
+    // §6.3 attestation, surfaced per side: a write-bundle replay that ran the correctness tier
+    // says so here; "—" on a write run means latency tier only (see the guard's warnings).
+    row2(
+        &mut out,
+        "outcome oracle",
+        &oracle_cell(baseline.meta.oracle_verified.as_ref()),
+        &oracle_cell(candidate.meta.oracle_verified.as_ref()),
+    );
 
     out.push_str(
         "\n_Δ is 100·(candidate−baseline)/baseline. **Latency: lower is better** (a positive Δ = \
@@ -143,6 +151,17 @@ fn diff_skip_note(
 /// (`A`/`B` for `diff_markdown`; `baseline`/`candidate` for the regression report).
 fn col_label(r: &Report, fallback: &str) -> String {
     r.meta.label.clone().unwrap_or_else(|| fallback.to_string())
+}
+
+/// One side's §6.3 oracle-attestation cell: `"verified — 7 op(s), 1792 outcome(s)"` when the
+/// replay re-verified a write outcome oracle, `"—"` otherwise (read run or latency tier only).
+fn oracle_cell(att: Option<&std::collections::BTreeMap<String, usize>>) -> String {
+    att.map_or_else(
+        || "—".to_string(),
+        |m| {
+            format!("verified — {} op(s), {} outcome(s)", m.len(), m.values().sum::<usize>())
+        },
+    )
 }
 
 /// Render one op × cache-mode table (rows = concurrency levels present in either run). Skipped
@@ -351,6 +370,14 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
         "samples / warmup",
         &format!("{} / {}", meta.baseline.samples, meta.baseline.warmup),
         &format!("{} / {}", meta.candidate.samples, meta.candidate.warmup),
+    );
+    // §6.3 attestation per side (mirrors the plain diff's row): "—" on a write run means the
+    // latency tier only — the guard's warnings call that out below.
+    row2(
+        &mut head,
+        "outcome oracle",
+        &oracle_cell(meta.baseline.oracle_verified.as_ref()),
+        &oracle_cell(meta.candidate.oracle_verified.as_ref()),
     );
     head.push('\n');
     head.push_str(&meta.thresholds.settings_markdown());
@@ -894,6 +921,37 @@ mod tests {
         assert!(md.contains("diff — main → pr"), "title: {md}");
         assert!(md.contains("| main (baseline) | pr (candidate) |"), "header: {md}");
         assert!(md.contains("main total p50") && md.contains("pr tput"), "op header: {md}");
+    }
+
+    #[test]
+    fn diff_and_regression_render_the_oracle_attestation_row() {
+        use crate::synthetic::baseline::regression_guard;
+        let mut a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 1.1, 900.0);
+        // Un-attested pair: both sides show the placeholder.
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("| outcome oracle | — | — |"), "{md}");
+        // An attested side renders the compact verified summary — per side, so a one-sided
+        // (downgrade-shaped) pair is visible at a glance even before the guard's warnings.
+        a.meta.oracle_verified =
+            Some([("single_vertex_write".to_string(), 256)].into_iter().collect());
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(
+            md.contains("| outcome oracle | verified — 1 op(s), 256 outcome(s) | — |"),
+            "{md}"
+        );
+        // The regression report renders the same row from the analysis SideMeta.
+        let mut b2 = report(42002, 1.0, 1000.0);
+        b2.meta.oracle_verified = a.meta.oracle_verified.clone();
+        let g = regression_guard(&a, &b2);
+        let md = regression_md(&a, &b2, &g, &Thresholds::builtin(), None);
+        assert!(
+            md.contains(
+                "| outcome oracle | verified — 1 op(s), 256 outcome(s) | verified — 1 op(s), \
+                 256 outcome(s) |"
+            ),
+            "{md}"
+        );
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -863,6 +863,7 @@ mod tests {
                     workload_hash: "sha256:abc".to_string(),
                 }),
                 label: None,
+                oracle_verified: None,
             },
             operations,
         }
@@ -1369,6 +1370,7 @@ mod tests {
                     workload_hash: "sha256:abc".to_string(),
                 }),
                 label: Some(label.to_string()),
+                oracle_verified: None,
             },
             operations,
         }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1402,6 +1402,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             edges,
             recording,
             no_load,
+            require_oracle,
         } => {
             // Expand `--op all` / `--op '*'` to the concrete read ops before anything else.
             let ops = crate::cli::expand_op_selectors(&ops);
@@ -1434,8 +1435,18 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                     out: out.unwrap_or_else(|| "synthetic-report.json".to_string()),
                     server_image,
                     label,
+                    require_oracle,
                 };
                 return replay::run_and_report(&replay_config).await;
+            }
+            // clap enforces `--require-oracle requires --recording`; re-validate for directly
+            // constructed commands (tests, future callers) so the flag can never silently no-op.
+            if require_oracle {
+                return Err(OtherError(
+                    "--require-oracle requires --recording: the outcome oracle lives in a \
+                     recorded write bundle"
+                        .to_string(),
+                ));
             }
             let overrides = config::CliOverrides {
                 endpoint,
@@ -2381,6 +2392,7 @@ mod tests {
             edges: None,
             recording: None,
             no_load: false,
+            require_oracle: false,
         };
         assert!(run_command(command).await.is_err());
         let _ = std::fs::remove_file(&cfg_path);
@@ -2557,6 +2569,7 @@ mod tests {
             out: out_dir.join("unused.json").to_string_lossy().into_owned(),
             server_image: None,
             label: None,
+            require_oracle: false,
         };
         let err = crate::synthetic::replay::run(&replay_cfg).await.unwrap_err();
         assert!(
@@ -2869,6 +2882,7 @@ mod tests {
             edges: None,
             recording: None,
             no_load: false,
+            require_oracle: false,
         };
         let err = run_command(command).await.expect_err("no ops ⇒ error");
         assert!(
@@ -2904,9 +2918,46 @@ mod tests {
             edges: None,
             recording: Some("/nonexistent/rec".to_string()),
             no_load: false,
+            require_oracle: false,
         };
         let err = run_command(command).await.expect_err("recording + generate ⇒ error");
         assert!(format!("{err}").contains("--recording"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn run_command_rejects_require_oracle_without_recording() {
+        // clap enforces `requires = "recording"`; the handler re-validates for directly
+        // constructed commands so the flag can never silently no-op on a plain run.
+        let command = crate::cli::SyntheticCommands::Run {
+            config: None,
+            endpoint: None,
+            graph: None,
+            ops: vec![],
+            all_reads: false,
+            tier: None,
+            samples: None,
+            warmup: None,
+            concurrency: vec![],
+            reset_every: None,
+            seed: None,
+            cache: None,
+            server_timeout_ms: None,
+            client_deadline_ms: None,
+            out: None,
+            server_image: None,
+            label: None,
+            generate: false,
+            nodes: None,
+            edges: None,
+            recording: None,
+            no_load: false,
+            require_oracle: true,
+        };
+        let err = run_command(command).await.expect_err("--require-oracle without --recording");
+        assert!(
+            format!("{err}").contains("--require-oracle requires --recording"),
+            "got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -24,6 +24,7 @@ pub mod diff;
 pub mod engine;
 pub mod host;
 pub mod op_runner;
+pub mod oracle;
 pub mod provenance;
 pub mod recording;
 pub mod replay;
@@ -1476,8 +1477,23 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             seed,
             nodes,
             edges,
+            oracle,
+            oracle_samples,
             out_dir,
         } => {
+            // clap enforces `--oracle requires --repo-writes`; re-validate here so a directly
+            // constructed command (tests, future callers) can't capture an oracle for a read
+            // bundle either.
+            if oracle.is_none() && oracle_samples.is_some() {
+                return Err(OtherError("--oracle-samples requires --oracle".to_string()));
+            }
+            if oracle.is_some() && !repo_writes {
+                return Err(OtherError(
+                    "--oracle requires --repo-writes: the outcome oracle records mutation \
+                     counters, which only write bundles have"
+                        .to_string(),
+                ));
+            }
             // Expand `--op all` / `--op '*'` to the concrete read ops.
             let ops = crate::cli::expand_op_selectors(&ops);
             // Reuse the run-config resolution (with generate=true) to validate + resolve the
@@ -1595,6 +1611,26 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 out_dir,
                 manifest.workload_hash
             );
+            // §6.3: capture the outcome oracle ONLINE against the given endpoint and fold it into
+            // the just-written bundle (upgrading it to format v3 with a new workload_hash).
+            if let Some(endpoint) = &oracle {
+                let samples = oracle_samples.unwrap_or(oracle::DEFAULT_ORACLE_SAMPLES);
+                let manifest = oracle::capture(
+                    endpoint,
+                    std::path::Path::new(&out_dir),
+                    samples,
+                    resolved.server_timeout_ms,
+                    resolved.client_deadline_ms,
+                )
+                .await?;
+                let oracle_ops = manifest.ops.iter().filter(|e| e.oracle.is_some()).count();
+                let outcomes: usize = manifest.ops.iter().filter_map(|e| e.oracle).sum();
+                println!(
+                    "captured outcome oracle: {} outcome(s) across {} op(s), determinism proven \
+                     by a second pass (format v{}, workload_hash {})",
+                    outcomes, oracle_ops, manifest.format_version, manifest.workload_hash
+                );
+            }
             Ok(())
         }
         crate::cli::SyntheticCommands::Report {
@@ -2375,6 +2411,8 @@ mod tests {
             seed: Some(3),
             nodes: Some(200),
             edges: Some(600),
+            oracle: None,
+            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command).await.expect("offline record succeeds without a server");
@@ -2415,6 +2453,8 @@ mod tests {
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
+            oracle: None,
+            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2482,6 +2522,8 @@ mod tests {
             seed: Some(7),
             nodes: Some(300),
             edges: Some(900),
+            oracle: None,
+            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2562,6 +2604,8 @@ mod tests {
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
+            oracle: None,
+            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2630,6 +2674,8 @@ mod tests {
             seed: Some(7),
             nodes: Some(1000),
             edges: Some(5000),
+            oracle: None,
+            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command).await.expect("offline full repo-reads record succeeds");
@@ -2669,6 +2715,8 @@ mod tests {
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
+            oracle: None,
+            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2735,6 +2783,8 @@ mod tests {
             seed: Some(5),
             nodes: Some(300),
             edges: Some(900),
+            oracle: None,
+            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command).await.expect("offline combined record succeeds");
@@ -2760,6 +2810,55 @@ mod tests {
             "the FixtureDependent reads still bake the fixture"
         );
         std::fs::remove_dir_all(&out_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_command_record_rejects_oracle_flags_without_their_prerequisites() {
+        // The clap layer enforces `--oracle requires --repo-writes` (and `--oracle-samples
+        // requires --oracle`); these runtime guards keep directly-constructed commands honest
+        // too — both fail offline, before any file or network use.
+        let base = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: None,
+            ops: vec![],
+            all_reads: true,
+            tier: None,
+            repo_reads: None,
+            repo_algorithms: false,
+            repo_writes: false,
+            seed: Some(1),
+            nodes: Some(10),
+            edges: Some(20),
+            oracle: Some("falkor://127.0.0.1:1".to_string()),
+            oracle_samples: None,
+            out_dir: "unused".to_string(),
+        };
+        let err = run_command(base).await.unwrap_err();
+        assert!(
+            format!("{err}").contains("--oracle requires --repo-writes"),
+            "got: {err}"
+        );
+        let samples_only = crate::cli::SyntheticCommands::Record {
+            config: None,
+            graph: None,
+            ops: vec![],
+            all_reads: true,
+            tier: None,
+            repo_reads: None,
+            repo_algorithms: false,
+            repo_writes: false,
+            seed: Some(1),
+            nodes: Some(10),
+            edges: Some(20),
+            oracle: None,
+            oracle_samples: Some(4),
+            out_dir: "unused".to_string(),
+        };
+        let err = run_command(samples_only).await.unwrap_err();
+        assert!(
+            format!("{err}").contains("--oracle-samples requires --oracle"),
+            "got: {err}"
+        );
     }
 
     #[tokio::test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1615,6 +1615,9 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             // the just-written bundle (upgrading it to format v3 with a new workload_hash).
             if let Some(endpoint) = &oracle {
                 let samples = oracle_samples.unwrap_or(oracle::DEFAULT_ORACLE_SAMPLES);
+                // The resolved defaults budget only the single measured write per sample; the
+                // per-sample base restores are bulk loads and get replay's ≥60 s floor inside
+                // `load_recorded_graph`, so no capture-specific budget is needed.
                 let manifest = oracle::capture(
                     endpoint,
                     std::path::Path::new(&out_dir),

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -771,6 +771,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             host: host::collect(),
             dataset: dataset_info,
             label: config.label.clone(),
+            oracle_verified: None,
         },
         operations,
     })
@@ -1478,15 +1479,11 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             nodes,
             edges,
             oracle,
-            oracle_samples,
             out_dir,
         } => {
             // clap enforces `--oracle requires --repo-writes`; re-validate here so a directly
             // constructed command (tests, future callers) can't capture an oracle for a read
             // bundle either.
-            if oracle.is_none() && oracle_samples.is_some() {
-                return Err(OtherError("--oracle-samples requires --oracle".to_string()));
-            }
             if oracle.is_some() && !repo_writes {
                 return Err(OtherError(
                     "--oracle requires --repo-writes: the outcome oracle records mutation \
@@ -1614,14 +1611,12 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             // §6.3: capture the outcome oracle ONLINE against the given endpoint and fold it into
             // the just-written bundle (upgrading it to format v3 with a new workload_hash).
             if let Some(endpoint) = &oracle {
-                let samples = oracle_samples.unwrap_or(oracle::DEFAULT_ORACLE_SAMPLES);
                 // The resolved defaults budget only the single measured write per sample; the
                 // per-sample base restores are bulk loads and get replay's ≥60 s floor inside
                 // `load_recorded_graph`, so no capture-specific budget is needed.
                 let manifest = oracle::capture(
                     endpoint,
                     std::path::Path::new(&out_dir),
-                    samples,
                     resolved.server_timeout_ms,
                     resolved.client_deadline_ms,
                 )
@@ -1629,8 +1624,9 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 let oracle_ops = manifest.ops.iter().filter(|e| e.oracle.is_some()).count();
                 let outcomes: usize = manifest.ops.iter().filter_map(|e| e.oracle).sum();
                 println!(
-                    "captured outcome oracle: {} outcome(s) across {} op(s), determinism proven \
-                     by a second pass (format v{}, workload_hash {})",
+                    "captured outcome oracle: {} outcome(s) across {} op(s) — the complete \
+                     corpus of every eligible shape, determinism proven by a second pass \
+                     (format v{}, workload_hash {})",
                     outcomes, oracle_ops, manifest.format_version, manifest.workload_hash
                 );
             }
@@ -2415,7 +2411,6 @@ mod tests {
             nodes: Some(200),
             edges: Some(600),
             oracle: None,
-            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command).await.expect("offline record succeeds without a server");
@@ -2457,7 +2452,6 @@ mod tests {
             nodes: Some(300),
             edges: Some(900),
             oracle: None,
-            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2526,7 +2520,6 @@ mod tests {
             nodes: Some(300),
             edges: Some(900),
             oracle: None,
-            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2608,7 +2601,6 @@ mod tests {
             nodes: Some(300),
             edges: Some(900),
             oracle: None,
-            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2678,7 +2670,6 @@ mod tests {
             nodes: Some(1000),
             edges: Some(5000),
             oracle: None,
-            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command).await.expect("offline full repo-reads record succeeds");
@@ -2719,7 +2710,6 @@ mod tests {
             nodes: Some(300),
             edges: Some(900),
             oracle: None,
-            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command)
@@ -2787,7 +2777,6 @@ mod tests {
             nodes: Some(300),
             edges: Some(900),
             oracle: None,
-            oracle_samples: None,
             out_dir: out_dir.to_string_lossy().into_owned(),
         };
         run_command(command).await.expect("offline combined record succeeds");
@@ -2816,10 +2805,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_command_record_rejects_oracle_flags_without_their_prerequisites() {
-        // The clap layer enforces `--oracle requires --repo-writes` (and `--oracle-samples
-        // requires --oracle`); these runtime guards keep directly-constructed commands honest
-        // too — both fail offline, before any file or network use.
+    async fn run_command_record_rejects_an_oracle_without_repo_writes() {
+        // The clap layer enforces `--oracle requires --repo-writes`; this runtime guard keeps
+        // directly-constructed commands honest too — failing offline, before any file or
+        // network use.
         let base = crate::cli::SyntheticCommands::Record {
             config: None,
             graph: None,
@@ -2833,33 +2822,11 @@ mod tests {
             nodes: Some(10),
             edges: Some(20),
             oracle: Some("falkor://127.0.0.1:1".to_string()),
-            oracle_samples: None,
             out_dir: "unused".to_string(),
         };
         let err = run_command(base).await.unwrap_err();
         assert!(
             format!("{err}").contains("--oracle requires --repo-writes"),
-            "got: {err}"
-        );
-        let samples_only = crate::cli::SyntheticCommands::Record {
-            config: None,
-            graph: None,
-            ops: vec![],
-            all_reads: true,
-            tier: None,
-            repo_reads: None,
-            repo_algorithms: false,
-            repo_writes: false,
-            seed: Some(1),
-            nodes: Some(10),
-            edges: Some(20),
-            oracle: None,
-            oracle_samples: Some(4),
-            out_dir: "unused".to_string(),
-        };
-        let err = run_command(samples_only).await.unwrap_err();
-        assert!(
-            format!("{err}").contains("--oracle-samples requires --oracle"),
             "got: {err}"
         );
     }

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -103,18 +103,38 @@ pub async fn capture(
         out: String::new(),
         server_image: None,
         label: None,
+        require_oracle: false,
     };
     let graph_name = bundle.manifest.graph.clone();
     let dataset_spec = bundle.spec();
 
     // Establish the pristine base and capture its CONTENT digests first (§3.5: the final restore
-    // is verified against these, not just count-checked). If this fails, no measured command has
-    // run yet — the load either failed outright or the read-only content scan did — so the error
-    // propagates directly with nothing to reconcile.
-    restore_base(&config, &bundle, &graph_name, &dataset_spec).await?;
-    let pristine = {
+    // is verified against these, not just count-checked). The load is drop-then-rebuild, so a
+    // transient mid-load failure would leave the graph partial — bring this setup under the same
+    // error-safe discipline as the measured passes below: on failure, run one recovery restore so
+    // the endpoint is left on the recorded base, and surface BOTH errors when that fails too.
+    let setup = async {
+        restore_base(&config, &bundle, &graph_name, &dataset_spec).await?;
         let mut graph = open_graph(&config.endpoint, &graph_name).await?;
-        capture_graph_content(&mut graph, &config).await?
+        capture_graph_content(&mut graph, &config).await
+    }
+    .await;
+    let pristine = match setup {
+        Ok(pristine) => pristine,
+        Err(e) => {
+            return Err(match restore_base(&config, &bundle, &graph_name, &dataset_spec).await {
+                Ok(()) => OtherError(format!(
+                    "oracle capture setup failed (graph '{}' was re-restored to the recorded \
+                     base): {}",
+                    graph_name, e
+                )),
+                Err(restore) => OtherError(format!(
+                    "oracle capture setup failed AND the recovery restore failed — graph '{}' \
+                     may be left partially loaded (setup error: {}; restore error: {})",
+                    graph_name, e, restore
+                )),
+            });
+        }
     };
 
     let captured: BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> = async {
@@ -282,6 +302,21 @@ mod tests {
             "must get past the stray-file gate to the eligibility check: {err}"
         );
         assert!(!dir.join("oracle").exists(), "orphan cleared");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn capture_setup_failure_surfaces_both_errors() {
+        // §3.5 discipline for the setup path (duck round-2 F2): the initial load is
+        // drop-then-rebuild, so a setup failure triggers one recovery restore; when THAT fails
+        // too (unreachable endpoint here) the combined error must surface both failures and warn
+        // that the graph may be left partial.
+        let dir = record_write_bundle("synthorc-setup", "single_vertex_write");
+        let err = capture("falkor://127.0.0.1:1", &dir, 1_000, 1_500).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("setup failed AND the recovery restore failed"), "got: {msg}");
+        assert!(msg.contains("may be left partially loaded"), "got: {msg}");
+        assert!(msg.contains("setup error:") && msg.contains("restore error:"), "got: {msg}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -10,8 +10,14 @@
 //! exact outcome per invocation (per-invocation restore, C=1). Capture never times anything: it is
 //! a correctness pass, run once at record time.
 //!
+//! Capture is **per-command over the complete corpus**: every command of every eligible op gets
+//! its outcome recorded (a sampled prefix would leave later commands — e.g. a MERGE that first
+//! matches deep into the corpus — unverified, silently shrinking the tier below what the design
+//! requires).
+//!
 //! Restore discipline mirrors replay's §3.5: every command runs from a freshly restored base
-//! ([`replay::restore_base`]), and a final restore runs on success **and** failure — a dual
+//! ([`replay::restore_base`]), and a final restore runs on success **and** failure with the
+//! restored **content digests** verified against the pristine post-load capture — a dual
 //! failure surfaces both errors, never just the first.
 
 use crate::error::BenchmarkError::OtherError;
@@ -19,8 +25,8 @@ use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::synthetic::op_runner::run_and_drain;
 use crate::synthetic::recording::{self, Bundle};
-use crate::synthetic::replay::{restore_base, ReplayConfig};
-use crate::synthetic::shapes::{write_shapes, OracleEligibility};
+use crate::synthetic::replay::{capture_graph_content, restore_and_verify, restore_base, ReplayConfig};
+use crate::synthetic::shapes::oracle_eligible_names;
 use crate::synthetic::writes::MutationStats;
 use crate::synthetic::{open_graph, CacheSelection};
 use std::collections::BTreeMap;
@@ -28,22 +34,16 @@ use std::path::Path;
 use std::time::Duration;
 use tracing::info;
 
-/// Default per-op oracle sample count (`--oracle-samples`): how many leading commands of each
-/// eligible op are captured and later re-verified. 8 balances coverage of the corpus's parameter
-/// variety against capture/verify cost (each sample is a full base restore + one command, twice at
-/// record time and once per replay).
-pub const DEFAULT_ORACLE_SAMPLES: usize = 8;
-
 /// Capture the §6.3 outcome oracle for the (already-recorded) write bundle in `dir` against the
 /// live engine at `endpoint`, and fold it into the bundle (upgrading it to format v3).
 ///
 /// For every **oracle-eligible** write op (the deterministic subset —
-/// [`ShapeSpec::oracle`](crate::synthetic::shapes::ShapeSpec::oracle)), the first
-/// `samples_per_op` commands (capped at the corpus size) each run **once from a freshly restored
-/// pristine base**, recording the [`MutationStats`] the engine reports. A second full pass then
-/// repeats the capture; any difference is a hard error naming the op/seq — determinism is proven
-/// at record time, not assumed (design §3.2: the recorded outcome is only an oracle if it is
-/// reproducible). Ineligible write ops stay latency-only.
+/// [`ShapeSpec::oracle`](crate::synthetic::shapes::ShapeSpec::oracle)), **every command of the
+/// full corpus** runs **once from a freshly restored pristine base**, recording the
+/// [`MutationStats`] the engine reports. A second full pass then repeats the capture; any
+/// difference is a hard error naming the op/seq — determinism is proven at record time, not
+/// assumed (design §3.2: the recorded outcome is only an oracle if it is reproducible).
+/// Ineligible write ops stay latency-only.
 ///
 /// `server_timeout_ms`/`client_deadline_ms` budget each **measured write command** (one small
 /// CREATE/SET/MERGE — the resolved CLI defaults are ample and match what a replay-time verify
@@ -51,17 +51,16 @@ pub const DEFAULT_ORACLE_SAMPLES: usize = 8;
 /// replay restore ([`load_recorded_graph`](crate::synthetic::replay) applies it internally).
 ///
 /// The bundle's graph on `endpoint` is left restored to the pristine base on success **and**
-/// failure (§3.5 discipline); a dual failure reports both errors.
+/// failure, with the restored **content digests** verified against the pristine post-load
+/// capture (§3.5 discipline); a dual failure reports both errors.
 pub async fn capture(
     endpoint: &str,
     dir: &Path,
-    samples_per_op: usize,
     server_timeout_ms: i64,
     client_deadline_ms: u64,
 ) -> BenchmarkResult<recording::Manifest> {
-    if samples_per_op == 0 {
-        return Err(OtherError("--oracle-samples must be greater than 0".to_string()));
-    }
+    // Heal an interrupted previous attach BEFORE the load gate, or a retry could never get here.
+    recording::heal_orphaned_oracle(dir)?;
     let bundle = recording::load(dir)?;
     if bundle.manifest.format_version >= recording::RECORDING_FORMAT_VERSION_ORACLE {
         return Err(OtherError(format!(
@@ -72,20 +71,14 @@ pub async fn capture(
         )));
     }
     // The §6.3 eligibility table (single source of truth: the annotated write-shape table).
-    let eligible: BTreeMap<&str, ()> = write_shapes()
-        .iter()
-        .filter(|s| s.oracle == OracleEligibility::Eligible)
-        .map(|s| (s.name, ()))
-        .collect();
+    // Every eligible op is captured over its COMPLETE corpus — the exact set + exact counts that
+    // `recording::attach_oracle`/`load` enforce on the resulting v3 bundle.
+    let eligible = oracle_eligible_names();
     let targets: Vec<(String, Vec<String>)> = bundle
         .commands
         .iter()
-        .filter(|(op, _)| op.kind() == QueryType::Write && eligible.contains_key(op.name()))
-        .map(|(op, cyphers)| {
-            // Only the first `samples_per_op` commands are ever executed — don't clone the rest.
-            let take = samples_per_op.min(cyphers.len());
-            (op.name().to_string(), cyphers[..take].to_vec())
-        })
+        .filter(|(op, _)| op.kind() == QueryType::Write && eligible.contains(op.name()))
+        .map(|(op, cyphers)| (op.name().to_string(), cyphers.clone()))
         .collect();
     if targets.is_empty() {
         return Err(OtherError(
@@ -114,11 +107,19 @@ pub async fn capture(
     let graph_name = bundle.manifest.graph.clone();
     let dataset_spec = bundle.spec();
 
+    // Establish the pristine base and capture its CONTENT digests first (§3.5: the final restore
+    // is verified against these, not just count-checked). If this fails, no measured command has
+    // run yet — the load either failed outright or the read-only content scan did — so the error
+    // propagates directly with nothing to reconcile.
+    restore_base(&config, &bundle, &graph_name, &dataset_spec).await?;
+    let pristine = {
+        let mut graph = open_graph(&config.endpoint, &graph_name).await?;
+        capture_graph_content(&mut graph, &config).await?
+    };
+
     let captured: BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> = async {
-        let first =
-            capture_pass(&config, &bundle, &graph_name, &targets, samples_per_op).await?;
-        let second =
-            capture_pass(&config, &bundle, &graph_name, &targets, samples_per_op).await?;
+        let first = capture_pass(&config, &bundle, &graph_name, &targets).await?;
+        let second = capture_pass(&config, &bundle, &graph_name, &targets).await?;
         for (name, first_outcomes) in &first {
             let second_outcomes = &second[name];
             for (seq, (a, b)) in first_outcomes.iter().zip(second_outcomes).enumerate() {
@@ -136,35 +137,35 @@ pub async fn capture(
     }
     .await;
     // §3.5 at record time: leave the endpoint's graph restored to the pristine base whether the
-    // capture succeeded or not, and surface BOTH errors on a dual failure.
-    let restored = restore_base(&config, &bundle, &graph_name, &dataset_spec).await;
+    // capture succeeded or not — verifying the restored CONTENT against the pristine digests,
+    // exactly like replay's final restore — and surface BOTH errors on a dual failure.
+    let restored = restore_and_verify(&bundle, &graph_name, &dataset_spec, &config, &pristine).await;
     let captured = reconcile_capture_and_restore(captured, restored, &graph_name)?;
 
     let ops = captured.len();
     let outcomes: usize = captured.values().map(Vec::len).sum();
     let manifest = recording::attach_oracle(dir, &captured)?;
     info!(
-        "oracle captured: {} outcome(s) across {} op(s), determinism proven by a second pass",
+        "oracle captured: {} outcome(s) across {} op(s) (complete corpus), determinism proven \
+         by a second pass",
         outcomes, ops
     );
     Ok(manifest)
 }
 
 /// One full capture pass: for each target op, restore the pristine base, run command `seq` once,
-/// and record the [`MutationStats`] the engine reports — for `seq` in `0..min(k, corpus)`.
+/// and record the [`MutationStats`] the engine reports — for every `seq` in the corpus.
 async fn capture_pass(
     config: &ReplayConfig,
     bundle: &Bundle,
     graph_name: &str,
     targets: &[(String, Vec<String>)],
-    samples_per_op: usize,
 ) -> BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> {
     let client_deadline = Duration::from_millis(config.client_deadline_ms);
     let mut out = BTreeMap::new();
     for (name, cyphers) in targets {
-        let n = samples_per_op.min(cyphers.len());
-        let mut outcomes = Vec::with_capacity(n);
-        for (seq, cypher) in cyphers.iter().take(n).enumerate() {
+        let mut outcomes = Vec::with_capacity(cyphers.len());
+        for (seq, cypher) in cyphers.iter().enumerate() {
             restore_base(config, bundle, graph_name, &bundle.spec()).await?;
             let mut graph = open_graph(&config.endpoint, graph_name).await?;
             let sample = run_and_drain(
@@ -233,34 +234,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn capture_rejects_zero_samples_offline() {
-        let err = capture("falkor://127.0.0.1:1", Path::new("/nonexistent"), 0, 5_000, 6_000)
-            .await
-            .unwrap_err();
-        assert!(format!("{err}").contains("--oracle-samples"), "got: {err}");
-    }
-
-    #[tokio::test]
     async fn capture_rejects_a_bundle_with_no_eligible_op_offline() {
         // A write bundle whose only op is not in the §6.3 deterministic subset has nothing to
         // capture — fail offline, before any connection (the endpoint is unroutable).
         let dir = record_write_bundle("synthorc-inel", "w_custom");
-        let err = capture("falkor://127.0.0.1:1", &dir, 2, 5_000, 6_000).await.unwrap_err();
+        let err = capture("falkor://127.0.0.1:1", &dir, 5_000, 6_000).await.unwrap_err();
         assert!(format!("{err}").contains("no oracle-eligible write op"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
     }
 
     #[tokio::test]
     async fn a_failed_capture_leaves_the_bundle_valid_and_pre_oracle() {
-        // An eligible op but an unreachable endpoint: the capture fails at connect time, AFTER
-        // the offline validation — and must leave the recorded v2 bundle exactly as it was
-        // (attach only runs on a successful, determinism-proven capture).
+        // An eligible op but an unreachable endpoint: the capture fails while establishing the
+        // pristine base, AFTER the offline validation — and must leave the recorded v2 bundle
+        // exactly as it was (attach only runs on a successful, determinism-proven capture).
         let dir = record_write_bundle("synthorc-conn", "single_vertex_write");
         let before = recording::load(&dir).unwrap().manifest;
-        let err = capture("falkor://127.0.0.1:1", &dir, 1, 1_000, 1_500).await.unwrap_err();
-        // Both the capture and the §3.5 final restore hit the same unreachable endpoint — the
-        // combined error must surface the pollution risk rather than hide the restore failure.
-        assert!(format!("{err}").contains("restore failed"), "got: {err}");
+        capture("falkor://127.0.0.1:1", &dir, 1_000, 1_500).await.unwrap_err();
         let after = recording::load(&dir).unwrap().manifest;
         assert_eq!(after, before, "a failed capture must not touch the bundle");
         assert_eq!(after.format_version, recording::RECORDING_FORMAT_VERSION_WRITES);
@@ -273,8 +263,25 @@ mod tests {
         let mut oracle = BTreeMap::new();
         oracle.insert("single_vertex_write".to_string(), vec![MutationStats::default()]);
         recording::attach_oracle(&dir, &oracle).unwrap();
-        let err = capture("falkor://127.0.0.1:1", &dir, 1, 5_000, 6_000).await.unwrap_err();
+        let err = capture("falkor://127.0.0.1:1", &dir, 5_000, 6_000).await.unwrap_err();
         assert!(format!("{err}").contains("already carries"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn capture_self_heals_an_orphaned_oracle_dir_before_the_load_gate() {
+        // Finding-1 regression: an interrupted attach leaves oracle/ next to a v2 manifest; a
+        // retrying capture must clear it and proceed to the (offline-failing) eligibility check
+        // rather than brick on load()'s stray-file gate.
+        let dir = record_write_bundle("synthorc-heal", "w_custom");
+        std::fs::create_dir_all(dir.join("oracle")).unwrap();
+        std::fs::write(dir.join("oracle").join("w_custom.jsonl"), "junk").unwrap();
+        let err = capture("falkor://127.0.0.1:1", &dir, 5_000, 6_000).await.unwrap_err();
+        assert!(
+            format!("{err}").contains("no oracle-eligible write op"),
+            "must get past the stray-file gate to the eligibility check: {err}"
+        );
+        assert!(!dir.join("oracle").exists(), "orphan cleared");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -81,7 +81,11 @@ pub async fn capture(
         .commands
         .iter()
         .filter(|(op, _)| op.kind() == QueryType::Write && eligible.contains_key(op.name()))
-        .map(|(op, cyphers)| (op.name().to_string(), cyphers.clone()))
+        .map(|(op, cyphers)| {
+            // Only the first `samples_per_op` commands are ever executed — don't clone the rest.
+            let take = samples_per_op.min(cyphers.len());
+            (op.name().to_string(), cyphers[..take].to_vec())
+        })
         .collect();
     if targets.is_empty() {
         return Err(OtherError(

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -1,0 +1,309 @@
+//! Record-side §6.3 **outcome-oracle capture**: run each oracle-eligible write command against the
+//! recorded **pristine base** on a live engine, capture the [`MutationStats`] it effects, prove the
+//! outcomes are deterministic with a second independent pass, and fold them into the bundle
+//! ([`recording::attach_oracle`], format v3).
+//!
+//! This is the one deliberate departure from the offline read recorder (design §3.2 / risk §7.2):
+//! write counters are state/value/order-dependent — MERGE create-vs-match, SET-same-value counting
+//! 0, an upsert *removing* a property — so no static model can predict them. The oracle instead
+//! records what each command **actually did** from the pristine base, and replay re-verifies that
+//! exact outcome per invocation (per-invocation restore, C=1). Capture never times anything: it is
+//! a correctness pass, run once at record time.
+//!
+//! Restore discipline mirrors replay's §3.5: every command runs from a freshly restored base
+//! ([`replay::restore_base`]), and a final restore runs on success **and** failure — a dual
+//! failure surfaces both errors, never just the first.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::queries_repository::QueryType;
+use crate::synthetic::op_runner::run_and_drain;
+use crate::synthetic::recording::{self, Bundle};
+use crate::synthetic::replay::{restore_base, ReplayConfig};
+use crate::synthetic::shapes::{write_shapes, OracleEligibility};
+use crate::synthetic::writes::MutationStats;
+use crate::synthetic::{open_graph, CacheSelection};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Duration;
+use tracing::info;
+
+/// Default per-op oracle sample count (`--oracle-samples`): how many leading commands of each
+/// eligible op are captured and later re-verified. 8 balances coverage of the corpus's parameter
+/// variety against capture/verify cost (each sample is a full base restore + one command, twice at
+/// record time and once per replay).
+pub const DEFAULT_ORACLE_SAMPLES: usize = 8;
+
+/// Capture the §6.3 outcome oracle for the (already-recorded) write bundle in `dir` against the
+/// live engine at `endpoint`, and fold it into the bundle (upgrading it to format v3).
+///
+/// For every **oracle-eligible** write op (the deterministic subset —
+/// [`ShapeSpec::oracle`](crate::synthetic::shapes::ShapeSpec::oracle)), the first
+/// `samples_per_op` commands (capped at the corpus size) each run **once from a freshly restored
+/// pristine base**, recording the [`MutationStats`] the engine reports. A second full pass then
+/// repeats the capture; any difference is a hard error naming the op/seq — determinism is proven
+/// at record time, not assumed (design §3.2: the recorded outcome is only an oracle if it is
+/// reproducible). Ineligible write ops stay latency-only.
+///
+/// The bundle's graph on `endpoint` is left restored to the pristine base on success **and**
+/// failure (§3.5 discipline); a dual failure reports both errors.
+pub async fn capture(
+    endpoint: &str,
+    dir: &Path,
+    samples_per_op: usize,
+    server_timeout_ms: i64,
+    client_deadline_ms: u64,
+) -> BenchmarkResult<recording::Manifest> {
+    if samples_per_op == 0 {
+        return Err(OtherError("--oracle-samples must be greater than 0".to_string()));
+    }
+    let bundle = recording::load(dir)?;
+    if bundle.manifest.format_version >= recording::RECORDING_FORMAT_VERSION_ORACLE {
+        return Err(OtherError(format!(
+            "{} already carries an outcome oracle (format_version {}) — re-record instead of \
+             re-capturing",
+            dir.display(),
+            bundle.manifest.format_version
+        )));
+    }
+    // The §6.3 eligibility table (single source of truth: the annotated write-shape table).
+    let eligible: BTreeMap<&str, ()> = write_shapes()
+        .iter()
+        .filter(|s| s.oracle == OracleEligibility::Eligible)
+        .map(|s| (s.name, ()))
+        .collect();
+    let targets: Vec<(String, Vec<String>)> = bundle
+        .commands
+        .iter()
+        .filter(|(op, _)| op.kind() == QueryType::Write && eligible.contains_key(op.name()))
+        .map(|(op, cyphers)| (op.name().to_string(), cyphers.clone()))
+        .collect();
+    if targets.is_empty() {
+        return Err(OtherError(
+            "--oracle: the bundle records no oracle-eligible write op (the §6.3 deterministic \
+             subset) — nothing to capture"
+                .to_string(),
+        ));
+    }
+
+    // A minimal replay-shaped config: `restore_base` needs only the endpoint + timeouts.
+    let config = ReplayConfig {
+        recording_dir: dir.to_path_buf(),
+        endpoint: endpoint.to_string(),
+        graph: None,
+        load: true,
+        samples: 1,
+        warmup: 0,
+        concurrency: vec![1],
+        cache: CacheSelection::Cached,
+        server_timeout_ms,
+        client_deadline_ms,
+        out: String::new(),
+        server_image: None,
+        label: None,
+    };
+    let graph_name = bundle.manifest.graph.clone();
+    let dataset_spec = bundle.spec();
+
+    let captured: BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> = async {
+        let first =
+            capture_pass(&config, &bundle, &graph_name, &targets, samples_per_op).await?;
+        let second =
+            capture_pass(&config, &bundle, &graph_name, &targets, samples_per_op).await?;
+        for (name, first_outcomes) in &first {
+            let second_outcomes = &second[name];
+            for (seq, (a, b)) in first_outcomes.iter().zip(second_outcomes).enumerate() {
+                if a != b {
+                    return Err(OtherError(format!(
+                        "oracle capture is not deterministic for op '{}' seq {}: pass 1 reported \
+                         {:?}, pass 2 reported {:?} — the op cannot be oracle-verified on this \
+                         engine (both passes ran from the same restored pristine base)",
+                        name, seq, a, b
+                    )));
+                }
+            }
+        }
+        Ok(first)
+    }
+    .await;
+    // §3.5 at record time: leave the endpoint's graph restored to the pristine base whether the
+    // capture succeeded or not, and surface BOTH errors on a dual failure.
+    let restored = restore_base(&config, &bundle, &graph_name, &dataset_spec).await;
+    let captured = reconcile_capture_and_restore(captured, restored, &graph_name)?;
+
+    let ops = captured.len();
+    let outcomes: usize = captured.values().map(Vec::len).sum();
+    let manifest = recording::attach_oracle(dir, &captured)?;
+    info!(
+        "oracle captured: {} outcome(s) across {} op(s), determinism proven by a second pass",
+        outcomes, ops
+    );
+    Ok(manifest)
+}
+
+/// One full capture pass: for each target op, restore the pristine base, run command `seq` once,
+/// and record the [`MutationStats`] the engine reports — for `seq` in `0..min(k, corpus)`.
+async fn capture_pass(
+    config: &ReplayConfig,
+    bundle: &Bundle,
+    graph_name: &str,
+    targets: &[(String, Vec<String>)],
+    samples_per_op: usize,
+) -> BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> {
+    let client_deadline = Duration::from_millis(config.client_deadline_ms);
+    let mut out = BTreeMap::new();
+    for (name, cyphers) in targets {
+        let n = samples_per_op.min(cyphers.len());
+        let mut outcomes = Vec::with_capacity(n);
+        for (seq, cypher) in cyphers.iter().take(n).enumerate() {
+            restore_base(config, bundle, graph_name, &bundle.spec()).await?;
+            let mut graph = open_graph(&config.endpoint, graph_name).await?;
+            let sample = run_and_drain(
+                &mut graph,
+                QueryType::Write,
+                cypher,
+                config.server_timeout_ms,
+                client_deadline,
+            )
+            .await
+            .map_err(|e| {
+                OtherError(format!("oracle capture: op '{}' seq {}: {}", name, seq, e))
+            })?;
+            outcomes.push(sample.mutations);
+        }
+        out.insert(name.clone(), outcomes);
+    }
+    Ok(out)
+}
+
+/// Combine the capture result with the final-restore result (§3.5): a restore failure must never
+/// be shadowed by the capture error alone — a dual failure reports both.
+fn reconcile_capture_and_restore(
+    captured: BenchmarkResult<BTreeMap<String, Vec<MutationStats>>>,
+    restored: BenchmarkResult<()>,
+    graph_name: &str,
+) -> BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> {
+    match (captured, restored) {
+        (Ok(v), Ok(())) => Ok(v),
+        (Ok(_), Err(restore)) => Err(restore),
+        (Err(original), Ok(())) => Err(original),
+        (Err(original), Err(restore)) => Err(OtherError(format!(
+            "oracle capture failed AND its final restore failed — graph '{}' may be left polluted \
+             (capture error: {}; restore error: {})",
+            graph_name, original, restore
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::synthetic::dataset::DatasetSpec;
+    use crate::synthetic::recording::{record_rendered, temp_bundle_dir, RecordedOp};
+    use crate::synthetic::OpKey;
+
+    fn record_write_bundle(
+        prefix: &str,
+        op_name: &str,
+    ) -> std::path::PathBuf {
+        let dir = temp_bundle_dir(prefix);
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic(op_name, crate::queries_repository::QueryType::Write),
+            result_gated: false,
+            budget: Default::default(),
+            capability: None,
+            commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn capture_rejects_zero_samples_offline() {
+        let err = capture("falkor://127.0.0.1:1", Path::new("/nonexistent"), 0, 5_000, 6_000)
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("--oracle-samples"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn capture_rejects_a_bundle_with_no_eligible_op_offline() {
+        // A write bundle whose only op is not in the §6.3 deterministic subset has nothing to
+        // capture — fail offline, before any connection (the endpoint is unroutable).
+        let dir = record_write_bundle("synthorc-inel", "w_custom");
+        let err = capture("falkor://127.0.0.1:1", &dir, 2, 5_000, 6_000).await.unwrap_err();
+        assert!(format!("{err}").contains("no oracle-eligible write op"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn a_failed_capture_leaves_the_bundle_valid_and_pre_oracle() {
+        // An eligible op but an unreachable endpoint: the capture fails at connect time, AFTER
+        // the offline validation — and must leave the recorded v2 bundle exactly as it was
+        // (attach only runs on a successful, determinism-proven capture).
+        let dir = record_write_bundle("synthorc-conn", "single_vertex_write");
+        let before = recording::load(&dir).unwrap().manifest;
+        let err = capture("falkor://127.0.0.1:1", &dir, 1, 1_000, 1_500).await.unwrap_err();
+        // Both the capture and the §3.5 final restore hit the same unreachable endpoint — the
+        // combined error must surface the pollution risk rather than hide the restore failure.
+        assert!(format!("{err}").contains("restore failed"), "got: {err}");
+        let after = recording::load(&dir).unwrap().manifest;
+        assert_eq!(after, before, "a failed capture must not touch the bundle");
+        assert_eq!(after.format_version, recording::RECORDING_FORMAT_VERSION_WRITES);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn capture_rejects_a_bundle_that_already_carries_an_oracle_offline() {
+        let dir = record_write_bundle("synthorc-v3", "single_vertex_write");
+        let mut oracle = BTreeMap::new();
+        oracle.insert("single_vertex_write".to_string(), vec![MutationStats::default()]);
+        recording::attach_oracle(&dir, &oracle).unwrap();
+        let err = capture("falkor://127.0.0.1:1", &dir, 1, 5_000, 6_000).await.unwrap_err();
+        assert!(format!("{err}").contains("already carries"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn reconcile_capture_and_restore_combines_a_dual_failure() {
+        // §3.5 at record time: when the capture AND the final restore both fail, the caller must
+        // see both — the restore failure means the endpoint's graph may be left polluted, which
+        // the capture error alone would hide.
+        let err = reconcile_capture_and_restore(
+            Err(OtherError("capture exploded".to_string())),
+            Err(OtherError("restore diverged".to_string())),
+            "g9",
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("may be left polluted"), "got: {msg}");
+        assert!(msg.contains("g9"), "must name the graph: {msg}");
+        assert!(msg.contains("capture exploded"), "must carry the capture error: {msg}");
+        assert!(msg.contains("restore diverged"), "must carry the restore error: {msg}");
+    }
+
+    #[test]
+    fn reconcile_capture_and_restore_passes_through_single_outcomes() {
+        let ok: BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> = Ok(BTreeMap::new());
+        assert!(reconcile_capture_and_restore(ok, Ok(()), "g").is_ok());
+        let restore_only = reconcile_capture_and_restore(
+            Ok(BTreeMap::new()),
+            Err(OtherError("restore failed".to_string())),
+            "g",
+        )
+        .unwrap_err();
+        assert!(format!("{restore_only}").contains("restore failed"));
+        let capture_only = reconcile_capture_and_restore(
+            Err(OtherError("capture failed".to_string())),
+            Ok(()),
+            "g",
+        )
+        .unwrap_err();
+        assert!(format!("{capture_only}").contains("capture failed"));
+    }
+}

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -45,6 +45,11 @@ pub const DEFAULT_ORACLE_SAMPLES: usize = 8;
 /// at record time, not assumed (design §3.2: the recorded outcome is only an oracle if it is
 /// reproducible). Ineligible write ops stay latency-only.
 ///
+/// `server_timeout_ms`/`client_deadline_ms` budget each **measured write command** (one small
+/// CREATE/SET/MERGE — the resolved CLI defaults are ample and match what a replay-time verify
+/// uses); the per-sample base restores are bulk loads and get the same ≥60 s floor as every
+/// replay restore ([`load_recorded_graph`](crate::synthetic::replay) applies it internally).
+///
 /// The bundle's graph on `endpoint` is left restored to the pristine base on success **and**
 /// failure (§3.5 discipline); a dual failure reports both errors.
 pub async fn capture(

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -2456,6 +2456,88 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    #[tokio::test]
+    async fn replay_refuses_a_rehashed_v3_to_v2_downgrade_under_require_oracle() {
+        // The two-sided blind spot: strip a v3 bundle's oracle entirely, declare it v2, and
+        // REHASH under the v2 rules — the result is byte-indistinguishable from a legitimate
+        // latency-tier recording (v2 hashes never covered oracle data), loads cleanly, and would
+        // replay with `oracle_verified: None`. Only the operator's stated expectation can refuse
+        // it: `--require-oracle`.
+        use crate::synthetic::replay::{self, ReplayConfig};
+        use crate::synthetic::CacheSelection;
+
+        let dir = record_write_bundle_to_temp("synthrec-downgrade");
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        let bundle = load(&dir).unwrap();
+
+        // Downgrade: v2 format, no per-op oracle counts, no oracle/ dir, valid v2 hash.
+        let mut manifest = bundle.manifest.clone();
+        manifest.format_version = RECORDING_FORMAT_VERSION_WRITES;
+        for entry in &mut manifest.ops {
+            entry.oracle = None;
+        }
+        let mut hasher = WorkloadHasher::new(
+            manifest.format_version,
+            &manifest.generator_version,
+            &manifest.dataset,
+            &manifest.graph,
+            manifest.corpus_seed,
+        );
+        for (phase, cypher) in &bundle.graph_statements {
+            hasher.graph_record(phase.tag(), cypher);
+        }
+        for ((_, cyphers), entry) in bundle.commands.iter().zip(&manifest.ops) {
+            hasher.op_header(&entry.name, cyphers.len(), entry.kind);
+            for cypher in cyphers {
+                hasher.command(cypher);
+            }
+        }
+        manifest.workload_hash = hasher.finalize();
+        std::fs::write(
+            dir.join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        std::fs::remove_dir_all(dir.join("oracle")).unwrap();
+
+        // The downgrade IS a legitimate v2 — the load hash gate cannot object…
+        load(&dir).expect("a rehashed v3→v2 strip must be indistinguishable from a real v2");
+
+        // …so the replay-side flag is the only refusal point.
+        let config = ReplayConfig {
+            recording_dir: dir.clone(),
+            // Closed port: nothing must connect — both run() calls below fail offline or on
+            // connect, never against a live server.
+            endpoint: "falkor://127.0.0.1:1".to_string(),
+            graph: None,
+            load: true,
+            samples: 5,
+            warmup: 0,
+            concurrency: vec![1],
+            cache: CacheSelection::Cached,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: "unused.json".to_string(),
+            server_image: None,
+            label: None,
+            require_oracle: true,
+        };
+        let err = replay::run(&config).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("carries no outcome oracle"), "got: {msg}");
+        assert!(msg.contains("re-hashed v3→v2 downgrade"), "got: {msg}");
+
+        // Negative control: restore the oracle (v3 again) — the same flag now clears the gate
+        // and the run proceeds to the connection attempt (no oracle complaint on the closed
+        // port's error).
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        let err = replay::run(&config).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(!msg.contains("oracle"), "v3 must clear the require-oracle gate, got: {msg}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     #[test]
     fn load_rejects_an_oracle_on_a_non_eligible_write_op() {
         // Mixed bundle (one eligible + one custom write op): attach the valid exact-set oracle,

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -17,6 +17,9 @@
 //! - `commands/<op>.jsonl` — one [`CommandRecord`] per line: the fully-rendered measured queries.
 //! - `oracle/<op>.jsonl` (format v3+ only) — one [`OracleRecord`] per line: the §6.3 per-command
 //!   mutation outcomes captured online at record time ([`attach_oracle`]), re-verified at replay.
+//!   A v3 bundle carries the oracle for **exactly** the oracle-eligible write ops it records —
+//!   complete command corpus per op, none anywhere else — enforced at [`load`], [`attach_oracle`]
+//!   and replay, so oracle coverage can never silently shrink.
 //!
 //! The [`Manifest::workload_hash`] is a **length-framed** SHA-256 over the header, every graph
 //! record, every op's commands (in order), and — under format v3 — every oracle record, so any
@@ -553,6 +556,15 @@ fn record_rendered_impl(
     let commands_dir = out_dir.join("commands");
     std::fs::create_dir_all(&commands_dir)
         .map_err(|e| OtherError(format!("creating {}: {}", commands_dir.display(), e)))?;
+    // Recording replaces the bundle wholesale with a v1/v2 manifest that can never reference an
+    // oracle — clear any stale oracle/ left by a previous v3 recording (or an interrupted attach)
+    // in the same directory, or the fresh bundle would fail load()'s stray-file gate.
+    let stale_oracle = out_dir.join("oracle");
+    if stale_oracle.is_dir() {
+        std::fs::remove_dir_all(&stale_oracle).map_err(|e| {
+            OtherError(format!("removing stale {}: {}", stale_oracle.display(), e))
+        })?;
+    }
 
     let mut hasher = WorkloadHasher::new(
         format_version,
@@ -696,6 +708,50 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
             RECORDING_FORMAT_VERSION_WRITES
         )));
     }
+    // Exact-set enforcement (§6.3): a v3 bundle must carry an oracle for EVERY recorded
+    // oracle-eligible write op, covering its COMPLETE command corpus, and for nothing else — so
+    // oracle coverage can never silently shrink (a crafted 1-of-7 subset, or a padded oracle on
+    // an op outside the deterministic subset, is rejected here rather than replayed).
+    if manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE {
+        let eligible = crate::synthetic::shapes::oracle_eligible_names();
+        for entry in &manifest.ops {
+            let is_eligible =
+                entry.kind == QueryType::Write && eligible.contains(entry.name.as_str());
+            match (is_eligible, entry.oracle) {
+                (true, None) => {
+                    return Err(OtherError(format!(
+                        "oracle-eligible op '{}' carries no outcome oracle — a v{} bundle must \
+                         cover every eligible op (§6.3 exact-set rule; crafted/corrupt manifest)",
+                        entry.name, RECORDING_FORMAT_VERSION_ORACLE
+                    )));
+                }
+                (true, Some(n)) if n != entry.count => {
+                    return Err(OtherError(format!(
+                        "op '{}' declares {} oracle record(s) for {} command(s) — the §6.3 \
+                         oracle covers the complete corpus (crafted/corrupt manifest)",
+                        entry.name, n, entry.count
+                    )));
+                }
+                (false, Some(_)) if entry.kind != QueryType::Write => {
+                    return Err(OtherError(format!(
+                        "manifest declares an outcome oracle for read op '{}' — the oracle \
+                         records mutation counters, which only write ops produce \
+                         (crafted/corrupt manifest)",
+                        entry.name
+                    )));
+                }
+                (false, Some(_)) => {
+                    return Err(OtherError(format!(
+                        "manifest declares an outcome oracle for op '{}', which is not \
+                         oracle-eligible (§6.3 deterministic subset only; crafted/corrupt \
+                         manifest)",
+                        entry.name
+                    )));
+                }
+                _ => {}
+            }
+        }
+    }
 
     // graph.jsonl → ordered (phase, cypher).
     let graph_path = dir.join("graph.jsonl");
@@ -773,27 +829,14 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
         commands.push((op, recs.into_iter().map(|r| r.cypher).collect::<Vec<_>>()));
     }
 
-    // oracle/<op>.jsonl for each oracle-bearing op (§6.3, v3+): validate the entry structurally
-    // (write-kind only, 1..=count records, contiguous seq) BEFORE the hash recompute below, so a
-    // malformed oracle fails with an actionable error naming the op instead of a bare hash
-    // mismatch. The stats themselves are hash-bound — see [`WorkloadHasher::oracle_record`].
+    // oracle/<op>.jsonl for each oracle-bearing op (§6.3, v3+): the manifest-level shape was
+    // validated by the exact-set pass above; here validate the files structurally (record count,
+    // contiguous seq) BEFORE the hash recompute below, so a malformed oracle fails with an
+    // actionable error naming the op instead of a bare hash mismatch. The stats themselves are
+    // hash-bound — see [`WorkloadHasher::oracle_record`].
     let mut oracle: BTreeMap<String, Vec<MutationStats>> = BTreeMap::new();
     for entry in &manifest.ops {
         let Some(count) = entry.oracle else { continue };
-        if entry.kind != QueryType::Write {
-            return Err(OtherError(format!(
-                "manifest declares an outcome oracle for read op '{}' — the oracle records \
-                 mutation counters, which only write ops produce (crafted/corrupt manifest)",
-                entry.name
-            )));
-        }
-        if count == 0 || count > entry.count {
-            return Err(OtherError(format!(
-                "op '{}' declares {} oracle record(s) but has {} command(s) — an oracle covers \
-                 1..=count leading commands (crafted/corrupt manifest)",
-                entry.name, count, entry.count
-            )));
-        }
         let path = dir.join("oracle").join(format!("{}.jsonl", entry.name));
         let recs: Vec<OracleRecord> = read_jsonl(&path)?;
         if recs.len() != count {
@@ -906,14 +949,11 @@ impl Bundle {
 ///
 /// The capture itself (running commands against a live engine) lives in
 /// [`oracle::capture`](crate::synthetic::oracle::capture); this function is the offline half.
-pub fn attach_oracle(
-    dir: &Path,
-    oracle: &BTreeMap<String, Vec<MutationStats>>,
-) -> BenchmarkResult<Manifest> {
-    // Self-heal an interrupted previous attach before the integrity gate: a pre-v3 manifest
-    // cannot declare oracle entries, so an oracle/ directory next to one is provably orphaned
-    // (files written, manifest never upgraded) — remove it so a retry never bricks on load()'s
-    // stray-file check. A v3+ manifest is left untouched (attach rejects it below anyway).
+/// Remove an orphaned `oracle/` directory left by an **interrupted attach**: a pre-v3 manifest
+/// cannot reference oracle entries, so an `oracle/` directory sitting next to one is provably
+/// dead content that would otherwise brick every retry on [`load`]'s stray-file gate. A v3+
+/// manifest (or an unreadable one) is left untouched — [`load`] stays the arbiter there.
+pub(crate) fn heal_orphaned_oracle(dir: &Path) -> BenchmarkResult<()> {
     let manifest_path = dir.join("manifest.json");
     if let Ok(bytes) = std::fs::read(&manifest_path) {
         if let Ok(peek) = serde_json::from_slice::<Manifest>(&bytes) {
@@ -929,6 +969,14 @@ pub fn attach_oracle(
             }
         }
     }
+    Ok(())
+}
+
+pub fn attach_oracle(
+    dir: &Path,
+    oracle: &BTreeMap<String, Vec<MutationStats>>,
+) -> BenchmarkResult<Manifest> {
+    heal_orphaned_oracle(dir)?;
     // Verify the bundle as it stands before touching it (hash gate included).
     let bundle = load(dir)?;
     if bundle.manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE {
@@ -942,28 +990,47 @@ pub fn attach_oracle(
     if oracle.is_empty() {
         return Err(OtherError("no oracle outcomes to attach (empty capture)".to_string()));
     }
-    for (name, outcomes) in oracle {
-        let Some(entry) = bundle.manifest.ops.iter().find(|e| &e.name == name) else {
-            return Err(OtherError(format!(
-                "oracle captured for op '{}', which the bundle does not record",
-                name
-            )));
-        };
-        if entry.kind != QueryType::Write {
-            return Err(OtherError(format!(
-                "oracle captured for read op '{}' — only write ops have mutation outcomes",
-                name
-            )));
+    // Exact-set enforcement (§6.3): the oracle must cover every recorded oracle-eligible write op
+    // with its COMPLETE command corpus — no subset, no strays — so v3 coverage can never silently
+    // shrink below the tier the format version promises.
+    let eligible = crate::synthetic::shapes::oracle_eligible_names();
+    for entry in &bundle.manifest.ops {
+        let is_eligible =
+            entry.kind == QueryType::Write && eligible.contains(entry.name.as_str());
+        match (is_eligible, oracle.get(&entry.name)) {
+            (true, None) => {
+                return Err(OtherError(format!(
+                    "no oracle captured for oracle-eligible op '{}' — a v{} bundle must cover \
+                     every eligible op (§6.3 exact-set rule)",
+                    entry.name, RECORDING_FORMAT_VERSION_ORACLE
+                )));
+            }
+            (true, Some(outcomes)) if outcomes.len() != entry.count => {
+                return Err(OtherError(format!(
+                    "oracle for op '{}' has {} outcome(s) but the op records {} command(s) — \
+                     the §6.3 oracle covers the complete corpus",
+                    entry.name,
+                    outcomes.len(),
+                    entry.count
+                )));
+            }
+            (false, Some(_)) => {
+                return Err(OtherError(format!(
+                    "oracle captured for op '{}', which is not oracle-eligible (§6.3 \
+                     deterministic subset only)",
+                    entry.name
+                )));
+            }
+            _ => {}
         }
-        if outcomes.is_empty() || outcomes.len() > entry.count {
-            return Err(OtherError(format!(
-                "oracle for op '{}' has {} outcome(s) but the op records {} command(s) — an \
-                 oracle covers 1..=count leading commands",
-                name,
-                outcomes.len(),
-                entry.count
-            )));
-        }
+    }
+    if let Some(name) =
+        oracle.keys().find(|name| !bundle.manifest.ops.iter().any(|e| &e.name == *name))
+    {
+        return Err(OtherError(format!(
+            "oracle captured for op '{}', which the bundle does not record",
+            name
+        )));
     }
 
     // oracle/<op>.jsonl.
@@ -1008,6 +1075,7 @@ pub fn attach_oracle(
     }
     manifest.workload_hash = hasher.finalize();
 
+    let manifest_path = dir.join("manifest.json");
     let json = serde_json::to_string_pretty(&manifest)
         .map_err(|e| OtherError(format!("serializing manifest: {}", e)))?;
     std::fs::write(&manifest_path, json)
@@ -2054,7 +2122,10 @@ mod tests {
 
     // ---- §6.3 outcome oracle (format v3) ----
 
-    /// A recorded two-op write bundle (2 + 3 commands) for oracle tests.
+    /// A recorded two-op write bundle (2 + 3 commands) for oracle tests. The ops carry REAL
+    /// oracle-eligible shape names (`OpKey::dynamic` resolves built-ins by name) because the
+    /// §6.3 exact-set rule pins v3 oracles to exactly the eligible set — custom rendered names
+    /// could never be attached.
     fn record_write_bundle_to_temp(prefix: &str) -> PathBuf {
         let dir = temp_bundle_dir(prefix);
         let spec = DatasetSpec {
@@ -2071,7 +2142,15 @@ mod tests {
                 .map(|i| format!("CYPHER x={} CREATE (n:User {{id:$x}})", i))
                 .collect(),
         };
-        record_rendered(&spec, "g", &[op("w_alpha", 2), op("w_beta", 3)], 1, 8, &dir).unwrap();
+        record_rendered(
+            &spec,
+            "g",
+            &[op("single_vertex_write", 2), op("single_vertex_update", 3)],
+            1,
+            8,
+            &dir,
+        )
+        .unwrap();
         dir
     }
 
@@ -2083,23 +2162,28 @@ mod tests {
         }
     }
 
+    /// The exact-set oracle for [`record_write_bundle_to_temp`]: every eligible op, full corpus.
+    fn full_oracle() -> BTreeMap<String, Vec<MutationStats>> {
+        let mut oracle = BTreeMap::new();
+        oracle.insert("single_vertex_write".to_string(), vec![stats(1), stats(2)]);
+        oracle.insert("single_vertex_update".to_string(), vec![stats(3), stats(4), stats(5)]);
+        oracle
+    }
+
     #[test]
     fn attach_oracle_upgrades_a_v2_bundle_to_v3_and_round_trips() {
         let dir = record_write_bundle_to_temp("synthrec-oracle-rt");
         let v2_hash = load(&dir).unwrap().manifest.workload_hash.clone();
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
-        oracle.insert("w_beta".to_string(), vec![stats(3)]);
-        let manifest = attach_oracle(&dir, &oracle).unwrap();
+        let manifest = attach_oracle(&dir, &full_oracle()).unwrap();
         assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE);
         assert_ne!(manifest.workload_hash, v2_hash, "the oracle must land in the hash");
-        let alpha = manifest.ops.iter().find(|e| e.name == "w_alpha").unwrap();
-        let beta = manifest.ops.iter().find(|e| e.name == "w_beta").unwrap();
-        assert_eq!((alpha.oracle, beta.oracle), (Some(2), Some(1)));
+        let write = manifest.ops.iter().find(|e| e.name == "single_vertex_write").unwrap();
+        let update = manifest.ops.iter().find(|e| e.name == "single_vertex_update").unwrap();
+        assert_eq!((write.oracle, update.oracle), (Some(2), Some(3)));
         // The upgraded bundle loads through the standard gate with the outcomes intact.
         let bundle = load(&dir).unwrap();
-        assert_eq!(bundle.oracle["w_alpha"], vec![stats(1), stats(2)]);
-        assert_eq!(bundle.oracle["w_beta"], vec![stats(3)]);
+        assert_eq!(bundle.oracle["single_vertex_write"], vec![stats(1), stats(2)]);
+        assert_eq!(bundle.oracle["single_vertex_update"], vec![stats(3), stats(4), stats(5)]);
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -2109,9 +2193,7 @@ mod tests {
         // workload_hash — the record-once/attach-once flow stays reproducible end to end.
         let hash_of = |prefix: &str| {
             let dir = record_write_bundle_to_temp(prefix);
-            let mut oracle = BTreeMap::new();
-            oracle.insert("w_alpha".to_string(), vec![stats(1)]);
-            let h = attach_oracle(&dir, &oracle).unwrap().workload_hash;
+            let h = attach_oracle(&dir, &full_oracle()).unwrap().workload_hash;
             std::fs::remove_dir_all(&dir).ok();
             h
         };
@@ -2124,10 +2206,8 @@ mod tests {
         // is workload content — replay hard-fails on divergence from it — so it must be
         // tamper-evident like the commands themselves.
         let dir = record_write_bundle_to_temp("synthrec-oracle-tamper");
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1)]);
-        attach_oracle(&dir, &oracle).unwrap();
-        let path = dir.join("oracle").join("w_alpha.jsonl");
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        let path = dir.join("oracle").join("single_vertex_write.jsonl");
         let text = std::fs::read_to_string(&path).unwrap();
         let bad = text.replacen("\"nodes_created\":1", "\"nodes_created\":2", 1);
         assert_ne!(text, bad, "expected the counter to rewrite");
@@ -2142,10 +2222,8 @@ mod tests {
         // A reordered/renumbered oracle file fails STRUCTURALLY (before the hash recompute), with
         // an error naming the record — more actionable than a bare hash mismatch.
         let dir = record_write_bundle_to_temp("synthrec-oracle-seq");
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
-        attach_oracle(&dir, &oracle).unwrap();
-        let path = dir.join("oracle").join("w_alpha.jsonl");
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        let path = dir.join("oracle").join("single_vertex_write.jsonl");
         let text = std::fs::read_to_string(&path).unwrap();
         let bad = text.replacen("\"seq\":1", "\"seq\":5", 1);
         assert_ne!(text, bad);
@@ -2159,10 +2237,8 @@ mod tests {
     #[test]
     fn load_rejects_an_oracle_count_mismatch() {
         let dir = record_write_bundle_to_temp("synthrec-oracle-count");
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
-        attach_oracle(&dir, &oracle).unwrap();
-        let path = dir.join("oracle").join("w_alpha.jsonl");
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        let path = dir.join("oracle").join("single_vertex_write.jsonl");
         let text = std::fs::read_to_string(&path).unwrap();
         let first_line = text.lines().next().unwrap().to_string();
         std::fs::write(&path, first_line).unwrap();
@@ -2177,9 +2253,7 @@ mod tests {
         // An oracle file not named by the manifest would be dead, UNHASHED content in a bundle
         // that claims integrity — reject it.
         let dir = record_write_bundle_to_temp("synthrec-oracle-stray");
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1)]);
-        attach_oracle(&dir, &oracle).unwrap();
+        attach_oracle(&dir, &full_oracle()).unwrap();
         std::fs::write(dir.join("oracle").join("ghost.jsonl"), "{}").unwrap();
         let err = load(&dir).unwrap_err();
         let msg = format!("{err}");
@@ -2214,15 +2288,42 @@ mod tests {
         // succeed rather than brick on load()'s stray-file gate.
         let dir = record_write_bundle_to_temp("synthrec-oracle-selfheal");
         std::fs::create_dir_all(dir.join("oracle")).unwrap();
-        std::fs::write(dir.join("oracle").join("w_alpha.jsonl"), "not even json").unwrap();
+        std::fs::write(dir.join("oracle").join("single_vertex_write.jsonl"), "not even json")
+            .unwrap();
         std::fs::write(dir.join("oracle").join("ghost.jsonl"), "{}").unwrap();
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
-        let manifest = attach_oracle(&dir, &oracle).unwrap();
+        let manifest = attach_oracle(&dir, &full_oracle()).unwrap();
         assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE);
         assert!(!dir.join("oracle").join("ghost.jsonl").exists(), "orphan cleared");
         let bundle = load(&dir).unwrap();
-        assert_eq!(bundle.oracle["w_alpha"], vec![stats(1), stats(2)]);
+        assert_eq!(bundle.oracle["single_vertex_write"], vec![stats(1), stats(2)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn re_recording_over_a_v3_bundle_clears_the_stale_oracle() {
+        // §6.3 lifecycle: `record` replaces the bundle wholesale. Re-recording into a directory
+        // holding a v3 bundle must not leave the old oracle/ files behind — the fresh manifest is
+        // v2 and can't reference them, so a stale directory would brick every subsequent load.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-rerecord");
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        assert!(dir.join("oracle").is_dir(), "precondition: v3 bundle with oracle/");
+        // Re-record (same shape as the helper, fresh corpus) into the SAME directory.
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let op = RecordedOp {
+            key: OpKey::dynamic("single_vertex_write", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["CREATE (n:User)".to_string()],
+        };
+        let manifest = record_rendered(&spec, "g", &[op], 1, 8, &dir).unwrap();
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_WRITES);
+        assert!(!dir.join("oracle").exists(), "stale oracle/ must be cleared by record");
+        load(&dir).expect("the re-recorded v2 bundle must load cleanly");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -2282,11 +2383,10 @@ mod tests {
     #[test]
     fn load_rejects_an_oracle_longer_than_the_corpus() {
         // Manifest declares more oracle records than the op has commands: replay would index past
-        // the corpus. Craft it by editing an attached bundle's counts (structural gate, pre-hash).
+        // the corpus. Craft it by editing an attached bundle's counts — the §6.3 exact-set pass
+        // rejects it at manifest level (pre-hash).
         let dir = record_write_bundle_to_temp("synthrec-oracle-onlylong");
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
-        attach_oracle(&dir, &oracle).unwrap();
+        attach_oracle(&dir, &full_oracle()).unwrap();
         let path = dir.join("manifest.json");
         let text = std::fs::read_to_string(&path).unwrap();
         let bad = text.replacen("\"oracle\": 2", "\"oracle\": 9", 1);
@@ -2294,7 +2394,110 @@ mod tests {
         std::fs::write(&path, bad).unwrap();
         let err = load(&dir).unwrap_err();
         let msg = format!("{err}");
-        assert!(msg.contains("declares 9 oracle record(s)") && msg.contains("1..=count"), "got: {msg}");
+        assert!(
+            msg.contains("declares 9 oracle record(s) for 2 command(s)")
+                && msg.contains("complete corpus"),
+            "got: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_hash_valid_oracle_subset() {
+        // A v3 bundle whose oracle covers only SOME eligible ops must be rejected even when the
+        // workload_hash is recomputed to match (the duck exploit: strip one op's oracle, rehash).
+        // Coverage is part of what "format v3" promises — the exact-set gate, not the hash, is
+        // what stops a silent shrink.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-subset");
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        let bundle = load(&dir).unwrap();
+        // Strip single_vertex_update's oracle and REHASH so only the exact-set gate can object.
+        let mut manifest = bundle.manifest.clone();
+        for entry in &mut manifest.ops {
+            if entry.name == "single_vertex_update" {
+                entry.oracle = None;
+            }
+        }
+        let mut hasher = WorkloadHasher::new(
+            manifest.format_version,
+            &manifest.generator_version,
+            &manifest.dataset,
+            &manifest.graph,
+            manifest.corpus_seed,
+        );
+        for (phase, cypher) in &bundle.graph_statements {
+            hasher.graph_record(phase.tag(), cypher);
+        }
+        for ((_, cyphers), entry) in bundle.commands.iter().zip(&manifest.ops) {
+            hasher.op_header(&entry.name, cyphers.len(), entry.kind);
+            for cypher in cyphers {
+                hasher.command(cypher);
+            }
+            if entry.oracle.is_some() {
+                for (seq, s) in bundle.oracle[&entry.name].iter().enumerate() {
+                    hasher.oracle_record(seq, s);
+                }
+            }
+        }
+        manifest.workload_hash = hasher.finalize();
+        std::fs::write(
+            dir.join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        std::fs::remove_file(dir.join("oracle").join("single_vertex_update.jsonl")).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("oracle-eligible op 'single_vertex_update' carries no outcome oracle")
+                && msg.contains("exact-set"),
+            "got: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_an_oracle_on_a_non_eligible_write_op() {
+        // Mixed bundle (one eligible + one custom write op): attach the valid exact-set oracle,
+        // then hand-edit the manifest to declare an oracle on the non-eligible op — the §6.3
+        // exact-set pass must reject it at manifest level (a padded oracle outside the
+        // deterministic subset is as much a coverage lie as a shrunken one).
+        let dir = temp_bundle_dir("synthrec-oracle-noneligible");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let op = |name: &str, n: usize| RecordedOp {
+            key: OpKey::dynamic(name, QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: (0..n).map(|i| format!("CYPHER x={} CREATE (:User)", i)).collect(),
+        };
+        record_rendered(
+            &spec,
+            "g",
+            &[op("single_vertex_write", 2), op("w_custom", 1)],
+            1,
+            8,
+            &dir,
+        )
+        .unwrap();
+        let mut oracle = BTreeMap::new();
+        oracle.insert("single_vertex_write".to_string(), vec![stats(1), stats(2)]);
+        attach_oracle(&dir, &oracle).unwrap();
+        let path = dir.join("manifest.json");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let bad = text.replacen("\"count\": 1", "\"oracle\": 1,\n      \"count\": 1", 1);
+        assert_ne!(text, bad);
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("'w_custom'") && msg.contains("not oracle-eligible"),
+            "got: {msg}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -2304,19 +2507,27 @@ mod tests {
         // Empty capture.
         let err = attach_oracle(&dir, &BTreeMap::new()).unwrap_err();
         assert!(format!("{err}").contains("empty capture"), "got: {err}");
-        // Unknown op.
-        let mut unknown = BTreeMap::new();
+        // Unknown op alongside the exact set: the bundle does not record it.
+        let mut unknown = full_oracle();
         unknown.insert("nope".to_string(), vec![stats(1)]);
         let err = attach_oracle(&dir, &unknown).unwrap_err();
         assert!(format!("{err}").contains("does not record"), "got: {err}");
-        // Empty outcome vector.
-        let mut empty = BTreeMap::new();
-        empty.insert("w_alpha".to_string(), Vec::new());
+        // Missing eligible op (§6.3 exact-set rule: no subsets).
+        let mut partial = full_oracle();
+        partial.remove("single_vertex_update");
+        let err = attach_oracle(&dir, &partial).unwrap_err();
+        assert!(
+            format!("{err}").contains("no oracle captured for oracle-eligible op"),
+            "got: {err}"
+        );
+        // Empty outcome vector (an incomplete corpus).
+        let mut empty = full_oracle();
+        empty.insert("single_vertex_write".to_string(), Vec::new());
         let err = attach_oracle(&dir, &empty).unwrap_err();
-        assert!(format!("{err}").contains("0 outcome(s)"), "got: {err}");
+        assert!(format!("{err}").contains("has 0 outcome(s)"), "got: {err}");
         // More outcomes than commands.
-        let mut long = BTreeMap::new();
-        long.insert("w_alpha".to_string(), vec![stats(1), stats(2), stats(3)]);
+        let mut long = full_oracle();
+        long.insert("single_vertex_write".to_string(), vec![stats(1), stats(2), stats(3)]);
         let err = attach_oracle(&dir, &long).unwrap_err();
         assert!(format!("{err}").contains("has 3 outcome(s)"), "got: {err}");
         // The failed attempts must not have corrupted the bundle.
@@ -2326,20 +2537,33 @@ mod tests {
 
     #[test]
     fn attach_oracle_rejects_a_read_op_and_an_already_oracled_bundle() {
-        // Read op: a v1 read bundle's ops have no mutation outcome to attach.
+        // Read op: a v1 read bundle's ops have no mutation outcome to attach (and no read op is
+        // oracle-eligible).
         let (read_dir, man) = record_to_temp(13);
         let mut on_read = BTreeMap::new();
         on_read.insert(man.ops[0].name.clone(), vec![stats(1)]);
         let err = attach_oracle(&read_dir, &on_read).unwrap_err();
-        assert!(format!("{err}").contains("read op"), "got: {err}");
+        assert!(format!("{err}").contains("not oracle-eligible"), "got: {err}");
         std::fs::remove_dir_all(&read_dir).ok();
         // Double attach: the second must refuse (re-record instead).
         let dir = record_write_bundle_to_temp("synthrec-oracle-double");
-        let mut oracle = BTreeMap::new();
-        oracle.insert("w_alpha".to_string(), vec![stats(1)]);
-        attach_oracle(&dir, &oracle).unwrap();
-        let err = attach_oracle(&dir, &oracle).unwrap_err();
+        attach_oracle(&dir, &full_oracle()).unwrap();
+        let err = attach_oracle(&dir, &full_oracle()).unwrap_err();
         assert!(format!("{err}").contains("already carries"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn attach_oracle_heals_an_orphaned_oracle_from_an_interrupted_attach() {
+        // A crash between attach's oracle/ write and its manifest rewrite leaves a v2 manifest
+        // with an oracle/ directory next to it. The retry must clear the orphan and succeed.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-orphan");
+        let orphan = dir.join("oracle");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join("single_vertex_write.jsonl"), b"junk\n").unwrap();
+        let man = attach_oracle(&dir, &full_oracle()).unwrap();
+        assert_eq!(man.format_version, RECORDING_FORMAT_VERSION_ORACLE);
+        load(&dir).unwrap();
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -830,11 +830,18 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
                 .strip_suffix(".jsonl")
                 .is_some_and(|stem| oracle.contains_key(stem));
             if !known {
+                let hint = if manifest.format_version < RECORDING_FORMAT_VERSION_ORACLE {
+                    " — likely an interrupted `record --oracle` attach; delete the bundle's \
+                     oracle/ directory or re-run the oracle capture to repair"
+                } else {
+                    ""
+                };
                 return Err(OtherError(format!(
                     "{}: unexpected oracle file '{}' — not declared by any manifest op \
-                     (the bundle is corrupted or was edited)",
+                     (the bundle is corrupted or was edited){}",
                     oracle_dir.display(),
-                    file_name
+                    file_name,
+                    hint
                 )));
             }
         }
@@ -903,6 +910,25 @@ pub fn attach_oracle(
     dir: &Path,
     oracle: &BTreeMap<String, Vec<MutationStats>>,
 ) -> BenchmarkResult<Manifest> {
+    // Self-heal an interrupted previous attach before the integrity gate: a pre-v3 manifest
+    // cannot declare oracle entries, so an oracle/ directory next to one is provably orphaned
+    // (files written, manifest never upgraded) — remove it so a retry never bricks on load()'s
+    // stray-file check. A v3+ manifest is left untouched (attach rejects it below anyway).
+    let manifest_path = dir.join("manifest.json");
+    if let Ok(bytes) = std::fs::read(&manifest_path) {
+        if let Ok(peek) = serde_json::from_slice::<Manifest>(&bytes) {
+            let orphaned = dir.join("oracle");
+            if peek.format_version < RECORDING_FORMAT_VERSION_ORACLE && orphaned.is_dir() {
+                std::fs::remove_dir_all(&orphaned).map_err(|e| {
+                    OtherError(format!(
+                        "removing orphaned {} (interrupted previous attach): {}",
+                        orphaned.display(),
+                        e
+                    ))
+                })?;
+            }
+        }
+    }
     // Verify the bundle as it stands before touching it (hash gate included).
     let bundle = load(dir)?;
     if bundle.manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE {
@@ -982,7 +1008,6 @@ pub fn attach_oracle(
     }
     manifest.workload_hash = hasher.finalize();
 
-    let manifest_path = dir.join("manifest.json");
     let json = serde_json::to_string_pretty(&manifest)
         .map_err(|e| OtherError(format!("serializing manifest: {}", e)))?;
     std::fs::write(&manifest_path, json)
@@ -2159,6 +2184,45 @@ mod tests {
         let err = load(&dir).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("unexpected oracle file") && msg.contains("ghost"), "got: {msg}");
+        assert!(
+            !msg.contains("interrupted"),
+            "a v3 bundle's stray file is tampering, not an interrupted attach: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_names_the_repair_for_an_orphaned_pre_v3_oracle_dir() {
+        // An interrupted attach leaves oracle/ files next to a still-v2 manifest; load() stays
+        // strict but must point at the recovery instead of a bare corruption claim.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-orphan-msg");
+        std::fs::create_dir_all(dir.join("oracle")).unwrap();
+        std::fs::write(dir.join("oracle").join("w_alpha.jsonl"), "{}").unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("unexpected oracle file") && msg.contains("interrupted"),
+            "pre-v3 stray oracle files must name the repair path: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn attach_oracle_self_heals_an_interrupted_previous_attach() {
+        // Simulate a crash between writing oracle/ files and upgrading the manifest: the bundle
+        // is logically still v2, so a retrying attach must clear the orphaned directory and
+        // succeed rather than brick on load()'s stray-file gate.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-selfheal");
+        std::fs::create_dir_all(dir.join("oracle")).unwrap();
+        std::fs::write(dir.join("oracle").join("w_alpha.jsonl"), "not even json").unwrap();
+        std::fs::write(dir.join("oracle").join("ghost.jsonl"), "{}").unwrap();
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
+        let manifest = attach_oracle(&dir, &oracle).unwrap();
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE);
+        assert!(!dir.join("oracle").join("ghost.jsonl").exists(), "orphan cleared");
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.oracle["w_alpha"], vec![stats(1), stats(2)]);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -15,12 +15,18 @@
 //! - `graph.jsonl` — one [`GraphRecord`] per line: the ordered load statements
 //!   ([`crate::synthetic::dataset::load_statements`]) a loader executes (drop + these + verify).
 //! - `commands/<op>.jsonl` — one [`CommandRecord`] per line: the fully-rendered measured queries.
+//! - `oracle/<op>.jsonl` (format v3+ only) — one [`OracleRecord`] per line: the §6.3 per-command
+//!   mutation outcomes captured online at record time ([`attach_oracle`]), re-verified at replay.
 //!
 //! The [`Manifest::workload_hash`] is a **length-framed** SHA-256 over the header, every graph
-//! record, and every op's commands (in order) — so any edit to the graph *or* the commands is
-//! detected on [`load`] (the integrity gate), and two runs are only compared when it matches.
+//! record, every op's commands (in order), and — under format v3 — every oracle record, so any
+//! edit to the graph, the commands *or* the recorded outcomes is detected on [`load`] (the
+//! integrity gate), and two runs are only compared when it matches.
 //!
-//! Recording is **offline** (a pure function of the spec + seed) — no server is contacted.
+//! Recording is **offline** (a pure function of the spec + seed) — no server is contacted. The one
+//! deliberate exception is the §6.3 oracle (`record --oracle`,
+//! [`oracle::capture`](crate::synthetic::oracle::capture)): write outcomes are state-dependent and
+//! cannot be derived offline, so they are captured **online** and folded in afterwards.
 
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
@@ -29,11 +35,13 @@ use crate::synthetic::catalog::{spec, RecordedBudget};
 use crate::synthetic::dataset::{
     fixture_statements, load_statements, DatasetSpec, LoadPhase, GENERATOR_VERSION,
 };
+use crate::synthetic::writes::MutationStats;
 use crate::synthetic::{OpKey, OpName};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -49,8 +57,16 @@ pub const RECORDING_FORMAT_VERSION: u32 = 1;
 /// content-determined at record time: any write op ⇒ v2, all-reads ⇒ v1.
 pub const RECORDING_FORMAT_VERSION_WRITES: u32 = 2;
 
+/// On-disk bundle format version for **write** bundles carrying a §6.3 **outcome oracle**:
+/// per-command [`MutationStats`] captured online against the pristine base at record time
+/// (`oracle/<op>.jsonl`, written by [`attach_oracle`]) and re-verified per invocation at replay.
+/// Oracle records **are** folded into the `workload_hash` (tagged, length-framed parts), so a
+/// recorded outcome cannot be edited without detection; v1/v2 bundles and their hashes stay
+/// byte-identical.
+pub const RECORDING_FORMAT_VERSION_ORACLE: u32 = 3;
+
 /// The newest bundle format this build can [`load`].
-const RECORDING_FORMAT_VERSION_MAX: u32 = RECORDING_FORMAT_VERSION_WRITES;
+const RECORDING_FORMAT_VERSION_MAX: u32 = RECORDING_FORMAT_VERSION_ORACLE;
 
 /// The dataset knobs a bundle was recorded from (mirrors [`DatasetSpec`], but owned + serde).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -110,6 +126,15 @@ pub struct OpEntry {
     /// to `None` (never probed/skipped) for bundles written before this field existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capability: Option<String>,
+    /// How many §6.3 oracle records `oracle/<name>.jsonl` holds — per-command [`MutationStats`]
+    /// captured online from the pristine base at record time ([`attach_oracle`]) and re-verified
+    /// per invocation at replay. `None` (omitted when serializing, so v1/v2 manifests stay
+    /// byte-identical) for latency-only ops and for every pre-oracle bundle; `Some` requires
+    /// format v3+ and a write op. Unlike the replay-policy fields above, the oracle records
+    /// themselves **are** folded into the [`Manifest::workload_hash`] — an expected outcome is
+    /// workload content (replay hard-fails on divergence from it), not tuning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oracle: Option<usize>,
     pub count: usize,
 }
 
@@ -187,6 +212,17 @@ pub struct CommandRecord {
     pub cypher: String,
 }
 
+/// One line of `oracle/<op>.jsonl`: the [`MutationStats`] the op's command `seq` effected against
+/// the **pristine base** at record time (§6.3) — the outcome replay must reproduce, per
+/// invocation, from the same restored base. `seq` is validated contiguous-from-0 at [`load`], and
+/// the stats are folded into the workload hash, so records can be neither reordered nor edited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OracleRecord {
+    pub seq: usize,
+    pub stats: MutationStats,
+}
+
 /// A loaded bundle held in memory, ready to load into a server and replay.
 #[derive(Debug, Clone)]
 pub struct Bundle {
@@ -196,6 +232,10 @@ pub struct Bundle {
     /// Each recorded op's ordered commands, in the manifest's op order. The [`OpKey`] carries the
     /// op's stable name + kind (a built-in [`OpName`] or a string-keyed dynamic op).
     pub commands: Vec<(OpKey, Vec<String>)>,
+    /// Each oracle-bearing op's recorded per-command outcomes (§6.3), keyed by op name — entry
+    /// `i` is the [`MutationStats`] the op's command `i` must effect from the pristine base.
+    /// Empty for every pre-oracle (v1/v2) bundle.
+    pub oracle: BTreeMap<String, Vec<MutationStats>>,
 }
 
 /// Length-framed workload hasher. Every part is prefixed with its byte length (u64 LE) before the
@@ -270,6 +310,33 @@ impl WorkloadHasher {
     ) {
         self.part(b"C");
         self.part(cypher.as_bytes());
+    }
+
+    /// Feed one §6.3 oracle record (tagged `M`, v3+): the record's index followed by the seven
+    /// [`MutationStats`] counters, fixed-width little-endian. The on-disk `seq` is validated
+    /// contiguous-from-0 **before** the hash recompute, so feeding the canonical index here binds
+    /// it — a reordered file fails structurally, an edited counter fails the hash.
+    fn oracle_record(
+        &mut self,
+        seq: usize,
+        stats: &MutationStats,
+    ) {
+        self.part(b"M");
+        self.part(&(seq as u64).to_le_bytes());
+        let counters = [
+            stats.nodes_created,
+            stats.nodes_deleted,
+            stats.relationships_created,
+            stats.relationships_deleted,
+            stats.properties_set,
+            stats.properties_removed,
+            stats.labels_removed,
+        ];
+        let mut bytes = [0u8; 56];
+        for (i, c) in counters.into_iter().enumerate() {
+            bytes[i * 8..(i + 1) * 8].copy_from_slice(&c.to_le_bytes());
+        }
+        self.part(&bytes);
     }
 
     fn finalize(self) -> String {
@@ -548,6 +615,7 @@ fn record_rendered_impl(
             result_gated: op.result_gated,
             budget: op.budget.clone(),
             capability: op.capability.clone(),
+            oracle: None,
             count: cyphers.len(),
         });
     }
@@ -606,6 +674,27 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
                 manifest.format_version, entry.name, RECORDING_FORMAT_VERSION_WRITES
             )));
         }
+    }
+    // The oracle (§6.3) is a v3 feature: a pre-v3 manifest naming an oracle count was hand-edited
+    // (its hash never covered oracle records, so the kind-blind recompute below could pass it),
+    // and a v3 bundle with NO oracle should have been recorded as v2 — reject both, so the format
+    // version states exactly what the bundle carries.
+    let oracle_entries = manifest.ops.iter().filter(|e| e.oracle.is_some()).count();
+    if manifest.format_version < RECORDING_FORMAT_VERSION_ORACLE && oracle_entries > 0 {
+        return Err(OtherError(format!(
+            "format_version {} bundle declares an outcome oracle — oracle bundles are \
+             format_version {}+ (crafted/corrupt manifest)",
+            manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE
+        )));
+    }
+    if manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE && oracle_entries == 0 {
+        return Err(OtherError(format!(
+            "format_version {} bundle declares no outcome oracle for any op — the oracle is \
+             what distinguishes v{} from v{} (crafted/corrupt manifest)",
+            manifest.format_version,
+            RECORDING_FORMAT_VERSION_ORACLE,
+            RECORDING_FORMAT_VERSION_WRITES
+        )));
     }
 
     // graph.jsonl → ordered (phase, cypher).
@@ -684,6 +773,73 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
         commands.push((op, recs.into_iter().map(|r| r.cypher).collect::<Vec<_>>()));
     }
 
+    // oracle/<op>.jsonl for each oracle-bearing op (§6.3, v3+): validate the entry structurally
+    // (write-kind only, 1..=count records, contiguous seq) BEFORE the hash recompute below, so a
+    // malformed oracle fails with an actionable error naming the op instead of a bare hash
+    // mismatch. The stats themselves are hash-bound — see [`WorkloadHasher::oracle_record`].
+    let mut oracle: BTreeMap<String, Vec<MutationStats>> = BTreeMap::new();
+    for entry in &manifest.ops {
+        let Some(count) = entry.oracle else { continue };
+        if entry.kind != QueryType::Write {
+            return Err(OtherError(format!(
+                "manifest declares an outcome oracle for read op '{}' — the oracle records \
+                 mutation counters, which only write ops produce (crafted/corrupt manifest)",
+                entry.name
+            )));
+        }
+        if count == 0 || count > entry.count {
+            return Err(OtherError(format!(
+                "op '{}' declares {} oracle record(s) but has {} command(s) — an oracle covers \
+                 1..=count leading commands (crafted/corrupt manifest)",
+                entry.name, count, entry.count
+            )));
+        }
+        let path = dir.join("oracle").join(format!("{}.jsonl", entry.name));
+        let recs: Vec<OracleRecord> = read_jsonl(&path)?;
+        if recs.len() != count {
+            return Err(OtherError(format!(
+                "{}: has {} oracle record(s) but manifest says {}",
+                path.display(),
+                recs.len(),
+                count
+            )));
+        }
+        if let Some((i, rec)) = recs.iter().enumerate().find(|(i, rec)| rec.seq != *i) {
+            return Err(OtherError(format!(
+                "{}: oracle record {} declares seq {} — records must be contiguous from 0 \
+                 (the bundle is corrupted or was edited)",
+                path.display(),
+                i,
+                rec.seq
+            )));
+        }
+        oracle.insert(entry.name.clone(), recs.into_iter().map(|r| r.stats).collect());
+    }
+    // Reject stray oracle files not named by the manifest: they would be dead, UNHASHED content
+    // in a bundle that claims integrity (and a signal of a hand-edited bundle).
+    let oracle_dir = dir.join("oracle");
+    if oracle_dir.is_dir() {
+        let listing = std::fs::read_dir(&oracle_dir)
+            .map_err(|e| OtherError(format!("reading {}: {}", oracle_dir.display(), e)))?;
+        for dirent in listing {
+            let dirent =
+                dirent.map_err(|e| OtherError(format!("reading {}: {}", oracle_dir.display(), e)))?;
+            let file_name = dirent.file_name();
+            let file_name = file_name.to_string_lossy();
+            let known = file_name
+                .strip_suffix(".jsonl")
+                .is_some_and(|stem| oracle.contains_key(stem));
+            if !known {
+                return Err(OtherError(format!(
+                    "{}: unexpected oracle file '{}' — not declared by any manifest op \
+                     (the bundle is corrupted or was edited)",
+                    oracle_dir.display(),
+                    file_name
+                )));
+            }
+        }
+    }
+
     // Recompute the workload hash from the on-disk content and gate on it.
     let mut hasher = WorkloadHasher::new(
         manifest.format_version,
@@ -699,6 +855,13 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
         hasher.op_header(&entry.name, cyphers.len(), entry.kind);
         for cypher in cyphers {
             hasher.command(cypher);
+        }
+        // §6.3: the op's oracle records follow its commands in the hash stream (v3+; validated
+        // contiguous above, so the canonical index binds each record's position).
+        if let Some(stats) = oracle.get(&entry.name) {
+            for (seq, s) in stats.iter().enumerate() {
+                hasher.oracle_record(seq, s);
+            }
         }
     }
     let recomputed = hasher.finalize();
@@ -716,6 +879,7 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
         manifest,
         graph_statements,
         commands,
+        oracle,
     })
 }
 
@@ -724,6 +888,109 @@ impl Bundle {
     pub fn spec(&self) -> DatasetSpec {
         self.manifest.dataset.spec()
     }
+}
+
+/// Fold captured §6.3 oracle outcomes into an existing **v2 write bundle**, upgrading it in place
+/// to format v3: write `oracle/<op>.jsonl` for every op in `oracle`, mark each op's manifest entry
+/// with its record count, and recompute the [`Manifest::workload_hash`] under v3 rules (the oracle
+/// records are hash-bound — see [`WorkloadHasher::oracle_record`]). The upgraded bundle is
+/// re-[`load`]ed as the final step, so the function returns exactly what every future load will
+/// verify — any inconsistency this function could write fails here, at record time.
+///
+/// The capture itself (running commands against a live engine) lives in
+/// [`oracle::capture`](crate::synthetic::oracle::capture); this function is the offline half.
+pub fn attach_oracle(
+    dir: &Path,
+    oracle: &BTreeMap<String, Vec<MutationStats>>,
+) -> BenchmarkResult<Manifest> {
+    // Verify the bundle as it stands before touching it (hash gate included).
+    let bundle = load(dir)?;
+    if bundle.manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE {
+        return Err(OtherError(format!(
+            "{} already carries an outcome oracle (format_version {}) — re-record instead of \
+             re-attaching",
+            dir.display(),
+            bundle.manifest.format_version
+        )));
+    }
+    if oracle.is_empty() {
+        return Err(OtherError("no oracle outcomes to attach (empty capture)".to_string()));
+    }
+    for (name, outcomes) in oracle {
+        let Some(entry) = bundle.manifest.ops.iter().find(|e| &e.name == name) else {
+            return Err(OtherError(format!(
+                "oracle captured for op '{}', which the bundle does not record",
+                name
+            )));
+        };
+        if entry.kind != QueryType::Write {
+            return Err(OtherError(format!(
+                "oracle captured for read op '{}' — only write ops have mutation outcomes",
+                name
+            )));
+        }
+        if outcomes.is_empty() || outcomes.len() > entry.count {
+            return Err(OtherError(format!(
+                "oracle for op '{}' has {} outcome(s) but the op records {} command(s) — an \
+                 oracle covers 1..=count leading commands",
+                name,
+                outcomes.len(),
+                entry.count
+            )));
+        }
+    }
+
+    // oracle/<op>.jsonl.
+    let oracle_dir = dir.join("oracle");
+    std::fs::create_dir_all(&oracle_dir)
+        .map_err(|e| OtherError(format!("creating {}: {}", oracle_dir.display(), e)))?;
+    for (name, outcomes) in oracle {
+        let path = oracle_dir.join(format!("{}.jsonl", name));
+        let mut w = BufWriter::new(create_file(&path)?);
+        for (seq, stats) in outcomes.iter().enumerate() {
+            write_jsonl(&mut w, &path, &OracleRecord { seq, stats: *stats })?;
+        }
+        w.flush().map_err(|e| OtherError(format!("flushing {}: {}", path.display(), e)))?;
+    }
+
+    // Upgraded manifest: v3, per-op oracle counts, hash recomputed over the full v3 stream.
+    let mut manifest = bundle.manifest.clone();
+    manifest.format_version = RECORDING_FORMAT_VERSION_ORACLE;
+    for entry in &mut manifest.ops {
+        entry.oracle = oracle.get(&entry.name).map(Vec::len);
+    }
+    let mut hasher = WorkloadHasher::new(
+        manifest.format_version,
+        &manifest.generator_version,
+        &manifest.dataset,
+        &manifest.graph,
+        manifest.corpus_seed,
+    );
+    for (phase, cypher) in &bundle.graph_statements {
+        hasher.graph_record(phase.tag(), cypher);
+    }
+    for ((_, cyphers), entry) in bundle.commands.iter().zip(&manifest.ops) {
+        hasher.op_header(&entry.name, cyphers.len(), entry.kind);
+        for cypher in cyphers {
+            hasher.command(cypher);
+        }
+        if let Some(stats) = oracle.get(&entry.name) {
+            for (seq, s) in stats.iter().enumerate() {
+                hasher.oracle_record(seq, s);
+            }
+        }
+    }
+    manifest.workload_hash = hasher.finalize();
+
+    let manifest_path = dir.join("manifest.json");
+    let json = serde_json::to_string_pretty(&manifest)
+        .map_err(|e| OtherError(format!("serializing manifest: {}", e)))?;
+    std::fs::write(&manifest_path, json)
+        .map_err(|e| OtherError(format!("writing {}: {}", manifest_path.display(), e)))?;
+
+    // Prove the upgraded bundle round-trips through the same gate every replay will use.
+    let reloaded = load(dir)?;
+    Ok(reloaded.manifest)
 }
 
 fn create_file(path: &Path) -> BenchmarkResult<std::fs::File> {
@@ -1758,5 +2025,303 @@ mod tests {
         let err = load(&dir).unwrap_err();
         assert!(format!("{err}").contains("format_version"), "got: {err}");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // ---- §6.3 outcome oracle (format v3) ----
+
+    /// A recorded two-op write bundle (2 + 3 commands) for oracle tests.
+    fn record_write_bundle_to_temp(prefix: &str) -> PathBuf {
+        let dir = temp_bundle_dir(prefix);
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let op = |name: &str, n: usize| RecordedOp {
+            key: OpKey::dynamic(name, QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: (0..n)
+                .map(|i| format!("CYPHER x={} CREATE (n:User {{id:$x}})", i))
+                .collect(),
+        };
+        record_rendered(&spec, "g", &[op("w_alpha", 2), op("w_beta", 3)], 1, 8, &dir).unwrap();
+        dir
+    }
+
+    fn stats(nodes_created: i64) -> MutationStats {
+        MutationStats {
+            nodes_created,
+            properties_set: 1,
+            ..MutationStats::default()
+        }
+    }
+
+    #[test]
+    fn attach_oracle_upgrades_a_v2_bundle_to_v3_and_round_trips() {
+        let dir = record_write_bundle_to_temp("synthrec-oracle-rt");
+        let v2_hash = load(&dir).unwrap().manifest.workload_hash.clone();
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
+        oracle.insert("w_beta".to_string(), vec![stats(3)]);
+        let manifest = attach_oracle(&dir, &oracle).unwrap();
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE);
+        assert_ne!(manifest.workload_hash, v2_hash, "the oracle must land in the hash");
+        let alpha = manifest.ops.iter().find(|e| e.name == "w_alpha").unwrap();
+        let beta = manifest.ops.iter().find(|e| e.name == "w_beta").unwrap();
+        assert_eq!((alpha.oracle, beta.oracle), (Some(2), Some(1)));
+        // The upgraded bundle loads through the standard gate with the outcomes intact.
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.oracle["w_alpha"], vec![stats(1), stats(2)]);
+        assert_eq!(bundle.oracle["w_beta"], vec![stats(3)]);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn attach_oracle_is_deterministic_for_identical_outcomes() {
+        // Two identically-recorded bundles with identical captured outcomes must agree on the v3
+        // workload_hash — the record-once/attach-once flow stays reproducible end to end.
+        let hash_of = |prefix: &str| {
+            let dir = record_write_bundle_to_temp(prefix);
+            let mut oracle = BTreeMap::new();
+            oracle.insert("w_alpha".to_string(), vec![stats(1)]);
+            let h = attach_oracle(&dir, &oracle).unwrap().workload_hash;
+            std::fs::remove_dir_all(&dir).ok();
+            h
+        };
+        assert_eq!(hash_of("synthrec-oracle-da"), hash_of("synthrec-oracle-db"));
+    }
+
+    #[test]
+    fn workload_hash_binds_the_oracle_outcomes() {
+        // Editing one counter in one oracle record must fail the hash gate: an expected outcome
+        // is workload content — replay hard-fails on divergence from it — so it must be
+        // tamper-evident like the commands themselves.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-tamper");
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1)]);
+        attach_oracle(&dir, &oracle).unwrap();
+        let path = dir.join("oracle").join("w_alpha.jsonl");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let bad = text.replacen("\"nodes_created\":1", "\"nodes_created\":2", 1);
+        assert_ne!(text, bad, "expected the counter to rewrite");
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        assert!(format!("{err}").contains("workload_hash mismatch"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_non_contiguous_oracle_seq() {
+        // A reordered/renumbered oracle file fails STRUCTURALLY (before the hash recompute), with
+        // an error naming the record — more actionable than a bare hash mismatch.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-seq");
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
+        attach_oracle(&dir, &oracle).unwrap();
+        let path = dir.join("oracle").join("w_alpha.jsonl");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let bad = text.replacen("\"seq\":1", "\"seq\":5", 1);
+        assert_ne!(text, bad);
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("contiguous") && msg.contains("seq 5"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_an_oracle_count_mismatch() {
+        let dir = record_write_bundle_to_temp("synthrec-oracle-count");
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
+        attach_oracle(&dir, &oracle).unwrap();
+        let path = dir.join("oracle").join("w_alpha.jsonl");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let first_line = text.lines().next().unwrap().to_string();
+        std::fs::write(&path, first_line).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("has 1 oracle record(s) but manifest says 2"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_stray_oracle_file() {
+        // An oracle file not named by the manifest would be dead, UNHASHED content in a bundle
+        // that claims integrity — reject it.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-stray");
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1)]);
+        attach_oracle(&dir, &oracle).unwrap();
+        std::fs::write(dir.join("oracle").join("ghost.jsonl"), "{}").unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("unexpected oracle file") && msg.contains("ghost"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_pre_v3_manifest_declaring_an_oracle() {
+        // The oracle field is manifest metadata (unhashed) — a v2 manifest declaring one is a
+        // hand-edit, gated on the format version before anything else is read.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-v2decl");
+        let path = dir.join("manifest.json");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let bad = text.replacen("\"count\": 2", "\"oracle\": 1,\n      \"count\": 2", 1);
+        assert_ne!(text, bad);
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("oracle bundles are format_version 3+"),
+            "got: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_v3_bundle_with_no_oracle() {
+        // v3 exists to carry the oracle: a v3 manifest without one should have been v2 — a
+        // crafted version bump must not be a free pass.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-v3empty");
+        let path = dir.join("manifest.json");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let bad = text.replacen("\"format_version\": 2", "\"format_version\": 3", 1);
+        assert_ne!(text, bad);
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("declares no outcome oracle"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_an_oracle_on_a_read_op() {
+        // Craft a v3 READ bundle whose entry declares an oracle: the kind gate must fire (before
+        // any hash work) — mutation outcomes exist only for writes.
+        let (dir, _man) = record_to_temp(11);
+        let path = dir.join("manifest.json");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let bad = text
+            .replacen("\"format_version\": 1", "\"format_version\": 3", 1)
+            .replacen("\"count\":", "\"oracle\": 1,\n      \"count\":", 1);
+        assert_ne!(text, bad);
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("oracle for read op"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_an_oracle_longer_than_the_corpus() {
+        // Manifest declares more oracle records than the op has commands: replay would index past
+        // the corpus. Craft it by editing an attached bundle's counts (structural gate, pre-hash).
+        let dir = record_write_bundle_to_temp("synthrec-oracle-onlylong");
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1), stats(2)]);
+        attach_oracle(&dir, &oracle).unwrap();
+        let path = dir.join("manifest.json");
+        let text = std::fs::read_to_string(&path).unwrap();
+        let bad = text.replacen("\"oracle\": 2", "\"oracle\": 9", 1);
+        assert_ne!(text, bad);
+        std::fs::write(&path, bad).unwrap();
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("declares 9 oracle record(s)") && msg.contains("1..=count"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn attach_oracle_rejects_invalid_attachments() {
+        let dir = record_write_bundle_to_temp("synthrec-oracle-invalid");
+        // Empty capture.
+        let err = attach_oracle(&dir, &BTreeMap::new()).unwrap_err();
+        assert!(format!("{err}").contains("empty capture"), "got: {err}");
+        // Unknown op.
+        let mut unknown = BTreeMap::new();
+        unknown.insert("nope".to_string(), vec![stats(1)]);
+        let err = attach_oracle(&dir, &unknown).unwrap_err();
+        assert!(format!("{err}").contains("does not record"), "got: {err}");
+        // Empty outcome vector.
+        let mut empty = BTreeMap::new();
+        empty.insert("w_alpha".to_string(), Vec::new());
+        let err = attach_oracle(&dir, &empty).unwrap_err();
+        assert!(format!("{err}").contains("0 outcome(s)"), "got: {err}");
+        // More outcomes than commands.
+        let mut long = BTreeMap::new();
+        long.insert("w_alpha".to_string(), vec![stats(1), stats(2), stats(3)]);
+        let err = attach_oracle(&dir, &long).unwrap_err();
+        assert!(format!("{err}").contains("has 3 outcome(s)"), "got: {err}");
+        // The failed attempts must not have corrupted the bundle.
+        load(&dir).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn attach_oracle_rejects_a_read_op_and_an_already_oracled_bundle() {
+        // Read op: a v1 read bundle's ops have no mutation outcome to attach.
+        let (read_dir, man) = record_to_temp(13);
+        let mut on_read = BTreeMap::new();
+        on_read.insert(man.ops[0].name.clone(), vec![stats(1)]);
+        let err = attach_oracle(&read_dir, &on_read).unwrap_err();
+        assert!(format!("{err}").contains("read op"), "got: {err}");
+        std::fs::remove_dir_all(&read_dir).ok();
+        // Double attach: the second must refuse (re-record instead).
+        let dir = record_write_bundle_to_temp("synthrec-oracle-double");
+        let mut oracle = BTreeMap::new();
+        oracle.insert("w_alpha".to_string(), vec![stats(1)]);
+        attach_oracle(&dir, &oracle).unwrap();
+        let err = attach_oracle(&dir, &oracle).unwrap_err();
+        assert!(format!("{err}").contains("already carries"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn v2_write_bundles_serialize_no_oracle_field() {
+        // Pre-oracle byte-identity (§7.5): a plain write bundle's manifest must not mention the
+        // oracle at all — v1/v2 bundles and their hashes are unchanged by the v3 feature.
+        let dir = record_write_bundle_to_temp("synthrec-oracle-absent");
+        let text = std::fs::read_to_string(dir.join("manifest.json")).unwrap();
+        assert!(!text.contains("oracle"), "v2 manifest must omit the oracle field: {text}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn oracle_record_serde_is_strict() {
+        // Round-trip.
+        let rec = OracleRecord {
+            seq: 3,
+            stats: stats(1),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: OracleRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rec);
+        // Unknown fields are rejected (a typo'd counter must not silently read as 0)…
+        let unknown = r#"{"seq":0,"stats":{"nodes_created":1,"nodes_deleted":0,"relationships_created":0,"relationships_deleted":0,"properties_set":0,"properties_removed":0,"labels_removed":0,"labels_added":9}}"#;
+        assert!(serde_json::from_str::<OracleRecord>(unknown).is_err());
+        // …and every counter is required (a truncated record must not default to 0).
+        let missing = r#"{"seq":0,"stats":{"nodes_created":1}}"#;
+        assert!(serde_json::from_str::<OracleRecord>(missing).is_err());
+    }
+
+    #[test]
+    fn oracle_hash_parts_are_order_and_value_sensitive() {
+        // The hasher's oracle framing: same records in a different order, or one changed counter,
+        // must hash differently; identical streams must agree.
+        let hash = |records: &[(usize, MutationStats)]| {
+            let mut h = WorkloadHasher(Sha256::new(), RECORDING_FORMAT_VERSION_ORACLE);
+            for (seq, s) in records {
+                h.oracle_record(*seq, s);
+            }
+            h.finalize()
+        };
+        let a = [(0, stats(1)), (1, stats(2))];
+        let b = [(0, stats(2)), (1, stats(1))];
+        let c = [(0, stats(1)), (1, stats(2))];
+        assert_eq!(hash(&a), hash(&c));
+        assert_ne!(hash(&a), hash(&b));
     }
 }

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -84,6 +84,10 @@ pub struct ReplayConfig {
     pub server_image: Option<String>,
     /// Optional display name for this run (e.g. `pr`/`main`), recorded into the report.
     pub label: Option<String>,
+    /// When `true`, refuse to measure a write bundle that carries no outcome oracle (recording
+    /// format < v3). A re-hashed v3→v2 strip is a perfectly legitimate-looking v2 bundle, so only
+    /// the operator's *expectation* can catch the downgrade — this flag states it (§6.3).
+    pub require_oracle: bool,
 }
 
 /// Replay `config`'s bundle: load the recorded graph, then measure the recorded commands through the
@@ -101,6 +105,28 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // C=1 only, nothing result-gated, nothing capability-gated — are guarded up front, offline,
     // before any connection.
     let has_writes = bundle.commands.iter().any(|(op, _)| op.kind() == QueryType::Write);
+    // §6.3 downgrade guard, offline: a v2 write bundle is a legitimate latency-tier recording,
+    // which is exactly why a re-hashed v3→v2 strip replays cleanly — only the operator's stated
+    // expectation can refuse it. `load()` already guarantees a v3 bundle carries the complete
+    // exact-set oracle, so the format version alone decides.
+    if config.require_oracle {
+        if !has_writes {
+            return Err(OtherError(
+                "--require-oracle: the bundle records no write ops — the outcome oracle applies \
+                 to write bundles only (drop the flag for a read bundle)"
+                    .to_string(),
+            ));
+        }
+        if bundle.manifest.format_version < recording::RECORDING_FORMAT_VERSION_ORACLE {
+            return Err(OtherError(format!(
+                "--require-oracle: the write bundle at {} carries no outcome oracle (recording \
+                 format v{}) — latency tier only. Re-record it with --oracle; if it should \
+                 already carry one, this bundle may be a re-hashed v3→v2 downgrade",
+                config.recording_dir.display(),
+                bundle.manifest.format_version
+            )));
+        }
+    }
     if has_writes {
         validate_write_replay(&bundle, config, &concurrency)?;
     }
@@ -984,6 +1010,7 @@ mod tests {
             out: "unused.json".to_string(),
             server_image: None,
             label: None,
+            require_oracle: false,
         }
     }
 
@@ -1173,6 +1200,69 @@ mod tests {
         config.recording_dir = dir.clone();
         let err = run(&config).await.unwrap_err();
         assert!(format!("{err}").contains("never capability-gated"), "got: {err}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_require_oracle_rejects_a_read_bundle() {
+        // Reads have no outcome oracle by definition — asking for one is operator error, and
+        // silently ignoring the flag would train users to pass it everywhere.
+        use crate::synthetic::recording::{record_rendered, temp_bundle_dir, RecordedOp};
+
+        let dir = temp_bundle_dir("replay-require-oracle-read");
+        let spec = DatasetSpec {
+            seed: 7,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("r_op", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["MATCH (n) RETURN count(n)".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 7, 64, &dir).expect("record a read bundle");
+
+        let mut config = replay_config(true, vec![1]);
+        config.recording_dir = dir.clone();
+        config.require_oracle = true;
+        let err = run(&config).await.unwrap_err();
+        assert!(format!("{err}").contains("records no write ops"), "got: {err}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_require_oracle_rejects_a_latency_tier_write_bundle() {
+        // A v2 write bundle is legitimate — but the operator stated the correctness tier is
+        // expected, so the replay must refuse offline instead of measuring latency-only.
+        use crate::synthetic::recording::{record_rendered, temp_bundle_dir, RecordedOp};
+
+        let dir = temp_bundle_dir("replay-require-oracle-v2");
+        let spec = DatasetSpec {
+            seed: 7,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("w_op", QueryType::Write),
+            result_gated: false,
+            budget: write_budget(),
+            capability: None,
+            commands: vec!["CREATE (n:X)".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 7, 64, &dir).expect("record a v2 write bundle");
+
+        let mut config = replay_config(true, vec![1]);
+        config.recording_dir = dir.clone();
+        config.require_oracle = true;
+        let err = run(&config).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("carries no outcome oracle"), "got: {msg}");
+        assert!(msg.contains("recording format v2"), "got: {msg}");
+        assert!(msg.contains("re-hashed v3→v2 downgrade"), "got: {msg}");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -325,6 +325,48 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         // must scream — and an oracle-bearing op that got skipped fails closed rather than
         // silently bypassing the tier.) Untimed, single-flight, per-invocation restore — sample
         // latencies stay clean because restores run between invocations, never inside one.
+        //
+        // Exact-set re-check (belt-and-braces over the identical load() gate): every eligible
+        // write op must carry an oracle covering its complete corpus — replay never proceeds on
+        // a bundle whose oracle coverage silently shrank.
+        let eligible = crate::synthetic::shapes::oracle_eligible_names();
+        if bundle.manifest.format_version >= recording::RECORDING_FORMAT_VERSION_ORACLE {
+            for (op, cyphers) in &bundle.commands {
+                if op.kind() != QueryType::Write || !eligible.contains(op.name()) {
+                    continue;
+                }
+                match bundle.oracle.get(op.name()) {
+                    None => {
+                        return Err(OtherError(format!(
+                            "oracle-eligible op '{}' carries no outcome oracle — the bundle's \
+                             correctness coverage shrank below what format v{} promises",
+                            op.name(),
+                            recording::RECORDING_FORMAT_VERSION_ORACLE
+                        )));
+                    }
+                    Some(outcomes) if outcomes.len() != cyphers.len() => {
+                        return Err(OtherError(format!(
+                            "op '{}' has {} recorded outcome(s) for {} command(s) — the §6.3 \
+                             oracle covers the complete corpus",
+                            op.name(),
+                            outcomes.len(),
+                            cyphers.len()
+                        )));
+                    }
+                    Some(_) => {}
+                }
+            }
+        } else if has_writes {
+            // Downgrade visibility: a write bundle WITHOUT an oracle is legitimate (pre-§6.3
+            // latency tier) but must say so loudly, so a v3→v2 strip can't pass as the real
+            // thing unnoticed. The report's `meta.oracle_verified` stays absent for the same
+            // reason.
+            info!(
+                "write bundle carries no outcome oracle (recording format v{}) — latency tier \
+                 only, no correctness verification",
+                bundle.manifest.format_version
+            );
+        }
         for (op, cyphers) in &bundle.commands {
             let Some(expected) = bundle.oracle.get(op.name()) else { continue };
             if let Some(reason) = skipped.get(op.name()) {
@@ -513,6 +555,11 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                 workload_hash: bundle.manifest.workload_hash.clone(),
             }),
             label: config.label.clone(),
+            oracle_verified: if bundle.oracle.is_empty() {
+                None
+            } else {
+                Some(bundle.oracle.iter().map(|(op, v)| (op.clone(), v.len())).collect())
+            },
         },
         operations,
     })
@@ -727,7 +774,7 @@ fn reconcile_measure_and_restore(
 /// The write replay's final restore (§3.5): reload the recorded base graph, then verify its
 /// **content** — not just its counts — matches the pristine post-load capture, so the replay
 /// provably leaves the endpoint's graph exactly as recorded.
-async fn restore_and_verify(
+pub(crate) async fn restore_and_verify(
     bundle: &Bundle,
     graph_name: &str,
     dataset_spec: &DatasetSpec,

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -36,6 +36,7 @@ use crate::synthetic::catalog::DEFAULT_RESET_EVERY;
 use crate::synthetic::dataset::{self, DatasetSpec};
 use crate::synthetic::op_runner::{capture_result, run_and_drain, ResultShape};
 use crate::synthetic::recording::{self, Bundle};
+use crate::synthetic::writes::{verify_mutation, ExpectedOutcome};
 use crate::synthetic::report::{
     DatasetInfo, LevelReport, Meta, OperationReport, Report, ServerInfo, SCHEMA_VERSION,
 };
@@ -314,6 +315,64 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         }
         // Setup connection done; drop it so it isn't an idle extra connection during the sweep.
         drop(graph);
+
+        // §6.3 correctness pass: when the bundle carries an outcome oracle, re-verify every
+        // recorded outcome BEFORE any latency measurement — restore the pristine base, run the
+        // command once, and require the engine's mutation counters to EQUAL the recorded stats
+        // (`ExpectedOutcome::exactly`). A mismatch is a hard replay error naming the op, seq and
+        // command: the engine no longer effects the recorded outcome, so it is doing *different
+        // work* — measuring its latency anyway would poison the A/B trend silently. (Divergence
+        // must scream; skips never gate.) Untimed, single-flight, per-invocation restore — sample
+        // latencies stay clean because restores run between invocations, never inside one.
+        for (op, cyphers) in &bundle.commands {
+            let Some(expected) = bundle.oracle.get(op.name()) else { continue };
+            if skipped.contains_key(op.name()) {
+                continue;
+            }
+            let entry = entry_for(op.name());
+            let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);
+            let op_deadline = entry
+                .budget
+                .client_deadline_ms
+                .map(Duration::from_millis)
+                .unwrap_or(client_deadline);
+            for (seq, want) in expected.iter().enumerate() {
+                restore_base(config, &bundle, &graph_name, &dataset_spec).await?;
+                let mut g = open_graph(&config.endpoint, &graph_name).await?;
+                let sample =
+                    run_and_drain(&mut g, QueryType::Write, &cyphers[seq], op_st, op_deadline)
+                        .await
+                        .map_err(|e| {
+                            OtherError(format!(
+                                "oracle verify: op '{}' seq {}: {}",
+                                op.name(),
+                                seq,
+                                e
+                            ))
+                        })?;
+                verify_mutation(ExpectedOutcome::exactly(*want), &sample.mutations).map_err(
+                    |e| {
+                        OtherError(format!(
+                            "oracle mismatch for op '{}' seq {} (command: {}): {} — the engine \
+                             diverged from the recorded outcome, so its write latencies would \
+                             measure different work",
+                            op.name(),
+                            seq,
+                            cyphers[seq],
+                            e
+                        ))
+                    },
+                )?;
+            }
+        }
+        if !bundle.oracle.is_empty() {
+            let outcomes: usize = bundle.oracle.values().map(Vec::len).sum();
+            info!(
+                "oracle verified: {} recorded outcome(s) across {} op(s) reproduced exactly",
+                outcomes,
+                bundle.oracle.len()
+            );
+        }
 
         for (op, corpus, shapes) in &reference {
             let entry = entry_for(op.name());
@@ -884,6 +943,7 @@ mod tests {
                 result_gated: *gated,
                 budget: budget.clone(),
                 capability: None,
+                oracle: None,
                 count: 1,
             })
             .collect();
@@ -912,6 +972,7 @@ mod tests {
             },
             graph_statements: Vec::new(),
             commands,
+            oracle: std::collections::BTreeMap::new(),
         }
     }
 

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -322,12 +322,22 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         // (`ExpectedOutcome::exactly`). A mismatch is a hard replay error naming the op, seq and
         // command: the engine no longer effects the recorded outcome, so it is doing *different
         // work* — measuring its latency anyway would poison the A/B trend silently. (Divergence
-        // must scream; skips never gate.) Untimed, single-flight, per-invocation restore — sample
+        // must scream — and an oracle-bearing op that got skipped fails closed rather than
+        // silently bypassing the tier.) Untimed, single-flight, per-invocation restore — sample
         // latencies stay clean because restores run between invocations, never inside one.
         for (op, cyphers) in &bundle.commands {
             let Some(expected) = bundle.oracle.get(op.name()) else { continue };
-            if skipped.contains_key(op.name()) {
-                continue;
+            if let Some(reason) = skipped.get(op.name()) {
+                // Fail closed: unreachable through load() (write bundles can never be
+                // capability-gated, and only write ops carry oracles), but a skip must never
+                // bypass the correctness tier.
+                return Err(OtherError(format!(
+                    "op '{}' carries {} recorded oracle outcome(s) but was skipped ({}) — a \
+                     skip cannot bypass the correctness tier",
+                    op.name(),
+                    expected.len(),
+                    reason
+                )));
             }
             let entry = entry_for(op.name());
             let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -114,6 +114,12 @@ pub struct Meta {
     /// column header in `report --diff`/`--regression`; falls back to `A`/`B` when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    /// §6.3 oracle attestation: op → number of recorded outcomes the replay **re-verified** before
+    /// measuring (present only for a format-v3 write-bundle replay). Its absence on a write-bundle
+    /// report makes a v3→v2 downgrade visible when comparing runs — a replay without this field
+    /// measured the latency tier only. `#[serde(default)]` so pre-§6.3 reports still deserialize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oracle_verified: Option<std::collections::BTreeMap<String, usize>>,
 }
 
 /// Provenance for a synthetic dataset: its knobs and the `workload_hash` that identifies the whole
@@ -765,6 +771,7 @@ mod tests {
                 },
                 dataset: None,
                 label: None,
+                oracle_verified: None,
             },
             operations,
         }
@@ -791,6 +798,26 @@ mod tests {
         let _ = l0.cached.as_ref().unwrap().metrics.server_ms.p95;
         assert_eq!(back.meta.server.module_graph_ver, Some(42001));
         assert_eq!(back.meta.server.cache_size, Some(25));
+    }
+
+    #[test]
+    fn oracle_attestation_round_trips_and_defaults_to_none() {
+        // A v3 write-bundle replay attests its verified oracle coverage (op → outcome count)…
+        let mut report = sample_report();
+        let mut coverage = std::collections::BTreeMap::new();
+        coverage.insert("single_vertex_write".to_string(), 256);
+        report.meta.oracle_verified = Some(coverage.clone());
+        let json = report.to_json().unwrap();
+        assert!(json.contains("\"oracle_verified\""), "attestation serialized: {json}");
+        let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.meta.oracle_verified, Some(coverage));
+        // …while oracle-less runs omit the field entirely, and pre-§6.3 reports (no field at
+        // all) still deserialize — so a v3→v2 downgrade shows up as a missing attestation.
+        let plain = sample_report();
+        let json = plain.to_json().unwrap();
+        assert!(!json.contains("oracle_verified"), "None must not serialize: {json}");
+        let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.meta.oracle_verified, None);
     }
 
     #[test]

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -158,7 +158,29 @@ pub struct ShapeSpec {
     /// Per-op runtime budget recorded into the bundle ([`OpBudget`], design §3.4) and overlaid on
     /// the global config at replay. [`OpBudget::INHERIT`] for every current repo read.
     pub budget: OpBudget,
+    /// Whether `record --oracle` captures this shape's per-command mutation outcomes into the
+    /// bundle (Phase 7 §6.3) — [`OracleEligibility::Eligible`] only for the deterministic write
+    /// subset; every read/algorithm shape and every excluded write carries the design-cited
+    /// reason. Declared per row so adding a shape forces an explicit eligibility decision.
+    pub oracle: OracleEligibility,
 }
+
+/// Whether the §6.3 online outcome oracle applies to a shape (Phase 7 §5): `record --oracle`
+/// captures per-command [`MutationStats`](crate::synthetic::writes::MutationStats) only for
+/// **eligible** writes — the deterministic fixed-outcome subset whose counters are reproducible
+/// from a pristine base at C=1 — and replay re-verifies each recorded outcome per invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OracleEligibility {
+    /// In the §6.3 deterministic subset: oracle-captured at record time, re-verified at replay.
+    Eligible,
+    /// Never oracle-captured, with the design-cited reason.
+    Excluded(&'static str),
+}
+
+/// The [`OracleEligibility::Excluded`] annotation every non-write shape carries: the oracle
+/// captures **mutation** counters, which reads and algorithm procedures never produce.
+const ORACLE_NOT_A_WRITE: OracleEligibility =
+    OracleEligibility::Excluded("not a write — no mutation outcome to capture (§6.3)");
 
 /// The curated annotation for the **46 baseline non-algorithm read shapes** (design §3.4).
 ///
@@ -190,6 +212,7 @@ pub fn baseline_read_shapes() -> Vec<ShapeSpec> {
             capability: None,
             corpus_size: CORPUS_SIZE,
             budget: OpBudget::INHERIT,
+            oracle: ORACLE_NOT_A_WRITE,
         }
     }
     vec![
@@ -268,6 +291,7 @@ pub fn extended_core_read_shapes() -> Vec<ShapeSpec> {
         capability: None,
         corpus_size: CORPUS_SIZE,
         budget: OpBudget::INHERIT,
+        oracle: ORACLE_NOT_A_WRITE,
     }]
 }
 
@@ -301,6 +325,7 @@ pub fn fixture_dependent_read_shapes() -> Vec<ShapeSpec> {
             capability: None,
             corpus_size: CORPUS_SIZE,
             budget: OpBudget::INHERIT,
+            oracle: ORACLE_NOT_A_WRITE,
         }
     }
     vec![
@@ -425,6 +450,7 @@ pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {
             capability: Some(capability),
             corpus_size,
             budget: ALGORITHM_BUDGET,
+            oracle: ORACLE_NOT_A_WRITE,
         }
     }
     vec![
@@ -486,15 +512,21 @@ const WRITE_BUDGET: OpBudget = OpBudget {
 /// Every shape is **latency-tier** (design §4.1): replayed via `GRAPH.QUERY` with periodic
 /// base-graph resets, and `ResultPolicy::NotApplicable` — mutation outcomes are state- and
 /// value-dependent (MERGE create-vs-match, SET-same-value counting 0, DETACH DELETE no-ops on
-/// repeat — §2/§10.1), `timestamp()`/`date()`/`rand()` values are non-reproducible (§3.4), and the
-/// correctness tier (an online per-command outcome oracle with per-invocation restore) is
-/// deliberately deferred to later Phase 7 PRs (§6.2–6.3). No capability: all plain Cypher.
+/// repeat — §2/§10.1), `timestamp()`/`date()`/`rand()` values are non-reproducible (§3.4), and no
+/// **statically modelled** counter expectation exists. The §6.3 **correctness tier** instead
+/// records each command's *actual* outcome online (`record --oracle`) for the deterministic
+/// subset — the seven [`OracleEligibility::Eligible`] rows below — and replay re-verifies those
+/// recorded outcomes per invocation from a pristine base; the three excluded rows carry the
+/// design-cited reason (§3.4 server `rand()`, §6.4 prepared-state/variable-count deferral).
+/// No capability: all plain Cypher.
 pub fn write_shapes() -> Vec<ShapeSpec> {
+    use OracleEligibility::{Eligible, Excluded};
     // Every row is a Write-family, Full-tier, result-N/A shape with the write budget and a full
-    // corpus; only the name and the N/A reason vary.
+    // corpus; only the name, the N/A reason and the §6.3 oracle eligibility vary.
     fn s(
         name: &'static str,
         why_na: &'static str,
+        oracle: OracleEligibility,
     ) -> ShapeSpec {
         ShapeSpec {
             name,
@@ -504,48 +536,59 @@ pub fn write_shapes() -> Vec<ShapeSpec> {
             capability: None,
             corpus_size: CORPUS_SIZE,
             budget: WRITE_BUDGET,
+            oracle,
         }
     }
     vec![
         s(
             "single_vertex_write",
             "latency tier — plain CREATE grows the graph (duplicate ids); outcome untracked",
+            Eligible,
         ),
         s(
             "single_vertex_update",
             "latency tier — SET counters are value-dependent (1↔0 on repeated value, §10.1)",
+            Eligible,
         ),
         s(
             "single_edge_update",
             "latency tier — server rand() picks the target edge; never correctness-verifiable (§3.4)",
+            Excluded("server rand() picks the target edge — outcome not reproducible (§3.4)"),
         ),
         s(
             "single_edge_write",
             "latency tier — MERGE create-vs-match depends on accumulated state; date() non-reproducible",
+            Eligible,
         ),
         s(
             "merge_user_insert_path",
             "latency tier — create-once-then-match ordering; timestamp() non-reproducible (§10.2)",
+            Eligible,
         ),
         s(
             "merge_user_upsert_existing",
             "latency tier — ON MATCH SET counters value-dependent; timestamp() non-reproducible",
+            Eligible,
         ),
         s(
             "merge_friend_edge_upsert",
             "latency tier — MERGE create-vs-match depends on accumulated state; date() non-reproducible",
+            Eligible,
         ),
         s(
             "detach_delete_user",
             "latency tier — deletes are state-dependent (no-op on repeat) with variable counts",
+            Excluded("variable delete counts — deferred to §6.4 (phasing item 4)"),
         ),
         s(
             "remove_user_property_and_label",
             "latency tier — REMOVE needs prepared state; deferred to the correctness tier (§4.2)",
+            Excluded("needs prepared state (pristine-base REMOVE is a no-op) — deferred to §6.4"),
         ),
         s(
             "foreach_loop_mutation",
             "latency tier — SET counters value-dependent on repeat against the same User",
+            Eligible,
         ),
     ]
 }
@@ -985,6 +1028,49 @@ mod tests {
             assert_eq!(shape.budget, WRITE_BUDGET, "{}", shape.name);
         }
         assert_eq!(WRITE_BUDGET.concurrency, Some(&WRITE_SWEEP[..]), "write replay is C=1 (§5)");
+    }
+
+    #[test]
+    fn oracle_eligibility_names_the_deterministic_subset_exactly() {
+        // §6.3 (design §5): the oracle captures the deterministic fixed-outcome subset — the two
+        // plain create/update, the create-once MERGEs, foreach_loop_mutation — and excludes the
+        // server-rand() shape (§3.4) plus the two §6.4-deferred shapes. Every non-write shape is
+        // excluded by construction (no mutation outcome exists to capture).
+        let eligible: Vec<&str> = write_shapes()
+            .iter()
+            .filter(|s| s.oracle == OracleEligibility::Eligible)
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(
+            eligible,
+            vec![
+                "single_vertex_write",
+                "single_vertex_update",
+                "single_edge_write",
+                "merge_user_insert_path",
+                "merge_user_upsert_existing",
+                "merge_friend_edge_upsert",
+                "foreach_loop_mutation",
+            ],
+            "the §6.3 deterministic subset drifted"
+        );
+        let excluded: Vec<&str> = write_shapes()
+            .iter()
+            .filter(|s| matches!(s.oracle, OracleEligibility::Excluded(_)))
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(
+            excluded,
+            vec!["single_edge_update", "detach_delete_user", "remove_user_property_and_label"],
+            "the excluded set drifted"
+        );
+        for shape in repo_read_shapes().iter().chain(algorithm_read_shapes().iter()) {
+            assert!(
+                matches!(shape.oracle, OracleEligibility::Excluded(_)),
+                "non-write shape '{}' must be oracle-excluded",
+                shape.name
+            );
+        }
     }
 
     #[test]
@@ -1477,6 +1563,7 @@ mod tests {
             capability: None,
             corpus_size: CORPUS_SIZE,
             budget: OpBudget::INHERIT,
+            oracle: ORACLE_NOT_A_WRITE,
         }];
         let err = record_selected_shapes(&bogus, 1000, 5000, 1).unwrap_err();
         assert!(
@@ -1515,6 +1602,7 @@ mod tests {
                 concurrency: Some(&SWEEP),
                 ..OpBudget::INHERIT
             },
+            oracle: ORACLE_NOT_A_WRITE,
         }];
         let ops = record_selected_shapes(&small, 1000, 5000, 42).unwrap();
         assert_eq!(ops.len(), 1);
@@ -1547,6 +1635,7 @@ mod tests {
             capability: None,
             corpus_size: 0,
             budget: OpBudget::INHERIT,
+            oracle: ORACLE_NOT_A_WRITE,
         }];
         let err = record_selected_shapes(&bogus, 1000, 5000, 42).unwrap_err();
         let msg = format!("{err}");

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -182,6 +182,18 @@ pub enum OracleEligibility {
 const ORACLE_NOT_A_WRITE: OracleEligibility =
     OracleEligibility::Excluded("not a write — no mutation outcome to capture (§6.3)");
 
+/// The names of the oracle-eligible write shapes (the §6.3 deterministic subset) — the single
+/// source of truth for which ops a format-v3 bundle **must** carry outcomes for: capture targets
+/// exactly this set, and `recording::load` + replay enforce it exactly (no subset, no strays), so
+/// oracle coverage can never silently shrink.
+pub fn oracle_eligible_names() -> std::collections::BTreeSet<&'static str> {
+    write_shapes()
+        .iter()
+        .filter(|s| s.oracle == OracleEligibility::Eligible)
+        .map(|s| s.name)
+        .collect()
+}
+
 /// The curated annotation for the **46 baseline non-algorithm read shapes** (design §3.4).
 ///
 /// The op *set* is auto-discovered from [`queries_repository`] — the drift-guard test asserts this

--- a/src/synthetic/writes.rs
+++ b/src/synthetic/writes.rs
@@ -223,8 +223,9 @@ pub struct WritePlan {
 /// statistics).
 ///
 /// Serialized verbatim into a bundle's §6.3 oracle records (`oracle/<op>.jsonl`), so the serde
-/// contract is strict: every counter is required (no defaults) and unknown fields are rejected —
-/// a hand-edited or truncated record fails to parse rather than reading as zeros.
+/// contract is strict: every counter field must be present in the JSON (no `serde(default)` — the
+/// `Default` derive serves in-memory construction only) and unknown fields are rejected — a
+/// hand-edited or truncated record fails to parse rather than reading as zeros.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MutationStats {

--- a/src/synthetic/writes.rs
+++ b/src/synthetic/writes.rs
@@ -22,6 +22,7 @@
 use crate::error::BenchmarkError::OtherError;
 use crate::error::BenchmarkResult;
 use crate::query::Query;
+use serde::{Deserialize, Serialize};
 
 /// Fires a reset every `reset_every` operations, counted over the **global** invocation sequence
 /// (warm-up + measured), so scratch that warm-up mutated is bounded too.
@@ -220,7 +221,12 @@ pub struct WritePlan {
 /// plans verify (Phase 7 §6.2) — a deliberate subset of the server's statistics (e.g. `labels_added`
 /// and index counters are not tracked): absent counters read as 0 (FalkorDB omits untouched
 /// statistics).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+///
+/// Serialized verbatim into a bundle's §6.3 oracle records (`oracle/<op>.jsonl`), so the serde
+/// contract is strict: every counter is required (no defaults) and unknown fields are rejected —
+/// a hand-edited or truncated record fails to parse rather than reading as zeros.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MutationStats {
     pub nodes_created: i64,
     pub nodes_deleted: i64,

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1515,6 +1515,8 @@ async fn record_and_replay_via_run_command() {
         seed: Some(11),
         nodes: Some(400),
         edges: Some(1200),
+        oracle: None,
+        oracle_samples: None,
         out_dir: out_dir.clone(),
     })
     .await
@@ -1589,6 +1591,8 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
         seed: Some(7),
         nodes: Some(300),
         edges: Some(900),
+        oracle: None,
+        oracle_samples: None,
         out_dir: out_dir.clone(),
     })
     .await
@@ -1724,6 +1728,8 @@ async fn record_and_replay_write_shapes_end_to_end() {
         seed: Some(7),
         nodes: Some(300),
         edges: Some(900),
+        oracle: None,
+        oracle_samples: None,
         out_dir: out_dir.clone(),
     })
     .await
@@ -2121,5 +2127,214 @@ async fn max_flow_runs_on_the_generated_simple_graph() {
         .expect("max_flow is a float");
     assert!(flow > 0.0, "ring backbone connects every pair, got max_flow = {flow}");
 
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.3 — the full oracle flow end to end: `record --repo-writes --oracle` captures each
+/// eligible write's per-command outcomes online (double-pass determinism proven at record time),
+/// upgrades the bundle to format v3 with the outcomes hash-bound, and `replay::run` re-verifies
+/// every recorded outcome from a pristine base before measuring latency.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::run_command;
+    use benchmark::synthetic::shapes::{write_shapes, OracleEligibility};
+
+    let graph = "syn_it_oracle";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-oracle");
+    let out_dir = dir.to_string_lossy().into_owned();
+
+    run_command(SyntheticCommands::Record {
+        config: None,
+        graph: Some(graph.to_string()),
+        ops: vec![],
+        all_reads: false,
+        tier: None,
+        repo_reads: None,
+        repo_algorithms: false,
+        repo_writes: true,
+        seed: Some(7),
+        nodes: Some(300),
+        edges: Some(900),
+        oracle: Some(endpoint()),
+        oracle_samples: Some(2),
+        out_dir: out_dir.clone(),
+    })
+    .await
+    .expect("record --repo-writes --oracle via run_command");
+
+    let bundle = recording::load(&dir).expect("load the oracle bundle");
+    assert_eq!(bundle.manifest.format_version, 3, "oracle bundles are recording format v3");
+    let mut eligible: Vec<&str> = write_shapes()
+        .iter()
+        .filter(|s| s.oracle == OracleEligibility::Eligible)
+        .map(|s| s.name)
+        .collect();
+    eligible.sort_unstable(); // bundle.oracle is a BTreeMap — compare in key order
+    assert_eq!(
+        bundle.oracle.keys().map(String::as_str).collect::<Vec<_>>(),
+        eligible,
+        "exactly the §6.3 deterministic subset is oracle-captured"
+    );
+    for entry in &bundle.manifest.ops {
+        if eligible.contains(&entry.name.as_str()) {
+            assert_eq!(entry.oracle, Some(2), "{}: --oracle-samples 2", entry.name);
+            assert_eq!(bundle.oracle[&entry.name].len(), 2, "{}", entry.name);
+        } else {
+            assert_eq!(entry.oracle, None, "{} is excluded from the oracle", entry.name);
+        }
+    }
+    // The first outcome of the plain CREATE shape is knowable a priori — pin it as a smoke check
+    // that the oracle recorded real counters (everything else is engine-reported).
+    let svw = &bundle.oracle["single_vertex_write"][0];
+    assert_eq!(svw.nodes_created, 1, "CREATE makes one node: {svw:?}");
+
+    // Replay: the oracle verify pass runs before measurement and the whole run stays green.
+    let out = dir.join("oracle.json").to_string_lossy().into_owned();
+    let mut config = replay_config(&dir, graph, &out, true);
+    config.samples = 2;
+    config.warmup = 0;
+    config.cache = benchmark::synthetic::CacheSelection::Cached;
+    let report = replay::run(&config).await.expect("replay a v3 oracle bundle");
+    assert_eq!(report.operations.len(), 10, "all 10 write shapes still measured");
+
+    // §3.5: the endpoint's graph is left exactly at the recorded base.
+    let mut g = open_graph(&endpoint(), graph).await.expect("open restored graph");
+    assert_eq!(scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await, 300);
+    assert_eq!(scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await, 900);
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.3 — a recorded outcome the engine no longer reproduces must HARD-FAIL the replay
+/// (naming the op, seq and command), and the §3.5 error-safe final restore must still leave the
+/// recorded base behind. A diverged write means the engine is doing different work — measuring
+/// its latency anyway would silently poison the A/B trend.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn replay_hard_fails_on_a_diverged_oracle_outcome() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::run_command;
+    use benchmark::synthetic::writes::MutationStats;
+    use std::collections::BTreeMap;
+
+    let graph = "syn_it_oracle_diverged";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-oracle-div");
+
+    run_command(SyntheticCommands::Record {
+        config: None,
+        graph: Some(graph.to_string()),
+        ops: vec![],
+        all_reads: false,
+        tier: None,
+        repo_reads: None,
+        repo_algorithms: false,
+        repo_writes: true,
+        seed: Some(7),
+        nodes: Some(300),
+        edges: Some(900),
+        oracle: None,
+        oracle_samples: None,
+        out_dir: dir.to_string_lossy().into_owned(),
+    })
+    .await
+    .expect("record a plain v2 write bundle");
+
+    // Attach a hash-valid but WRONG oracle: the plain CREATE reports nodes_created=1, so
+    // expecting 7 is a guaranteed, deterministic divergence.
+    let mut wrong = BTreeMap::new();
+    wrong.insert(
+        "single_vertex_write".to_string(),
+        vec![MutationStats {
+            nodes_created: 7,
+            ..MutationStats::default()
+        }],
+    );
+    recording::attach_oracle(&dir, &wrong).expect("attach the crafted oracle");
+
+    let out = dir.join("diverged.json").to_string_lossy().into_owned();
+    let mut config = replay_config(&dir, graph, &out, true);
+    config.samples = 2;
+    config.warmup = 0;
+    config.cache = benchmark::synthetic::CacheSelection::Cached;
+    let err = replay::run(&config).await.expect_err("a diverged oracle outcome must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("oracle mismatch for op 'single_vertex_write' seq 0"),
+        "must name the op and seq: {msg}"
+    );
+    assert!(msg.contains("nodes_created"), "must name the diverged counter: {msg}");
+    assert!(msg.contains("expected exactly 7"), "must show the recorded expectation: {msg}");
+
+    // The hard failure still ran the §3.5 final restore.
+    let mut g = open_graph(&endpoint(), graph).await.expect("open restored graph");
+    assert_eq!(scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await, 300);
+    assert_eq!(scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await, 900);
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.3 — capture determinism end to end: two independent record+capture flows over the
+/// same seed produce byte-identical v3 bundles (same `workload_hash`, engine outcomes included),
+/// and a completed capture leaves the endpoint's graph content-identical to a fresh restore of
+/// the recorded base (§3.5 at record time).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
+    use benchmark::synthetic::oracle;
+    use benchmark::synthetic::replay::capture_graph_content;
+    use benchmark::synthetic::shapes::record_repo_writes;
+
+    let graph = "syn_it_oracle_det";
+    drop_graph(graph).await;
+
+    let record_one = |prefix: &str| {
+        let dir = temp_bundle_dir(prefix);
+        let spec = DatasetSpec {
+            seed: 7,
+            nodes: 300,
+            edges: 900,
+        };
+        let ops = record_repo_writes(300, 900, 7).expect("render the write shapes");
+        recording::record_rendered(&spec, graph, &ops, 7, 1_000, &dir).expect("record v2");
+        dir
+    };
+
+    let dir_a = record_one("syn-it-oracle-det-a");
+    let manifest_a = oracle::capture(&endpoint(), &dir_a, 2, 10_000, 60_000)
+        .await
+        .expect("capture oracle for bundle A");
+
+    // Post-capture, BEFORE any further restore: the graph must already be the pristine base.
+    let bundle_a = recording::load(&dir_a).expect("reload bundle A");
+    let cfg = replay_config(&dir_a, graph, "unused.json", true);
+    let mut g = open_graph(&endpoint(), graph).await.expect("open post-capture graph");
+    let post_capture = capture_graph_content(&mut g, &cfg).await.expect("digest post-capture");
+    replay::restore_base(&cfg, &bundle_a, graph, &bundle_a.spec())
+        .await
+        .expect("explicit fresh restore");
+    let pristine = capture_graph_content(&mut g, &cfg).await.expect("digest fresh restore");
+    assert_eq!(
+        post_capture, pristine,
+        "capture must leave the base content-identical to a fresh restore"
+    );
+    drop(g);
+
+    let dir_b = record_one("syn-it-oracle-det-b");
+    let manifest_b = oracle::capture(&endpoint(), &dir_b, 2, 10_000, 60_000)
+        .await
+        .expect("capture oracle for bundle B");
+    assert_eq!(
+        manifest_a.workload_hash, manifest_b.workload_hash,
+        "same seed + same engine ⇒ identical v3 bundles, oracle outcomes included"
+    );
+
+    std::fs::remove_dir_all(&dir_a).ok();
+    std::fs::remove_dir_all(&dir_b).ok();
     drop_graph(graph).await;
 }

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1084,6 +1084,7 @@ fn replay_config(dir: &std::path::Path, graph: &str, out: &str, load: bool) -> R
         out: out.to_string(),
         server_image: None,
         label: None,
+        require_oracle: false,
     }
 }
 
@@ -1546,6 +1547,7 @@ async fn record_and_replay_via_run_command() {
         edges: None,
         recording: Some(out_dir),
         no_load: false,
+        require_oracle: false,
     })
     .await
     .expect("run --recording via run_command");
@@ -2018,6 +2020,7 @@ async fn replay_concurrency_sweep_verifies_results_and_reports_levels() {
         out: dir.join("conc.json").to_string_lossy().into_owned(),
         server_image: None,
         label: None,
+        require_oracle: false,
     };
     // If any op returned different results at C=4 vs the single-flight reference, run() errors here.
     // The two LIMIT ops (expand_hops_5, aggregate_group) are totally ordered, so their value digests
@@ -2192,12 +2195,14 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
     let svw = &bundle.oracle["single_vertex_write"][0];
     assert_eq!(svw.nodes_created, 1, "CREATE makes one node: {svw:?}");
 
-    // Replay: the oracle verify pass runs before measurement and the whole run stays green.
+    // Replay: the oracle verify pass runs before measurement and the whole run stays green —
+    // with --require-oracle asserting the bundle really is v3 (the downgrade guard's happy path).
     let out = dir.join("oracle.json").to_string_lossy().into_owned();
     let mut config = replay_config(&dir, graph, &out, true);
     config.samples = 2;
     config.warmup = 0;
     config.cache = benchmark::synthetic::CacheSelection::Cached;
+    config.require_oracle = true;
     let report = replay::run(&config).await.expect("replay a v3 oracle bundle");
     assert_eq!(report.operations.len(), 10, "all 10 write shapes still measured");
     // The report attests the verified oracle coverage (op → outcome count), so a v3→v2

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1516,7 +1516,6 @@ async fn record_and_replay_via_run_command() {
         nodes: Some(400),
         edges: Some(1200),
         oracle: None,
-        oracle_samples: None,
         out_dir: out_dir.clone(),
     })
     .await
@@ -1592,7 +1591,6 @@ async fn record_and_replay_algorithm_shapes_end_to_end() {
         nodes: Some(300),
         edges: Some(900),
         oracle: None,
-        oracle_samples: None,
         out_dir: out_dir.clone(),
     })
     .await
@@ -1729,7 +1727,6 @@ async fn record_and_replay_write_shapes_end_to_end() {
         nodes: Some(300),
         edges: Some(900),
         oracle: None,
-        oracle_samples: None,
         out_dir: out_dir.clone(),
     })
     .await
@@ -2159,7 +2156,6 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
         nodes: Some(300),
         edges: Some(900),
         oracle: Some(endpoint()),
-        oracle_samples: Some(2),
         out_dir: out_dir.clone(),
     })
     .await
@@ -2180,8 +2176,13 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
     );
     for entry in &bundle.manifest.ops {
         if eligible.contains(&entry.name.as_str()) {
-            assert_eq!(entry.oracle, Some(2), "{}: --oracle-samples 2", entry.name);
-            assert_eq!(bundle.oracle[&entry.name].len(), 2, "{}", entry.name);
+            assert_eq!(
+                entry.oracle,
+                Some(entry.count),
+                "{}: the oracle covers the complete command corpus",
+                entry.name
+            );
+            assert_eq!(bundle.oracle[&entry.name].len(), entry.count, "{}", entry.name);
         } else {
             assert_eq!(entry.oracle, None, "{} is excluded from the oracle", entry.name);
         }
@@ -2199,6 +2200,19 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
     config.cache = benchmark::synthetic::CacheSelection::Cached;
     let report = replay::run(&config).await.expect("replay a v3 oracle bundle");
     assert_eq!(report.operations.len(), 10, "all 10 write shapes still measured");
+    // The report attests the verified oracle coverage (op → outcome count), so a v3→v2
+    // downgrade is visible to report consumers, not just to the replay log.
+    let attested = report.meta.oracle_verified.as_ref().expect("v3 replay attests its oracle");
+    assert_eq!(
+        attested.keys().map(String::as_str).collect::<Vec<_>>(),
+        eligible,
+        "the attestation names exactly the verified ops"
+    );
+    for entry in &bundle.manifest.ops {
+        if let Some(n) = entry.oracle {
+            assert_eq!(attested[&entry.name], n, "{}", entry.name);
+        }
+    }
 
     // §3.5: the endpoint's graph is left exactly at the recorded base.
     let mut g = open_graph(&endpoint(), graph).await.expect("open restored graph");
@@ -2213,36 +2227,35 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
 /// (naming the op, seq and command), and the §3.5 error-safe final restore must still leave the
 /// recorded base behind. A diverged write means the engine is doing different work — measuring
 /// its latency anyway would silently poison the A/B trend.
+///
+/// The bundle is a hand-rendered single-op recording carrying the eligible `single_vertex_write`
+/// name: the §6.3 exact-set rule makes it a valid v3 bundle (one recorded eligible op, full
+/// corpus), and crafting the outcome offline keeps the divergence deterministic — the plain
+/// CREATE reports `nodes_created=1`, so expecting 7 always diverges at seq 0.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
 async fn replay_hard_fails_on_a_diverged_oracle_outcome() {
-    use benchmark::cli::SyntheticCommands;
-    use benchmark::synthetic::run_command;
+    use benchmark::synthetic::recording::RecordedOp;
     use benchmark::synthetic::writes::MutationStats;
+    use benchmark::synthetic::OpKey;
     use std::collections::BTreeMap;
 
     let graph = "syn_it_oracle_diverged";
     drop_graph(graph).await;
     let dir = temp_bundle_dir("syn-it-oracle-div");
-
-    run_command(SyntheticCommands::Record {
-        config: None,
-        graph: Some(graph.to_string()),
-        ops: vec![],
-        all_reads: false,
-        tier: None,
-        repo_reads: None,
-        repo_algorithms: false,
-        repo_writes: true,
-        seed: Some(7),
-        nodes: Some(300),
-        edges: Some(900),
-        oracle: None,
-        oracle_samples: None,
-        out_dir: dir.to_string_lossy().into_owned(),
-    })
-    .await
-    .expect("record a plain v2 write bundle");
+    let spec = DatasetSpec {
+        seed: 7,
+        nodes: 60,
+        edges: 180,
+    };
+    let op = RecordedOp {
+        key: OpKey::dynamic("single_vertex_write", QueryType::Write),
+        result_gated: false,
+        budget: Default::default(),
+        capability: None,
+        commands: vec!["CREATE (:User {id: 999983})".to_string()],
+    };
+    recording::record_rendered(&spec, graph, &[op], 7, 1_000, &dir).expect("record v2");
 
     // Attach a hash-valid but WRONG oracle: the plain CREATE reports nodes_created=1, so
     // expecting 7 is a guaranteed, deterministic divergence.
@@ -2272,8 +2285,92 @@ async fn replay_hard_fails_on_a_diverged_oracle_outcome() {
 
     // The hard failure still ran the §3.5 final restore.
     let mut g = open_graph(&endpoint(), graph).await.expect("open restored graph");
-    assert_eq!(scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await, 300);
-    assert_eq!(scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await, 900);
+    assert_eq!(scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await, 60);
+    assert_eq!(scalar_i64(&mut g, "MATCH ()-[r]->() RETURN count(r)").await, 180);
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.3 — engine failures inside the oracle paths carry the op/seq context: a command the
+/// engine rejects fails the record-time capture as `oracle capture: op … seq …` (base restored),
+/// and the same command in a crafted v3 bundle fails the replay verify pass as
+/// `oracle verify: op … seq …` — both name where the failure happened, not just what.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn oracle_paths_name_the_op_and_seq_on_engine_failures() {
+    use benchmark::synthetic::oracle;
+    use benchmark::synthetic::recording::RecordedOp;
+    use benchmark::synthetic::writes::MutationStats;
+    use benchmark::synthetic::OpKey;
+    use std::collections::BTreeMap;
+
+    let graph = "syn_it_oracle_enginefail";
+    drop_graph(graph).await;
+    let spec = DatasetSpec {
+        seed: 7,
+        nodes: 60,
+        edges: 180,
+    };
+    let broken_op = || RecordedOp {
+        key: OpKey::dynamic("single_vertex_write", QueryType::Write),
+        result_gated: false,
+        budget: Default::default(),
+        capability: None,
+        commands: vec!["THIS IS NOT CYPHER".to_string()],
+    };
+
+    // Record-time: capture must fail with the op/seq context and leave the base restored.
+    let dir = temp_bundle_dir("syn-it-oracle-capfail");
+    recording::record_rendered(&spec, graph, &[broken_op()], 7, 1_000, &dir).expect("record v2");
+    let err = oracle::capture(&endpoint(), &dir, 5_000, 6_000)
+        .await
+        .expect_err("capturing an engine-rejected command must fail");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("oracle capture: op 'single_vertex_write' seq 0"),
+        "capture errors carry op/seq context: {msg}"
+    );
+    let mut g = open_graph(&endpoint(), graph).await.expect("open restored graph");
+    assert_eq!(scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await, 60);
+    drop(g);
+    std::fs::remove_dir_all(&dir).ok();
+
+    // Replay-time: a crafted v3 bundle whose SECOND command the engine rejects fails the verify
+    // pass with the mirrored context — the first command is valid (and its outcome correct), so
+    // the fail-fast probe and verify seq 0 both pass, isolating the engine error at seq 1.
+    let dir = temp_bundle_dir("syn-it-oracle-verifyfail");
+    let two_cmd_op = RecordedOp {
+        key: OpKey::dynamic("single_vertex_write", QueryType::Write),
+        result_gated: false,
+        budget: Default::default(),
+        capability: None,
+        commands: vec!["CREATE ()".to_string(), "THIS IS NOT CYPHER".to_string()],
+    };
+    recording::record_rendered(&spec, graph, &[two_cmd_op], 7, 1_000, &dir).expect("record v2");
+    let mut crafted = BTreeMap::new();
+    crafted.insert(
+        "single_vertex_write".to_string(),
+        vec![
+            MutationStats {
+                nodes_created: 1,
+                ..MutationStats::default()
+            },
+            MutationStats::default(),
+        ],
+    );
+    recording::attach_oracle(&dir, &crafted).expect("attach a well-formed oracle");
+    let out = dir.join("enginefail.json").to_string_lossy().into_owned();
+    let mut config = replay_config(&dir, graph, &out, true);
+    config.samples = 2;
+    config.warmup = 0;
+    config.cache = benchmark::synthetic::CacheSelection::Cached;
+    let err = replay::run(&config).await.expect_err("verify pass must surface the engine error");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("oracle verify: op 'single_vertex_write' seq 1"),
+        "verify errors carry op/seq context: {msg}"
+    );
 
     std::fs::remove_dir_all(&dir).ok();
     drop_graph(graph).await;
@@ -2283,12 +2380,18 @@ async fn replay_hard_fails_on_a_diverged_oracle_outcome() {
 /// same seed produce byte-identical v3 bundles (same `workload_hash`, engine outcomes included),
 /// and a completed capture leaves the endpoint's graph content-identical to a fresh restore of
 /// the recorded base (§3.5 at record time).
+///
+/// The bundle is a hand-rendered two-op recording carrying eligible shape names (the exact-set
+/// rule pins v3 oracles to eligible names): capture semantics — double pass, full corpus,
+/// content-verified final restore — are identical to the full repo-writes flow (covered by the
+/// end-to-end test above) while the small corpus keeps the double capture fast.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
 async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
     use benchmark::synthetic::oracle;
+    use benchmark::synthetic::recording::RecordedOp;
     use benchmark::synthetic::replay::capture_graph_content;
-    use benchmark::synthetic::shapes::record_repo_writes;
+    use benchmark::synthetic::OpKey;
 
     let graph = "syn_it_oracle_det";
     drop_graph(graph).await;
@@ -2297,18 +2400,42 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
         let dir = temp_bundle_dir(prefix);
         let spec = DatasetSpec {
             seed: 7,
-            nodes: 300,
-            edges: 900,
+            nodes: 60,
+            edges: 180,
         };
-        let ops = record_repo_writes(300, 900, 7).expect("render the write shapes");
+        let op = |name: &str, commands: Vec<String>| RecordedOp {
+            key: OpKey::dynamic(name, QueryType::Write),
+            result_gated: false,
+            budget: Default::default(),
+            capability: None,
+            commands,
+        };
+        let ops = [
+            op(
+                "single_vertex_write",
+                (0..3).map(|i| format!("CREATE (:User {{id: {}}})", 999_900 + i)).collect(),
+            ),
+            op(
+                "single_vertex_update",
+                (0..2).map(|i| format!("MATCH (u:User {{id: {i}}}) SET u.probe = {i}")).collect(),
+            ),
+        ];
         recording::record_rendered(&spec, graph, &ops, 7, 1_000, &dir).expect("record v2");
         dir
     };
 
     let dir_a = record_one("syn-it-oracle-det-a");
-    let manifest_a = oracle::capture(&endpoint(), &dir_a, 2, 5_000, 6_000)
+    let manifest_a = oracle::capture(&endpoint(), &dir_a, 5_000, 6_000)
         .await
         .expect("capture oracle for bundle A");
+    for entry in &manifest_a.ops {
+        assert_eq!(
+            entry.oracle,
+            Some(entry.count),
+            "{}: capture covers the complete corpus",
+            entry.name
+        );
+    }
 
     // Post-capture, BEFORE any further restore: the graph must already be the pristine base.
     let bundle_a = recording::load(&dir_a).expect("reload bundle A");
@@ -2326,7 +2453,7 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
     drop(g);
 
     let dir_b = record_one("syn-it-oracle-det-b");
-    let manifest_b = oracle::capture(&endpoint(), &dir_b, 2, 5_000, 6_000)
+    let manifest_b = oracle::capture(&endpoint(), &dir_b, 5_000, 6_000)
         .await
         .expect("capture oracle for bundle B");
     assert_eq!(
@@ -2336,5 +2463,56 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
 
     std::fs::remove_dir_all(&dir_a).ok();
     std::fs::remove_dir_all(&dir_b).ok();
+    drop_graph(graph).await;
+}
+
+/// Phase 7 §6.3 — re-recording over an existing v3 bundle must work, with and without `--oracle`
+/// (the duck repro: a stale `oracle/` directory used to survive the plain re-record and brick
+/// every subsequent load, and the `--oracle` retry loaded the stale bundle before the repair
+/// could run). Exercises the real CLI `record` path end to end, twice over the same directory.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn re_recording_over_a_v3_bundle_succeeds_with_and_without_oracle() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::run_command;
+
+    let graph = "syn_it_oracle_rerecord";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-oracle-rerec");
+    let out_dir = dir.to_string_lossy().into_owned();
+    let record = |oracle: bool| SyntheticCommands::Record {
+        config: None,
+        graph: Some(graph.to_string()),
+        ops: vec![],
+        all_reads: false,
+        tier: None,
+        repo_reads: None,
+        repo_algorithms: false,
+        repo_writes: true,
+        seed: Some(7),
+        nodes: Some(60),
+        edges: Some(180),
+        oracle: oracle.then(endpoint),
+        out_dir: out_dir.clone(),
+    };
+
+    run_command(record(true)).await.expect("initial record --oracle");
+    let v3_hash = recording::load(&dir).expect("v3 loads").manifest.workload_hash;
+
+    // Re-record WITH --oracle over the v3 bundle: the capture-side self-heal must let the retry
+    // through (capture loads the bundle BEFORE attach's own heal), reproducing the identical v3.
+    run_command(record(true)).await.expect("re-record --oracle over v3");
+    let again = recording::load(&dir).expect("the re-captured v3 bundle loads");
+    assert_eq!(again.manifest.format_version, 3);
+    assert_eq!(again.manifest.workload_hash, v3_hash, "same seed + engine ⇒ same v3 bundle");
+
+    // Re-record WITHOUT --oracle over the v3 bundle: the stale oracle/ must be cleared and the
+    // resulting v2 bundle must load cleanly.
+    run_command(record(false)).await.expect("re-record without --oracle over v3");
+    assert!(!dir.join("oracle").exists(), "stale oracle/ cleared by the plain re-record");
+    let v2 = recording::load(&dir).expect("the re-recorded v2 bundle loads");
+    assert_eq!(v2.manifest.format_version, 2);
+
+    std::fs::remove_dir_all(&dir).ok();
     drop_graph(graph).await;
 }

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -2306,7 +2306,7 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
     };
 
     let dir_a = record_one("syn-it-oracle-det-a");
-    let manifest_a = oracle::capture(&endpoint(), &dir_a, 2, 10_000, 60_000)
+    let manifest_a = oracle::capture(&endpoint(), &dir_a, 2, 5_000, 6_000)
         .await
         .expect("capture oracle for bundle A");
 
@@ -2326,7 +2326,7 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
     drop(g);
 
     let dir_b = record_one("syn-it-oracle-det-b");
-    let manifest_b = oracle::capture(&endpoint(), &dir_b, 2, 10_000, 60_000)
+    let manifest_b = oracle::capture(&endpoint(), &dir_b, 2, 5_000, 6_000)
         .await
         .expect("capture oracle for bundle B");
     assert_eq!(


### PR DESCRIPTION
# Phase 7 / PR-3 — §6.3 online write outcome oracle + C=1 correctness tier

Implements phasing item 3 of the binding design
[`docs/design/synthetic-cover-writes-phase7.md`](../blob/barakb/phase7-online-oracle/docs/design/synthetic-cover-writes-phase7.md):
an **online outcome oracle** captured at record time and a **C=1 correctness tier** re-verified at
every replay, for the deterministic subset of the write shapes.

## What it does

**Record** — `synthetic record --repo-writes --oracle <endpoint>`:

1. Records the plain v2 write bundle exactly as before (offline, unchanged bytes), clearing any
   stale `oracle/` directory left by a previous v3 recording (record replaces the bundle
   wholesale, so re-recording over a v3 bundle is always safe — with or without `--oracle`).
2. Establishes the pristine base on the live endpoint and captures its **content digests** up
   front, then runs **every** recorded command of each **oracle-eligible** write shape (the
   **complete command corpus** — per-command outcomes, no sampling) once against the freshly
   restored pristine base — `restore_base` (drop + reload + count-verify) before **every**
   invocation — capturing the engine's `MutationStats` (all seven counters).
3. Runs a **second full capture pass**; every outcome must reproduce **exactly**, or the record
   fails naming the op/seq and both stat lines (determinism is proven, not assumed — §3.2's
   corrected thesis).
4. Folds the outcomes into the bundle via `recording::attach_oracle`: `oracle/<op>.jsonl` files,
   manifest → **format v3** with per-op `oracle` counts, `workload_hash` **recomputed with every
   oracle record bound in**, then **re-loads the bundle through the full `load()` gate** as its
   own proof of validity.
5. The endpoint's graph is left restored on success **and** failure (§3.5), with the restored
   **content** verified against the up-front pristine digests (same `restore_and_verify` the
   write replay uses — not just count-checked); a dual capture+restore failure surfaces **both**
   errors. A failed capture leaves the v2 bundle untouched. The **initial setup load** (step 2)
   is under the same discipline (round-2 F2): it is drop-then-rebuild, so a mid-load failure
   triggers **one recovery restore** — success returns the setup error noting the graph was
   re-restored; a second failure returns a **combined error** warning the graph may be left
   partially loaded. (No blind retry: at capture time the load statements are running for the
   first time, so a bad statement would fail identically on retry.)

**Replay** — a v3 bundle first runs an untimed **oracle verify pass** (after the fail-fast
reference probes, before any measurement): per recorded outcome, restore base → run command once →
`verify_mutation(ExpectedOutcome::exactly(recorded))`. Any divergence **hard-fails the replay**:

```
oracle mismatch for op 'single_vertex_write' seq 0 (command: CREATE (:User…)): write outcome
mismatch (nodes_created: expected exactly 7, server reported 1) — … the engine diverged from the
recorded outcome, so its write latencies would measure different work
```

Only then are latencies measured, exactly as for a plain write bundle (C=1, per-cell reset,
error-safe final restore — all unchanged).

## Exact-set enforcement — oracle coverage can never silently shrink

A format-v3 bundle must carry an oracle for **exactly** the recorded oracle-eligible write ops —
**complete corpus per op, none anywhere else**. Enforced three times over
(`shapes::oracle_eligible_names()` is the single source of truth):

- **`load()`** — manifest-level pass before any file read: an eligible op with no oracle (the
  hash-valid 1-of-7 subset exploit), a count ≠ the op's command count, or an oracle on a read /
  non-eligible op is rejected outright.
- **`attach_oracle()`** — the same rule pre-validated against the capture map.
- **Replay** — a belt-and-braces re-check of the loaded bundle before the verify pass (defense in
  depth; unreachable through `load()` by construction).

**Downgrade enforcement** (round-2 rework — the earlier "no flag needed" rationale is
**retracted**: it only covered a downgrade compared *against a genuine v3*, where the hash
differs. A **re-hashed v3→v2 strip is byte-indistinguishable from a legitimate v2** — v2 hashes
never covered oracle data — so it loads cleanly, replays with `oracle_verified` absent, and two
such downgrades diff cleanly against each other. Two complementary guards close that):

- **`synthetic run --recording --require-oracle`** — operator-stated expectation, checked
  **offline** (before any connection): refuses a write bundle without an oracle (`recording
  format v2 … may be a re-hashed v3→v2 downgrade`) and errors on a read bundle (reads have no
  oracle). `just synthetic-replay <name> <endpoint> --require-oracle` forwards it (no recipe
  rewiring: **no CI/Justfile recipe replays write bundles today** — `synthetic-sanity`/`verify`
  are `--repo-reads` — so the flag is documented for operators instead; the Justfile
  recipe doc-comment says so).
- **Comparison-side attestation guard + rendering** — both `report --diff` (strict) and
  `--regression`: a **one-sided or differing** `meta.oracle_verified` is a hard abort /
  not-comparable (the runs did not run the same correctness tier); the per-side attestation
  renders as an **`outcome oracle`** header row (`verified — 7 op(s), 1792 outcome(s)` / `—`);
  and two **un-attested** runs over oracle-eligible write ops stay comparable with a prominent
  **latency-tier-only warning** naming the ops and both flags (the two-sided-downgrade blind
  spot, made visible). Baselines (`synthetic-baseline`/`compare`) carry the attestation +
  eligible-op set through `BaselineKey` (additive, serde-defaulted — pre-§6.3 baseline JSON loads
  and read baselines stay byte-identical).

## Eligibility (single source of truth: `ShapeSpec.oracle` in `shapes.rs`)

| Shape | Oracle | Reason |
| --- | --- | --- |
| `single_vertex_write` | ✅ eligible | pure CREATE from pristine base |
| `single_vertex_update` | ✅ eligible | SET on existing node |
| `single_edge_write` | ✅ eligible | CREATE edge between existing nodes |
| `merge_user_insert_path` | ✅ eligible | MERGE miss ⇒ create-once |
| `merge_user_upsert_existing` | ✅ eligible | MERGE hit + ON MATCH |
| `merge_friend_edge_upsert` | ✅ eligible | MERGE edge create-once |
| `foreach_loop_mutation` | ✅ eligible | FOREACH over fixed range |
| `single_edge_update` | ⛔ excluded | server-side `rand()` (§3.4) — outside any oracle |
| `detach_delete_user` | ⛔ excluded | variable counts — §6.4 |
| `remove_user_property_and_label` | ⛔ excluded | prepared state — §6.4 (pristine-base REMOVE is a degenerate no-op) |

A drift test pins both lists, so adding a write shape forces an explicit eligibility decision.

## Format v3 & hash discipline

- `OpEntry.oracle: Option<usize>` (`skip_serializing_if` — **v1/v2 manifests stay
  byte-identical**, pinned by existing goldens), `oracle/<op>.jsonl` with `{seq, stats}` records,
  `Bundle.oracle: BTreeMap<String, Vec<MutationStats>>`.
- `WorkloadHasher::oracle_record`: tag `M`, seq (u64 LE) + fixed 56-byte frame of the seven
  counters (i64 LE), length-framed like every other hash record, fed **after the op's commands**.
- `load()` gates (all before/at hash verification): pre-v3 manifest declaring oracle → reject;
  v3 with zero oracle entries → reject ("should have been v2"); the **exact-set pass** (above);
  jsonl length ≠ manifest count → reject; non-contiguous `seq` → **structural** reject (before
  hash, so seq edits give actionable errors while stat edits give a hash mismatch); stray
  `oracle/*.jsonl` not in the manifest → reject (with a repair hint when it is provably an
  interrupted attach next to a pre-v3 manifest — attach and capture both self-heal that case).
- `MutationStats` serde is strict: `deny_unknown_fields`, all seven counters required.

## Interpretation notes (explicit, per house rules)

1. **Oracle records are bound into the `workload_hash`.** The design's hash section predates v3;
   we bind outcomes because an unhashed oracle would be tamperable into silently-green replays —
   the exact class of the #265 duck findings (unhashed capability / kind reinterpretation). §7.5's
   byte-stability constraint concerns the **read** corpus hash; the A/B protocol is
   record-once/replay-twice, so an engine-build-specific v3 hash is compared only against itself.
2. **Stats only, not result values.** §6 item 3's sketch says "stats+result", but §5-Out rules out
   "any digest gating of write results" and §3.4 makes returned values irreproducible (`rand()`,
   engine-internal ids). The oracle records the seven `MutationStats` counters only. Documented as
   a deviation note on the phasing item in the design doc.
3. **Divergence is a hard replay error** (not a skip, not an advisory): a diverged outcome means
   the engine does *different work*, so measuring its latency would silently poison the A/B trend
   — and skips never gate (#265 finding 2). Mirrors the read tier's result-digest hard-gate. An
   oracle-bearing op that would be skipped fails closed for the same reason.
4. **Double-capture determinism guard at record time**: outcomes are only trusted after two
   independent full passes agree exactly (empirically verified **3584/3584** outcomes
   byte-identical at the repo-writes scale below).
5. **Complete-corpus capture cost is record-time-only** — but the replay verify pass scales with
   it too: verifying 1792 recorded outcomes (7 ops × 256) means 1792 untimed restore+run cycles
   per replay (~6.9 min at the 1 000/5 000 scale, below) **before** measurement. That is the cost
   of the correctness tier doing what it says; the latency tier (a plain v2 bundle) is unchanged.
6. **`meta.oracle_verified` is a non-breaking report addition**: optional, `serde(default)`,
   skip-serializing when `None` — the same pattern as `meta.label` (#234), which did not bump the
   run-report `SCHEMA_VERSION`. Pre-§6.3 reports still parse; old tools ignore the new field.

## Empirical evidence (pinned image)

Image: `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`
(edge, digest resolved at pull).

**Full-corpus capture + replay at the documented repo-writes scale**
(`--repo-writes --nodes 1000 --edges 5000 --seed 42`, this branch's binary, release build):

| Step | Result |
| --- | --- |
| `record --repo-writes --oracle` | **13 min 27 s** wall — 1792 outcomes (7 eligible ops × 256-command corpus) × 2 determinism passes = 3584 restore+run cycles; `workload_hash sha256:79f06e3f6f9604272f22378c8bb5bbce9e897268dbd08a1316400fd1c16db563` |
| Determinism | **3584/3584** outcomes byte-identical across the two passes (capture succeeds only if all agree) |
| `run --recording` of that v3 bundle | **6 min 53 s** wall (samples 2, C=1, cached) — verify pass re-reproduced all 1792 outcomes, then measured all 10 shapes; report `meta.oracle_verified` = 7 ops × 256 |

Design-phase probes (same image, probe scale 300/900): `restore_base` ≈ 36 ms/restore;
`merge_user_upsert_existing` → `properties_set:2, properties_removed:1`,
`foreach_loop_mutation` → `properties_set:3, properties_removed:2` — counters are value/state
dependent and must be captured, not modeled (§3.2).

Live e2e (this branch, same image): record+oracle at 300/900 → v3 manifest with exactly the 7
eligible ops, each covering its complete corpus → replay (under `--require-oracle`) green with
oracle verify pass + `meta.oracle_verified` attestation → base restored to 300/900; crafted
diverged oracle
(`attach_oracle` with a wrong counter) → replay hard-fails naming op/seq/counter **and still
restores the base**; two independent record+capture flows at the same seed → identical
`workload_hash`, post-capture graph content digest == fresh-restore digest; CLI re-record over a
v3 bundle → clean, both with `--oracle` (identical v3 reproduced) and without (v2, stale oracle
cleared).

## Part B delta — one additive optional field

Summary (v3) and cells (**v2**) schema versions are **unchanged**, but the cells `meta.baseline` /
`meta.candidate` (SideMeta) gain an **additive optional** `oracle_verified` field (op → verified
outcome count; key **absent**, not null, when un-attested — so pre-§6.3 payloads are unchanged
byte-wise). Same no-bump precedent as `meta.label` (#234) and the run report's `oracle_verified`
(this PR, note 6). Next-gen consumers need only forward-tolerance for an extra optional key;
frozen-contract tests (top-level field set) still pass unchanged.

## Gates

- `just ci` ✅ (build + clippy deny-warnings + tests)
- `FALKORDB_HOST/PORT just coverage` vs the pinned container ✅ — patch coverage **96.6%**
  (1423/1473 diff lines; ≥ 90% gate). Remaining misses are defensive-unreachable arms — the
  replay-side exact-set re-check and skip fail-closed guard, both unreachable through `load()` by
  construction — plus IO/engine-failure formatting closures, the capture nondeterminism error
  (needs a nondeterministic engine), and the setup-recovery *success* arm (needs a live mid-load
  failure with a subsequently healthy endpoint; the dual-failure arm **is** covered offline)
- `just doc-check` ✅ (doc-links + doc-shell), `just synthetic-sanity` ✅, `just synthetic-verify` ✅
- Live: all `synthetic_probe` tests including the 5 oracle e2e tests (full flow incl. attestation,
  diverged hard-fail, determinism + content-restore, CLI re-record retry, engine-failure context)
  + the pre-existing write/read replay suites ✅

## Docs

Design doc §6.3 status + phasing item (complete-corpus + exact-set + attestation + the
`--require-oracle` downgrade guard and error-safe setup, with the stats-only deviation note) + §5
deferred bullet; readme record/replay + `report --diff` sections (attestation guard, outcome-oracle
row, latency-tier warning); cookbook §6.3 variant (replay example now passes `--require-oracle`);
`recording.rs` module doc (bundle layout, exact-set rule, hash coverage,
offline-with-one-exception); CLI help for `--repo-writes`, `--oracle`, `--require-oracle`;
`synthetic-replay` Justfile doc-comment (flag forwarding).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional outcome-oracle capture for deterministic write benchmarks using `--oracle <endpoint>`.
  * Added oracle verification during replay before latency measurement, with hard failures on mismatched mutation outcomes.
  * Added `--require-oracle` to require verified write-benchmark outcomes.
  * Reports now show oracle verification status and coverage.

* **Bug Fixes**
  * Prevented incomplete, tampered, or mismatched oracle data from being replayed or compared.
  * Comparisons now flag oracle-attestation mismatches as not comparable.

* **Documentation**
  * Updated benchmark guides and design documentation with oracle usage, supported write shapes, and comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->