### PR TITLE
feat(synthetic): §6.5 decision — recorded write replay stays C=1 (empirically grounded)

### DIFF
--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -19,7 +19,9 @@ not-comparable; **stats only** — write result *values* stay un-captured per §
 tier — minting **recording format v4**; **amendment (post-review):** v4 requires the prepared
 phase and the nine-op exact set, while **format v3 is frozen** as the §6.3-era layout — the
 seven-op eligible set, no prepared phase — so pre-§6.4 v3 bundles keep loading and replaying
-under their own exact-set rule; cross-version rehash flips v3↔v4 are refused); §6.5 (concurrency) **not implemented**. **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+under their own exact-set rule; cross-version rehash flips v3↔v4 are refused); §6.5 (concurrency) **decided — recorded write replay stays C=1 permanently** (phasing
+item 5: verbatim replay of a fixed corpus on one shared graph cannot be partitioned across
+workers; enforced at record and replay). **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
 merged in PRs #240–#250) and is the sibling of the algorithms design (Phase 6). The parent design
@@ -140,8 +142,10 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
   create/update, the create-once MERGEs, `foreach_loop_mutation`) via the online oracle at C=1;
   since §6.4 also `remove_user_property_and_label` (against the recorded prepared state) and
   `detach_delete_user` (variable counts, reproducible per-command from the restored base).
-- **Deferred:** `single_edge_update` (server `rand()`, §3.4 — outside any oracle); C>1 writes.
-- **Out:** Neo4j/Memgraph variants; any digest gating of write results; any change to the per-PR read
+- **Deferred:** `single_edge_update` (server `rand()`, §3.4 — outside any oracle).
+- **Out:** C>1 recorded writes (decided by §6.5 — see phasing item 5's evidence; the **live**
+  probe's partitioned scratch shapes remain the write concurrency-scaling story); Neo4j/Memgraph
+  variants; any digest gating of write results; any change to the per-PR read
   gate or the A/B `--query-profile`.
 
 ## 6. Phasing (each its own PR)
@@ -195,7 +199,36 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
    per-command loops opened two fresh TCP connections per command (~9 200 rapid connects per
    capture), which stalls macOS Docker port-forwarding into a spurious send timeout — the §6.3
    loops now reuse **one connection per pass** (`restore_base_on`).
-5. ⛔ **Concurrency** — decide C>1 (per-worker id partitioning) or keep C=1 for correctness.
+5. ✅ **Concurrency — decided: recorded write replay stays C=1, permanently (both tiers).**
+   The design's option (a), per-worker id partitioning, already exists in the **live** probe
+   (`synthetic run` without `--recording`): each worker mutates its own id band of a run-unique
+   scratch label (`writes.rs` `WriteScratch`), so concurrent write *scaling* stays the live
+   probe's job. That mechanism does **not** transfer to recorded replay — a bundle replays its
+   pre-rendered command text verbatim on one shared recorded graph, and re-rendering per worker
+   would break the record-once/replay-verbatim `workload_hash` contract. Splitting a recorded
+   corpus across workers instead was measured and rejected empirically (all evidence on
+   `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`,
+   the digest behind the `:edge` tag used throughout Phase 7):
+   - *Corpus collisions (engine-independent, primary):* in the 9 write corpora of a
+     1 000-node/5 000-edge seed-42 bundle (`workload_hash`
+     `sha256:b998ea3b8b769bb987e367c795f9af0680bda3109dc1b46071dd8fc18365111f`), 27–107 of each
+     op's 256 commands hit a duplicate target id, and 25–101 of those pairs land on *different*
+     workers under an 8-way contiguous split — racing mutations of the same node/edge.
+   - *Topology (engine-independent, primary):* 35 068 of 50 000 edges (70%) in the 10 k/50 k
+     seed-42 graph cross an 8-way contiguous id-band partition, so edge-touching shapes cannot be
+     band-isolated at all.
+   - *MERGE races corrupt the graph (measured on the pinned engine):* two barrier-synced
+     connections MERGE-ing the same edge both fired `ON CREATE` in 200/200 trials, leaving two
+     duplicate edges each time — a C>1 split replay would *nondeterministically mutate the
+     recorded graph itself*, invalidating both latency comparison and the §6.3 oracle (whose
+     recorded outcomes are sequential by construction).
+   - *Control:* the engine itself scales partitioned point writes fine — indexed disjoint-band
+     `SET`s reached 3.2× throughput at C=8 vs C=1 — confirming the constraint is the recorded
+     corpus, not a global engine write lock.
+   Enforcement: replay has always validated the effective sweep (`validate_write_replay`,
+   `replay.rs`); record now also fails fast on a write op whose budget explicitly pins a non-`[1]`
+   sweep (`recording.rs`), so such a bundle can no longer be written. Budgets stay outside
+   `workload_hash`; no schema, format, or hash change.
 6. 🚧 **Docs** — folded into each phase's PR (doc sync is part of each phase's definition of
    done): §6.1's readme + cookbook updates shipped with phase 1.
 

--- a/docs/design/synthetic-cover-writes-phase7.md
+++ b/docs/design/synthetic-cover-writes-phase7.md
@@ -19,9 +19,10 @@ not-comparable; **stats only** — write result *values* stay un-captured per §
 tier — minting **recording format v4**; **amendment (post-review):** v4 requires the prepared
 phase and the nine-op exact set, while **format v3 is frozen** as the §6.3-era layout — the
 seven-op eligible set, no prepared phase — so pre-§6.4 v3 bundles keep loading and replaying
-under their own exact-set rule; cross-version rehash flips v3↔v4 are refused); §6.5 (concurrency) **decided — recorded write replay stays C=1 permanently** (phasing
-item 5: verbatim replay of a fixed corpus on one shared graph cannot be partitioned across
-workers; enforced at record and replay). **Rubber-duck reviewed**; this revision folds in the review's corrections — the
+under their own exact-set rule; cross-version rehash flips v3↔v4 are refused); §6.5 (concurrency) **decided — recorded write replay stays C=1 by policy** (phasing
+item 5: the shared-graph corpora as recorded interleave across any contiguous worker split, and
+partitioned-correct C>1 replay would take corpus-partitioning engineering we choose not to build
+now; enforced at record and replay). **Rubber-duck reviewed**; this revision folds in the review's corrections — the
 first draft's "counters are deterministic" thesis was wrong (see §10). Follows the reads-scope work
 (design [`synthetic-cover-ab-query-shapes.md`](./synthetic-cover-ab-query-shapes.md), Phases 1–5,
 merged in PRs #240–#250) and is the sibling of the algorithms design (Phase 6). The parent design
@@ -199,38 +200,61 @@ so a mixed bundle cannot express C=1 writes alongside C=1,8 reads).
    per-command loops opened two fresh TCP connections per command (~9 200 rapid connects per
    capture), which stalls macOS Docker port-forwarding into a spurious send timeout — the §6.3
    loops now reuse **one connection per pass** (`restore_base_on`).
-5. ✅ **Concurrency — decided: recorded write replay stays C=1, permanently (both tiers).**
+5. ✅ **Concurrency — decided: recorded write replay stays C=1, by policy (both tiers).**
    The design's option (a), per-worker id partitioning, already exists in the **live** probe
    (`synthetic run` without `--recording`): each worker mutates its own id band of a run-unique
    scratch label (`writes.rs` `WriteScratch`), so concurrent write *scaling* stays the live
-   probe's job. That mechanism does **not** transfer to recorded replay — a bundle replays its
-   pre-rendered command text verbatim on one shared recorded graph, and re-rendering per worker
-   would break the record-once/replay-verbatim `workload_hash` contract. Splitting a recorded
-   corpus across workers instead was measured and rejected empirically (all evidence on
+   probe's job. That mechanism does **not** transfer to recorded replay as-is — a bundle replays
+   its pre-rendered command text verbatim on one shared recorded graph, and re-rendering per
+   worker would break the record-once/replay-verbatim `workload_hash` contract. A
+   *partitioned-correct* C>1 replay is not impossible, but it is real corpus-partitioning
+   engineering — id-band-clean corpora rendered against the band layout, per-worker command
+   assignment, and a band-aware oracle — that we **choose not to build now**: the shared-graph
+   corpora as recorded do interleave across any contiguous worker split (measured below), and
+   naive C>1 on colliding commands corrupts the graph (measured below). Evidence (engine
+   measurements on
    `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`,
-   the digest behind the `:edge` tag used throughout Phase 7):
-   - *Corpus collisions (engine-independent, primary):* in the 9 write corpora of a
-     1 000-node/5 000-edge seed-42 bundle (`workload_hash`
-     `sha256:b998ea3b8b769bb987e367c795f9af0680bda3109dc1b46071dd8fc18365111f`), 27–107 of each
-     op's 256 commands hit a duplicate target id, and 25–101 of those pairs land on *different*
-     workers under an 8-way contiguous split — racing mutations of the same node/edge.
-   - *Topology (engine-independent, primary):* 35 068 of 50 000 edges (70%) in the 10 k/50 k
-     seed-42 graph cross an 8-way contiguous id-band partition, so edge-touching shapes cannot be
-     band-isolated at all.
-   - *MERGE races corrupt the graph (measured on the pinned engine):* two barrier-synced
-     connections MERGE-ing the same edge both fired `ON CREATE` in 200/200 trials, leaving two
-     duplicate edges each time — a C>1 split replay would *nondeterministically mutate the
-     recorded graph itself*, invalidating both latency comparison and the §6.3 oracle (whose
-     recorded outcomes are sequential by construction).
+   the digest behind the `:edge` tag used throughout Phase 7; corpus/topology analysis is
+   engine-independent and reproducible offline via
+   `scripts/synthetic_p65_partition_analysis.py` — `corpus`/`edges` mode respectively, over
+   bundles re-recorded offline with the cited seed/sizes):
+   - *Corpus collisions (engine-independent, primary):* in the 9 param-targeted write corpora of
+     a 1 000-node/5 000-edge seed-42 bundle (`workload_hash`
+     `sha256:b998ea3b8b769bb987e367c795f9af0680bda3109dc1b46071dd8fc18365111f`; `single_edge_update`
+     is rand()-targeted and skipped), commands collide on the node ids they touch (node shapes
+     touch `{id}`, edge-MERGE shapes touch `{from, to}`): per op, 27–107 of the 256 commands'
+     id-touches repeat an id an earlier command touched (`Σ (touches(id) − 1)` over ids touched
+     ≥ 2×), and 24–96 of those repeat-touches land on a *different* worker than an earlier touch
+     of the same id under an 8-way contiguous split into 32-command chunks
+     (`worker(seq) = seq // 32`) — mutations of the same node racing across workers. The two
+     edge-MERGE corpora never repeat a *directed `(from, to)` pair*, so same-edge MERGE
+     duplication (next bullet) is not triggered by these corpora as recorded — the collisions
+     here are same-*node* interleavings (`SET`/`DELETE`/`REMOVE` vs `MERGE` endpoints), which
+     reorder under a split and change what each command observes.
+   - *Topology (engine-independent, primary):* 35 063 of 50 000 edges (70.1%) in the 10 k/50 k
+     seed-42 graph cross an 8-way contiguous id-band partition (bands of 1 250 ids,
+     `band(id) = (id − 1) // 1250`), so edge-touching shapes cannot be band-isolated without
+     re-rendering the corpus against a band-clean layout.
+   - *Colliding MERGEs corrupt the graph (measured on the pinned engine):* two barrier-synced
+     connections MERGE-ing the *same* edge both fired `ON CREATE` in 200/200 trials, leaving two
+     duplicate edges each time. This pins the failure mode for *colliding* commands — not a
+     property of the recorded corpora themselves (whose directed edge pairs are unique, above),
+     but what a naive C>1 split risks wherever commands do collide on a target, and why
+     partitioned C>1 would demand collision-clean corpora by construction rather than by luck of
+     the seed. Any such corruption would *nondeterministically mutate the recorded graph itself*,
+     invalidating both latency comparison and the §6.3 oracle (whose recorded outcomes are
+     sequential by construction).
    - *Control:* the engine itself scales partitioned point writes fine — indexed disjoint-band
      `SET`s reached 3.2× throughput at C=8 vs C=1 — confirming the constraint is the recorded
      corpus, not a global engine write lock.
    Enforcement: replay has always validated the effective sweep (`validate_write_replay`,
    `replay.rs`); record now also fails fast on a write op whose budget explicitly pins a non-`[1]`
    sweep (`recording.rs`), so such a bundle can no longer be written. Budgets stay outside
-   `workload_hash`; no schema, format, or hash change.
-6. 🚧 **Docs** — folded into each phase's PR (doc sync is part of each phase's definition of
-   done): §6.1's readme + cookbook updates shipped with phase 1.
+   `workload_hash`; no schema, format, or hash change. Revisiting the policy means building the
+   partitioned-replay machinery above, not flipping the guard.
+6. ✅ **Docs** — folded into each phase's PR (doc sync is part of each phase's definition of
+   done): §6.1's readme + cookbook updates shipped with phase 1, and each later phase (§6.2–§6.5)
+   landed its readme/cookbook/design updates in its own PR.
 
 ## 7. Risks & open questions
 1. **Reset cost / throughput accounting (§3.3)** — per-invocation restore is expensive and pollutes

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -240,7 +240,10 @@ benchmark synthetic run --recording rec-writes --endpoint falkor://127.0.0.1:637
 ```
 
 This is the **latency tier** of the writes design: replay measures each write shape via
-`GRAPH.QUERY` at its pinned **C=1 budget** (100 samples, warm-up 10), **resets the base graph
+`GRAPH.QUERY` at its pinned **C=1 budget** (100 samples, warm-up 10; C=1 is **permanent** for
+recorded write replay per the design's §6.5 decision — a recorded corpus replays verbatim on one
+shared graph, so a worker split races on duplicate targets, and concurrent write *scaling* stays
+the live probe's job), **resets the base graph
 before every measured cell** (op × cache mode) so mutation drift stays bounded, and asserts
 **nothing** about results or mutation counters (`result_digest` stays `null` — outcomes are state-
 and value-dependent). The recorded graph ends with a deterministic **prepared-state** statement

--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -240,9 +240,10 @@ benchmark synthetic run --recording rec-writes --endpoint falkor://127.0.0.1:637
 ```
 
 This is the **latency tier** of the writes design: replay measures each write shape via
-`GRAPH.QUERY` at its pinned **C=1 budget** (100 samples, warm-up 10; C=1 is **permanent** for
-recorded write replay per the design's §6.5 decision — a recorded corpus replays verbatim on one
-shared graph, so a worker split races on duplicate targets, and concurrent write *scaling* stays
+`GRAPH.QUERY` at its pinned **C=1 budget** (100 samples, warm-up 10; C=1 is **policy** for
+recorded write replay per the design's §6.5 decision — the recorded commands interleave on shared
+node ids across any contiguous worker split, so a naive split races mutations of the same node,
+and concurrent write *scaling* stays
 the live probe's job), **resets the base graph
 before every measured cell** (op × cache mode) so mutation drift stays bounded, and asserts
 **nothing** about results or mutation counters (`result_digest` stays `null` — outcomes are state-

--- a/readme.md
+++ b/readme.md
@@ -501,9 +501,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   (design §6.4: every `User` gains `rpc_social_credit` + `:TemporaryLabel`, deterministically) so
   the `REMOVE` shape mutates state that actually exists — re-established by every base restore and
   hash-bound like every other load statement. Every write shape pins a **C=1 budget**
-  (100 samples, warm-up 10) — recorded write replay is **C=1 permanently** (design §6.5 decision:
-  a recorded corpus replays verbatim on one shared graph and cannot be partitioned across workers;
-  enforced at record *and* replay, while concurrent write **scaling** remains the live
+  (100 samples, warm-up 10) — recorded write replay is **C=1 by policy** (design §6.5 decision:
+  the recorded corpora interleave on shared node ids across any contiguous worker split, and a
+  partitioned-correct C>1 replay would take corpus-partitioning engineering that is deliberately
+  not built; enforced at record *and* replay, while concurrent write **scaling** remains the live
   `--write-ops` probe's job via per-worker scratch partitioning) — and is **result-N/A by
   design** — this is the **latency tier** of the
   writes design: mutation outcomes (result stats/counters) are state- and value-dependent, so

--- a/readme.md
+++ b/readme.md
@@ -501,7 +501,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   (design §6.4: every `User` gains `rpc_social_credit` + `:TemporaryLabel`, deterministically) so
   the `REMOVE` shape mutates state that actually exists — re-established by every base restore and
   hash-bound like every other load statement. Every write shape pins a **C=1 budget**
-  (100 samples, warm-up 10) and is **result-N/A by design** — this is the **latency tier** of the
+  (100 samples, warm-up 10) — recorded write replay is **C=1 permanently** (design §6.5 decision:
+  a recorded corpus replays verbatim on one shared graph and cannot be partitioned across workers;
+  enforced at record *and* replay, while concurrent write **scaling** remains the live
+  `--write-ops` probe's job via per-worker scratch partitioning) — and is **result-N/A by
+  design** — this is the **latency tier** of the
   writes design: mutation outcomes (result stats/counters) are state- and value-dependent, so
   nothing is asserted about them. Write bundles are single-kind, so `--repo-writes` is mutually
   exclusive with **every** read selector (`--op`/`--all-reads`/`--tier`/`--repo-reads`/

--- a/scripts/synthetic_p65_partition_analysis.py
+++ b/scripts/synthetic_p65_partition_analysis.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Phase 7 §6.5 evidence: corpus/topology partition analysis for a recorded bundle (E3/E4).
+
+Reproduces the two engine-independent figures behind the "recorded write replay stays C=1"
+decision in `docs/design/synthetic-cover-writes-phase7.md` (phasing item 5), from a bundle's
+on-disk files only (no server):
+
+- `edges <bundle-dir>`  — E3, topology: how many recorded base-graph edges cross a W-way
+  contiguous node-id band partition. Bands split the 1-based id range `1..=N` into W equal
+  bands of `N/W` ids: `band(id) = (id - 1) // (N / W)`; an edge crosses iff
+  `band(src) != band(dst)`.
+- `corpus <bundle-dir>` — E4, collisions: per write-op corpus (the K=256 rendered commands),
+  how commands collide on the node ids they target. Each command *touches* the node ids in
+  its rendered params — node-targeted shapes touch `{id}`, edge-MERGE shapes touch
+  `{from, to}`; `single_edge_update` (rand()-targeted, no param target) is skipped. Reported
+  per op, for a W-way contiguous split of the corpus into `K/W`-command chunks
+  (`worker(seq) = seq // (K / W)`):
+    - `repeat-touches`: touches of an id already touched by an earlier command,
+      `sum(touches(id) - 1)` over ids touched >= 2 times;
+    - `cross-worker`: the subset of repeat touches landing on a *different* worker than an
+      earlier touch of the same id — mutations of one node racing across workers;
+    - for edge-MERGE shapes, whether any directed `(from, to)` pair repeats within the
+      corpus (in the seed-42 bundles it never does — every MERGE targets a distinct edge).
+
+Usage:
+    python3 scripts/synthetic_p65_partition_analysis.py edges  <bundle-dir> [workers]
+    python3 scripts/synthetic_p65_partition_analysis.py corpus <bundle-dir> [workers]
+
+The bundles themselves are reproducible offline: `synthetic record --seed <s> --nodes <n>
+--edges <e> …` is deterministic (same seed + same tool build ⇒ identical bundle).
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+EDGE_PAIR = re.compile(r"\{src:(\d+),dst:(\d+)")
+PARAMS = re.compile(r"(\w+)\s*=\s*(\d+)")
+
+
+def load_edges(bundle: Path) -> List[Tuple[int, int]]:
+    pairs = []
+    with open(bundle / "graph.jsonl") as fh:
+        for line in fh:
+            record = json.loads(line)
+            if record["phase"] == "edges":
+                pairs += [(int(a), int(b)) for a, b in EDGE_PAIR.findall(record["cypher"])]
+    return pairs
+
+
+def edges_report(bundle: Path, workers: int) -> None:
+    pairs = load_edges(bundle)
+    nodes = json.load(open(bundle / "manifest.json"))["dataset"]["nodes"]
+    band_size = nodes // workers
+
+    def band(node_id: int) -> int:
+        return (node_id - 1) // band_size
+
+    crossing = sum(1 for src, dst in pairs if band(src) != band(dst))
+    print(f"nodes={nodes} edges={len(pairs)} workers={workers} band_size={band_size}")
+    print(f"band(id) = (id - 1) // {band_size}  (ids are 1-based)")
+    print(f"crossing edges: {crossing} / {len(pairs)} ({100 * crossing / len(pairs):.1f}%)")
+
+
+def corpus_targets(bundle: Path, op: str) -> Optional[List[tuple]]:
+    """Per-command rendered param targets: `(from, to)` for edge shapes, `(id,)` for node
+    shapes, or None when the op has no deterministic param target (rand()-picked)."""
+    targets = []
+    with open(bundle / "commands" / f"{op}.jsonl") as fh:
+        for line in fh:
+            record = json.loads(line)
+            params = dict(PARAMS.findall(record["cypher"].split(" MATCH", 1)[0].split(" MERGE", 1)[0]))
+            if "from" in params and "to" in params:
+                targets.append((int(params["from"]), int(params["to"])))
+            elif "id" in params:
+                targets.append((int(params["id"]),))
+            else:
+                return None
+    return targets
+
+
+def corpus_report(bundle: Path, workers: int) -> None:
+    ops = sorted(p.stem for p in (bundle / "commands").glob("*.jsonl"))
+    for op in ops:
+        targets = corpus_targets(bundle, op)
+        if targets is None:
+            print(f"{op:32} skipped (no param target — rand()-picked)")
+            continue
+        k = len(targets)
+        chunk = k // workers
+        touch_seqs: Dict[int, List[int]] = {}
+        for seq, target in enumerate(targets):
+            for node_id in set(target):
+                touch_seqs.setdefault(node_id, []).append(seq)
+        repeat_touches = sum(len(seqs) - 1 for seqs in touch_seqs.values())
+        cross_worker = sum(
+            1
+            for seqs in touch_seqs.values()
+            for later, seq in enumerate(seqs[1:], 1)
+            if any(seq // chunk != seqs[earlier] // chunk for earlier in range(later))
+        )
+        pair_note = ""
+        if targets and len(targets[0]) == 2:
+            dup_pairs = k - len(set(targets))
+            pair_note = f"  directed (from,to) pairs: {'all unique' if dup_pairs == 0 else f'{dup_pairs} repeated'}"
+        print(
+            f"{op:32} K={k}  repeat-touches={repeat_touches:4}  "
+            f"cross-worker (chunk={chunk}): {cross_worker:3}{pair_note}"
+        )
+
+
+def main() -> None:
+    if len(sys.argv) < 3 or sys.argv[1] not in ("edges", "corpus"):
+        sys.exit(__doc__)
+    bundle = Path(sys.argv[2])
+    workers = int(sys.argv[3]) if len(sys.argv) > 3 else 8
+    if sys.argv[1] == "edges":
+        edges_report(bundle, workers)
+    else:
+        corpus_report(bundle, workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/synthetic_p65_partition_analysis.py
+++ b/scripts/synthetic_p65_partition_analysis.py
@@ -12,15 +12,19 @@ on-disk files only (no server):
 - `corpus <bundle-dir>` — E4, collisions: per write-op corpus (the K=256 rendered commands),
   how commands collide on the node ids they target. Each command *touches* the node ids in
   its rendered params — node-targeted shapes touch `{id}`, edge-MERGE shapes touch
-  `{from, to}`; `single_edge_update` (rand()-targeted, no param target) is skipped. Reported
-  per op, for a W-way contiguous split of the corpus into `K/W`-command chunks
-  (`worker(seq) = seq // (K / W)`):
+  `{from, to}`; `single_edge_update` (rand()-targeted, no param target) is skipped, and any
+  other command without a recognizable target is an error (fail closed — a format change
+  must not silently drop collision evidence). Reported per op, for a W-way contiguous split
+  of the corpus into `K/W`-command chunks (`worker(seq) = seq // (K / W)`):
     - `repeat-touches`: touches of an id already touched by an earlier command,
       `sum(touches(id) - 1)` over ids touched >= 2 times;
     - `cross-worker`: the subset of repeat touches landing on a *different* worker than an
       earlier touch of the same id — mutations of one node racing across workers;
     - for edge-MERGE shapes, whether any directed `(from, to)` pair repeats within the
       corpus (in the seed-42 bundles it never does — every MERGE targets a distinct edge).
+
+W must be >= 1 and divide the node count (`edges`) / corpus size (`corpus`) exactly, so
+bands/chunks are equal — the split the figures are defined over; anything else is rejected.
 
 Usage:
     python3 scripts/synthetic_p65_partition_analysis.py edges  <bundle-dir> [workers]
@@ -39,6 +43,22 @@ from typing import Dict, List, Optional, Tuple
 EDGE_PAIR = re.compile(r"\{src:(\d+),dst:(\d+)")
 PARAMS = re.compile(r"(\w+)\s*=\s*(\d+)")
 
+# Ops with no deterministic param target (the server picks the row via rand()) — the only
+# corpora the collision analysis may skip; anything else unparsable is an error.
+RAND_TARGETED = {"single_edge_update"}
+
+
+def split_size(total: int, workers: int, what: str) -> int:
+    """The per-worker share of an exact W-way contiguous split, validating the split exists."""
+    if workers < 1:
+        sys.exit(f"workers must be >= 1, got {workers}")
+    if total == 0 or total % workers != 0:
+        sys.exit(
+            f"{what} ({total}) must be a non-zero multiple of workers ({workers}) — the "
+            f"figures are defined over equal contiguous bands/chunks"
+        )
+    return total // workers
+
 
 def load_edges(bundle: Path) -> List[Tuple[int, int]]:
     pairs = []
@@ -52,8 +72,11 @@ def load_edges(bundle: Path) -> List[Tuple[int, int]]:
 
 def edges_report(bundle: Path, workers: int) -> None:
     pairs = load_edges(bundle)
-    nodes = json.load(open(bundle / "manifest.json"))["dataset"]["nodes"]
-    band_size = nodes // workers
+    with open(bundle / "manifest.json") as fh:
+        nodes = json.load(fh)["dataset"]["nodes"]
+    band_size = split_size(nodes, workers, "node count")
+    if not pairs:
+        sys.exit("no edges found in the bundle's graph.jsonl edges phase")
 
     def band(node_id: int) -> int:
         return (node_id - 1) // band_size
@@ -66,10 +89,13 @@ def edges_report(bundle: Path, workers: int) -> None:
 
 def corpus_targets(bundle: Path, op: str) -> Optional[List[tuple]]:
     """Per-command rendered param targets: `(from, to)` for edge shapes, `(id,)` for node
-    shapes, or None when the op has no deterministic param target (rand()-picked)."""
-    targets = []
+    shapes, or None for the known rand()-targeted ops. A command without a recognizable
+    target in any other op — or a mix of target shapes within one op — is an error."""
+    if op in RAND_TARGETED:
+        return None
+    targets: List[tuple] = []
     with open(bundle / "commands" / f"{op}.jsonl") as fh:
-        for line in fh:
+        for seq, line in enumerate(fh):
             record = json.loads(line)
             params = dict(PARAMS.findall(record["cypher"].split(" MATCH", 1)[0].split(" MERGE", 1)[0]))
             if "from" in params and "to" in params:
@@ -77,7 +103,9 @@ def corpus_targets(bundle: Path, op: str) -> Optional[List[tuple]]:
             elif "id" in params:
                 targets.append((int(params["id"]),))
             else:
-                return None
+                sys.exit(f"{op} seq {seq}: no `id` or `from`/`to` param target — fail closed")
+            if len(targets[0]) != len(targets[-1]):
+                sys.exit(f"{op} seq {seq}: mixed target shapes within one op — fail closed")
     return targets
 
 
@@ -89,7 +117,7 @@ def corpus_report(bundle: Path, workers: int) -> None:
             print(f"{op:32} skipped (no param target — rand()-picked)")
             continue
         k = len(targets)
-        chunk = k // workers
+        chunk = split_size(k, workers, f"{op} corpus size")
         touch_seqs: Dict[int, List[int]] = {}
         for seq, target in enumerate(targets):
             for node_id in set(target):

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -650,17 +650,19 @@ fn record_rendered_impl(
             op.capability.as_deref().unwrap_or_default()
         )));
     }
-    // Recorded write replay is C=1 by decision (§6.5): the corpus is replayed verbatim on one
-    // shared graph, so a concurrency split races on duplicate targets and cross-band edges —
-    // measured on the pinned dev image, racing MERGEs of one edge both fire ON CREATE and
-    // duplicate it. Replay enforces the effective sweep; fail the explicit pin early here too.
+    // Recorded write replay is C=1 by policy (§6.5): the corpus is replayed verbatim on one
+    // shared graph, and its commands interleave on shared node ids across any contiguous worker
+    // split — measured on the pinned dev image, racing MERGEs of one colliding edge both fire
+    // ON CREATE and duplicate it. A partitioned-correct C>1 replay would take corpus-partitioning
+    // engineering (id-band-clean corpora, per-worker assignment) that is deliberately not built.
+    // Replay enforces the effective sweep; fail the explicit pin early here too.
     if let Some(op) = ops.iter().find(|op| {
         op.key.kind() == QueryType::Write
             && op.budget.concurrency.as_deref().is_some_and(|sweep| sweep != [1])
     }) {
         return Err(OtherError(format!(
             "write op '{}' pins concurrency sweep {:?} — recorded write replay is C=1 only \
-             (design §6.5: a recorded corpus cannot be partitioned across workers)",
+             (design §6.5 policy: the recorded corpus is not partitioned across workers)",
             op.key.name(),
             op.budget.concurrency.as_deref().unwrap_or_default()
         )));
@@ -1751,7 +1753,7 @@ mod tests {
 
     #[test]
     fn record_rejects_a_write_op_pinning_a_non_c1_sweep() {
-        // §6.5: recorded write replay is C=1 permanently. Replay enforces the *effective* sweep
+        // §6.5 policy: recorded write replay stays C=1. Replay enforces the *effective* sweep
         // (budgets are outside workload_hash), but an explicitly pinned C>1 budget is caught at
         // record time too — fail before writing a bundle replay can only reject.
         let spec = DatasetSpec {

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -650,6 +650,21 @@ fn record_rendered_impl(
             op.capability.as_deref().unwrap_or_default()
         )));
     }
+    // Recorded write replay is C=1 by decision (§6.5): the corpus is replayed verbatim on one
+    // shared graph, so a concurrency split races on duplicate targets and cross-band edges —
+    // measured on the pinned dev image, racing MERGEs of one edge both fire ON CREATE and
+    // duplicate it. Replay enforces the effective sweep; fail the explicit pin early here too.
+    if let Some(op) = ops.iter().find(|op| {
+        op.key.kind() == QueryType::Write
+            && op.budget.concurrency.as_deref().is_some_and(|sweep| sweep != [1])
+    }) {
+        return Err(OtherError(format!(
+            "write op '{}' pins concurrency sweep {:?} — recorded write replay is C=1 only \
+             (design §6.5: a recorded corpus cannot be partitioned across workers)",
+            op.key.name(),
+            op.budget.concurrency.as_deref().unwrap_or_default()
+        )));
+    }
     // Content-determined format version: any write op ⇒ v2 (kind folded into the workload hash);
     // an all-read bundle stays v1, byte-identical to every bundle recorded before writes existed.
     let format_version = if has_writes {
@@ -1732,6 +1747,47 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).ok();
         std::fs::remove_dir_all(&dir2).ok();
+    }
+
+    #[test]
+    fn record_rejects_a_write_op_pinning_a_non_c1_sweep() {
+        // §6.5: recorded write replay is C=1 permanently. Replay enforces the *effective* sweep
+        // (budgets are outside workload_hash), but an explicitly pinned C>1 budget is caught at
+        // record time too — fail before writing a bundle replay can only reject.
+        let spec = DatasetSpec {
+            seed: 5,
+            nodes: 200,
+            edges: 400,
+        };
+        let op = |sweep: Option<Vec<usize>>| RecordedOp {
+            key: OpKey::dynamic("w_solo", QueryType::Write),
+            result_gated: false,
+            budget: RecordedBudget {
+                concurrency: sweep,
+                ..RecordedBudget::default()
+            },
+            capability: None,
+            commands: vec!["MATCH (u:User {id: 1}) SET u.x = 1".to_string()],
+        };
+
+        let dir = temp_bundle_dir("synthrec-c8-write");
+        let err = record_rendered(&spec, "g", &[op(Some(vec![8]))], 9, 32, &dir).unwrap_err();
+        assert!(
+            format!("{err}").contains("recorded write replay is C=1 only"),
+            "got: {err}"
+        );
+        assert!(format!("{err}").contains("[8]"), "must name the offending sweep: {err}");
+
+        // An explicit [1] pin and an inherit budget (None) both record fine — replay guards the
+        // effective sweep for the inherit case.
+        let dir_ok = temp_bundle_dir("synthrec-c1-write");
+        record_rendered(&spec, "g", &[op(Some(vec![1]))], 9, 32, &dir_ok).unwrap();
+        let dir_inherit = temp_bundle_dir("synthrec-inherit-write");
+        record_rendered(&spec, "g", &[op(None)], 9, 32, &dir_inherit).unwrap();
+
+        std::fs::remove_dir_all(&dir).ok();
+        std::fs::remove_dir_all(&dir_ok).ok();
+        std::fs::remove_dir_all(&dir_inherit).ok();
     }
 
     #[test]

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -614,7 +614,7 @@ pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
 /// - **`--no-load` forbidden**: write measurement is defined from the recorded base graph
 ///   (per-cell resets reload it — §3.3);
 /// - **C=1 only**: every write op's *effective* sweep (its recorded budget's, else the run's)
-///   must be exactly `[1]` (§5 defers concurrent writes);
+///   must be exactly `[1]` (§6.5: recorded write replay is C=1 permanently);
 /// - **never result-gated**: the latency tier asserts nothing (§4.1) — a gated write would imply
 ///   a correctness capture the write path deliberately skips;
 /// - **never capability-gated**: write shapes are algorithm-free plain Cypher (§4.1), and
@@ -647,7 +647,7 @@ fn validate_write_replay(
         if sweep != [1] {
             return Err(OtherError(format!(
                 "write op '{}' resolves to concurrency sweep {:?} — write replay is C=1 only \
-                 (design §5; budgets are outside workload_hash, so this is enforced at replay)",
+                 (design §6.5; budgets are outside workload_hash, so this is enforced at replay)",
                 op.name(),
                 sweep
             )));
@@ -732,8 +732,8 @@ async fn measure_write_op(
     };
     Ok(OperationReport {
         levels: vec![LevelReport {
-            // The op's effective sweep — `[1]` today, enforced by `validate_write_replay`, and
-            // derived (not hardcoded) so the report stays honest if §5's C>1 decision ever lands.
+            // The op's effective sweep — `[1]`, enforced by `validate_write_replay` per the §6.5
+            // decision, and derived (not hardcoded) so the report stays honest with the guard.
             concurrency: op_concurrency.first().copied().unwrap_or(1),
             cached,
             uncached,

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -614,7 +614,7 @@ pub async fn run_and_report(config: &ReplayConfig) -> BenchmarkResult<()> {
 /// - **`--no-load` forbidden**: write measurement is defined from the recorded base graph
 ///   (per-cell resets reload it — §3.3);
 /// - **C=1 only**: every write op's *effective* sweep (its recorded budget's, else the run's)
-///   must be exactly `[1]` (§6.5: recorded write replay is C=1 permanently);
+///   must be exactly `[1]` (§6.5 policy: recorded write replay stays C=1);
 /// - **never result-gated**: the latency tier asserts nothing (§4.1) — a gated write would imply
 ///   a correctness capture the write path deliberately skips;
 /// - **never capability-gated**: write shapes are algorithm-free plain Cypher (§4.1), and
@@ -1137,7 +1137,7 @@ mod tests {
 
     #[test]
     fn validate_write_replay_rejects_a_non_c1_sweep() {
-        // §5: C=1 only — budgets are outside workload_hash, so a tampered budget passes the load
+        // §6.5: C=1 only — budgets are outside workload_hash, so a tampered budget passes the load
         // hash gate and MUST be caught here, whether the sweep comes from the budget…
         let tampered = RecordedBudget {
             concurrency: Some(vec![8]),

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -496,9 +496,10 @@ pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {
     ]
 }
 
-/// The per-op replay budget every write shape records (Phase 7 §4.1): **C=1 only** — concurrent
-/// writes are explicitly deferred (design §5; interleaved mutations change what each invocation
-/// does, so a C>1 latency number would not be comparable across versions) — with a modest
+/// The per-op replay budget every write shape records (Phase 7 §4.1): **C=1 only** — decided
+/// permanent by §6.5 (a recorded corpus is replayed verbatim on one shared graph: duplicate
+/// targets and cross-band edges make any worker split race, and interleaved mutations change what
+/// each invocation does, so a C>1 latency number would not be comparable across versions) — with a modest
 /// samples/warmup so the drift a cell accumulates between base resets stays small (~110
 /// invocations/cell). Cache modes + timeouts inherit the run's global knobs: the write shapes are
 /// single-entity point mutations, as cheap as the point reads, and their uncached-vs-cached
@@ -1029,8 +1030,8 @@ mod tests {
     fn write_shapes_are_uniformly_latency_tier_annotated() {
         // Phase 7 §4.1 (latency tier): every write shape is Write-family, Full-tier (never in the
         // per-PR Core gate), result-N/A (mutation outcomes are state/value-dependent — §2/§10),
-        // plain Cypher (no capability), full corpus, and pinned to the C=1 write budget (§5 defers
-        // concurrent writes).
+        // plain Cypher (no capability), full corpus, and pinned to the C=1 write budget (§6.5:
+        // recorded write replay is C=1 permanently).
         for shape in write_shapes() {
             assert_eq!(shape.family, CoverageFamily::Write, "{}", shape.name);
             assert_eq!(shape.tier, Tier::Full, "{}", shape.name);
@@ -1043,7 +1044,7 @@ mod tests {
             assert_eq!(shape.corpus_size, CORPUS_SIZE, "{}", shape.name);
             assert_eq!(shape.budget, WRITE_BUDGET, "{}", shape.name);
         }
-        assert_eq!(WRITE_BUDGET.concurrency, Some(&WRITE_SWEEP[..]), "write replay is C=1 (§5)");
+        assert_eq!(WRITE_BUDGET.concurrency, Some(&WRITE_SWEEP[..]), "write replay is C=1 (§6.5)");
     }
 
     #[test]

--- a/src/synthetic/shapes.rs
+++ b/src/synthetic/shapes.rs
@@ -496,10 +496,11 @@ pub fn algorithm_read_shapes() -> Vec<ShapeSpec> {
     ]
 }
 
-/// The per-op replay budget every write shape records (Phase 7 §4.1): **C=1 only** — decided
-/// permanent by §6.5 (a recorded corpus is replayed verbatim on one shared graph: duplicate
-/// targets and cross-band edges make any worker split race, and interleaved mutations change what
-/// each invocation does, so a C>1 latency number would not be comparable across versions) — with a modest
+/// The per-op replay budget every write shape records (Phase 7 §4.1): **C=1 only** — the §6.5
+/// policy decision (a recorded corpus is replayed verbatim on one shared graph: its commands
+/// interleave on shared node ids across any contiguous worker split, so a naive split races
+/// mutations of the same node and a C>1 latency number would not be comparable across versions;
+/// a partitioned-correct C>1 replay is corpus-partitioning engineering deliberately not built) — with a modest
 /// samples/warmup so the drift a cell accumulates between base resets stays small (~110
 /// invocations/cell). Cache modes + timeouts inherit the run's global knobs: the write shapes are
 /// single-entity point mutations, as cheap as the point reads, and their uncached-vs-cached
@@ -1030,8 +1031,8 @@ mod tests {
     fn write_shapes_are_uniformly_latency_tier_annotated() {
         // Phase 7 §4.1 (latency tier): every write shape is Write-family, Full-tier (never in the
         // per-PR Core gate), result-N/A (mutation outcomes are state/value-dependent — §2/§10),
-        // plain Cypher (no capability), full corpus, and pinned to the C=1 write budget (§6.5:
-        // recorded write replay is C=1 permanently).
+        // plain Cypher (no capability), full corpus, and pinned to the C=1 write budget (§6.5
+        // policy: recorded write replay stays C=1).
         for shape in write_shapes() {
             assert_eq!(shape.family, CoverageFamily::Write, "{}", shape.name);
             assert_eq!(shape.tier, Tier::Full, "{}", shape.name);


### PR DESCRIPTION
## What

Closes the last open Phase 7 phasing item (design §6.5 / phasing item 5, [`docs/design/synthetic-cover-writes-phase7.md`](../blob/barakb/phase7-concurrency-decision/docs/design/synthetic-cover-writes-phase7.md)): **recorded write replay stays C=1 — by policy, for both tiers.** The design asked to *"decide C>1 (per-worker id partitioning) or keep C=1 for correctness"*; this PR makes the decision empirically, documents the evidence in the design doc, and adds the missing record-side enforcement.

**No schema, recording-format, or `workload_hash` change** (budgets are outside the hash; all hash goldens pass unchanged). **Part B delta: none.**

## The decision, in one paragraph

A recorded bundle replays its pre-rendered command text **verbatim on one shared recorded graph**. A *partitioned-correct* C>1 replay is not impossible — but it is real corpus-partitioning engineering (id-band-clean corpora rendered against the band layout, per-worker command assignment, a band-aware oracle) that we **choose not to build now**. What the evidence pins: the corpora as recorded interleave on shared node ids across any contiguous worker split (E4), most edges cross any id-band partition (E3), and where commands *do* collide on a target, the engine corrupts under a naive race — two connections MERGE-ing the same edge each fire `ON CREATE` (E5) — which would nondeterministically mutate the recorded graph itself, invalidating both the latency comparison and the §6.3 oracle (whose recorded outcomes are sequential by construction). The design's option (a) — per-worker id partitioning — already exists in the **live** probe (`WriteScratch` id bands, `writes.rs`), which remains the write concurrency-*scaling* story; it cannot transfer to recorded replay without re-rendering command text per worker, which would break the record-once/replay-verbatim `workload_hash` contract.

## Evidence

Engine measurements (E1/E2/E5) on `falkordb/falkordb@sha256:e47e0fb112ff29764965a1c25e2f983dd269de33367ca3f2fba61368b735f38c`, the digest behind `:edge` used throughout Phase 7. Corpus/topology analysis (E3/E4) is engine-independent and reproducible offline with `scripts/synthetic_p65_partition_analysis.py` (added in this PR) over bundles re-recorded with the cited seed/sizes.

| # | Probe | Result | Reading |
|---|---|---|---|
| E1 | Live probe (`synthetic run`, non-recorded), 10 k/50 k seed 42, C=1,2,4,8 cached, 2 000 samples | `create_node` 3.33×@C8, `match_by_index` (read control) 4.18×, but `merge_hit` 0.19× / `set_property` 0.14× | Live write shapes that MATCH/MERGE on the **unindexed** scratch label collapse under C>1 — a shape artifact (label scan under write lock), *not* engine serialization; noted as possible future live-probe improvement, out of scope here |
| E2 | Control: indexed `User.id` point-`SET`s, disjoint 1 000-id band per worker | 2 187 qps @C1 → 7 041 qps @C8 = **3.2×** | The engine scales partitioned point writes fine — no global write lock; the constraint is the recorded corpus |
| E3 | Topology: 10 k/50 k seed-42 graph vs an 8-way contiguous id-band partition (bands of 1 250 ids, `band(id) = (id − 1) // 1250`) | **35 063 / 50 000 edges (70.1 %) cross bands** | Edge-touching shapes cannot be band-isolated without re-rendering the corpus against a band-clean layout |
| E4 | The 9 param-targeted write corpora of a 1 000/5 000 seed-42 bundle (`workload_hash` `sha256:b998ea3b8b769bb987e367c795f9af0680bda3109dc1b46071dd8fc18365111f`; `single_edge_update` is rand()-targeted, skipped). Node shapes touch `{id}`, edge-MERGE shapes touch `{from, to}` | Per op, **27–107 of 256** commands' id-touches repeat an earlier command's id (`Σ (touches(id) − 1)` over ids touched ≥ 2×); **24–96** of those repeat-touches land on a *different* worker under an 8-way split into 32-command chunks (`worker(seq) = seq // 32`). Both edge-MERGE corpora: directed `(from, to)` pairs **all unique** | Any contiguous split of a recorded corpus races mutations of the same *node* across workers; same-edge MERGE duplication (E5) is a collision failure mode, not a property of these corpora as recorded |
| E5 | Two barrier-synced connections `MERGE` the same edge, 200 trials | **200/200: both fired `ON CREATE` → two duplicate edges every time** (sequential control: second MERGE matched) | `MERGE` is not atomic across connections on the pinned engine — pins what a naive C>1 split risks wherever commands collide on a target, and why partitioned C>1 would demand collision-clean corpora by construction rather than by luck of the seed |

E3/E4 are engine-independent (inherent to verbatim replay of a fixed corpus) and are the primary grounds; E5 pins the corruption failure mode for colliding commands on the pinned engine. E1/E2 rule out the tempting counter-argument ("the engine can't scale writes anyway — nothing lost"): it can, and the live probe is where that is measured.

## Code changes (small, enforcement + docs)

- **`recording.rs`** — new record-side fail-fast: a write op whose budget **explicitly pins** a non-`[1]` concurrency sweep is rejected at record time (mirrors the existing result-gated/capability guards), so a bundle that replay could only reject can no longer be written. `None`/inherit budgets stay legal at record — replay has always validated the **effective** sweep (`validate_write_replay`) and still does.
- **`replay.rs` / `shapes.rs`** — deferral phrasings ("§5 defers concurrent writes", "if §5's C>1 decision ever lands") flipped to the §6.5 decision; the replay error's design cite updated (`§5` → `§6.5`; asserted substrings unchanged).
- **`scripts/synthetic_p65_partition_analysis.py`** — the E3/E4 analysis, committed so the corpus/topology figures are reproducible offline (`edges <bundle>` / `corpus <bundle>`; formulas in the doc match the script).
- **Design doc** — phasing item 5 ⛔ → ✅ with the evidence above (C=1 framed as *policy*, with the partitioned-replay engineering named as the not-built alternative); §5 scope moves "C>1 writes" from *Deferred* to *Out (decided)*; phasing item 6 (docs) 🚧 → ✅; status header updated.
- **`readme.md` / cookbook** — the write-bundle sections state the C=1-by-policy decision.
- **Test** — `record_rejects_a_write_op_pinning_a_non_c1_sweep`: explicit `[8]` rejected (message names the sweep + §6.5), explicit `[1]` accepted, inherit (`None`) accepted.

## Interpretation note

The design phrased item 5 as *decide or implement*. I chose **decide-with-enforcement**: the decision is recorded in the design doc with its evidence, and both ends of the pipeline now enforce it (record-side new, replay-side pre-existing). No mechanism for C>1 recorded writes is built or half-built; revisiting the policy means building the partitioned-replay machinery named in the design doc (id-band-clean corpora, per-worker assignment, band-aware oracle), not flipping the guard.

## Validation

- `just ci` ✅ (build + clippy `-D warnings` + tests)
- `just coverage` ✅ against the pinned image — **patch coverage 100 %** (all instrumented added lines)
- `just doc-check` ✅ (doc-links + doc-shell)
- Hash goldens unchanged ✅ (the guard is record-time validation only; budgets are outside `workload_hash`)
- E3/E4 figures re-derived from the committed script against freshly re-recorded offline bundles (same seeds) — output matches the tables above verbatim

Retargeted to `master` after #268 merged. Not for merge until the maintainer decides (per plan, §6.5 lands in a later window).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line analysis tool for examining recorded benchmark bundle partitioning, repeated node touches, and cross-worker collisions.
* **Bug Fixes**
  * Recorded write replays now consistently enforce a single-worker concurrency setting.
  * Recording rejects write configurations that explicitly request unsupported concurrency levels.
* **Documentation**
  * Clarified write replay concurrency, reset behavior, result reporting, deferred scaling, and Phase 7 completion criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->