### PR TITLE
feat(synthetic): §6.4 prepared state — REMOVE + DETACH DELETE join the write oracle (9 of 10)

### DIFF
--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -121,9 +121,10 @@ not live state. **Fix:** error-safe final restore, forbid `--no-load` for writes
    This alone delivers per-op **trend** coverage for all 10 write shapes — the A/B trend goal.
 2. **Correctness tier (harder, partial, staged):** an **online-recorded per-command outcome oracle**
    (full `MutationStats` incl. deleted/removed counters) + **per-invocation pristine restore** + C=1,
-   initially for the **deterministic subset only** — excluding `single_edge_update` (server
-   `rand()`, permanently) and deferring `remove_user_property_and_label` (needs prepared state) +
-   `detach_delete_user` (variable counts) to §6.4, which delivered both (phasing item 4).
+   covering **9 of the 10 write shapes** — every shape except `single_edge_update` (server
+   `rand()`, permanently excluded per §3.4). Delivered in two stages: §6.3 shipped the initial
+   7-shape deterministic subset, then §6.4 (phasing item 4) added `remove_user_property_and_label`
+   (via the prepared load phase) and `detach_delete_user` (variable counts, exact per-command).
    Replaces the 5-variant `ExpectedMutation` with a **generalized per-invocation expected outcome**.
 
 Selection is an **orthogonal** `--repo-writes` axis (like Phase 6's `--repo-algorithms`), initially

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -16,7 +16,10 @@ guard) and the diff/regression guards treat a one-sided or differing attestation
 not-comparable; **stats only** — write result *values* stay un-captured per §3.4/§5-Out);
 §6.4 **implemented** (prepared state as a recorded load phase + `detach_delete_user` /
 `remove_user_property_and_label` oracle-eligible — 9 of the 10 shapes covered by the correctness
-tier); §6.5 (concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+tier — minting **recording format v4**; **amendment (post-review):** v4 requires the prepared
+phase and the nine-op exact set, while **format v3 is frozen** as the §6.3-era layout — the
+seven-op eligible set, no prepared phase — so pre-§6.4 v3 bundles keep loading and replaying
+under their own exact-set rule; cross-version rehash flips v3↔v4 are refused); §6.5 (concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
 merged in PRs #240–#250) and is the sibling of the algorithms design (Phase 6). The parent design
@@ -180,7 +183,15 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
    per-command setup statements because the §6.3 per-invocation restore already guarantees the
    state precedes every captured command, with zero new bundle machinery. Write-bundle
    `workload_hash`es change (the prepared statement is hashed); no committed bundle or golden
-   pins one. This phase also root-caused and fixed a pre-existing capture/verify flake: the
+   pins one. **Format amendment (review round 2):** growing the eligible set in place would have
+   re-defined what a valid v3 bundle *is* — a #267-era bundle (7 oracle ops, no prepared phase)
+   would retroactively fail the nine-op exact-set check. So §6.4 bundles mint **recording format
+   v4** (prepared phase **required**, nine-op exact set, `attach_oracle` upgrades v2→v4), and
+   **v3 is frozen** as recorded history: the seven-op eligible set (`LEGACY_V3_ORACLE_OPS`), no
+   prepared phase, still loading/replaying/verifying under its own exact-set rule and satisfying
+   `--require-oracle`. A v3 bundle carrying a prepared phase, a v4 bundle lacking one, and
+   rehashed v3↔v4 version flips are all rejected at load. This phase also root-caused and fixed
+   a pre-existing capture/verify flake: the
    per-command loops opened two fresh TCP connections per command (~9 200 rapid connects per
    capture), which stalls macOS Docker port-forwarding into a spurious send timeout — the §6.3
    loops now reuse **one connection per pass** (`restore_base_on`).

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -14,7 +14,9 @@ re-verifies every recorded outcome against the engine as an untimed C=1 correctn
 hard-fails on divergence, `--require-oracle` refuses oracle-less write bundles (v3→v2 downgrade
 guard) and the diff/regression guards treat a one-sided or differing attestation as
 not-comparable; **stats only** — write result *values* stay un-captured per §3.4/§5-Out);
-§6.4–§6.5 (prepared-state variants, concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+§6.4 **implemented** (prepared state as a recorded load phase + `detach_delete_user` /
+`remove_user_property_and_label` oracle-eligible — 9 of the 10 shapes covered by the correctness
+tier); §6.5 (concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
 merged in PRs #240–#250) and is the sibling of the algorithms design (Phase 6). The parent design
@@ -117,10 +119,11 @@ not live state. **Fix:** error-safe final restore, forbid `--no-load` for writes
    recorded-write worker, versioned bundle) that **measures write latency/throughput** with periodic
    base-graph reset to bound drift, and **asserts no correctness** (result + counters both untracked).
    This alone delivers per-op **trend** coverage for all 10 write shapes — the A/B trend goal.
-2. **Correctness tier (harder, partial, deferred):** an **online-recorded per-command outcome oracle**
+2. **Correctness tier (harder, partial, staged):** an **online-recorded per-command outcome oracle**
    (full `MutationStats` incl. deleted/removed counters) + **per-invocation pristine restore** + C=1,
-   for the **deterministic subset only** — excludes `single_edge_update` (server `rand()`) and defers
-   `remove_user_property_and_label` (needs prepared state) until the counter model is generalized.
+   initially for the **deterministic subset only** — excluding `single_edge_update` (server
+   `rand()`, permanently) and deferring `remove_user_property_and_label` (needs prepared state) +
+   `detach_delete_user` (variable counts) to §6.4, which delivered both (phasing item 4).
    Replaces the 5-variant `ExpectedMutation` with a **generalized per-invocation expected outcome**.
 
 Selection is an **orthogonal** `--repo-writes` axis (like Phase 6's `--repo-algorithms`), initially
@@ -130,10 +133,10 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 ## 5. Scope: in / out
 - **In (latency tier):** all 10 shapes, latency/throughput, periodic reset, opt-in nightly.
 - **In (correctness tier, staged):** the deterministic fixed-outcome subset (the two plain
-  create/update, the create-once MERGEs, `foreach_loop_mutation`) via the online oracle at C=1.
-- **Deferred:** `single_edge_update` (server `rand()`, §3.4 — outside any oracle),
-  `remove_user_property_and_label` (prepared state — from the pristine base the removal is a
-  degenerate no-op) and `detach_delete_user`'s variable counts (both §6.4); C>1 writes.
+  create/update, the create-once MERGEs, `foreach_loop_mutation`) via the online oracle at C=1;
+  since §6.4 also `remove_user_property_and_label` (against the recorded prepared state) and
+  `detach_delete_user` (variable counts, reproducible per-command from the restored base).
+- **Deferred:** `single_edge_update` (server `rand()`, §3.4 — outside any oracle); C>1 writes.
 - **Out:** Neo4j/Memgraph variants; any digest gating of write results; any change to the per-PR read
   gate or the A/B `--query-profile`.
 
@@ -163,8 +166,23 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
    above:* per-command **result values** are **not** captured — §5-Out rules out digest-gating
    write results and §3.4 makes returned values irreproducible (`rand()`, engine-internal ids),
    so the oracle records the `MutationStats` counters only.
-4. ⛔ **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count
-   `detach_delete_user`.
+4. ✅ **Prepared-state + removal shapes** (`remove_user_property_and_label`) and variable-count
+   `detach_delete_user` — both now **oracle-eligible** (9 of the 10 shapes; only
+   `single_edge_update` remains excluded, §3.4). The prepared state is a **recorded load
+   phase** (`prepared`, one deterministic constant statement appended to every `--repo-writes`
+   `graph.jsonl`: every `User` gains `rpc_social_credit = id % 97` + `:TemporaryLabel`), so it is
+   bound into the `workload_hash` and re-established by **every** base restore — each captured
+   `REMOVE` performs a real removal (`properties_removed=1`, `labels_removed=1`) and each
+   `DETACH DELETE` deletes the target plus its full degree (variable `relationships_deleted`
+   recorded per command). *Interpretation note:* the design sketch said "prepared state" without
+   fixing a mechanism; a load phase (mirroring §3.4's fixture precedent) was chosen over
+   per-command setup statements because the §6.3 per-invocation restore already guarantees the
+   state precedes every captured command, with zero new bundle machinery. Write-bundle
+   `workload_hash`es change (the prepared statement is hashed); no committed bundle or golden
+   pins one. This phase also root-caused and fixed a pre-existing capture/verify flake: the
+   per-command loops opened two fresh TCP connections per command (~9 200 rapid connects per
+   capture), which stalls macOS Docker port-forwarding into a spurious send timeout — the §6.3
+   loops now reuse **one connection per pass** (`restore_base_on`).
 5. ⛔ **Concurrency** — decide C>1 (per-worker id partitioning) or keep C=1 for correctness.
 6. 🚧 **Docs** — folded into each phase's PR (doc sync is part of each phase's definition of
    done): §6.1's readme + cookbook updates shipped with phase 1.

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -5,7 +5,7 @@ shapes — recording format v2 with kind-bound `workload_hash`, `--repo-writes` 
 `GRAPH.QUERY` C=1 measure path with per-cell base reset + verified error-safe final restore);
 §6.2 **implemented** (generalized `ExpectedOutcome` model, full 7-counter `MutationStats`,
 `restore_base` per-invocation restore primitive); §6.3 **implemented** (online outcome oracle:
-`record --oracle <endpoint>` captures per-command `MutationStats` for the deterministic subset
+`record --oracle <endpoint>` captures per-command `MutationStats` for the oracle-eligible shapes
 over each eligible op's **complete command corpus** — twice, determinism proven at record time —
 into **recording format v3** with the outcomes bound into the `workload_hash`; a v3 bundle must
 carry the oracle for **exactly** the eligible set, full corpus per op — enforced at load, attach
@@ -147,7 +147,7 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 2. ✅ **Generalized outcome model + full `MutationStats`** (`relationships_deleted`/`properties_removed`/
    `labels_removed`); per-invocation restore primitive (`replay::restore_base`).
 3. ✅ **Online outcome oracle** at record time (capture per-command stats), C=1 correctness tier
-   for the deterministic subset — 7 of the 10 shapes eligible; `single_edge_update` excluded
+   for the initial deterministic subset — 7 of the 10 shapes eligible at that stage; `single_edge_update` excluded
    (server `rand()`, §3.4), `detach_delete_user` + `remove_user_property_and_label` excluded
    until §6.4. The capture covers each eligible op's **complete command corpus** (per-command
    outcomes, no sampling), and a v3 bundle must carry the oracle for **exactly** the eligible
@@ -203,9 +203,10 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
 ## 8. Acceptance
 Latency tier: opt-in record + replay of all 10 write shapes on the FalkorDB per-PR image with periodic
 base reset, off the per-PR read gate, no correctness assertion. Correctness tier (staged): the
-deterministic subset verified at C=1 against an online-recorded per-command outcome oracle with
-per-invocation restore; `single_edge_update` and the removal/variable-count shapes explicitly
-deferred. A drift-guard binds the shape table to `queries_repository`'s 10 write names.
+oracle-eligible shapes verified at C=1 against an online-recorded per-command outcome oracle with
+per-invocation restore; `single_edge_update` permanently excluded (§3.4), and the
+removal/variable-count shapes — deferred by the initial §6.3 stage — delivered in §6.4
+(9 of the 10). A drift-guard binds the shape table to `queries_repository`'s 10 write names.
 
 ## 9. Rollout
 Land the phases behind `--repo-writes` in `FalkorDB/benchmark`; `falkordb-rs-next-gen` picks each up on

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -11,8 +11,8 @@ into **recording format v3** with the outcomes bound into the `workload_hash`; a
 carry the oracle for **exactly** the eligible set, full corpus per op — enforced at load, attach
 and replay — and the replay report attests the verified coverage (`meta.oracle_verified`); replay
 re-verifies every recorded outcome against the engine as an untimed C=1 correctness pass and
-hard-fails on divergence, `--require-oracle` refuses oracle-less write bundles (v3→v2 downgrade
-guard) and the diff/regression guards treat a one-sided or differing attestation as
+hard-fails on divergence, `--require-oracle` refuses oracle-less write bundles (oracle→v2
+downgrade guard) and the diff/regression guards treat a one-sided or differing attestation as
 not-comparable; **stats only** — write result *values* stay un-captured per §3.4/§5-Out);
 §6.4 **implemented** (prepared state as a recorded load phase + `detach_delete_user` /
 `remove_user_property_and_label` oracle-eligible — 9 of the 10 shapes covered by the correctness

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -256,10 +256,10 @@ per-PR `synthetic-verify` gate.
 record to also capture what each write **does** — not just how fast it is:
 
 ```bash
-# Record + capture the outcome oracle on a live FalkorDB (format v3; hash binds the outcomes):
+# Record + capture the outcome oracle on a live FalkorDB (format v4; hash binds the outcomes):
 benchmark synthetic record --repo-writes --nodes 1000 --edges 5000 --seed 7 \
-  --oracle falkor://127.0.0.1:6379 --out-dir rec-writes-v3
-benchmark synthetic run --recording rec-writes-v3 --require-oracle \
+  --oracle falkor://127.0.0.1:6379 --out-dir rec-writes-oracle
+benchmark synthetic run --recording rec-writes-oracle --require-oracle \
   --endpoint falkor://127.0.0.1:6379 --out writes.json
 ```
 
@@ -270,10 +270,12 @@ reproducible because every invocation starts from the restored base — and
 statement seeds on every `User`; only `single_edge_update` is excluded, for server `rand()`) once
 against the freshly restored pristine base and records the
 engine's mutation counters, then a **second pass** must reproduce every outcome exactly. The
-capture covers each eligible op's **complete command corpus**, and a v3 bundle must carry an
+capture covers each eligible op's **complete command corpus**, and a v4 bundle must carry an
 oracle for **exactly** the eligible set (full corpus per op, none anywhere else — enforced at
-load, attach and replay), so coverage can never silently shrink. Capture is a record-time-only
-cost: the two full passes over this 1 000/5 000 bundle take ~18 min. Replay of a v3 bundle
+load, attach and replay), so coverage can never silently shrink. Format **v3** is the frozen
+pre-§6.4 seven-op layout (no prepared phase): legacy v3 bundles still load and replay under
+their own exact-set rule, but new captures always mint v4. Capture is a record-time-only
+cost: the two full passes over this 1 000/5 000 bundle take ~18 min. Replay of an oracle bundle
 re-verifies each recorded outcome the same way (untimed, C=1, restore before every invocation)
 **before** measuring latency and **hard-fails on any divergence** — an engine that no longer
 creates/updates what was recorded is doing different work, so its latency would be meaningless —

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -243,14 +243,17 @@ This is the **latency tier** of the writes design: replay measures each write sh
 `GRAPH.QUERY` at its pinned **C=1 budget** (100 samples, warm-up 10), **resets the base graph
 before every measured cell** (op × cache mode) so mutation drift stays bounded, and asserts
 **nothing** about results or mutation counters (`result_digest` stays `null` — outcomes are state-
-and value-dependent). The replay finishes with an **error-safe final restore**: on success *and*
+and value-dependent). The recorded graph ends with a deterministic **prepared-state** statement
+(design §6.4: every `User` gains `rpc_social_credit` + `:TemporaryLabel`) so the `REMOVE` shape
+targets state that exists; it loads and restores like every other recorded statement and is bound
+into the `workload_hash`. The replay finishes with an **error-safe final restore**: on success *and*
 failure the recorded base is reloaded and its node/edge **content digests** are verified against
 the pristine post-load capture, so the endpoint's graph is provably left exactly as recorded.
 `--no-load` is refused for write bundles. Writes never enter `--repo-reads`, any tier, or the
 per-PR `synthetic-verify` gate.
 
-**Variant — the §6.3 outcome oracle (correctness tier).** Add `--oracle <endpoint>` to the record
-to also capture what each write **does** — not just how fast it is:
+**Variant — the §6.3/§6.4 outcome oracle (correctness tier).** Add `--oracle <endpoint>` to the
+record to also capture what each write **does** — not just how fast it is:
 
 ```bash
 # Record + capture the outcome oracle on a live FalkorDB (format v3; hash binds the outcomes):
@@ -260,14 +263,17 @@ benchmark synthetic run --recording rec-writes-v3 --require-oracle \
   --endpoint falkor://127.0.0.1:6379 --out writes.json
 ```
 
-Record-time capture runs every **oracle-eligible** command (the deterministic subset — 7 of the
-10 shapes; `single_edge_update` is excluded for server `rand()`, the two §6.4 prepared-state
-shapes stay latency-only) once against the freshly restored pristine base and records the
+Record-time capture runs every **oracle-eligible** command (9 of the 10 shapes: the §6.3
+deterministic subset plus, since §6.4, `detach_delete_user` — variable per-command delete counts,
+reproducible because every invocation starts from the restored base — and
+`remove_user_property_and_label`, which removes the property/label the recorded **prepared-state**
+statement seeds on every `User`; only `single_edge_update` is excluded, for server `rand()`) once
+against the freshly restored pristine base and records the
 engine's mutation counters, then a **second pass** must reproduce every outcome exactly. The
 capture covers each eligible op's **complete command corpus**, and a v3 bundle must carry an
 oracle for **exactly** the eligible set (full corpus per op, none anywhere else — enforced at
 load, attach and replay), so coverage can never silently shrink. Capture is a record-time-only
-cost: the two full passes over this 1 000/5 000 bundle take ~13½ min. Replay of a v3 bundle
+cost: the two full passes over this 1 000/5 000 bundle take ~18 min. Replay of a v3 bundle
 re-verifies each recorded outcome the same way (untimed, C=1, restore before every invocation)
 **before** measuring latency and **hard-fails on any divergence** — an engine that no longer
 creates/updates what was recorded is doing different work, so its latency would be meaningless —

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -281,7 +281,8 @@ re-verifies each recorded outcome the same way (untimed, C=1, restore before eve
 creates/updates what was recorded is doing different work, so its latency would be meaningless —
 and the report's `meta.oracle_verified` attests the verified coverage. Pass **`--require-oracle`**
 on the replay whenever the bundle is *expected* to carry the correctness tier (as above): a
-re-hashed v3→v2 strip is byte-indistinguishable from a legitimate latency-tier recording, so only
+re-hashed oracle→v2 strip is byte-indistinguishable from a legitimate latency-tier recording, so
+only
 your stated expectation can refuse the downgrade — and on the comparison side, `report --diff`
 aborts on a one-sided or differing `meta.oracle_verified` and prominently warns when two
 un-attested runs measured oracle-eligible write ops.

--- a/readme.md
+++ b/readme.md
@@ -497,17 +497,22 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   `merge_friend_edge_upsert`, `detach_delete_user`) as a **single-kind write bundle** in
   **recording format v2**, whose `workload_hash` additionally binds each op's read/write **kind**
   (v1 read bundles hash byte-identically to before). Same render-once discipline and full
-  256-command corpora as the reads; no fixture. Every write shape pins a **C=1 budget**
+  256-command corpora as the reads. The recorded graph ends with a **prepared-state statement**
+  (design §6.4: every `User` gains `rpc_social_credit` + `:TemporaryLabel`, deterministically) so
+  the `REMOVE` shape mutates state that actually exists — re-established by every base restore and
+  hash-bound like every other load statement. Every write shape pins a **C=1 budget**
   (100 samples, warm-up 10) and is **result-N/A by design** — this is the **latency tier** of the
   writes design: mutation outcomes (result stats/counters) are state- and value-dependent, so
   nothing is asserted about them. Write bundles are single-kind, so `--repo-writes` is mutually
   exclusive with **every** read selector (`--op`/`--all-reads`/`--tier`/`--repo-reads`/
   `--repo-algorithms`); writes never enter `--repo-reads`, any tier, or the per-PR
   `synthetic-verify` gate.
-  Adding **`--oracle <endpoint>`** (write bundles only) additionally captures the **§6.3 outcome
-  oracle**: every **oracle-eligible** write command (the deterministic subset — 7 of the 10 shapes;
-  excluded: `single_edge_update` (server `rand()`), `detach_delete_user` and
-  `remove_user_property_and_label` (deferred)) runs once against the recorded **pristine base** on
+  Adding **`--oracle <endpoint>`** (write bundles only) additionally captures the **§6.3/§6.4
+  outcome oracle**: every **oracle-eligible** write command (9 of the 10 shapes — the §6.3
+  deterministic subset plus, since §6.4, `detach_delete_user` (variable per-command delete counts,
+  reproducible from the restored base) and `remove_user_property_and_label` (real removals against
+  the prepared state); only `single_edge_update` stays excluded (server `rand()`)) runs once
+  against the recorded **pristine base** on
   that live FalkorDB endpoint — restored before every invocation — recording the mutation counters
   it reports; a **second full pass** must reproduce every outcome exactly (determinism is proven at
   record time, or the record fails naming the op/seq). The capture covers each eligible op's
@@ -519,7 +524,7 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   dual capture+restore failure surfaces both errors; the *initial* setup load is under the same
   discipline — a mid-load failure triggers one recovery restore and a combined error when that
   fails too). Capture is a record-time-only cost (the two
-  full passes over the 1 000-node/5 000-edge repo-writes bundle take ~13½ min); plain (oracle-free)
+  full passes over the 1 000-node/5 000-edge repo-writes bundle take ~18 min); plain (oracle-free)
   v1/v2 bundles stay byte-identical.
 - **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency

--- a/readme.md
+++ b/readme.md
@@ -573,17 +573,17 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   verified coverage (op → outcome
   count) — absent for oracle-less runs — so an oracle→v2 downgrade is visible when comparing runs.
   Only then are latencies measured, exactly as for a plain write bundle. Because a re-hashed
-  v3→v2 strip is byte-indistinguishable from a legitimate latency-tier recording (v2 hashes never
-  covered oracle data), pass **`--require-oracle`** whenever the bundle is *expected* to carry
-  the correctness tier: the replay then refuses (offline, before any connection) a write bundle
-  without an oracle, and errors on a read bundle (reads have none).
+  oracle→v2 strip is byte-indistinguishable from a legitimate latency-tier recording (v2 hashes
+  never covered oracle data), pass **`--require-oracle`** whenever the bundle is *expected* to
+  carry the correctness tier: the replay then refuses (offline, before any connection) a write
+  bundle without an oracle, and errors on a read bundle (reads have none).
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is
   expected and recorded), then writes a **Markdown diff** across every op × cache-mode × concurrency
   level (throughput + total-latency p50/p90/p95/p99 with deltas). The §6.3 **oracle attestation** is
   guarded the same way: a one-sided or differing `meta.oracle_verified` aborts (the runs did not run
-  the same correctness tier — a re-hashed v3→v2 downgrade looks exactly like this), the per-side
+  the same correctness tier — a re-hashed oracle→v2 downgrade looks exactly like this), the per-side
   attestation renders as an **outcome oracle** header row, and a pair of *un*-attested runs over
   oracle-eligible write ops gets a prominent latency-tier-only warning. `just
   synthetic-compare-versions` runs `run --recording` against both endpoints then `report --diff`.

--- a/readme.md
+++ b/readme.md
@@ -516,9 +516,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   that live FalkorDB endpoint — restored before every invocation — recording the mutation counters
   it reports; a **second full pass** must reproduce every outcome exactly (determinism is proven at
   record time, or the record fails naming the op/seq). The capture covers each eligible op's
-  **complete command corpus** (per-command outcomes, no sampling), and the resulting **format v3**
+  **complete command corpus** (per-command outcomes, no sampling), and the resulting **format v4**
   bundle must carry an oracle for **exactly** the eligible set — full corpus per op, none anywhere
-  else — enforced at load, attach and replay, so oracle coverage can never silently shrink. The
+  else — enforced at load, attach and replay, so oracle coverage can never silently shrink
+  (format **v3** is the frozen pre-§6.4 seven-op layout — no prepared phase — and legacy v3
+  bundles still load and replay under their own exact-set rule). The
   outcomes are **bound into the `workload_hash`**, and the endpoint's graph is left restored — on
   failure too, with the restored **content** verified against the pristine post-load digests (a
   dual capture+restore failure surfaces both errors; the *initial* setup load is under the same
@@ -560,14 +562,16 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   surfaces **both** errors). `--no-load` is refused for write bundles, a bundle can never mix
   reads with writes, and a write op can never be capability-gated (capabilities are unhashed, so
   a crafted one could otherwise skip-shrink the ten-shape coverage). When the bundle carries a
-  **§6.3 outcome oracle** (format v3, recorded with `--oracle`), replay first runs an untimed
+  **§6.3 outcome oracle** (format v4 — or the frozen legacy v3 — recorded with `--oracle`),
+  replay first runs an untimed
   **correctness pass**: every recorded outcome is re-verified — pristine base restored before
   each invocation, command run once, engine counters required to **equal** the recorded stats —
   and any divergence **hard-fails the replay** naming the op/seq/command (an engine that no
   longer effects the recorded outcome is doing *different work*, so measuring its latency would
   poison the A/B trend silently). The pass re-checks the exact-set rule (every eligible op, full
-  corpus) and the report's `meta.oracle_verified` attests the verified coverage (op → outcome
-  count) — absent for oracle-less runs — so a v3→v2 downgrade is visible when comparing runs.
+  corpus) against the bundle's format version and the report's `meta.oracle_verified` attests the
+  verified coverage (op → outcome
+  count) — absent for oracle-less runs — so an oracle→v2 downgrade is visible when comparing runs.
   Only then are latencies measured, exactly as for a plain write bundle. Because a re-hashed
   v3→v2 strip is byte-indistinguishable from a legitimate latency-tier recording (v2 hashes never
   covered oracle data), pass **`--require-oracle`** whenever the bundle is *expected* to carry

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -501,7 +501,7 @@ pub enum SyntheticCommands {
         #[arg(
             long = "require-oracle",
             requires = "recording",
-            help = "with --recording: refuse to measure a write bundle that carries no outcome oracle (recording format < v3). Guards against re-hashed v3-to-v2 downgrades; errors on read bundles (reads have no oracle)."
+            help = "with --recording: refuse to measure a write bundle that carries no outcome oracle (recording format < v3). Guards against re-hashed oracle-to-v2 downgrades; errors on read bundles (reads have no oracle)."
         )]
         require_oracle: bool,
     },
@@ -571,7 +571,7 @@ pub enum SyntheticCommands {
             long,
             requires = "repo_writes",
             value_name = "ENDPOINT",
-            help = "capture the write outcome ORACLE while recording (write bundles only): run EVERY command of each oracle-eligible write shape (9 of the 10 shapes — only the server-rand() single_edge_update is excluded; complete corpus) once against the recorded pristine base on this live FalkorDB endpoint (falkor://host:port), per-invocation restore, capture its mutation counters, prove determinism with a second full pass, and fold the outcomes into the bundle (format v3; hash-bound; the oracle must cover every eligible op exactly — no subset). Replay then re-verifies every recorded outcome at C=1 before measuring latency; any divergence is a hard replay error naming the op/seq/command."
+            help = "capture the write outcome ORACLE while recording (write bundles only): run EVERY command of each oracle-eligible write shape (9 of the 10 shapes — only the server-rand() single_edge_update is excluded; complete corpus) once against the recorded pristine base on this live FalkorDB endpoint (falkor://host:port), per-invocation restore, capture its mutation counters, prove determinism with a second full pass, and fold the outcomes into the bundle (format v4; hash-bound; the oracle must cover every eligible op exactly — no subset. Format v3 is the frozen seven-op pre-prepared-state layout; v3 bundles still load and replay under their own exact-set rule). Replay then re-verifies every recorded outcome at C=1 before measuring latency; any divergence is a hard replay error naming the op/seq/command."
         )]
         oracle: Option<String>,
         #[arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -555,7 +555,7 @@ pub enum SyntheticCommands {
         #[arg(
             long = "repo-writes",
             conflicts_with_all = ["ops", "all_reads", "tier", "repo_reads", "repo_algorithms"],
-            help = "record the A/B benchmark's 10 WRITE shapes from queries_repository (CREATE/SET/MERGE/DELETE/REMOVE/FOREACH) as a write bundle (recording format v2; the workload_hash binds each op's read/write kind). Replay measures them via GRAPH.QUERY at C=1 only, resetting the base graph before every measured cell and restoring + content-verifying it afterwards; results/counters are NOT asserted (latency tier) unless the bundle carries the --oracle outcomes. Write bundles are single-kind: mutually exclusive with every read selector."
+            help = "record the A/B benchmark's 10 WRITE shapes from queries_repository (CREATE/SET/MERGE/DELETE/REMOVE/FOREACH) as a write bundle (recording format v2; the workload_hash binds each op's read/write kind). The recorded graph includes a deterministic prepared-state statement (every User gains rpc_social_credit + :TemporaryLabel) so the REMOVE shape mutates state that exists. Replay measures them via GRAPH.QUERY at C=1 only, resetting the base graph before every measured cell and restoring + content-verifying it afterwards; results/counters are NOT asserted (latency tier) unless the bundle carries the --oracle outcomes. Write bundles are single-kind: mutually exclusive with every read selector."
         )]
         repo_writes: bool,
         #[arg(
@@ -571,7 +571,7 @@ pub enum SyntheticCommands {
             long,
             requires = "repo_writes",
             value_name = "ENDPOINT",
-            help = "capture the write outcome ORACLE while recording (write bundles only): run EVERY command of each oracle-eligible write shape (the deterministic subset — 7 of the 10 shapes, complete corpus) once against the recorded pristine base on this live FalkorDB endpoint (falkor://host:port), per-invocation restore, capture its mutation counters, prove determinism with a second full pass, and fold the outcomes into the bundle (format v3; hash-bound; the oracle must cover every eligible op exactly — no subset). Replay then re-verifies every recorded outcome at C=1 before measuring latency; any divergence is a hard replay error naming the op/seq/command."
+            help = "capture the write outcome ORACLE while recording (write bundles only): run EVERY command of each oracle-eligible write shape (9 of the 10 shapes — only the server-rand() single_edge_update is excluded; complete corpus) once against the recorded pristine base on this live FalkorDB endpoint (falkor://host:port), per-invocation restore, capture its mutation counters, prove determinism with a second full pass, and fold the outcomes into the bundle (format v3; hash-bound; the oracle must cover every eligible op exactly — no subset). Replay then re-verifies every recorded outcome at C=1 before measuring latency; any divergence is a hard replay error naming the op/seq/command."
         )]
         oracle: Option<String>,
         #[arg(

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -49,7 +49,7 @@ pub struct BaselineKey {
     /// The **oracle-eligible** write ops (§6.3 + §6.4, `shapes::oracle_eligible_names`) this run
     /// measured. Lets
     /// the guards flag a pair that measured eligible writes with *no* oracle on either side —
-    /// legitimate for a v2 latency-tier bundle, but exactly what a two-sided v3→v2 downgrade
+    /// legitimate for a v2 latency-tier bundle, but exactly what a two-sided oracle→v2 downgrade
     /// looks like, so it warrants a prominent warning. Empty for read runs and older baselines.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub eligible_write_ops: BTreeSet<String>,
@@ -110,7 +110,7 @@ fn attestation_summary(m: &BTreeMap<String, usize>) -> String {
 ///
 /// `Ok(warnings)` may carry the **downgrade-visibility** warning: both sides measured
 /// oracle-eligible write ops with no attestation at all. That pair is legitimate (a v2
-/// latency-tier bundle) but indistinguishable from a two-sided re-hashed v3→v2 strip, so it is
+/// latency-tier bundle) but indistinguishable from a two-sided re-hashed oracle→v2 strip, so it is
 /// surfaced prominently rather than silently passed (§6.3 — duck's downgrade finding).
 fn oracle_attestation_check(
     baseline: Option<&BTreeMap<String, usize>>,
@@ -128,16 +128,16 @@ fn oracle_attestation_check(
         )),
         (Some(b), None) => Err(format!(
             "oracle attestation is one-sided — baseline re-verified the write outcome oracle \
-             ({}) but candidate carries no attestation (latency tier only): a re-hashed v3→v2 \
-             downgrade looks exactly like this. Re-run the candidate against the oracle-bearing \
-             (v3) bundle, with `--require-oracle` to refuse the downgrade",
+             ({}) but candidate carries no attestation (latency tier only): a re-hashed \
+             oracle→v2 downgrade looks exactly like this. Re-run the candidate against the \
+             oracle-bearing bundle, with `--require-oracle` to refuse the downgrade",
             attestation_summary(b)
         )),
         (None, Some(c)) => Err(format!(
             "oracle attestation is one-sided — candidate re-verified the write outcome oracle \
-             ({}) but baseline carries no attestation (latency tier only): a re-hashed v3→v2 \
-             downgrade looks exactly like this. Re-run the baseline against the oracle-bearing \
-             (v3) bundle, with `--require-oracle` to refuse the downgrade",
+             ({}) but baseline carries no attestation (latency tier only): a re-hashed \
+             oracle→v2 downgrade looks exactly like this. Re-run the baseline against the \
+             oracle-bearing bundle, with `--require-oracle` to refuse the downgrade",
             attestation_summary(c)
         )),
         (None, None) if !eligible_ops.is_empty() => Ok(vec![format!(
@@ -851,7 +851,7 @@ mod tests {
             assert!(err.contains("one-sided"), "{err}");
             assert!(err.contains(&format!("Re-run the {side}")), "{err}");
             assert!(err.contains("--require-oracle"), "{err}");
-            assert!(err.contains("v3→v2"), "{err}");
+            assert!(err.contains("oracle→v2"), "{err}");
         }
         // Both absent over eligible write ops: legitimate but downgrade-shaped ⇒ warning.
         let warnings = oracle_attestation_check(None, None, &eligible).unwrap();

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -46,7 +46,8 @@ pub struct BaselineKey {
     /// kept it. Absent from pre-§6.3 baselines.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oracle_verified: Option<BTreeMap<String, usize>>,
-    /// The **oracle-eligible** write ops (the §6.3 deterministic subset) this run measured. Lets
+    /// The **oracle-eligible** write ops (§6.3 + §6.4, `shapes::oracle_eligible_names`) this run
+    /// measured. Lets
     /// the guards flag a pair that measured eligible writes with *no* oracle on either side —
     /// legitimate for a v2 latency-tier bundle, but exactly what a two-sided v3→v2 downgrade
     /// looks like, so it warrants a prominent warning. Empty for read runs and older baselines.
@@ -83,7 +84,7 @@ impl BaselineKey {
     }
 }
 
-/// The oracle-eligible write ops (§6.3 deterministic subset) present in a report's op set.
+/// The oracle-eligible write ops (§6.3 + §6.4) present in a report's op set.
 fn eligible_write_ops(report: &Report) -> BTreeSet<String> {
     let eligible = crate::synthetic::shapes::oracle_eligible_names();
     report

--- a/src/synthetic/dataset.rs
+++ b/src/synthetic/dataset.rs
@@ -290,8 +290,8 @@ pub fn corpus_hash(
 
 /// The phase a load statement belongs to, so a recorded bundle can label statements and a loader
 /// can report which phase failed. All phases run identically (execute + drain), but the ordering
-/// (index first, then nodes, then edges, then the optional fixture) matters and is preserved by
-/// [`load_statements`] / [`fixture_statements`].
+/// (index first, then nodes, then edges, then the optional fixture or prepared state) matters and
+/// is preserved by [`load_statements`] / [`fixture_statements`] / [`prepared_statements`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoadPhase {
     Index,
@@ -301,6 +301,10 @@ pub enum LoadPhase {
     /// the FixtureDependent read shapes. Emitted only when a recording includes those shapes; see
     /// [`fixture_statements`].
     Fixture,
+    /// The optional prepared state required by the state-dependent write shapes (design §6.4):
+    /// seeds the property/label that `remove_user_property_and_label` removes. Emitted only for
+    /// write bundles; see [`prepared_statements`].
+    Prepared,
 }
 
 impl LoadPhase {
@@ -311,6 +315,7 @@ impl LoadPhase {
             LoadPhase::Nodes => "nodes",
             LoadPhase::Edges => "edges",
             LoadPhase::Fixture => "fixture",
+            LoadPhase::Prepared => "prepared",
         }
     }
 
@@ -321,6 +326,7 @@ impl LoadPhase {
             "nodes" => Some(LoadPhase::Nodes),
             "edges" => Some(LoadPhase::Edges),
             "fixture" => Some(LoadPhase::Fixture),
+            "prepared" => Some(LoadPhase::Prepared),
             _ => None,
         }
     }
@@ -427,6 +433,27 @@ pub(crate) fn fixture_statements() -> impl Iterator<Item = (LoadPhase, String)> 
     FIXTURE_STMTS
         .iter()
         .map(|stmt| (LoadPhase::Fixture, (*stmt).to_string()))
+}
+
+/// The optional prepared-state statement required by the state-dependent write shapes
+/// (design §6.4): every base `User` gains the `rpc_social_credit` property and the
+/// `:TemporaryLabel` label, so `remove_user_property_and_label` (`REMOVE u.rpc_social_credit,
+/// u:TemporaryLabel`) performs a real removal on any target id instead of a pristine-base no-op.
+/// The statement is **constant** — no `spec`-derived values — and deterministic (`u.id % 97`
+/// mirrors the fixture's id-slice arithmetic), so it records and replays byte-identically and the
+/// oracle's per-invocation `restore_base` (drop + full reload) re-prepares the state before every
+/// captured command. Must run **after** [`load_statements`] (it `MATCH`es the loaded `:User`s).
+const PREPARED_STMTS: [&str; 1] =
+    ["MATCH (u:User) SET u.rpc_social_credit = u.id % 97, u:TemporaryLabel"];
+
+/// The [`PREPARED_STMTS`] tagged as [`LoadPhase::Prepared`], appended **after**
+/// [`load_statements`] when a **write** recording is made (`record_rendered_with_prepared`). Kept
+/// separate from `load_statements` so the live loader and every existing recording stay
+/// byte-identical: only write bundles carry these statements.
+pub(crate) fn prepared_statements() -> impl Iterator<Item = (LoadPhase, String)> {
+    PREPARED_STMTS
+        .iter()
+        .map(|stmt| (LoadPhase::Prepared, (*stmt).to_string()))
 }
 
 /// Generate the dataset described by `spec` and bulk-load it into `graph`, **replacing** whatever
@@ -732,6 +759,28 @@ mod tests {
         let s = spec(7, 200, 400);
         let phases: Vec<LoadPhase> = load_statements(&s, 32).map(|(p, _)| p).collect();
         assert!(!phases.contains(&LoadPhase::Fixture));
+        // Same guarantee for the §6.4 prepared state: only write bundles opt in.
+        assert!(!phases.contains(&LoadPhase::Prepared));
+    }
+
+    #[test]
+    fn prepared_statements_are_constant_deterministic_and_tagged() {
+        let a: Vec<(LoadPhase, String)> = prepared_statements().collect();
+        let b: Vec<(LoadPhase, String)> = prepared_statements().collect();
+        // Byte-identical across calls (constant, no spec/seed input) — the record-once/replay
+        // guarantee for the prepared state.
+        assert_eq!(a, b);
+        // One deterministic SET under the Prepared phase, seeding exactly what
+        // `remove_user_property_and_label` removes.
+        assert_eq!(a.len(), 1);
+        assert!(a.iter().all(|(p, _)| *p == LoadPhase::Prepared));
+        assert_eq!(a[0].1, "MATCH (u:User) SET u.rpc_social_credit = u.id % 97, u:TemporaryLabel");
+    }
+
+    #[test]
+    fn prepared_phase_tag_round_trips() {
+        assert_eq!(LoadPhase::Prepared.tag(), "prepared");
+        assert_eq!(LoadPhase::from_tag("prepared"), Some(LoadPhase::Prepared));
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1537,16 +1537,18 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             })?;
             let manifest = if repo_writes {
                 // Phase 7: record the 10 opt-in write shapes as a single-kind write bundle
-                // (recording format v2 — the workload_hash binds each op's kind). Same
-                // render-once discipline as the read shapes; no fixture (writes address the plain
-                // generated dataset). `--repo-writes` conflicts with every read selector, so a
-                // bundle is never mixed.
+                // (recording format v2+ — the workload_hash binds each op's kind). Same
+                // render-once discipline as the read shapes. The prepared-state statement (§6.4)
+                // is baked into the recorded graph so `remove_user_property_and_label` removes a
+                // property/label that exists, and the oracle's per-invocation restore re-prepares
+                // it before every captured command. `--repo-writes` conflicts with every read
+                // selector, so a bundle is never mixed.
                 let recorded = crate::synthetic::shapes::record_repo_writes(
                     spec.nodes as i32,
                     spec.edges as i32,
                     resolved.seed,
                 )?;
-                recording::record_rendered(
+                recording::record_rendered_with_prepared(
                     &spec,
                     &resolved.graph,
                     &recorded,
@@ -2544,6 +2546,12 @@ mod tests {
             crate::synthetic::shapes::write_shapes().iter().map(|s| s.name).collect();
         let recorded: Vec<&str> = bundle.manifest.ops.iter().map(|e| e.name.as_str()).collect();
         assert_eq!(recorded, expected, "exactly the 10 write shapes, in definition order");
+        // §6.4: the CLI arm records via `record_rendered_with_prepared`, so the graph ends with
+        // exactly the prepared-state statement (hash-bound; re-established by every restore).
+        let prepared: Vec<(dataset::LoadPhase, String)> =
+            crate::synthetic::dataset::prepared_statements().collect();
+        let tail = &bundle.graph_statements[bundle.graph_statements.len() - prepared.len()..];
+        assert_eq!(tail, prepared.as_slice(), "write bundles bake the §6.4 prepared state last");
         for entry in &bundle.manifest.ops {
             assert_eq!(entry.kind, QueryType::Write, "{}", entry.name);
             assert!(!entry.result_gated, "{} is latency-tier (§4.1)", entry.name);

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -72,7 +72,7 @@ pub async fn capture(
             bundle.manifest.format_version
         )));
     }
-    // The §6.3 eligibility table (single source of truth: the annotated write-shape table).
+    // The §6.3 + §6.4 eligibility table (single source of truth: the annotated write-shape table).
     // Every eligible op is captured over its COMPLETE corpus — the exact set + exact counts that
     // `recording::attach_oracle`/`load` enforce on the resulting v3 bundle.
     let eligible = oracle_eligible_names();
@@ -84,8 +84,8 @@ pub async fn capture(
         .collect();
     if targets.is_empty() {
         return Err(OtherError(
-            "--oracle: the bundle records no oracle-eligible write op (the §6.3 deterministic \
-             subset) — nothing to capture"
+            "--oracle: the bundle records no oracle-eligible write op (the §6.3 + §6.4 \
+             oracle-eligible set) — nothing to capture"
                 .to_string(),
         ));
     }
@@ -260,7 +260,7 @@ mod tests {
 
     #[tokio::test]
     async fn capture_rejects_a_bundle_with_no_eligible_op_offline() {
-        // A write bundle whose only op is not in the §6.3 deterministic subset has nothing to
+        // A write bundle whose only op is not in the §6.3 + §6.4 oracle-eligible set has nothing to
         // capture — fail offline, before any connection (the endpoint is unroutable).
         let dir = record_write_bundle("synthorc-inel", "w_custom");
         let err = capture("falkor://127.0.0.1:1", &dir, 5_000, 6_000).await.unwrap_err();

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -1,7 +1,9 @@
-//! Record-side §6.3 **outcome-oracle capture**: run each oracle-eligible write command against the
+//! Record-side §6.3/§6.4 **outcome-oracle capture**: run each oracle-eligible write command
+//! against the
 //! recorded **pristine base** on a live engine, capture the [`MutationStats`] it effects, prove the
 //! outcomes are deterministic with a second independent pass, and fold them into the bundle
-//! ([`recording::attach_oracle`], format v4).
+//! ([`recording::attach_oracle`], format v4 — the §6.4 nine-op eligible set over the recorded
+//! prepared state).
 //!
 //! This is the one deliberate departure from the offline read recorder (design §3.2 / risk §7.2):
 //! write counters are state/value/order-dependent — MERGE create-vs-match, SET-same-value counting
@@ -88,6 +90,21 @@ pub async fn capture(
              oracle-eligible set) — nothing to capture"
                 .to_string(),
         ));
+    }
+    // Preflight the §6.4 prepared-phase requirement `attach_oracle` enforces at the END of the
+    // capture, so a stale/hand-crafted bundle fails here in milliseconds instead of after the
+    // two full online passes.
+    if !bundle
+        .graph_statements
+        .iter()
+        .any(|(p, _)| *p == crate::synthetic::dataset::LoadPhase::Prepared)
+    {
+        return Err(OtherError(format!(
+            "{} lacks the §6.4 prepared load phase — a v{} oracle bundle records the prepared \
+             state; re-record the bundle with this build instead of capturing over a stale one",
+            dir.display(),
+            recording::RECORDING_FORMAT_VERSION_ORACLE_PREPARED
+        )));
     }
 
     // A minimal replay-shaped config: `restore_base` needs only the endpoint + timeouts.
@@ -290,6 +307,32 @@ mod tests {
         recording::attach_oracle(&dir, &oracle).unwrap();
         let err = capture("falkor://127.0.0.1:1", &dir, 5_000, 6_000).await.unwrap_err();
         assert!(format!("{err}").contains("already carries"), "got: {err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn capture_rejects_a_bundle_without_the_prepared_phase_offline() {
+        // A stale/hand-crafted v2 bundle without the §6.4 prepared phase would only fail at the
+        // END of the (expensive) online capture, in attach_oracle — the preflight must refuse it
+        // immediately, before any connection (closed port ⇒ the error is the preflight's).
+        let dir = temp_bundle_dir("synthorc-noprep");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("single_vertex_write", crate::queries_repository::QueryType::Write),
+            result_gated: false,
+            budget: Default::default(),
+            capability: None,
+            commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
+        }];
+        crate::synthetic::recording::record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        let err = capture("falkor://127.0.0.1:1", &dir, 5_000, 6_000).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("lacks the §6.4 prepared load phase"), "got: {msg}");
+        assert!(msg.contains("re-record the bundle"), "got: {msg}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -1,7 +1,7 @@
 //! Record-side §6.3 **outcome-oracle capture**: run each oracle-eligible write command against the
 //! recorded **pristine base** on a live engine, capture the [`MutationStats`] it effects, prove the
 //! outcomes are deterministic with a second independent pass, and fold them into the bundle
-//! ([`recording::attach_oracle`], format v3).
+//! ([`recording::attach_oracle`], format v4).
 //!
 //! This is the one deliberate departure from the offline read recorder (design §3.2 / risk §7.2):
 //! write counters are state/value/order-dependent — MERGE create-vs-match, SET-same-value counting
@@ -37,7 +37,7 @@ use std::time::Duration;
 use tracing::info;
 
 /// Capture the §6.3 outcome oracle for the (already-recorded) write bundle in `dir` against the
-/// live engine at `endpoint`, and fold it into the bundle (upgrading it to format v3).
+/// live engine at `endpoint`, and fold it into the bundle (upgrading it to format v4).
 ///
 /// For every **oracle-eligible** write op (the eligible subset —
 /// [`ShapeSpec::oracle`](crate::synthetic::shapes::ShapeSpec::oracle)), **every command of the
@@ -74,7 +74,7 @@ pub async fn capture(
     }
     // The §6.3 + §6.4 eligibility table (single source of truth: the annotated write-shape table).
     // Every eligible op is captured over its COMPLETE corpus — the exact set + exact counts that
-    // `recording::attach_oracle`/`load` enforce on the resulting v3 bundle.
+    // `recording::attach_oracle`/`load` enforce on the resulting v4 bundle.
     let eligible = oracle_eligible_names();
     let targets: Vec<(String, Vec<String>)> = bundle
         .commands
@@ -234,7 +234,7 @@ fn reconcile_capture_and_restore(
 mod tests {
     use super::*;
     use crate::synthetic::dataset::DatasetSpec;
-    use crate::synthetic::recording::{record_rendered, temp_bundle_dir, RecordedOp};
+    use crate::synthetic::recording::{record_rendered_with_prepared, temp_bundle_dir, RecordedOp};
     use crate::synthetic::OpKey;
 
     fn record_write_bundle(
@@ -254,7 +254,7 @@ mod tests {
             capability: None,
             commands: vec!["CYPHER x=1 CREATE (n:User {id:$x})".to_string()],
         }];
-        record_rendered(&spec, "g", &ops, 1, 8, &dir).unwrap();
+        record_rendered_with_prepared(&spec, "g", &ops, 1, 8, &dir).unwrap();
         dir
     }
 

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -25,7 +25,9 @@ use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::synthetic::op_runner::run_and_drain;
 use crate::synthetic::recording::{self, Bundle};
-use crate::synthetic::replay::{capture_graph_content, restore_and_verify, restore_base, ReplayConfig};
+use crate::synthetic::replay::{
+    capture_graph_content, restore_and_verify, restore_base, restore_base_on, ReplayConfig,
+};
 use crate::synthetic::shapes::oracle_eligible_names;
 use crate::synthetic::writes::MutationStats;
 use crate::synthetic::{open_graph, CacheSelection};
@@ -37,7 +39,7 @@ use tracing::info;
 /// Capture the §6.3 outcome oracle for the (already-recorded) write bundle in `dir` against the
 /// live engine at `endpoint`, and fold it into the bundle (upgrading it to format v3).
 ///
-/// For every **oracle-eligible** write op (the deterministic subset —
+/// For every **oracle-eligible** write op (the eligible subset —
 /// [`ShapeSpec::oracle`](crate::synthetic::shapes::ShapeSpec::oracle)), **every command of the
 /// full corpus** runs **once from a freshly restored pristine base**, recording the
 /// [`MutationStats`] the engine reports. A second full pass then repeats the capture; any
@@ -183,11 +185,14 @@ async fn capture_pass(
 ) -> BenchmarkResult<BTreeMap<String, Vec<MutationStats>>> {
     let client_deadline = Duration::from_millis(config.client_deadline_ms);
     let mut out = BTreeMap::new();
+    // ONE connection for the whole pass: a per-command fresh socket (thousands of rapid
+    // connects) exhausts the host's ephemeral-port/proxy budget and stalls into a spurious
+    // send timeout — see `restore_base_on`.
+    let mut graph = open_graph(&config.endpoint, graph_name).await?;
     for (name, cyphers) in targets {
         let mut outcomes = Vec::with_capacity(cyphers.len());
         for (seq, cypher) in cyphers.iter().enumerate() {
-            restore_base(config, bundle, graph_name, &bundle.spec()).await?;
-            let mut graph = open_graph(&config.endpoint, graph_name).await?;
+            restore_base_on(&mut graph, config, bundle, graph_name, &bundle.spec()).await?;
             let sample = run_and_drain(
                 &mut graph,
                 QueryType::Write,

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -748,7 +748,7 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
     }
     // Exact-set enforcement (§6.3): a v3 bundle must carry an oracle for EVERY recorded
     // oracle-eligible write op, covering its COMPLETE command corpus, and for nothing else — so
-    // oracle coverage can never silently shrink (a crafted 1-of-7 subset, or a padded oracle on
+    // oracle coverage can never silently shrink (a crafted proper subset, or a padded oracle on
     // an op outside the eligible set, is rejected here rather than replayed).
     if manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE {
         let eligible = crate::synthetic::shapes::oracle_eligible_names();

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -875,6 +875,16 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
                 .to_string(),
         ));
     }
+    // The symmetric gate: the fixture phase (fulltext/vector DDL) exists solely for the
+    // FixtureDependent READ shapes — on a write bundle it is crafted/corrupt (and non-portable
+    // FalkorDB-specific DDL a write replay would blindly load).
+    if has_write_ops && graph_statements.iter().any(|(p, _)| *p == LoadPhase::Fixture) {
+        return Err(OtherError(
+            "bundle carries a fixture load phase but records write ops — the fixture exists \
+             solely for the fixture-dependent read shapes (crafted/corrupt bundle)"
+                .to_string(),
+        ));
+    }
     if manifest.format_version == RECORDING_FORMAT_VERSION_ORACLE && has_prepared {
         return Err(OtherError(format!(
             "format_version {} bundle carries a §6.4 prepared load phase — v{} is the frozen \
@@ -3067,6 +3077,37 @@ mod tests {
         let err = load(&dir).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("records no write ops"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_fixture_phase_on_a_write_bundle() {
+        // The symmetric gate: the fixture phase (fulltext/vector DDL) exists solely for the
+        // fixture-dependent READ shapes — crafted onto a write bundle it must be rejected even
+        // when hash-valid.
+        let dir = record_write_bundle_to_temp("synthrec-fixture-on-write");
+        let graph_path = dir.join("graph.jsonl");
+        let n_stmts = std::fs::read_to_string(&graph_path)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .count();
+        let rec = GraphRecord {
+            seq: n_stmts,
+            phase: "fixture".to_string(),
+            cypher: "CALL db.idx.fulltext.createNodeIndex('User', 'name')".to_string(),
+        };
+        let mut text = std::fs::read_to_string(&graph_path).unwrap();
+        text.push_str(&serde_json::to_string(&rec).unwrap());
+        text.push('\n');
+        std::fs::write(&graph_path, text).unwrap();
+        test_forge::rehash_bundle(&dir);
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("fixture") && msg.contains("records write ops"),
+            "got: {msg}"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -36,7 +36,8 @@ use crate::error::BenchmarkResult;
 use crate::queries_repository::QueryType;
 use crate::synthetic::catalog::{spec, RecordedBudget};
 use crate::synthetic::dataset::{
-    fixture_statements, load_statements, DatasetSpec, LoadPhase, GENERATOR_VERSION,
+    fixture_statements, load_statements, prepared_statements, DatasetSpec, LoadPhase,
+    GENERATOR_VERSION,
 };
 use crate::synthetic::writes::MutationStats;
 use crate::synthetic::{OpKey, OpName};
@@ -454,7 +455,7 @@ pub fn record_rendered(
     batch_size: usize,
     out_dir: &Path,
 ) -> BenchmarkResult<Manifest> {
-    record_rendered_impl(dataset, graph, ops, corpus_seed, batch_size, out_dir, false)
+    record_rendered_impl(dataset, graph, ops, corpus_seed, batch_size, out_dir, ExtraLoad::None)
 }
 
 /// Like [`record_rendered`], but also appends the post-load [`fixture_statements`] (the fulltext +
@@ -474,12 +475,53 @@ pub fn record_rendered_with_fixture(
     batch_size: usize,
     out_dir: &Path,
 ) -> BenchmarkResult<Manifest> {
-    record_rendered_impl(dataset, graph, ops, corpus_seed, batch_size, out_dir, true)
+    record_rendered_impl(dataset, graph, ops, corpus_seed, batch_size, out_dir, ExtraLoad::Fixture)
 }
 
-/// Shared body of [`record_rendered`] / [`record_rendered_with_fixture`]. When `include_fixture` is
-/// set, the fixture statements are streamed into `graph.jsonl` after the base load statements and
-/// hashed in the same order, so the two entry points differ only by whether the fixture is present.
+/// Like [`record_rendered`], but also appends the post-load [`prepared_statements`] (the
+/// deterministic prepared state the state-dependent write shapes address, design §6.4) to
+/// `graph.jsonl`, folded into the [`Manifest::workload_hash`]. Used for `--repo-writes` bundles so
+/// `remove_user_property_and_label` removes a property/label that actually exists — and because
+/// the oracle's per-invocation `restore_base` replays the full `graph.jsonl`, the prepared state
+/// is re-established before **every** captured command (a REMOVE is never a stale no-op). The
+/// statement is constant (no `spec`/seed-derived values) and plain Cypher, so write bundles remain
+/// engine-agnostic.
+pub fn record_rendered_with_prepared(
+    dataset: &DatasetSpec,
+    graph: &str,
+    ops: &[RecordedOp],
+    corpus_seed: u64,
+    batch_size: usize,
+    out_dir: &Path,
+) -> BenchmarkResult<Manifest> {
+    record_rendered_impl(dataset, graph, ops, corpus_seed, batch_size, out_dir, ExtraLoad::Prepared)
+}
+
+/// Which optional statement block [`record_rendered_impl`] appends to `graph.jsonl` after the base
+/// load statements: the FixtureDependent read fixture, the §6.4 prepared write state, or nothing.
+/// The two never coexist — a bundle is all-read or all-write.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ExtraLoad {
+    None,
+    Fixture,
+    Prepared,
+}
+
+impl ExtraLoad {
+    /// The extra statements, in load order, as a boxed iterator (`None` contributes nothing).
+    fn statements(self) -> Box<dyn Iterator<Item = (LoadPhase, String)>> {
+        match self {
+            ExtraLoad::None => Box::new(std::iter::empty()),
+            ExtraLoad::Fixture => Box::new(fixture_statements()),
+            ExtraLoad::Prepared => Box::new(prepared_statements()),
+        }
+    }
+}
+
+/// Shared body of [`record_rendered`] / [`record_rendered_with_fixture`] /
+/// [`record_rendered_with_prepared`]. The `extra` statements are streamed into `graph.jsonl` after
+/// the base load statements and hashed in the same order, so the entry points differ only by which
+/// optional block is present.
 fn record_rendered_impl(
     dataset: &DatasetSpec,
     graph: &str,
@@ -487,7 +529,7 @@ fn record_rendered_impl(
     corpus_seed: u64,
     batch_size: usize,
     out_dir: &Path,
-    include_fixture: bool,
+    extra: ExtraLoad,
 ) -> BenchmarkResult<Manifest> {
     dataset.validate()?;
     if batch_size == 0 {
@@ -575,17 +617,13 @@ fn record_rendered_impl(
     );
 
     // graph.jsonl — streamed straight from the lazy statement iterator (one batch in memory). When
-    // a fixture is requested, its statements follow the base load statements in the same stream, so
-    // they are written and hashed in that exact order (index → nodes → edges → fixture).
+    // an extra block (fixture / prepared state) is requested, its statements follow the base load
+    // statements in the same stream, so they are written and hashed in that exact order
+    // (index → nodes → edges → extra).
     let graph_path = out_dir.join("graph.jsonl");
     {
         let mut w = BufWriter::new(create_file(&graph_path)?);
-        // Append the fixture statements only when requested; `None` contributes nothing to the stream.
-        let fixture = include_fixture
-            .then(fixture_statements)
-            .into_iter()
-            .flatten();
-        let stmts = load_statements(dataset, batch_size).chain(fixture);
+        let stmts = load_statements(dataset, batch_size).chain(extra.statements());
         for (seq, (phase, stmt)) in stmts.enumerate() {
             hasher.graph_record(phase.tag(), &stmt);
             let rec = GraphRecord {
@@ -1355,6 +1393,52 @@ mod tests {
         // the fixture is folded into the hash (so it can't be silently dropped on replay).
         let dir2 = temp_bundle_dir("synthrec-nofixture");
         let without = record_rendered(&spec, "gfix", &ops, 9, 32, &dir2).unwrap();
+        assert_ne!(with.workload_hash, without.workload_hash);
+
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::remove_dir_all(&dir2).ok();
+    }
+
+    #[test]
+    fn record_rendered_with_prepared_appends_prepared_state_and_changes_hash() {
+        // A --repo-writes recording bakes the §6.4 prepared-state statement into `graph.jsonl`
+        // (so REMOVE targets state that exists, re-established by every oracle restore) and folds
+        // it into the workload_hash.
+        let dir = temp_bundle_dir("synthrec-prepared");
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 200,
+            edges: 400,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("remove_user_property_and_label", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec![
+                "MATCH (u:User {id: 3}) REMOVE u.rpc_social_credit, u:TemporaryLabel RETURN u.id"
+                    .to_string(),
+            ],
+        }];
+        let with = record_rendered_with_prepared(&spec, "gprep", &ops, 9, 32, &dir).unwrap();
+
+        // The bundle survives the integrity gate and its graph is base load stmts + prepared.
+        let bundle = load(&dir).unwrap();
+        assert_eq!(bundle.manifest, with);
+        let base: Vec<(LoadPhase, String)> = load_statements(&spec, 32).collect();
+        let prepared: Vec<(LoadPhase, String)> = prepared_statements().collect();
+        let want: Vec<(LoadPhase, String)> = base.iter().chain(prepared.iter()).cloned().collect();
+        assert_eq!(bundle.graph_statements, want);
+        // The trailing statements are exactly the prepared phase, in order.
+        let tail = &bundle.graph_statements[bundle.graph_statements.len() - prepared.len()..];
+        assert_eq!(tail, prepared.as_slice());
+        // A write-only bundle keeps the kind-bound format (v2 — no oracle data attached here).
+        assert_eq!(bundle.manifest.format_version, RECORDING_FORMAT_VERSION_WRITES);
+
+        // Recording the same spec/ops *without* the prepared state yields a different
+        // workload_hash, proving it is folded into the hash (it can't be silently dropped).
+        let dir2 = temp_bundle_dir("synthrec-noprepared");
+        let without = record_rendered(&spec, "gprep", &ops, 9, 32, &dir2).unwrap();
         assert_ne!(with.workload_hash, without.workload_hash);
 
         std::fs::remove_dir_all(&dir).ok();

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -63,14 +63,54 @@ pub const RECORDING_FORMAT_VERSION_WRITES: u32 = 2;
 
 /// On-disk bundle format version for **write** bundles carrying a §6.3 **outcome oracle**:
 /// per-command [`MutationStats`] captured online against the pristine base at record time
-/// (`oracle/<op>.jsonl`, written by [`attach_oracle`]) and re-verified per invocation at replay.
-/// Oracle records **are** folded into the `workload_hash` (tagged, length-framed parts), so a
-/// recorded outcome cannot be edited without detection; v1/v2 bundles and their hashes stay
-/// byte-identical.
+/// (`oracle/<op>.jsonl`) and re-verified per invocation at replay. Oracle records **are** folded
+/// into the `workload_hash` (tagged, length-framed parts), so a recorded outcome cannot be edited
+/// without detection; v1/v2 bundles and their hashes stay byte-identical.
+///
+/// **Frozen legacy layout (§6.3-era).** A v3 bundle carries oracles for exactly the
+/// [`LEGACY_V3_ORACLE_OPS`] (the seven-op §6.3 eligible set) and **no prepared load phase** —
+/// that is what every v3 bundle ever recorded looks like, and it keeps loading and replaying
+/// under its own exact-set rule forever. When §6.4 grew the eligible set to nine and added the
+/// prepared phase, the format moved to [`RECORDING_FORMAT_VERSION_ORACLE_PREPARED`] rather than
+/// changing v3's meaning in place.
 pub const RECORDING_FORMAT_VERSION_ORACLE: u32 = 3;
 
+/// On-disk bundle format version for §6.4 **prepared oracle** bundles — what
+/// [`attach_oracle`] mints today: the oracle covers exactly the **live** oracle-eligible set
+/// (nine ops, [`shapes::oracle_eligible_names`](crate::synthetic::shapes::oracle_eligible_names))
+/// and the recorded graph **must** end with the §6.4 prepared load phase (the state the
+/// `REMOVE` shape mutates). Same hash rules as v3 (oracle records hash-bound); the version
+/// byte differs, so a v3↔v4 rehash flip is caught by the layout gates even before content.
+pub const RECORDING_FORMAT_VERSION_ORACLE_PREPARED: u32 = 4;
+
 /// The newest bundle format this build can [`load`].
-const RECORDING_FORMAT_VERSION_MAX: u32 = RECORDING_FORMAT_VERSION_ORACLE;
+const RECORDING_FORMAT_VERSION_MAX: u32 = RECORDING_FORMAT_VERSION_ORACLE_PREPARED;
+
+/// The §6.3-era oracle-eligible write ops — **frozen** as recorded history: this is the exact
+/// set a format-v3 bundle must carry oracles for. Never derive it from the live shape registry
+/// (that is what [`RECORDING_FORMAT_VERSION_ORACLE_PREPARED`] uses); v3's meaning never changes
+/// again, or every existing v3 bundle would retroactively become "corrupt".
+const LEGACY_V3_ORACLE_OPS: [&str; 7] = [
+    "single_vertex_write",
+    "single_vertex_update",
+    "single_edge_write",
+    "merge_user_insert_path",
+    "merge_user_upsert_existing",
+    "merge_friend_edge_upsert",
+    "foreach_loop_mutation",
+];
+
+/// The oracle-eligible op names a bundle of `format_version` is required to cover exactly:
+/// the frozen [`LEGACY_V3_ORACLE_OPS`] for v3, the live registry for v4+.
+pub(crate) fn oracle_required_ops(
+    format_version: u32,
+) -> std::collections::BTreeSet<&'static str> {
+    if format_version >= RECORDING_FORMAT_VERSION_ORACLE_PREPARED {
+        crate::synthetic::shapes::oracle_eligible_names()
+    } else {
+        LEGACY_V3_ORACLE_OPS.iter().copied().collect()
+    }
+}
 
 /// The dataset knobs a bundle was recorded from (mirrors [`DatasetSpec`], but owned + serde).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -763,12 +803,14 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
             RECORDING_FORMAT_VERSION_WRITES
         )));
     }
-    // Exact-set enforcement (§6.3): a v3 bundle must carry an oracle for EVERY recorded
-    // oracle-eligible write op, covering its COMPLETE command corpus, and for nothing else — so
-    // oracle coverage can never silently shrink (a crafted proper subset, or a padded oracle on
-    // an op outside the eligible set, is rejected here rather than replayed).
+    // Exact-set enforcement (§6.3): an oracle bundle must carry an oracle for EVERY recorded
+    // write op its format version deems eligible ([`oracle_required_ops`]: the frozen legacy
+    // seven for v3, the live nine-op registry for v4+), covering its COMPLETE command corpus,
+    // and for nothing else — so oracle coverage can never silently shrink (a crafted proper
+    // subset, or a padded oracle on an op outside the eligible set, is rejected here rather
+    // than replayed).
     if manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE {
-        let eligible = crate::synthetic::shapes::oracle_eligible_names();
+        let eligible = oracle_required_ops(manifest.format_version);
         for entry in &manifest.ops {
             let is_eligible =
                 entry.kind == QueryType::Write && eligible.contains(entry.name.as_str());
@@ -777,7 +819,7 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
                     return Err(OtherError(format!(
                         "oracle-eligible op '{}' carries no outcome oracle — a v{} bundle must \
                          cover every eligible op (§6.3 exact-set rule; crafted/corrupt manifest)",
-                        entry.name, RECORDING_FORMAT_VERSION_ORACLE
+                        entry.name, manifest.format_version
                     )));
                 }
                 (true, Some(n)) if n != entry.count => {
@@ -798,9 +840,8 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
                 (false, Some(_)) => {
                     return Err(OtherError(format!(
                         "manifest declares an outcome oracle for op '{}', which is not \
-                         oracle-eligible (§6.3 + §6.4 eligible set only; crafted/corrupt \
-                         manifest)",
-                        entry.name
+                         oracle-eligible under format v{} (crafted/corrupt manifest)",
+                        entry.name, manifest.format_version
                     )));
                 }
                 _ => {}
@@ -821,6 +862,35 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
             ))
         })?;
         graph_statements.push((phase, rec.cypher.clone()));
+    }
+    // Format ↔ layout gates on the (hash-bound) prepared phase: v3 is the frozen §6.3-era
+    // layout that PREDATES the prepared state, v4 is defined by it — so a version flip on a
+    // rehashed bundle is caught structurally, not just by the eligible-set difference.
+    let has_prepared = graph_statements.iter().any(|(p, _)| *p == LoadPhase::Prepared);
+    let has_write_ops = manifest.ops.iter().any(|e| e.kind == QueryType::Write);
+    if has_prepared && !has_write_ops {
+        return Err(OtherError(
+            "bundle carries a §6.4 prepared load phase but records no write ops — the prepared \
+             state exists solely for the write shapes (crafted/corrupt bundle)"
+                .to_string(),
+        ));
+    }
+    if manifest.format_version == RECORDING_FORMAT_VERSION_ORACLE && has_prepared {
+        return Err(OtherError(format!(
+            "format_version {} bundle carries a §6.4 prepared load phase — v{} is the frozen \
+             §6.3-era layout that predates the prepared state; prepared oracle bundles are \
+             format_version {} (crafted/downgraded manifest)",
+            manifest.format_version,
+            RECORDING_FORMAT_VERSION_ORACLE,
+            RECORDING_FORMAT_VERSION_ORACLE_PREPARED
+        )));
+    }
+    if manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE_PREPARED && !has_prepared {
+        return Err(OtherError(format!(
+            "format_version {} bundle lacks the §6.4 prepared load phase — v{} bundles record \
+             the prepared state the REMOVE shape mutates (crafted/upgraded manifest)",
+            manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE_PREPARED
+        )));
     }
 
     // commands/<op>.jsonl for each op named in the manifest, in order.
@@ -995,10 +1065,13 @@ impl Bundle {
     }
 }
 
-/// Fold captured §6.3 oracle outcomes into an existing **v2 write bundle**, upgrading it in place
-/// to format v3: write `oracle/<op>.jsonl` for every op in `oracle`, mark each op's manifest entry
-/// with its record count, and recompute the [`Manifest::workload_hash`] under v3 rules (the oracle
-/// records are hash-bound — see [`WorkloadHasher::oracle_record`]). The upgraded bundle is
+/// Fold captured §6.3/§6.4 oracle outcomes into an existing **v2 write bundle**, upgrading it in
+/// place to format **v4** ([`RECORDING_FORMAT_VERSION_ORACLE_PREPARED`]): write
+/// `oracle/<op>.jsonl` for every op in `oracle`, mark each op's manifest entry
+/// with its record count, and recompute the [`Manifest::workload_hash`] under oracle rules (the
+/// oracle records are hash-bound — see [`WorkloadHasher::oracle_record`]). The bundle must carry
+/// the §6.4 prepared load phase (every write bundle recorded by this build does); the frozen
+/// legacy v3 layout is load/replay-only and can never be minted again. The upgraded bundle is
 /// re-[`load`]ed as the final step, so the function returns exactly what every future load will
 /// verify — any inconsistency this function could write fails here, at record time.
 ///
@@ -1046,9 +1119,9 @@ pub fn attach_oracle(
         return Err(OtherError("no oracle outcomes to attach (empty capture)".to_string()));
     }
     // Exact-set enforcement (§6.3): the oracle must cover every recorded oracle-eligible write op
-    // with its COMPLETE command corpus — no subset, no strays — so v3 coverage can never silently
+    // with its COMPLETE command corpus — no subset, no strays — so v4 coverage can never silently
     // shrink below the tier the format version promises.
-    let eligible = crate::synthetic::shapes::oracle_eligible_names();
+    let eligible = oracle_required_ops(RECORDING_FORMAT_VERSION_ORACLE_PREPARED);
     for entry in &bundle.manifest.ops {
         let is_eligible =
             entry.kind == QueryType::Write && eligible.contains(entry.name.as_str());
@@ -1057,7 +1130,7 @@ pub fn attach_oracle(
                 return Err(OtherError(format!(
                     "no oracle captured for oracle-eligible op '{}' — a v{} bundle must cover \
                      every eligible op (§6.3 exact-set rule)",
-                    entry.name, RECORDING_FORMAT_VERSION_ORACLE
+                    entry.name, RECORDING_FORMAT_VERSION_ORACLE_PREPARED
                 )));
             }
             (true, Some(outcomes)) if outcomes.len() != entry.count => {
@@ -1071,7 +1144,7 @@ pub fn attach_oracle(
             }
             (false, Some(_)) => {
                 return Err(OtherError(format!(
-                    "oracle captured for op '{}', which is not oracle-eligible (§6.3 + §6.4 \
+                    "oracle captured for op '{}', which is not oracle-eligible (the live \
                      eligible set only)",
                     entry.name
                 )));
@@ -1085,6 +1158,16 @@ pub fn attach_oracle(
         return Err(OtherError(format!(
             "oracle captured for op '{}', which the bundle does not record",
             name
+        )));
+    }
+    // v4 is defined by the §6.4 prepared phase: every write bundle this build records carries
+    // it, so its absence means a stale/crafted bundle that must be re-recorded, not upgraded.
+    if !bundle.graph_statements.iter().any(|(p, _)| *p == LoadPhase::Prepared) {
+        return Err(OtherError(format!(
+            "{} lacks the §6.4 prepared load phase — a v{} oracle bundle records the prepared \
+             state; re-record the bundle with this build instead of attaching to a stale one",
+            dir.display(),
+            RECORDING_FORMAT_VERSION_ORACLE_PREPARED
         )));
     }
 
@@ -1101,9 +1184,9 @@ pub fn attach_oracle(
         w.flush().map_err(|e| OtherError(format!("flushing {}: {}", path.display(), e)))?;
     }
 
-    // Upgraded manifest: v3, per-op oracle counts, hash recomputed over the full v3 stream.
+    // Upgraded manifest: v4, per-op oracle counts, hash recomputed over the full oracle stream.
     let mut manifest = bundle.manifest.clone();
-    manifest.format_version = RECORDING_FORMAT_VERSION_ORACLE;
+    manifest.format_version = RECORDING_FORMAT_VERSION_ORACLE_PREPARED;
     for entry in &mut manifest.ops {
         entry.oracle = oracle.get(&entry.name).map(Vec::len);
     }
@@ -1183,6 +1266,112 @@ pub fn temp_bundle_dir(prefix: &str) -> PathBuf {
         .unwrap_or(0);
     let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
     std::env::temp_dir().join(format!("{}-{}-{}-{}", prefix, std::process::id(), nanos, seq))
+}
+
+#[cfg(test)]
+pub(crate) mod test_forge {
+    //! Test-only bundle forgery: build hash-valid oracle bundles in arbitrary layouts —
+    //! including the frozen legacy v3 layout and the crafted cross-version flips load() must
+    //! reject — bypassing `attach_oracle`'s gates. Shared by the recording and replay tests.
+    use super::*;
+
+    /// Recompute the on-disk bundle's `workload_hash` from its raw files under the manifest's
+    /// declared `format_version` and rewrite `manifest.json` — the same stream `load()` hashes,
+    /// read without `load()`'s gates so a forged layout can be made hash-valid.
+    pub(crate) fn rehash_bundle(dir: &Path) {
+        let manifest_path = dir.join("manifest.json");
+        let mut manifest: Manifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        let graph_records: Vec<GraphRecord> = read_jsonl(&dir.join("graph.jsonl")).unwrap();
+        let mut hasher = WorkloadHasher::new(
+            manifest.format_version,
+            &manifest.generator_version,
+            &manifest.dataset,
+            &manifest.graph,
+            manifest.corpus_seed,
+        );
+        for rec in &graph_records {
+            hasher.graph_record(&rec.phase, &rec.cypher);
+        }
+        for entry in &manifest.ops {
+            let recs: Vec<CommandRecord> =
+                read_jsonl(&dir.join("commands").join(format!("{}.jsonl", entry.name))).unwrap();
+            hasher.op_header(&entry.name, recs.len(), entry.kind);
+            for rec in &recs {
+                hasher.command(&rec.cypher);
+            }
+            if entry.oracle.is_some() {
+                let orecs: Vec<OracleRecord> =
+                    read_jsonl(&dir.join("oracle").join(format!("{}.jsonl", entry.name)))
+                        .unwrap();
+                for (seq, r) in orecs.iter().enumerate() {
+                    hasher.oracle_record(seq, &r.stats);
+                }
+            }
+        }
+        manifest.workload_hash = hasher.finalize();
+        std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest).unwrap())
+            .unwrap();
+    }
+
+    /// Forge a hash-valid oracle bundle at `dir`: one `CREATE` command per `op_names` entry
+    /// (each oracled with its true outcome, `nodes_created = 1`, so a live replay verifies),
+    /// with or without the §6.4 prepared load phase, stamped with an arbitrary
+    /// `format_version`. Layout validity is deliberately NOT checked — that is load()'s job.
+    pub(crate) fn forge_oracle_bundle(
+        dir: &Path,
+        op_names: &[&str],
+        prepared: bool,
+        format_version: u32,
+    ) {
+        let spec = DatasetSpec {
+            seed: 3,
+            nodes: 50,
+            edges: 100,
+        };
+        let ops: Vec<RecordedOp> = op_names
+            .iter()
+            .map(|name| RecordedOp {
+                key: OpKey::dynamic(*name, QueryType::Write),
+                result_gated: false,
+                budget: RecordedBudget::default(),
+                capability: None,
+                commands: vec!["CREATE (:ForgedOracleProbe {k: 1})".to_string()],
+            })
+            .collect();
+        if prepared {
+            record_rendered_with_prepared(&spec, "g", &ops, 3, 32, dir).unwrap();
+        } else {
+            record_rendered(&spec, "g", &ops, 3, 32, dir).unwrap();
+        }
+        let oracle_dir = dir.join("oracle");
+        std::fs::create_dir_all(&oracle_dir).unwrap();
+        let stats = MutationStats {
+            nodes_created: 1,
+            ..MutationStats::default()
+        };
+        for name in op_names {
+            let path = oracle_dir.join(format!("{}.jsonl", name));
+            let mut w = BufWriter::new(create_file(&path).unwrap());
+            write_jsonl(&mut w, &path, &OracleRecord { seq: 0, stats }).unwrap();
+            w.flush().unwrap();
+        }
+        let manifest_path = dir.join("manifest.json");
+        let mut manifest: Manifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        manifest.format_version = format_version;
+        for entry in &mut manifest.ops {
+            entry.oracle = Some(1);
+        }
+        std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest).unwrap())
+            .unwrap();
+        rehash_bundle(dir);
+    }
+
+    /// The frozen legacy §6.3 op set, exposed for tests that forge v3 bundles.
+    pub(crate) fn legacy_v3_ops() -> Vec<&'static str> {
+        LEGACY_V3_ORACLE_OPS.to_vec()
+    }
 }
 
 #[cfg(test)]
@@ -2263,12 +2452,12 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    // ---- §6.3 outcome oracle (format v3) ----
+    // ---- §6.3/§6.4 outcome oracle (format v4; frozen legacy v3) ----
 
-    /// A recorded two-op write bundle (2 + 3 commands) for oracle tests. The ops carry REAL
-    /// oracle-eligible shape names (`OpKey::dynamic` resolves built-ins by name) because the
-    /// §6.3 exact-set rule pins v3 oracles to exactly the eligible set — custom rendered names
-    /// could never be attached.
+    /// A recorded two-op write bundle (2 + 3 commands, §6.4 prepared phase included) for oracle
+    /// tests. The ops carry REAL oracle-eligible shape names (`OpKey::dynamic` resolves
+    /// built-ins by name) because the exact-set rule pins oracles to exactly the eligible set —
+    /// custom rendered names could never be attached.
     fn record_write_bundle_to_temp(prefix: &str) -> PathBuf {
         let dir = temp_bundle_dir(prefix);
         let spec = DatasetSpec {
@@ -2285,7 +2474,7 @@ mod tests {
                 .map(|i| format!("CYPHER x={} CREATE (n:User {{id:$x}})", i))
                 .collect(),
         };
-        record_rendered(
+        record_rendered_with_prepared(
             &spec,
             "g",
             &[op("single_vertex_write", 2), op("single_vertex_update", 3)],
@@ -2314,11 +2503,11 @@ mod tests {
     }
 
     #[test]
-    fn attach_oracle_upgrades_a_v2_bundle_to_v3_and_round_trips() {
+    fn attach_oracle_upgrades_a_v2_bundle_to_v4_and_round_trips() {
         let dir = record_write_bundle_to_temp("synthrec-oracle-rt");
         let v2_hash = load(&dir).unwrap().manifest.workload_hash.clone();
         let manifest = attach_oracle(&dir, &full_oracle()).unwrap();
-        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE);
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE_PREPARED);
         assert_ne!(manifest.workload_hash, v2_hash, "the oracle must land in the hash");
         let write = manifest.ops.iter().find(|e| e.name == "single_vertex_write").unwrap();
         let update = manifest.ops.iter().find(|e| e.name == "single_vertex_update").unwrap();
@@ -2435,7 +2624,7 @@ mod tests {
             .unwrap();
         std::fs::write(dir.join("oracle").join("ghost.jsonl"), "{}").unwrap();
         let manifest = attach_oracle(&dir, &full_oracle()).unwrap();
-        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE);
+        assert_eq!(manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE_PREPARED);
         assert!(!dir.join("oracle").join("ghost.jsonl").exists(), "orphan cleared");
         let bundle = load(&dir).unwrap();
         assert_eq!(bundle.oracle["single_vertex_write"], vec![stats(1), stats(2)]);
@@ -2443,7 +2632,7 @@ mod tests {
     }
 
     #[test]
-    fn re_recording_over_a_v3_bundle_clears_the_stale_oracle() {
+    fn re_recording_over_an_oracle_bundle_clears_the_stale_oracle() {
         // §6.3 lifecycle: `record` replaces the bundle wholesale. Re-recording into a directory
         // holding a v3 bundle must not leave the old oracle/ files behind — the fresh manifest is
         // v2 and can't reference them, so a stale directory would brick every subsequent load.
@@ -2600,8 +2789,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replay_refuses_a_rehashed_v3_to_v2_downgrade_under_require_oracle() {
-        // The two-sided blind spot: strip a v3 bundle's oracle entirely, declare it v2, and
+    async fn replay_refuses_a_rehashed_v4_to_v2_downgrade_under_require_oracle() {
+        // The two-sided blind spot: strip a v4 bundle's oracle entirely, declare it v2, and
         // REHASH under the v2 rules — the result is byte-indistinguishable from a legitimate
         // latency-tier recording (v2 hashes never covered oracle data), loads cleanly, and would
         // replay with `oracle_verified: None`. Only the operator's stated expectation can refuse
@@ -2668,16 +2857,170 @@ mod tests {
         let err = replay::run(&config).await.unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("carries no outcome oracle"), "got: {msg}");
-        assert!(msg.contains("re-hashed v3→v2 downgrade"), "got: {msg}");
+        assert!(msg.contains("re-hashed oracle→v2 downgrade"), "got: {msg}");
 
-        // Negative control: restore the oracle (v3 again) — the same flag now clears the gate
+        // Negative control: restore the oracle (v4 again) — the same flag now clears the gate
         // and the run proceeds to the connection attempt (no oracle complaint on the closed
         // port's error).
         attach_oracle(&dir, &full_oracle()).unwrap();
         let err = replay::run(&config).await.unwrap_err();
         let msg = format!("{err}");
-        assert!(!msg.contains("oracle"), "v3 must clear the require-oracle gate, got: {msg}");
+        assert!(!msg.contains("oracle"), "v4 must clear the require-oracle gate, got: {msg}");
 
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn legacy_v3_bundle_loads_and_round_trips() {
+        // Format v3's meaning is FROZEN (§6.4 duck review): a #267-era bundle — the seven-op
+        // §6.3 exact set, no prepared phase — keeps loading under its own rule even though the
+        // live registry now has nine eligible ops and mints v4.
+        let dir = temp_bundle_dir("synthrec-legacy-v3");
+        test_forge::forge_oracle_bundle(
+            &dir,
+            &test_forge::legacy_v3_ops(),
+            false,
+            RECORDING_FORMAT_VERSION_ORACLE,
+        );
+        let bundle = load(&dir).expect("a legacy seven-op v3 bundle must keep loading");
+        assert_eq!(bundle.manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE);
+        assert_eq!(bundle.oracle.len(), 7, "the frozen legacy exact set");
+        assert!(
+            !bundle.graph_statements.iter().any(|(p, _)| *p == LoadPhase::Prepared),
+            "v3 bundles predate the prepared phase"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_v3_bundle_with_a_prepared_phase() {
+        // v3 predates §6.4: a hash-valid "v3" carrying the prepared phase is a crafted or
+        // downgraded v4, not recorded history.
+        let dir = temp_bundle_dir("synthrec-v3-prepared");
+        test_forge::forge_oracle_bundle(
+            &dir,
+            &test_forge::legacy_v3_ops(),
+            true,
+            RECORDING_FORMAT_VERSION_ORACLE,
+        );
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("predates the prepared state"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_v4_bundle_without_the_prepared_phase() {
+        // v4 is defined by the prepared phase: all nine live-eligible ops covered, but the
+        // prepared load phase stripped — a crafted/upgraded layout, rejected structurally.
+        let nine: Vec<&str> = crate::synthetic::shapes::oracle_eligible_names()
+            .into_iter()
+            .collect();
+        let dir = temp_bundle_dir("synthrec-v4-unprepared");
+        test_forge::forge_oracle_bundle(
+            &dir,
+            &nine,
+            false,
+            RECORDING_FORMAT_VERSION_ORACLE_PREPARED,
+        );
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("lacks the §6.4 prepared load phase"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_refuses_rehashed_cross_version_flips() {
+        // A version flip on an otherwise-valid rehashed bundle is refused in BOTH directions:
+        // the layout (prepared phase) and the per-version exact set disagree with the claimed
+        // version even when the hash is internally consistent.
+        // v3 → v4 upgrade: legacy seven-op layout claiming v4 lacks the prepared phase.
+        let dir_up = temp_bundle_dir("synthrec-flip-up");
+        test_forge::forge_oracle_bundle(
+            &dir_up,
+            &test_forge::legacy_v3_ops(),
+            false,
+            RECORDING_FORMAT_VERSION_ORACLE_PREPARED,
+        );
+        let msg = format!("{}", load(&dir_up).unwrap_err());
+        assert!(msg.contains("lacks the §6.4 prepared load phase"), "got: {msg}");
+
+        // v4 → v3 downgrade: nine-op prepared layout claiming v3 carries oracles for ops
+        // outside the frozen legacy set (and a prepared phase v3 forbids).
+        let nine: Vec<&str> = crate::synthetic::shapes::oracle_eligible_names()
+            .into_iter()
+            .collect();
+        let dir_down = temp_bundle_dir("synthrec-flip-down");
+        test_forge::forge_oracle_bundle(&dir_down, &nine, true, RECORDING_FORMAT_VERSION_ORACLE);
+        let msg = format!("{}", load(&dir_down).unwrap_err());
+        assert!(
+            msg.contains("not oracle-eligible under format v3"),
+            "got: {msg}"
+        );
+
+        std::fs::remove_dir_all(&dir_up).ok();
+        std::fs::remove_dir_all(&dir_down).ok();
+    }
+
+    #[test]
+    fn attach_oracle_rejects_a_bundle_without_the_prepared_phase() {
+        // attach mints v4, and v4 requires the prepared phase — a stale preparedless write
+        // bundle must be re-recorded, not upgraded into an unloadable state.
+        let dir = temp_bundle_dir("synthrec-attach-unprepared");
+        let spec = DatasetSpec {
+            seed: 1,
+            nodes: 10,
+            edges: 20,
+        };
+        let op = |name: &str, n: usize| RecordedOp {
+            key: OpKey::dynamic(name, QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: (0..n)
+                .map(|i| format!("CYPHER x={} CREATE (n:User {{id:$x}})", i))
+                .collect(),
+        };
+        record_rendered(
+            &spec,
+            "g",
+            &[op("single_vertex_write", 2), op("single_vertex_update", 3)],
+            1,
+            8,
+            &dir,
+        )
+        .unwrap();
+        let err = attach_oracle(&dir, &full_oracle()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("lacks the §6.4 prepared load phase"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_prepared_phase_on_a_read_bundle() {
+        // The prepared state exists solely for the write shapes; a read bundle carrying one is
+        // crafted (the recorder refuses to write it — see
+        // `record_rejects_a_mismatched_extra_load_block`).
+        let (dir, _man) = record_to_temp(21);
+        let graph_path = dir.join("graph.jsonl");
+        let n_stmts = std::fs::read_to_string(&graph_path)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .count();
+        let rec = GraphRecord {
+            seq: n_stmts,
+            phase: "prepared".to_string(),
+            cypher: "MATCH (u:User) SET u.crafted = 1".to_string(),
+        };
+        let mut text = std::fs::read_to_string(&graph_path).unwrap();
+        text.push_str(&serde_json::to_string(&rec).unwrap());
+        text.push('\n');
+        std::fs::write(&graph_path, text).unwrap();
+        test_forge::rehash_bundle(&dir);
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("records no write ops"), "got: {msg}");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -2700,7 +3043,7 @@ mod tests {
             capability: None,
             commands: (0..n).map(|i| format!("CYPHER x={} CREATE (:User)", i)).collect(),
         };
-        record_rendered(
+        record_rendered_with_prepared(
             &spec,
             "g",
             &[op("single_vertex_write", 2), op("w_custom", 1)],
@@ -2787,7 +3130,7 @@ mod tests {
         std::fs::create_dir_all(&orphan).unwrap();
         std::fs::write(orphan.join("single_vertex_write.jsonl"), b"junk\n").unwrap();
         let man = attach_oracle(&dir, &full_oracle()).unwrap();
-        assert_eq!(man.format_version, RECORDING_FORMAT_VERSION_ORACLE);
+        assert_eq!(man.format_version, RECORDING_FORMAT_VERSION_ORACLE_PREPARED);
         load(&dir).unwrap();
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -1336,7 +1336,7 @@ pub(crate) mod test_forge {
                 result_gated: false,
                 budget: RecordedBudget::default(),
                 capability: None,
-                commands: vec!["CREATE (:ForgedOracleProbe {k: 1})".to_string()],
+                commands: vec!["CREATE (:ForgedOracleProbe)".to_string()],
             })
             .collect();
         if prepared {

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -76,8 +76,9 @@ pub const RECORDING_FORMAT_VERSION_WRITES: u32 = 2;
 pub const RECORDING_FORMAT_VERSION_ORACLE: u32 = 3;
 
 /// On-disk bundle format version for §6.4 **prepared oracle** bundles — what
-/// [`attach_oracle`] mints today: the oracle covers exactly the **live** oracle-eligible set
-/// (nine ops, [`shapes::oracle_eligible_names`](crate::synthetic::shapes::oracle_eligible_names))
+/// [`attach_oracle`] mints today: the oracle covers exactly the **frozen** nine-op §6.4 set
+/// ([`V4_ORACLE_OPS`]; a drift-guard test pins it to the live
+/// [`shapes::oracle_eligible_names`](crate::synthetic::shapes::oracle_eligible_names) registry)
 /// and the recorded graph **must** end with the §6.4 prepared load phase (the state the
 /// `REMOVE` shape mutates). Same hash rules as v3 (oracle records hash-bound); the version
 /// byte differs, so a v3↔v4 rehash flip is caught by the layout gates even before content.
@@ -87,9 +88,9 @@ pub const RECORDING_FORMAT_VERSION_ORACLE_PREPARED: u32 = 4;
 const RECORDING_FORMAT_VERSION_MAX: u32 = RECORDING_FORMAT_VERSION_ORACLE_PREPARED;
 
 /// The §6.3-era oracle-eligible write ops — **frozen** as recorded history: this is the exact
-/// set a format-v3 bundle must carry oracles for. Never derive it from the live shape registry
-/// (that is what [`RECORDING_FORMAT_VERSION_ORACLE_PREPARED`] uses); v3's meaning never changes
-/// again, or every existing v3 bundle would retroactively become "corrupt".
+/// set a format-v3 bundle must carry oracles for. Never derive a version's required set from
+/// the live shape registry; a version's meaning never changes again, or every existing bundle
+/// of that version would retroactively become "corrupt".
 const LEGACY_V3_ORACLE_OPS: [&str; 7] = [
     "single_vertex_write",
     "single_vertex_update",
@@ -100,13 +101,29 @@ const LEGACY_V3_ORACLE_OPS: [&str; 7] = [
     "foreach_loop_mutation",
 ];
 
+/// The §6.4 oracle-eligible write ops — **frozen** exactly like [`LEGACY_V3_ORACLE_OPS`]: the
+/// exact set a format-v4 bundle must carry oracles for. A future eligibility change must mint a
+/// new format version, never edit this list (a drift-guard test pins it to the live registry so
+/// the divergence is loud at build time, not at load time on existing bundles).
+const V4_ORACLE_OPS: [&str; 9] = [
+    "single_vertex_write",
+    "single_vertex_update",
+    "single_edge_write",
+    "merge_user_insert_path",
+    "merge_user_upsert_existing",
+    "merge_friend_edge_upsert",
+    "foreach_loop_mutation",
+    "detach_delete_user",
+    "remove_user_property_and_label",
+];
+
 /// The oracle-eligible op names a bundle of `format_version` is required to cover exactly:
-/// the frozen [`LEGACY_V3_ORACLE_OPS`] for v3, the live registry for v4+.
+/// the frozen [`LEGACY_V3_ORACLE_OPS`] for v3, the frozen [`V4_ORACLE_OPS`] for v4.
 pub(crate) fn oracle_required_ops(
     format_version: u32,
 ) -> std::collections::BTreeSet<&'static str> {
     if format_version >= RECORDING_FORMAT_VERSION_ORACLE_PREPARED {
-        crate::synthetic::shapes::oracle_eligible_names()
+        V4_ORACLE_OPS.iter().copied().collect()
     } else {
         LEGACY_V3_ORACLE_OPS.iter().copied().collect()
     }
@@ -3078,6 +3095,19 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("records no write ops"), "got: {msg}");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn the_frozen_v4_set_matches_the_live_registry() {
+        // Drift-guard: v4's required set is FROZEN (V4_ORACLE_OPS) so future eligibility edits
+        // can't retroactively corrupt existing v4 bundles. If this fails, the live shape
+        // registry changed — mint a NEW recording format version for the new set (as v4 did for
+        // §6.4) instead of editing the frozen list.
+        assert_eq!(
+            oracle_required_ops(RECORDING_FORMAT_VERSION_ORACLE_PREPARED),
+            crate::synthetic::shapes::oracle_eligible_names(),
+            "the live oracle-eligible set diverged from frozen v4 — mint a new format version"
+        );
     }
 
     #[test]

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -892,6 +892,19 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
             manifest.format_version, RECORDING_FORMAT_VERSION_ORACLE_PREPARED
         )));
     }
+    // The prepared phase is the TRAILING load phase (§6.4): it re-establishes the prepared
+    // state over the complete base, so a base/fixture statement after it would create
+    // un-prepared `:User` rows the recorded outcomes never saw (crafted/reordered graph.jsonl).
+    if let Some(first) = graph_statements.iter().position(|(p, _)| *p == LoadPhase::Prepared) {
+        if graph_statements[first..].iter().any(|(p, _)| *p != LoadPhase::Prepared) {
+            return Err(OtherError(
+                "the §6.4 prepared load phase must be the final load phase — a base/fixture \
+                 statement follows a prepared statement, so the prepared state would not cover \
+                 the complete base (crafted/reordered graph.jsonl)"
+                    .to_string(),
+            ));
+        }
+    }
 
     // commands/<op>.jsonl for each op named in the manifest, in order.
     let mut commands = Vec::with_capacity(manifest.ops.len());
@@ -2926,6 +2939,38 @@ mod tests {
         let err = load(&dir).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("lacks the §6.4 prepared load phase"), "got: {msg}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn load_rejects_a_base_statement_after_the_prepared_phase() {
+        // The prepared phase must be the TRAILING load phase: a hash-valid v4 bundle whose
+        // graph.jsonl carries a base statement AFTER a prepared statement would load `:User`
+        // rows the prepared state never covered — rejected structurally, not by hash.
+        let nine: Vec<&str> = crate::synthetic::shapes::oracle_eligible_names()
+            .into_iter()
+            .collect();
+        let dir = temp_bundle_dir("synthrec-v4-reordered");
+        test_forge::forge_oracle_bundle(
+            &dir,
+            &nine,
+            true,
+            RECORDING_FORMAT_VERSION_ORACLE_PREPARED,
+        );
+        // Move the first (base) statement to the end of graph.jsonl, after the prepared
+        // statements, then rehash so only the layout gate can refuse it.
+        let graph_path = dir.join("graph.jsonl");
+        let text = std::fs::read_to_string(&graph_path).unwrap();
+        let mut lines: Vec<&str> = text.lines().collect();
+        assert!(lines.len() >= 2, "forged bundle has base + prepared statements");
+        let first = lines.remove(0);
+        assert!(!first.contains("prepared"), "the first statement is a base statement");
+        lines.push(first);
+        std::fs::write(&graph_path, lines.join("\n") + "\n").unwrap();
+        test_forge::rehash_bundle(&dir);
+        let err = load(&dir).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("must be the final load phase"), "got: {msg}");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -1083,7 +1083,8 @@ impl Bundle {
 /// `oracle/<op>.jsonl` for every op in `oracle`, mark each op's manifest entry
 /// with its record count, and recompute the [`Manifest::workload_hash`] under oracle rules (the
 /// oracle records are hash-bound — see [`WorkloadHasher::oracle_record`]). The bundle must carry
-/// the §6.4 prepared load phase (every write bundle recorded by this build does); the frozen
+/// the §6.4 prepared load phase (the `--repo-writes` recorder always emits it; a bundle
+/// rendered without it — stale or hand-crafted — is refused with re-record guidance); the frozen
 /// legacy v3 layout is load/replay-only and can never be minted again. The upgraded bundle is
 /// re-[`load`]ed as the final step, so the function returns exactly what every future load will
 /// verify — any inconsistency this function could write fails here, at record time.

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -551,6 +551,23 @@ fn record_rendered_impl(
             .to_string(),
         ));
     }
+    // Fail fast on a mismatched extra-load block (Copilot round 3): the fixture is FalkorDB
+    // index DDL for the FixtureDependent READ shapes — appending it to a write bundle would break
+    // engine-agnostic write recording; the prepared state exists solely for the §6.4 write shapes.
+    if extra == ExtraLoad::Fixture && has_writes {
+        return Err(OtherError(
+            "the fulltext/vector fixture is for read bundles — cannot record a write bundle with \
+             fixture statements"
+                .to_string(),
+        ));
+    }
+    if extra == ExtraLoad::Prepared && !has_writes {
+        return Err(OtherError(
+            "the §6.4 prepared state is for write bundles — cannot record a read bundle with \
+             prepared statements"
+                .to_string(),
+        ));
+    }
     // The write latency tier asserts nothing (Phase 7 §4.1), so a result-gated write op could be
     // recorded but never replayed (replay hard-rejects it) — fail early here instead.
     if let Some(op) =
@@ -1440,6 +1457,48 @@ mod tests {
         let dir2 = temp_bundle_dir("synthrec-noprepared");
         let without = record_rendered(&spec, "gprep", &ops, 9, 32, &dir2).unwrap();
         assert_ne!(with.workload_hash, without.workload_hash);
+
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::remove_dir_all(&dir2).ok();
+    }
+
+    #[test]
+    fn record_rejects_a_mismatched_extra_load_block() {
+        // Fail-fast guards: fixture on a write bundle (FalkorDB DDL would break engine-agnostic
+        // write recording) and prepared state on a read bundle are both constructor misuse.
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 200,
+            edges: 400,
+        };
+        let write_op = RecordedOp {
+            key: OpKey::dynamic("w_solo", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["MATCH (u:User {id: 1}) SET u.x = 1".to_string()],
+        };
+        let read_op = RecordedOp {
+            key: OpKey::dynamic("r_solo", QueryType::Read),
+            result_gated: false,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["MATCH (u:User {id: 1}) RETURN u.id".to_string()],
+        };
+
+        let dir = temp_bundle_dir("synthrec-fixture-on-write");
+        let err = record_rendered_with_fixture(&spec, "g", &[write_op], 9, 32, &dir).unwrap_err();
+        assert!(
+            format!("{err}").contains("fixture is for read bundles"),
+            "got: {err}"
+        );
+
+        let dir2 = temp_bundle_dir("synthrec-prepared-on-read");
+        let err = record_rendered_with_prepared(&spec, "g", &[read_op], 9, 32, &dir2).unwrap_err();
+        assert!(
+            format!("{err}").contains("prepared state is for write bundles"),
+            "got: {err}"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
         std::fs::remove_dir_all(&dir2).ok();

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -749,7 +749,7 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
     // Exact-set enforcement (§6.3): a v3 bundle must carry an oracle for EVERY recorded
     // oracle-eligible write op, covering its COMPLETE command corpus, and for nothing else — so
     // oracle coverage can never silently shrink (a crafted 1-of-7 subset, or a padded oracle on
-    // an op outside the deterministic subset, is rejected here rather than replayed).
+    // an op outside the eligible set, is rejected here rather than replayed).
     if manifest.format_version >= RECORDING_FORMAT_VERSION_ORACLE {
         let eligible = crate::synthetic::shapes::oracle_eligible_names();
         for entry in &manifest.ops {
@@ -781,7 +781,7 @@ pub fn load(dir: &Path) -> BenchmarkResult<Bundle> {
                 (false, Some(_)) => {
                     return Err(OtherError(format!(
                         "manifest declares an outcome oracle for op '{}', which is not \
-                         oracle-eligible (§6.3 deterministic subset only; crafted/corrupt \
+                         oracle-eligible (§6.3 + §6.4 eligible set only; crafted/corrupt \
                          manifest)",
                         entry.name
                     )));
@@ -1054,8 +1054,8 @@ pub fn attach_oracle(
             }
             (false, Some(_)) => {
                 return Err(OtherError(format!(
-                    "oracle captured for op '{}', which is not oracle-eligible (§6.3 \
-                     deterministic subset only)",
+                    "oracle captured for op '{}', which is not oracle-eligible (§6.3 + §6.4 \
+                     eligible set only)",
                     entry.name
                 )));
             }
@@ -2627,7 +2627,7 @@ mod tests {
         // Mixed bundle (one eligible + one custom write op): attach the valid exact-set oracle,
         // then hand-edit the manifest to declare an oracle on the non-eligible op — the §6.3
         // exact-set pass must reject it at manifest level (a padded oracle outside the
-        // deterministic subset is as much a coverage lie as a shrunken one).
+        // eligible set is as much a coverage lie as a shrunken one).
         let dir = temp_bundle_dir("synthrec-oracle-noneligible");
         let spec = DatasetSpec {
             seed: 1,

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -393,6 +393,13 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                 bundle.manifest.format_version
             );
         }
+        // ONE connection for the whole verify pass (like the capture pass): a per-command fresh
+        // socket exhausts the ephemeral-port/proxy budget — see `restore_base_on`.
+        let mut verify_conn = if bundle.oracle.is_empty() {
+            None
+        } else {
+            Some(open_graph(&config.endpoint, &graph_name).await?)
+        };
         for (op, cyphers) in &bundle.commands {
             let Some(expected) = bundle.oracle.get(op.name()) else { continue };
             if let Some(reason) = skipped.get(op.name()) {
@@ -415,10 +422,10 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                 .map(Duration::from_millis)
                 .unwrap_or(client_deadline);
             for (seq, want) in expected.iter().enumerate() {
-                restore_base(config, &bundle, &graph_name, &dataset_spec).await?;
-                let mut g = open_graph(&config.endpoint, &graph_name).await?;
+                let g = verify_conn.as_mut().expect("verify connection opened above");
+                restore_base_on(g, config, &bundle, &graph_name, &dataset_spec).await?;
                 let sample =
-                    run_and_drain(&mut g, QueryType::Write, &cyphers[seq], op_st, op_deadline)
+                    run_and_drain(g, QueryType::Write, &cyphers[seq], op_st, op_deadline)
                         .await
                         .map_err(|e| {
                             OtherError(format!(
@@ -881,6 +888,21 @@ pub async fn restore_base(
 ) -> BenchmarkResult<()> {
     let mut conn = open_graph(&config.endpoint, graph_name).await?;
     load_recorded_graph(&mut conn, bundle, graph_name, spec, config).await
+}
+
+/// [`restore_base`] on an **existing** connection. The per-command §6.3 loops (oracle capture and
+/// replay verify — thousands of restore+run cycles) MUST reuse one connection per pass: opening
+/// two fresh sockets per command exhausts the host's ephemeral-port/proxy budget (macOS Docker
+/// port-forwarding stalls after ~1k rapid connects) and fails the run with a spurious send
+/// timeout.
+pub(crate) async fn restore_base_on(
+    conn: &mut AsyncGraph,
+    config: &ReplayConfig,
+    bundle: &Bundle,
+    graph_name: &str,
+    spec: &DatasetSpec,
+) -> BenchmarkResult<()> {
+    load_recorded_graph(conn, bundle, graph_name, spec, config).await
 }
 
 /// Drop `graph`, execute the bundle's recorded load statements, and verify the node/edge counts.

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -85,8 +85,8 @@ pub struct ReplayConfig {
     /// Optional display name for this run (e.g. `pr`/`main`), recorded into the report.
     pub label: Option<String>,
     /// When `true`, refuse to measure a write bundle that carries no outcome oracle (recording
-    /// format < v3). A re-hashed v3→v2 strip is a perfectly legitimate-looking v2 bundle, so only
-    /// the operator's *expectation* can catch the downgrade — this flag states it (§6.3).
+    /// format < v3). A re-hashed oracle→v2 strip is a perfectly legitimate-looking v2 bundle, so
+    /// only the operator's *expectation* can catch the downgrade — this flag states it (§6.3).
     pub require_oracle: bool,
 }
 
@@ -106,9 +106,10 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // before any connection.
     let has_writes = bundle.commands.iter().any(|(op, _)| op.kind() == QueryType::Write);
     // §6.3 downgrade guard, offline: a v2 write bundle is a legitimate latency-tier recording,
-    // which is exactly why a re-hashed v3→v2 strip replays cleanly — only the operator's stated
-    // expectation can refuse it. `load()` already guarantees a v3 bundle carries the complete
-    // exact-set oracle, so the format version alone decides.
+    // which is exactly why a re-hashed oracle→v2 strip replays cleanly — only the operator's
+    // stated expectation can refuse it. `load()` already guarantees an oracle bundle (v3 legacy
+    // or v4) carries the complete exact-set oracle for its version, so the format version alone
+    // decides.
     if config.require_oracle {
         if !has_writes {
             return Err(OtherError(
@@ -121,7 +122,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             return Err(OtherError(format!(
                 "--require-oracle: the write bundle at {} carries no outcome oracle (recording \
                  format v{}) — latency tier only. Re-record it with --oracle; if it should \
-                 already carry one, this bundle may be a re-hashed v3→v2 downgrade",
+                 already carry one, this bundle may be a re-hashed oracle→v2 downgrade",
                 config.recording_dir.display(),
                 bundle.manifest.format_version
             )));
@@ -352,10 +353,11 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         // silently bypassing the tier.) Untimed, single-flight, per-invocation restore — sample
         // latencies stay clean because restores run between invocations, never inside one.
         //
-        // Exact-set re-check (belt-and-braces over the identical load() gate): every eligible
-        // write op must carry an oracle covering its complete corpus — replay never proceeds on
-        // a bundle whose oracle coverage silently shrank.
-        let eligible = crate::synthetic::shapes::oracle_eligible_names();
+        // Exact-set re-check (belt-and-braces over the identical load() gate): every write op
+        // the bundle's format version deems oracle-eligible must carry an oracle covering its
+        // complete corpus — replay never proceeds on a bundle whose oracle coverage silently
+        // shrank.
+        let eligible = recording::oracle_required_ops(bundle.manifest.format_version);
         if bundle.manifest.format_version >= recording::RECORDING_FORMAT_VERSION_ORACLE {
             for (op, cyphers) in &bundle.commands {
                 if op.kind() != QueryType::Write || !eligible.contains(op.name()) {
@@ -367,7 +369,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                             "oracle-eligible op '{}' carries no outcome oracle — the bundle's \
                              correctness coverage shrank below what format v{} promises",
                             op.name(),
-                            recording::RECORDING_FORMAT_VERSION_ORACLE
+                            bundle.manifest.format_version
                         )));
                     }
                     Some(outcomes) if outcomes.len() != cyphers.len() => {
@@ -384,9 +386,9 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             }
         } else if has_writes {
             // Downgrade visibility: a write bundle WITHOUT an oracle is legitimate (pre-§6.3
-            // latency tier) but must say so loudly, so a v3→v2 strip can't pass as the real
-            // thing unnoticed. The report's `meta.oracle_verified` stays absent for the same
-            // reason.
+            // latency tier) but must say so loudly, so an oracle→v2 strip can't pass as the
+            // real thing unnoticed. The report's `meta.oracle_verified` stays absent for the
+            // same reason.
             info!(
                 "write bundle carries no outcome oracle (recording format v{}) — latency tier \
                  only, no correctness verification",
@@ -1282,7 +1284,79 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("carries no outcome oracle"), "got: {msg}");
         assert!(msg.contains("recording format v2"), "got: {msg}");
-        assert!(msg.contains("re-hashed v3→v2 downgrade"), "got: {msg}");
+        assert!(msg.contains("re-hashed oracle→v2 downgrade"), "got: {msg}");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_require_oracle_accepts_a_legacy_v3_bundle() {
+        // Format v3's meaning is frozen (§6.4): a #267-era seven-op bundle still satisfies
+        // --require-oracle under its own exact-set rule — the run must clear every offline
+        // gate and proceed to the connection attempt (closed port ⇒ no oracle complaint).
+        use crate::synthetic::recording::{
+            temp_bundle_dir, test_forge, RECORDING_FORMAT_VERSION_ORACLE,
+        };
+
+        let dir = temp_bundle_dir("replay-require-oracle-legacy-v3");
+        test_forge::forge_oracle_bundle(
+            &dir,
+            &test_forge::legacy_v3_ops(),
+            false,
+            RECORDING_FORMAT_VERSION_ORACLE,
+        );
+
+        let mut config = replay_config(true, vec![1]);
+        config.recording_dir = dir.clone();
+        config.require_oracle = true;
+        let err = run(&config).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            !msg.contains("oracle"),
+            "a legacy v3 bundle must clear the require-oracle gate, got: {msg}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    #[ignore = "needs a live FalkorDB (FALKORDB_HOST/FALKORDB_PORT)"]
+    async fn legacy_v3_bundle_replays_and_verifies_end_to_end() {
+        // The frozen legacy layout stays REPLAYABLE, not merely loadable: a seven-op v3 bundle
+        // (no prepared phase) loads, passes its own exact-set rule, verifies every recorded
+        // outcome against the live engine, and measures all seven ops.
+        use crate::synthetic::recording::{
+            temp_bundle_dir, test_forge, RECORDING_FORMAT_VERSION_ORACLE,
+        };
+
+        let host = std::env::var("FALKORDB_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+        let port = std::env::var("FALKORDB_PORT").unwrap_or_else(|_| "6379".to_string());
+
+        let dir = temp_bundle_dir("replay-legacy-v3-e2e");
+        test_forge::forge_oracle_bundle(
+            &dir,
+            &test_forge::legacy_v3_ops(),
+            false,
+            RECORDING_FORMAT_VERSION_ORACLE,
+        );
+
+        let mut config = replay_config(true, vec![1]);
+        config.recording_dir = dir.clone();
+        config.endpoint = format!("falkor://{}:{}", host, port);
+        config.graph = Some("legacy_v3_e2e".to_string());
+        config.samples = 2;
+        config.warmup = 0;
+        config.require_oracle = true;
+        config.out = dir.join("report.json").to_string_lossy().into_owned();
+        let report = run(&config).await.expect("a legacy v3 bundle must replay cleanly");
+        assert_eq!(report.operations.len(), 7, "all seven legacy ops measured");
+        let attested = report
+            .meta
+            .oracle_verified
+            .as_ref()
+            .expect("a legacy v3 replay attests its oracle");
+        assert_eq!(attested.len(), 7, "attestation covers the legacy exact set");
+        assert!(attested.values().all(|&n| n == 1), "one outcome per forged op");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -1319,7 +1319,7 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore = "needs a live FalkorDB (FALKORDB_HOST/FALKORDB_PORT)"]
     async fn legacy_v3_bundle_replays_and_verifies_end_to_end() {
         // The frozen legacy layout stays REPLAYABLE, not merely loadable: a seven-op v3 bundle

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -394,63 +394,61 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             );
         }
         // ONE connection for the whole verify pass (like the capture pass): a per-command fresh
-        // socket exhausts the ephemeral-port/proxy budget — see `restore_base_on`.
-        let mut verify_conn = if bundle.oracle.is_empty() {
-            None
-        } else {
-            Some(open_graph(&config.endpoint, &graph_name).await?)
-        };
-        for (op, cyphers) in &bundle.commands {
-            let Some(expected) = bundle.oracle.get(op.name()) else { continue };
-            if let Some(reason) = skipped.get(op.name()) {
-                // Fail closed: unreachable through load() (write bundles can never be
-                // capability-gated, and only write ops carry oracles), but a skip must never
-                // bypass the correctness tier.
-                return Err(OtherError(format!(
-                    "op '{}' carries {} recorded oracle outcome(s) but was skipped ({}) — a \
-                     skip cannot bypass the correctness tier",
-                    op.name(),
-                    expected.len(),
-                    reason
-                )));
-            }
-            let entry = entry_for(op.name());
-            let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);
-            let op_deadline = entry
-                .budget
-                .client_deadline_ms
-                .map(Duration::from_millis)
-                .unwrap_or(client_deadline);
-            for (seq, want) in expected.iter().enumerate() {
-                let g = verify_conn.as_mut().expect("verify connection opened above");
-                restore_base_on(g, config, &bundle, &graph_name, &dataset_spec).await?;
-                let sample =
-                    run_and_drain(g, QueryType::Write, &cyphers[seq], op_st, op_deadline)
-                        .await
-                        .map_err(|e| {
+        // socket exhausts the ephemeral-port/proxy budget — see `restore_base_on`. Scoping the
+        // connection to the non-empty-oracle branch makes "oracle outcomes without a verify
+        // connection" unrepresentable (no fallible unwrap).
+        if !bundle.oracle.is_empty() {
+            let mut verify_conn = open_graph(&config.endpoint, &graph_name).await?;
+            for (op, cyphers) in &bundle.commands {
+                let Some(expected) = bundle.oracle.get(op.name()) else { continue };
+                if let Some(reason) = skipped.get(op.name()) {
+                    // Fail closed: unreachable through load() (write bundles can never be
+                    // capability-gated, and only write ops carry oracles), but a skip must never
+                    // bypass the correctness tier.
+                    return Err(OtherError(format!(
+                        "op '{}' carries {} recorded oracle outcome(s) but was skipped ({}) — a \
+                         skip cannot bypass the correctness tier",
+                        op.name(),
+                        expected.len(),
+                        reason
+                    )));
+                }
+                let entry = entry_for(op.name());
+                let op_st = entry.budget.server_timeout_ms.unwrap_or(config.server_timeout_ms);
+                let op_deadline = entry
+                    .budget
+                    .client_deadline_ms
+                    .map(Duration::from_millis)
+                    .unwrap_or(client_deadline);
+                for (seq, want) in expected.iter().enumerate() {
+                    let g = &mut verify_conn;
+                    restore_base_on(g, config, &bundle, &graph_name, &dataset_spec).await?;
+                    let sample =
+                        run_and_drain(g, QueryType::Write, &cyphers[seq], op_st, op_deadline)
+                            .await
+                            .map_err(|e| {
+                                OtherError(format!(
+                                    "oracle verify: op '{}' seq {}: {}",
+                                    op.name(),
+                                    seq,
+                                    e
+                                ))
+                            })?;
+                    verify_mutation(ExpectedOutcome::exactly(*want), &sample.mutations).map_err(
+                        |e| {
                             OtherError(format!(
-                                "oracle verify: op '{}' seq {}: {}",
+                                "oracle mismatch for op '{}' seq {} (command: {}): {} — the \
+                                 engine diverged from the recorded outcome, so its write \
+                                 latencies would measure different work",
                                 op.name(),
                                 seq,
+                                cyphers[seq],
                                 e
                             ))
-                        })?;
-                verify_mutation(ExpectedOutcome::exactly(*want), &sample.mutations).map_err(
-                    |e| {
-                        OtherError(format!(
-                            "oracle mismatch for op '{}' seq {} (command: {}): {} — the engine \
-                             diverged from the recorded outcome, so its write latencies would \
-                             measure different work",
-                            op.name(),
-                            seq,
-                            cyphers[seq],
-                            e
-                        ))
-                    },
-                )?;
+                        },
+                    )?;
+                }
             }
-        }
-        if !bundle.oracle.is_empty() {
             let outcomes: usize = bundle.oracle.values().map(Vec::len).sum();
             info!(
                 "oracle verified: {} recorded outcome(s) across {} op(s) reproduced exactly",

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -114,12 +114,11 @@ pub struct Meta {
     /// column header in `report --diff`/`--regression`; falls back to `A`/`B` when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
-    /// §6.3 oracle attestation: op → number of recorded outcomes the replay **re-verified** before
-    /// measuring (present only for an oracle-format write-bundle replay). Its absence on a
-    /// write-bundle
-    /// report makes an oracle→v2 downgrade visible when comparing runs — a replay without this
-    /// field
-    /// measured the latency tier only. `#[serde(default)]` so pre-§6.3 reports still deserialize.
+    /// §6.3 oracle attestation: op → number of recorded outcomes the replay **re-verified**
+    /// before measuring (present only for an oracle-format write-bundle replay). Its absence
+    /// on a write-bundle report makes an oracle→v2 downgrade visible when comparing runs —
+    /// a replay without this field measured the latency tier only. `#[serde(default)]` so
+    /// pre-§6.3 reports still deserialize.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oracle_verified: Option<std::collections::BTreeMap<String, usize>>,
 }

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -115,8 +115,10 @@ pub struct Meta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     /// §6.3 oracle attestation: op → number of recorded outcomes the replay **re-verified** before
-    /// measuring (present only for a format-v3 write-bundle replay). Its absence on a write-bundle
-    /// report makes a v3→v2 downgrade visible when comparing runs — a replay without this field
+    /// measuring (present only for an oracle-format write-bundle replay). Its absence on a
+    /// write-bundle
+    /// report makes an oracle→v2 downgrade visible when comparing runs — a replay without this
+    /// field
     /// measured the latency tier only. `#[serde(default)]` so pre-§6.3 reports still deserialize.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oracle_verified: Option<std::collections::BTreeMap<String, usize>>,
@@ -812,7 +814,7 @@ mod tests {
         let back: Report = serde_json::from_str(&json).unwrap();
         assert_eq!(back.meta.oracle_verified, Some(coverage));
         // …while oracle-less runs omit the field entirely, and pre-§6.3 reports (no field at
-        // all) still deserialize — so a v3→v2 downgrade shows up as a missing attestation.
+        // all) still deserialize — so an oracle→v2 downgrade shows up as a missing attestation.
         let plain = sample_report();
         let json = plain.to_json().unwrap();
         assert!(!json.contains("oracle_verified"), "None must not serialize: {json}");

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -188,7 +188,8 @@ const ORACLE_NOT_A_WRITE: OracleEligibility =
 /// prepared-state/variable-count shapes) — the single source of truth for which ops a format-v4
 /// bundle **must** carry outcomes for: capture targets exactly this set, and `recording::load` +
 /// replay enforce it exactly (no subset, no strays), so oracle coverage can never silently shrink.
-/// Frozen legacy v3 bundles are checked against `recording::LEGACY_V3_ORACLE_OPS` instead.
+/// Frozen legacy v3 bundles are checked against the recording module's frozen seven-op §6.3 list
+/// instead.
 pub fn oracle_eligible_names() -> std::collections::BTreeSet<&'static str> {
     write_shapes()
         .iter()

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -527,16 +527,16 @@ const WRITE_BUDGET: OpBudget = OpBudget {
 /// base-graph resets, and `ResultPolicy::NotApplicable` — mutation outcomes are state- and
 /// value-dependent (MERGE create-vs-match, SET-same-value counting 0, DETACH DELETE no-ops on
 /// repeat — §2/§10.1), `timestamp()`/`date()`/`rand()` values are non-reproducible (§3.4), and no
-/// **statically modelled** counter expectation exists. The §6.3 **correctness tier** instead
-/// records each command's *actual* outcome online (`record --oracle`) for the deterministic
-/// subset — the seven [`OracleEligibility::Eligible`] rows below — and replay re-verifies those
-/// recorded outcomes per invocation from a pristine base; the three excluded rows carry the
-/// design-cited reason (§3.4 server `rand()`, §6.4 prepared-state/variable-count deferral).
+/// **statically modelled** counter expectation exists. The §6.3 + §6.4 **correctness tier**
+/// instead records each command's *actual* outcome online (`record --oracle`) for the
+/// oracle-eligible set — the nine [`OracleEligibility::Eligible`] rows below — and replay
+/// re-verifies those recorded outcomes per invocation from a pristine base; the one excluded row
+/// carries the design-cited reason (§3.4 server `rand()`).
 /// No capability: all plain Cypher.
 pub fn write_shapes() -> Vec<ShapeSpec> {
     use OracleEligibility::{Eligible, Excluded};
     // Every row is a Write-family, Full-tier, result-N/A shape with the write budget and a full
-    // corpus; only the name, the N/A reason and the §6.3 oracle eligibility vary.
+    // corpus; only the name, the N/A reason and the §6.3 + §6.4 oracle eligibility vary.
     fn s(
         name: &'static str,
         why_na: &'static str,

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -185,9 +185,10 @@ const ORACLE_NOT_A_WRITE: OracleEligibility =
     OracleEligibility::Excluded("not a write — no mutation outcome to capture (§6.3)");
 
 /// The names of the oracle-eligible write shapes (the §6.3 deterministic subset plus the §6.4
-/// prepared-state/variable-count shapes) — the single source of truth for which ops a format-v3
+/// prepared-state/variable-count shapes) — the single source of truth for which ops a format-v4
 /// bundle **must** carry outcomes for: capture targets exactly this set, and `recording::load` +
 /// replay enforce it exactly (no subset, no strays), so oracle coverage can never silently shrink.
+/// Frozen legacy v3 bundles are checked against `recording::LEGACY_V3_ORACLE_OPS` instead.
 pub fn oracle_eligible_names() -> std::collections::BTreeSet<&'static str> {
     write_shapes()
         .iter()

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -1045,7 +1045,7 @@ mod tests {
     }
 
     #[test]
-    fn oracle_eligibility_names_the_deterministic_subset_exactly() {
+    fn oracle_eligibility_names_the_eligible_set_exactly() {
         // §6.3 + §6.4 (design §5, phasing item 4): the oracle captures every write shape whose
         // outcome is reproducible from the restored base — the two plain create/update, the
         // create-once MERGEs, foreach_loop_mutation (§6.3), plus the prepared-state REMOVE and the

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -171,7 +171,9 @@ pub struct ShapeSpec {
 /// from a pristine base at C=1 — and replay re-verifies each recorded outcome per invocation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OracleEligibility {
-    /// In the §6.3 deterministic subset: oracle-captured at record time, re-verified at replay.
+    /// In the oracle-eligible subset (§6.3 deterministic writes + the §6.4
+    /// prepared-state/variable-count writes): oracle-captured at record time, re-verified at
+    /// replay.
     Eligible,
     /// Never oracle-captured, with the design-cited reason.
     Excluded(&'static str),
@@ -182,10 +184,10 @@ pub enum OracleEligibility {
 const ORACLE_NOT_A_WRITE: OracleEligibility =
     OracleEligibility::Excluded("not a write — no mutation outcome to capture (§6.3)");
 
-/// The names of the oracle-eligible write shapes (the §6.3 deterministic subset) — the single
-/// source of truth for which ops a format-v3 bundle **must** carry outcomes for: capture targets
-/// exactly this set, and `recording::load` + replay enforce it exactly (no subset, no strays), so
-/// oracle coverage can never silently shrink.
+/// The names of the oracle-eligible write shapes (the §6.3 deterministic subset plus the §6.4
+/// prepared-state/variable-count shapes) — the single source of truth for which ops a format-v3
+/// bundle **must** carry outcomes for: capture targets exactly this set, and `recording::load` +
+/// replay enforce it exactly (no subset, no strays), so oracle coverage can never silently shrink.
 pub fn oracle_eligible_names() -> std::collections::BTreeSet<&'static str> {
     write_shapes()
         .iter()
@@ -590,12 +592,12 @@ pub fn write_shapes() -> Vec<ShapeSpec> {
         s(
             "detach_delete_user",
             "latency tier — deletes are state-dependent (no-op on repeat) with variable counts",
-            Excluded("variable delete counts — deferred to §6.4 (phasing item 4)"),
+            Eligible,
         ),
         s(
             "remove_user_property_and_label",
-            "latency tier — REMOVE needs prepared state; deferred to the correctness tier (§4.2)",
-            Excluded("needs prepared state (pristine-base REMOVE is a no-op) — deferred to §6.4"),
+            "latency tier — REMOVE outcome depends on prepared state consumed by earlier repeats",
+            Eligible,
         ),
         s(
             "foreach_loop_mutation",
@@ -1044,10 +1046,12 @@ mod tests {
 
     #[test]
     fn oracle_eligibility_names_the_deterministic_subset_exactly() {
-        // §6.3 (design §5): the oracle captures the deterministic fixed-outcome subset — the two
-        // plain create/update, the create-once MERGEs, foreach_loop_mutation — and excludes the
-        // server-rand() shape (§3.4) plus the two §6.4-deferred shapes. Every non-write shape is
-        // excluded by construction (no mutation outcome exists to capture).
+        // §6.3 + §6.4 (design §5, phasing item 4): the oracle captures every write shape whose
+        // outcome is reproducible from the restored base — the two plain create/update, the
+        // create-once MERGEs, foreach_loop_mutation (§6.3), plus the prepared-state REMOVE and the
+        // variable-count DETACH DELETE (§6.4: per-command capture + per-invocation restore make
+        // both reproducible). Only the server-rand() shape (§3.4) stays excluded; every non-write
+        // shape is excluded by construction (no mutation outcome exists to capture).
         let eligible: Vec<&str> = write_shapes()
             .iter()
             .filter(|s| s.oracle == OracleEligibility::Eligible)
@@ -1062,9 +1066,11 @@ mod tests {
                 "merge_user_insert_path",
                 "merge_user_upsert_existing",
                 "merge_friend_edge_upsert",
+                "detach_delete_user",
+                "remove_user_property_and_label",
                 "foreach_loop_mutation",
             ],
-            "the §6.3 deterministic subset drifted"
+            "the oracle-eligible subset drifted"
         );
         let excluded: Vec<&str> = write_shapes()
             .iter()
@@ -1073,7 +1079,7 @@ mod tests {
             .collect();
         assert_eq!(
             excluded,
-            vec!["single_edge_update", "detach_delete_user", "remove_user_property_and_label"],
+            vec!["single_edge_update"],
             "the excluded set drifted"
         );
         for shape in repo_read_shapes().iter().chain(algorithm_read_shapes().iter()) {

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -2330,7 +2330,8 @@ async fn oracle_paths_name_the_op_and_seq_on_engine_failures() {
 
     // Record-time: capture must fail with the op/seq context and leave the base restored.
     let dir = temp_bundle_dir("syn-it-oracle-capfail");
-    recording::record_rendered(&spec, graph, &[broken_op()], 7, 1_000, &dir).expect("record v2");
+    recording::record_rendered_with_prepared(&spec, graph, &[broken_op()], 7, 1_000, &dir)
+        .expect("record with prepared");
     let err = oracle::capture(&endpoint(), &dir, 5_000, 6_000)
         .await
         .expect_err("capturing an engine-rejected command must fail");

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -2520,7 +2520,7 @@ async fn re_recording_over_an_oracle_bundle_succeeds_with_and_without_oracle() {
 
     // Re-record WITHOUT --oracle over the v4 bundle: the stale oracle/ must be cleared and the
     // resulting v2 bundle must load cleanly.
-    run_command(record(false)).await.expect("re-record without --oracle over v3");
+    run_command(record(false)).await.expect("re-record without --oracle over the oracle bundle");
     assert!(!dir.join("oracle").exists(), "stale oracle/ cleared by the plain re-record");
     let v2 = recording::load(&dir).expect("the re-recorded v2 bundle loads");
     assert_eq!(v2.manifest.format_version, 2);

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -2132,7 +2132,7 @@ async fn max_flow_runs_on_the_generated_simple_graph() {
 
 /// Phase 7 §6.3 — the full oracle flow end to end: `record --repo-writes --oracle` captures each
 /// eligible write's per-command outcomes online (double-pass determinism proven at record time),
-/// upgrades the bundle to format v3 with the outcomes hash-bound, and `replay::run` re-verifies
+/// upgrades the bundle to format v4 with the outcomes hash-bound, and `replay::run` re-verifies
 /// every recorded outcome from a pristine base before measuring latency.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
@@ -2165,7 +2165,7 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
     .expect("record --repo-writes --oracle via run_command");
 
     let bundle = recording::load(&dir).expect("load the oracle bundle");
-    assert_eq!(bundle.manifest.format_version, 3, "oracle bundles are recording format v3");
+    assert_eq!(bundle.manifest.format_version, 4, "oracle bundles are recording format v4");
     let mut eligible: Vec<&str> = write_shapes()
         .iter()
         .filter(|s| s.oracle == OracleEligibility::Eligible)
@@ -2196,18 +2196,19 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
     assert_eq!(svw.nodes_created, 1, "CREATE makes one node: {svw:?}");
 
     // Replay: the oracle verify pass runs before measurement and the whole run stays green —
-    // with --require-oracle asserting the bundle really is v3 (the downgrade guard's happy path).
+    // with --require-oracle asserting the bundle really carries one (the downgrade guard's
+    // happy path).
     let out = dir.join("oracle.json").to_string_lossy().into_owned();
     let mut config = replay_config(&dir, graph, &out, true);
     config.samples = 2;
     config.warmup = 0;
     config.cache = benchmark::synthetic::CacheSelection::Cached;
     config.require_oracle = true;
-    let report = replay::run(&config).await.expect("replay a v3 oracle bundle");
+    let report = replay::run(&config).await.expect("replay a v4 oracle bundle");
     assert_eq!(report.operations.len(), 10, "all 10 write shapes still measured");
-    // The report attests the verified oracle coverage (op → outcome count), so a v3→v2
+    // The report attests the verified oracle coverage (op → outcome count), so an oracle→v2
     // downgrade is visible to report consumers, not just to the replay log.
-    let attested = report.meta.oracle_verified.as_ref().expect("v3 replay attests its oracle");
+    let attested = report.meta.oracle_verified.as_ref().expect("v4 replay attests its oracle");
     assert_eq!(
         attested.keys().map(String::as_str).collect::<Vec<_>>(),
         eligible,
@@ -2234,9 +2235,10 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
 /// its latency anyway would silently poison the A/B trend.
 ///
 /// The bundle is a hand-rendered single-op recording carrying the eligible `single_vertex_write`
-/// name: the §6.3 exact-set rule makes it a valid v3 bundle (one recorded eligible op, full
-/// corpus), and crafting the outcome offline keeps the divergence deterministic — the plain
-/// CREATE reports `nodes_created=1`, so expecting 7 always diverges at seq 0.
+/// name: recorded with the §6.4 prepared phase, the §6.3 exact-set rule makes it a valid v4
+/// bundle (one recorded eligible op, full corpus), and crafting the outcome offline keeps the
+/// divergence deterministic — the plain CREATE reports `nodes_created=1`, so expecting 7 always
+/// diverges at seq 0.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
 async fn replay_hard_fails_on_a_diverged_oracle_outcome() {
@@ -2260,7 +2262,8 @@ async fn replay_hard_fails_on_a_diverged_oracle_outcome() {
         capability: None,
         commands: vec!["CREATE (:User {id: 999983})".to_string()],
     };
-    recording::record_rendered(&spec, graph, &[op], 7, 1_000, &dir).expect("record v2");
+    recording::record_rendered_with_prepared(&spec, graph, &[op], 7, 1_000, &dir)
+        .expect("record with prepared");
 
     // Attach a hash-valid but WRONG oracle: the plain CREATE reports nodes_created=1, so
     // expecting 7 is a guaranteed, deterministic divergence.
@@ -2299,7 +2302,7 @@ async fn replay_hard_fails_on_a_diverged_oracle_outcome() {
 
 /// Phase 7 §6.3 — engine failures inside the oracle paths carry the op/seq context: a command the
 /// engine rejects fails the record-time capture as `oracle capture: op … seq …` (base restored),
-/// and the same command in a crafted v3 bundle fails the replay verify pass as
+/// and the same command in a crafted v4 bundle fails the replay verify pass as
 /// `oracle verify: op … seq …` — both name where the failure happened, not just what.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
@@ -2341,7 +2344,7 @@ async fn oracle_paths_name_the_op_and_seq_on_engine_failures() {
     drop(g);
     std::fs::remove_dir_all(&dir).ok();
 
-    // Replay-time: a crafted v3 bundle whose SECOND command the engine rejects fails the verify
+    // Replay-time: a crafted v4 bundle whose SECOND command the engine rejects fails the verify
     // pass with the mirrored context — the first command is valid (and its outcome correct), so
     // the fail-fast probe and verify seq 0 both pass, isolating the engine error at seq 1.
     let dir = temp_bundle_dir("syn-it-oracle-verifyfail");
@@ -2352,7 +2355,8 @@ async fn oracle_paths_name_the_op_and_seq_on_engine_failures() {
         capability: None,
         commands: vec!["CREATE ()".to_string(), "THIS IS NOT CYPHER".to_string()],
     };
-    recording::record_rendered(&spec, graph, &[two_cmd_op], 7, 1_000, &dir).expect("record v2");
+    recording::record_rendered_with_prepared(&spec, graph, &[two_cmd_op], 7, 1_000, &dir)
+        .expect("record with prepared");
     let mut crafted = BTreeMap::new();
     crafted.insert(
         "single_vertex_write".to_string(),
@@ -2382,12 +2386,13 @@ async fn oracle_paths_name_the_op_and_seq_on_engine_failures() {
 }
 
 /// Phase 7 §6.3 — capture determinism end to end: two independent record+capture flows over the
-/// same seed produce byte-identical v3 bundles (same `workload_hash`, engine outcomes included),
+/// same seed produce byte-identical v4 bundles (same `workload_hash`, engine outcomes included),
 /// and a completed capture leaves the endpoint's graph content-identical to a fresh restore of
 /// the recorded base (§3.5 at record time).
 ///
-/// The bundle is a hand-rendered two-op recording carrying eligible shape names (the exact-set
-/// rule pins v3 oracles to eligible names): capture semantics — double pass, full corpus,
+/// The bundle is a hand-rendered two-op recording (prepared phase included) carrying eligible
+/// shape names (the exact-set rule pins v4 oracles to eligible names): capture semantics —
+/// double pass, full corpus,
 /// content-verified final restore — are identical to the full repo-writes flow (covered by the
 /// end-to-end test above) while the small corpus keeps the double capture fast.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2425,7 +2430,8 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
                 (0..2).map(|i| format!("MATCH (u:User {{id: {i}}}) SET u.probe = {i}")).collect(),
             ),
         ];
-        recording::record_rendered(&spec, graph, &ops, 7, 1_000, &dir).expect("record v2");
+        recording::record_rendered_with_prepared(&spec, graph, &ops, 7, 1_000, &dir)
+            .expect("record with prepared");
         dir
     };
 
@@ -2463,7 +2469,7 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
         .expect("capture oracle for bundle B");
     assert_eq!(
         manifest_a.workload_hash, manifest_b.workload_hash,
-        "same seed + same engine ⇒ identical v3 bundles, oracle outcomes included"
+        "same seed + same engine ⇒ identical v4 bundles, oracle outcomes included"
     );
 
     std::fs::remove_dir_all(&dir_a).ok();
@@ -2471,13 +2477,14 @@ async fn oracle_capture_is_deterministic_and_leaves_the_base_restored() {
     drop_graph(graph).await;
 }
 
-/// Phase 7 §6.3 — re-recording over an existing v3 bundle must work, with and without `--oracle`
-/// (the duck repro: a stale `oracle/` directory used to survive the plain re-record and brick
-/// every subsequent load, and the `--oracle` retry loaded the stale bundle before the repair
-/// could run). Exercises the real CLI `record` path end to end, twice over the same directory.
+/// Phase 7 §6.3 — re-recording over an existing oracle bundle must work, with and without
+/// `--oracle` (the duck repro: a stale `oracle/` directory used to survive the plain re-record
+/// and brick every subsequent load, and the `--oracle` retry loaded the stale bundle before the
+/// repair could run). Exercises the real CLI `record` path end to end, twice over the same
+/// directory.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires a running FalkorDB server"]
-async fn re_recording_over_a_v3_bundle_succeeds_with_and_without_oracle() {
+async fn re_recording_over_an_oracle_bundle_succeeds_with_and_without_oracle() {
     use benchmark::cli::SyntheticCommands;
     use benchmark::synthetic::run_command;
 
@@ -2502,16 +2509,16 @@ async fn re_recording_over_a_v3_bundle_succeeds_with_and_without_oracle() {
     };
 
     run_command(record(true)).await.expect("initial record --oracle");
-    let v3_hash = recording::load(&dir).expect("v3 loads").manifest.workload_hash;
+    let v4_hash = recording::load(&dir).expect("v4 loads").manifest.workload_hash;
 
-    // Re-record WITH --oracle over the v3 bundle: the capture-side self-heal must let the retry
-    // through (capture loads the bundle BEFORE attach's own heal), reproducing the identical v3.
-    run_command(record(true)).await.expect("re-record --oracle over v3");
-    let again = recording::load(&dir).expect("the re-captured v3 bundle loads");
-    assert_eq!(again.manifest.format_version, 3);
-    assert_eq!(again.manifest.workload_hash, v3_hash, "same seed + engine ⇒ same v3 bundle");
+    // Re-record WITH --oracle over the v4 bundle: the capture-side self-heal must let the retry
+    // through (capture loads the bundle BEFORE attach's own heal), reproducing the identical v4.
+    run_command(record(true)).await.expect("re-record --oracle over v4");
+    let again = recording::load(&dir).expect("the re-captured v4 bundle loads");
+    assert_eq!(again.manifest.format_version, 4);
+    assert_eq!(again.manifest.workload_hash, v4_hash, "same seed + engine ⇒ same v4 bundle");
 
-    // Re-record WITHOUT --oracle over the v3 bundle: the stale oracle/ must be cleared and the
+    // Re-record WITHOUT --oracle over the v4 bundle: the stale oracle/ must be cleared and the
     // resulting v2 bundle must load cleanly.
     run_command(record(false)).await.expect("re-record without --oracle over v3");
     assert!(!dir.join("oracle").exists(), "stale oracle/ cleared by the plain re-record");

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -2175,7 +2175,7 @@ async fn record_with_oracle_captures_verifies_and_replays_end_to_end() {
     assert_eq!(
         bundle.oracle.keys().map(String::as_str).collect::<Vec<_>>(),
         eligible,
-        "exactly the §6.3 deterministic subset is oracle-captured"
+        "exactly the oracle-eligible subset (§6.3 + §6.4) is oracle-captured"
     );
     for entry in &bundle.manifest.ops {
         if eligible.contains(&entry.name.as_str()) {


### PR DESCRIPTION
Phase 7, PR-4 of the writes-coverage design ([`docs/design/synthetic-cover-writes-phase7.md`](../blob/master/docs/design/synthetic-cover-writes-phase7.md), phasing item 4 — §6.4): make `remove_user_property_and_label` and `detach_delete_user` **oracle-eligible**, growing the correctness tier from 7 to **9 of the 10 write shapes** (only the server-`rand()` `single_edge_update` remains excluded, per §3.4 — permanently).

## What §6.4 needed

- `remove_user_property_and_label` (`REMOVE u.rpc_social_credit, u:TemporaryLabel`) is a **degenerate no-op on the pristine base**: generated `User`s carry only `{id, age}`, so there is nothing to remove and the oracle would prove nothing.
- `detach_delete_user` has **variable per-command outcomes** (`relationships_deleted` = the target's degree), which the pre-§6.3 fixed-expectation model couldn't express — but #267's per-command capture + per-invocation restore make variable counts naturally reproducible.

## Mechanism: prepared state as a recorded load phase

A new `LoadPhase::Prepared` (tag `prepared`) appends **one constant, deterministic statement** to every `--repo-writes` `graph.jsonl`:

```cypher
MATCH (u:User) SET u.rpc_social_credit = u.id % 97, u:TemporaryLabel
```

- Written and hashed like every other load statement (`record_rendered_with_prepared`, mirroring the fixture entry point), so the prepared state is **bound into the `workload_hash`** and cannot be silently dropped on replay.
- The §6.3 oracle restores the base **before every captured/verified command** by replaying the full `graph.jsonl` — so the prepared state provably precedes every `REMOVE`/`DETACH DELETE`, and each capture records a real mutation.
- Plain Cypher, no `spec`/seed-derived values: write bundles stay engine-agnostic and record/replay byte-identically.

> **Interpretation note (design ambiguity):** §6.4 says "prepared state" without fixing a mechanism. I chose a **recorded load phase** (mirroring the §3.4 fixture precedent) over per-command setup statements: the per-invocation restore already guarantees the state precedes every captured command, with zero new bundle machinery or format changes. Flagged in the design doc's phasing item 4.

## Eligibility flips

`shapes.rs`: both shapes `Excluded → Eligible` (annotations updated). Everything downstream derives from `shapes::oracle_eligible_names()` — capture targets, v3 exact-set enforcement at load/attach/replay, `--require-oracle`, attestation (`meta.oracle_verified`, `BaselineKey.eligible_write_ops`) — so the whole §6.3 machinery picked the two ops up with **no enforcement-code changes**.

## Flake root-caused and fixed (pre-existing, promoted to near-certain by this PR)

The first 9-op capture at 300/900 failed with a spurious `RedisError("timed out")`. **Control experiment**: the unmodified #267 head failed identically (load ~860 of the run, both runs), proving it pre-existing. Root cause: the §6.3 per-command loops opened **two fresh TCP connections per command** (`restore_base` + `open_graph`); a 9-op capture is ~9,200 rapid connects, and macOS Docker port-forwarding stalls after ~1k rapid connects (reproduced standalone: 3,000 bare connects stall ~5 s around conn 1,000–1,500), surfacing as a send timeout. At 7 ops (#267) the run usually squeaked under the stall window; at 9 ops it failed twice in a row.

Fix (`restore_base_on`): the capture pass and the replay verify pass now each reuse **one connection for the whole pass** — the same discipline the latency-tier measurement loop already uses. Latency semantics unaffected (capture/verify are untimed correctness passes; per-cell latency resets keep their own connections).

## Empirics (pinned image)

Image: `falkordb/falkordb:edge` @ `sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c` (same pin as #265–#267). Digest values are per-engine-build; reproducibility of the *outcomes* is the claim.

**Small-scale probe** (`--repo-writes --nodes 300 --edges 900 --seed 7 --oracle …`): capture = 9 ops × 256 = **2,304 outcomes**, dual-pass determinism proven; replay re-verified all 2,304 exactly (`oracle verified: 2304 recorded outcome(s) across 9 op(s) reproduced exactly`), 10 ops measured, `meta.oracle_verified` attests 9 ops / 2,304 outcomes. Per-op outcome distributions:

| op | outcome distribution (256 commands) |
| --- | --- |
| `remove_user_property_and_label` | `properties_removed=1` and `labels_removed=1` — **uniformly**, all 256 (real removals against the prepared state; a pristine-base run would record 0s) |
| `detach_delete_user` | `nodes_deleted=1` all 256; `relationships_deleted` **variable 2–11** (degree of the deleted user: 2×5, 3×19, 4×36, 5×51, 6×50, 7×30, 8×39, 9×12, 10×11, 11×3) — reproduced exactly across both capture passes and the replay verify |

**Full-scale evidence run** (`--repo-writes --nodes 1000 --edges 5000 --seed 42 --oracle …`, release build):

| step | result |
| --- | --- |
| capture (2 passes × 9 ops × 256) | ✅ 17m39s — 2,304 outcomes, determinism proven by the second pass |
| `workload_hash` (v3) | `sha256:b998ea3b8b769bb987e367c795f9af0680bda3109dc1b46071dd8fc18365111f` |
| replay `--require-oracle` (verify + measure) | ✅ 9m04s — `oracle verified: 2304 recorded outcome(s) across 9 op(s) reproduced exactly`; 10 ops measured; `meta.oracle_verified` attests 9 ops / 2,304 outcomes |

## Hash / compatibility implications

- **Write-bundle `workload_hash`es change** (the prepared statement is hashed; the v3 hash additionally covers the 2 new ops' outcomes). No committed bundle, golden, or CI job pins a write hash (`synthetic-verify`/`synthetic-sanity` are `--repo-reads` only) — verified by grep.
- **Read bundles are byte-identical**: `record_rendered` / `record_rendered_with_fixture` are untouched delegates of the shared impl; the `read_bundles_stay_format_v1` golden pins it.
- Old tool builds cannot load new write bundles (unknown `prepared` phase tag fails `load()` explicitly) — recording-internal forward evolution, same class as the fixture phase when it was added; the recorder and replayer travel together.

## Part B delta

**None.** No serialized report/summary/cells schema change: recording formats stay v1/v2/v3, report `meta.oracle_verified` shape unchanged (just up to 9 keys now), summary/cells versions untouched. The new `prepared` phase tag lives inside `graph.jsonl` (recording-internal).

## Tests

- `dataset.rs`: prepared statement constancy/tag/round-trip; `load_statements` leak-guard extended to the prepared phase.
- `recording.rs`: `record_rendered_with_prepared` appends exactly the prepared phase, round-trips through `load()`, keeps format v2, and folds the statement into the hash (≠ hash without it).
- `shapes.rs`: eligibility drift-guards repinned to the 9/1 split (deliberate).
- Live (all green vs the pinned image): 5 oracle e2e + 7 write e2e + `restore_base` digest proof, including the 9-op capture/verify paths under the connection-reuse fix.

## Gates

- `just ci` ✅ (build + clippy -D warnings + tests)
- `just coverage` ✅ — patch **100% (100/100 new lines)**
- `just doc-check` ✅
- `just synthetic-sanity` ✅ / `just synthetic-verify` ✅ (read-bundle byte-stability unaffected)

Design doc, readme and cookbook updated in this PR (status header, phasing item 4, §4/§5 staging notes, "9 of the 10" texts, prepared-state paragraphs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded write-oracle coverage to **9 of 10** shapes, including **§6.4** removal/deletion operations; **single-edge updates** remain excluded.
  * Recorded write bundles can now include a **deterministic prepared state** (prepared load phase), enabling reproducible state-dependent writes.
  * Introduced/standardized **oracle bundle format v4** with enforced prepared-phase presence for the eligible-op set.
* **Bug Fixes**
  * Reduced oracle verification overhead by reusing a single connection per verification pass.
* **Documentation**
  * Updated README, CLI help, and synthetic benchmark/design docs for v4 behavior, eligibility rules, oracle replay verification, and the updated recording time (**~18 minutes**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->