### PR TITLE
synthetic: fix pinned repo-reads full workload hash golden

### DIFF
--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -2697,7 +2697,7 @@ mod tests {
         let bundle = recording::load(&out_dir).expect("golden bundle loads");
         assert_eq!(
             bundle.manifest.workload_hash,
-            "sha256:830faf23b57ed61be8e1728a2ec73f09cf3d6fe2d24f0d70b6f8c11ed00c8de4",
+            "sha256:894858b3aefc8b06d03edab41747e255c6eeb145b7cb87b683fb8c10f707721d",
             "the --repo-reads full command stream changed byte-wise"
         );
         std::fs::remove_dir_all(&out_dir).ok();


### PR DESCRIPTION
## Summary
- update the pinned hash in `src/synthetic/mod.rs` for `repo_reads_full_workload_hash_golden_is_pinned`
- align expected value with the new deterministic `--repo-reads full` command stream after extended-core 5/6-hop alignment

## Validation
- `cargo test --manifest-path /tmp/benchmark-golden-followup/Cargo.toml synthetic::tests::repo_reads_full_workload_hash_golden_is_pinned`
- `cargo test --manifest-path /tmp/benchmark-golden-followup/Cargo.toml synthetic::shapes::tests::`

Co-Authored-By: Oz <oz-agent@warp.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the recorded workload verification value to match the newly generated repository-reads workload.
  * Maintains validation for byte-identical workload output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->