### PR TITLE
feat(synthetic)!: gate regressions on server_ms by default (total-ms opt-in)

### DIFF
--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -28,7 +28,7 @@ at a glance (🟢 good / 🔴 regressed). It never fails the PR.
 | Coloring | 🟢 / 🔴 emoji per cell in the Markdown table. |
 | Sweep | full concurrency `1,2,4,8,16,32` × both cache modes. |
 | Verdict rule | 🟢 if PR is **faster** *or* **slower within budget**; 🔴 if slower beyond budget **and** the absolute p50 delta exceeds a noise floor; diverged op → correctness-🔴, perf verdict **N/A**. |
-| Metric definition | `p50` = the **total-latency median** (`total_ms` p50) of a cell. |
+| Metric definition | `p50` = the **total-latency median** (`total_ms` p50) of a cell. *(Later addition: `--gated-metric server-ms` gates the server-reported execution-time median instead; `total-ms` stays the default.)* |
 | Tool ref | a **separate** `SYNTHETIC_BENCHMARK_REF` **pinned to an immutable commit SHA** (tagged for reference) — the A/B's `BENCHMARK_REF=v2.2` is left untouched. |
 | Failure handling | the synthetic job is **non-blocking** (allowed-to-fail / not a required check); any tool/infra failure posts a "benchmark unavailable" note instead of blocking. |
 | Trigger scope | PR-triggered runs only (dispatch has no PR); **arch-specific** comment markers to avoid x86/arm races. |
@@ -69,7 +69,9 @@ column headers (falling back to `A (baseline)` / `B (candidate)` when absent), s
 
 New optional flag `--thresholds <file.toml>` (see A3 for the mode flag it accompanies). The tool
 ships a built-in default (budget 10 %, `metric = "p50"`, a small absolute floor); the file
-overrides. `p50` means the cell's **total-latency median** (`total_ms` p50). Format (lives in
+overrides. `p50` means the cell's **total-latency median** (`total_ms` p50). *(Later addition: the
+`--gated-metric` flag can point the gate at the `server_ms` median instead — the budget shapes
+below apply to whichever metric is selected.)* Format (lives in
 `falkordb-rs-next-gen`, TOML to match `synthetic-bench.toml`):
 
 ```toml

--- a/docs/design/synthetic-pr-regression-report.md
+++ b/docs/design/synthetic-pr-regression-report.md
@@ -28,7 +28,7 @@ at a glance (🟢 good / 🔴 regressed). It never fails the PR.
 | Coloring | 🟢 / 🔴 emoji per cell in the Markdown table. |
 | Sweep | full concurrency `1,2,4,8,16,32` × both cache modes. |
 | Verdict rule | 🟢 if PR is **faster** *or* **slower within budget**; 🔴 if slower beyond budget **and** the absolute p50 delta exceeds a noise floor; diverged op → correctness-🔴, perf verdict **N/A**. |
-| Metric definition | `p50` = the **total-latency median** (`total_ms` p50) of a cell. *(Later addition: `--gated-metric server-ms` gates the server-reported execution-time median instead; `total-ms` stays the default.)* |
+| Metric definition | `p50` = the **total-latency median** (`total_ms` p50) of a cell. *(Later change: the gate now defaults to the **server-reported execution-time** median — `--gated-metric server-ms`; the total-latency median stays available via the explicit `--gated-metric total-ms` opt-in.)* |
 | Tool ref | a **separate** `SYNTHETIC_BENCHMARK_REF` **pinned to an immutable commit SHA** (tagged for reference) — the A/B's `BENCHMARK_REF=v2.2` is left untouched. |
 | Failure handling | the synthetic job is **non-blocking** (allowed-to-fail / not a required check); any tool/infra failure posts a "benchmark unavailable" note instead of blocking. |
 | Trigger scope | PR-triggered runs only (dispatch has no PR); **arch-specific** comment markers to avoid x86/arm races. |
@@ -69,9 +69,10 @@ column headers (falling back to `A (baseline)` / `B (candidate)` when absent), s
 
 New optional flag `--thresholds <file.toml>` (see A3 for the mode flag it accompanies). The tool
 ships a built-in default (budget 10 %, `metric = "p50"`, a small absolute floor); the file
-overrides. `p50` means the cell's **total-latency median** (`total_ms` p50). *(Later addition: the
-`--gated-metric` flag can point the gate at the `server_ms` median instead — the budget shapes
-below apply to whichever metric is selected.)* Format (lives in
+overrides. `p50` means the cell's **total-latency median** (`total_ms` p50). *(Later change: the
+`--gated-metric` flag selects the gated median and now **defaults to `server-ms`** — the
+server-reported execution time; the budget shapes below apply to whichever metric is selected.)*
+Format (lives in
 `falkordb-rs-next-gen`, TOML to match `synthetic-bench.toml`):
 
 ```toml

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -105,6 +105,10 @@ question §8.1.)
 
 `p95` is also computed but **left out** (§8.2). Tail **Δ**s are left out (§8.3).
 
+> **Later addition — `--gated-metric`:** `report --regression --gated-metric server-ms` swaps the
+> gated median (and the context tails above) from `total_ms` to the server-reported `server_ms`;
+> the gate mechanics in this table are unchanged and `total-ms` remains the default.
+
 ## 6. Data availability (no new collection)
 
 - `Summary` already carries `median`/`p90`/`p95`/`p99` (`src/synthetic/stats.rs`); percentiles are a

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -108,8 +108,9 @@ question §8.1.)
 > **Later change — `--gated-metric`:** the gated median (and the context tails above) now
 > **defaults to the server-reported `server_ms`** (maintainer decision: only the server execution
 > time is measured); `report --regression --gated-metric total-ms` is the explicit opt-in that
-> restores the client-observed `total_ms` gate described in this table. The gate mechanics are
-> unchanged either way.
+> restores the client-observed `total_ms` gate described in this table. Under the default server
+> gate the client-observed total p50 is **demoted to the `context:` line** (informational, never
+> gated) so the wall clock stays visible. The gate mechanics are unchanged either way.
 
 ## 6. Data availability (no new collection)
 

--- a/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
+++ b/docs/design/synthetic-report-per-line-budget-and-tail-latencies.md
@@ -105,9 +105,11 @@ question §8.1.)
 
 `p95` is also computed but **left out** (§8.2). Tail **Δ**s are left out (§8.3).
 
-> **Later addition — `--gated-metric`:** `report --regression --gated-metric server-ms` swaps the
-> gated median (and the context tails above) from `total_ms` to the server-reported `server_ms`;
-> the gate mechanics in this table are unchanged and `total-ms` remains the default.
+> **Later change — `--gated-metric`:** the gated median (and the context tails above) now
+> **defaults to the server-reported `server_ms`** (maintainer decision: only the server execution
+> time is measured); `report --regression --gated-metric total-ms` is the explicit opt-in that
+> restores the client-observed `total_ms` gate described in this table. The gate mechanics are
+> unchanged either way.
 
 ## 6. Data availability (no new collection)
 

--- a/readme.md
+++ b/readme.md
@@ -594,7 +594,8 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   synthetic-compare-versions` runs `run --recording` against both endpoints then `report --diff`.
 - **`benchmark synthetic report --diff <A.json> <B.json> --regression [--thresholds t.toml]`** is a
   **non-fatal, colored** variant for a per-PR regression report: each op × cache-mode × concurrency
-  cell gets a **🟢 / 🔴 / N/A** verdict on **p50** — 🟢 if the candidate (B) is faster or slower
+  cell gets a **🟢 / 🔴 / N/A** verdict on **p50** (of the client-observed `total_ms` by default —
+  see `--gated-metric`) — 🟢 if the candidate (B) is faster or slower
   within budget, 🔴 if slower beyond it. The budget is a `budget_pct` plus an absolute `floor_ms`
   noise guard, defaulting to 10 % / 0.5 ms and overridable per-operation and per-operation×concurrency
   in a TOML file (`[default]` + `[op.<name>]` with a `concurrency` inline table). `<name>` may be a
@@ -650,6 +651,16 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
     `[cross-engine.op.<name>]` sections (same shape as the top-level `[default]`/`[op.<name>]`,
     typically looser for engine-vs-engine noise) and **errors** if the TOML doesn't define them —
     there is no silent fallback to the strict budgets.
+  - **`--gated-metric <total-ms|server-ms>`** (default `total-ms`) selects **which latency metric's
+    p50** the budget verdicts gate on. `total-ms` is the client-observed total latency — today's
+    behavior, unchanged. `server-ms` gates the **server-reported execution time** instead, removing
+    client scheduling and network jitter from the verdict entirely; the p90/p99 tails on each cell's
+    `context:` line follow the selected metric, so a cell never mixes clocks. If the server p50 is
+    missing/invalid on either side of a cell (a report predating server-time capture, or an engine
+    that doesn't report execution time) that cell's verdict is **N/A** and the affected ops are
+    named in **one advisory warning** — there is **never** a silent fallback to `total-ms`. The
+    choice is echoed as `gated_metric` in the report header, the `--summary` JSON and the `--cells`
+    model.
 
 A `--cells` file deserializes straight back into the tool's public `RegressionAnalysis` type, so
 downstream tooling consumes the analysis without re-parsing Markdown (compiled and type-checked as

--- a/readme.md
+++ b/readme.md
@@ -594,7 +594,7 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   synthetic-compare-versions` runs `run --recording` against both endpoints then `report --diff`.
 - **`benchmark synthetic report --diff <A.json> <B.json> --regression [--thresholds t.toml]`** is a
   **non-fatal, colored** variant for a per-PR regression report: each op × cache-mode × concurrency
-  cell gets a **🟢 / 🔴 / N/A** verdict on **p50** (of the client-observed `total_ms` by default —
+  cell gets a **🟢 / 🔴 / N/A** verdict on **p50** (of the server-reported `server_ms` by default —
   see `--gated-metric`) — 🟢 if the candidate (B) is faster or slower
   within budget, 🔴 if slower beyond it. The budget is a `budget_pct` plus an absolute `floor_ms`
   noise guard, defaulting to 10 % / 0.5 ms and overridable per-operation and per-operation×concurrency
@@ -651,16 +651,19 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
     `[cross-engine.op.<name>]` sections (same shape as the top-level `[default]`/`[op.<name>]`,
     typically looser for engine-vs-engine noise) and **errors** if the TOML doesn't define them —
     there is no silent fallback to the strict budgets.
-  - **`--gated-metric <total-ms|server-ms>`** (default `total-ms`) selects **which latency metric's
-    p50** the budget verdicts gate on. `total-ms` is the client-observed total latency — today's
-    behavior, unchanged. `server-ms` gates the **server-reported execution time** instead, removing
-    client scheduling and network jitter from the verdict entirely; the p90/p99 tails on each cell's
+  - **`--gated-metric <total-ms|server-ms>`** (default `server-ms`) selects **which latency
+    metric's p50** the budget verdicts gate on. `server-ms` — the default, by maintainer decision:
+    only the server-reported execution time is measured — is immune to client scheduling and
+    network jitter. `total-ms` is an explicit opt-in escape hatch gating the client-observed total
+    latency (including client scheduling and network time). The p90/p99 tails on each cell's
     `context:` line follow the selected metric, so a cell never mixes clocks. If the server p50 is
     missing/invalid on either side of a cell (a report predating server-time capture, or an engine
     that doesn't report execution time) that cell's verdict is **N/A** and the affected ops are
-    named in **one advisory warning** — there is **never** a silent fallback to `total-ms`. The
-    choice is echoed as `gated_metric` in the report header, the `--summary` JSON and the `--cells`
-    model.
+    named in **one loud advisory warning** that also names the `total-ms` escape hatch — there is
+    **never** a silent fallback. The choice is echoed as `gated_metric` in the report header, the
+    `--summary` JSON and the `--cells` model; the Markdown header and legend always name the gated
+    metric. *(Note: the default gate **changed** from `total-ms` to `server-ms`; pass
+    `--gated-metric total-ms` explicitly to reproduce the old behavior.)*
 
 A `--cells` file deserializes straight back into the tool's public `RegressionAnalysis` type, so
 downstream tooling consumes the analysis without re-parsing Markdown (compiled and type-checked as

--- a/readme.md
+++ b/readme.md
@@ -659,11 +659,14 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
     latency (including client scheduling and network time). The p90/p99 tails on each cell's
     `context:` line follow the selected metric, so a cell never mixes clocks; under the default
     server-ms gate the client-observed total p50 is **demoted to that `context:` line** —
-    visible, informational, never gated. If the server p50 is
-    missing/invalid on either side of a cell (a report predating server-time capture, or an engine
-    that doesn't report execution time) that cell's verdict is **N/A** and the affected ops are
-    named in **one loud advisory warning** that also names the `total-ms` escape hatch — there is
-    **never** a silent fallback. The choice is echoed as `gated_metric` in the report header, the
+    visible, informational, never gated. If the **selected metric's** p50 is missing/invalid
+    (≤ 0 / non-finite) on either side of a cell — whichever metric is gated — that cell's
+    verdict is **N/A**; there is **never** a silent fallback to the other clock. Under the
+    default `server-ms` gate (a report predating server-time capture, or an engine that doesn't
+    report execution time) the affected ops are additionally named in **one loud advisory
+    warning** that also names the `total-ms` escape hatch; `total_ms` is the always-captured
+    wall clock, so total-ms gating degrades this way only on a malformed report (N/A cells, no
+    dedicated warning). The choice is echoed as `gated_metric` in the report header, the
     `--summary` JSON and the `--cells` model; the Markdown header and legend always name the gated
     metric. *(Note: the default gate **changed** from `total-ms` to `server-ms`; pass
     `--gated-metric total-ms` explicitly to reproduce the old behavior.)*

--- a/readme.md
+++ b/readme.md
@@ -610,7 +610,8 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   passes **`--elapsed-secs <n>`** — a compute-time line (benchmark + reporting) for the run. Each cell
   row also prints the **effective `p50 guard`** applied to it (e.g. `15% AND 0.5 ms`, per-op×C
   overrides included) and the absolute `Δms`, and folds **p90/p99 + throughput** onto a smaller,
-  clearly non-gated `context:` line — the verdict stays **p50-only**. Each op's tables are wrapped in
+  clearly non-gated `context:` line — under the default server-ms gate that line also carries the
+  **demoted client-observed total p50** — the verdict stays **p50-only**. Each op's tables are wrapped in
   a **collapsed `<details>`** (with the op's 🟢/🔴 verdict on the summary row) so the PR sticky
   comment stays compact — the reader expands only the ops they care about.
 - Every regression comparison is computed **once** into a single analysis model and rolled up into a
@@ -656,7 +657,9 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
     only the server-reported execution time is measured — is immune to client scheduling and
     network jitter. `total-ms` is an explicit opt-in escape hatch gating the client-observed total
     latency (including client scheduling and network time). The p90/p99 tails on each cell's
-    `context:` line follow the selected metric, so a cell never mixes clocks. If the server p50 is
+    `context:` line follow the selected metric, so a cell never mixes clocks; under the default
+    server-ms gate the client-observed total p50 is **demoted to that `context:` line** —
+    visible, informational, never gated. If the server p50 is
     missing/invalid on either side of a cell (a report predating server-time capture, or an engine
     that doesn't report execution time) that cell's verdict is **N/A** and the affected ops are
     named in **one loud advisory warning** that also names the `total-ms` escape hatch — there is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -837,7 +837,7 @@ mod tests {
             argv.extend_from_slice(extra);
             Cli::try_parse_from(argv)
         };
-        // Both known values parse; the flag is optional (default total-ms applies downstream).
+        // Both known values parse; the flag is optional (default server-ms applies downstream).
         assert!(report(&["--regression", "--gated-metric", "total-ms"]).is_ok());
         assert!(report(&["--regression", "--gated-metric", "server-ms"]).is_ok());
         assert!(report(&["--regression"]).is_ok());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -655,7 +655,7 @@ pub enum SyntheticCommands {
             value_name = "METRIC",
             value_parser = ["total-ms", "server-ms"],
             requires = "regression",
-            help = "with --diff --regression: which latency metric's p50 median the budget verdicts gate on. `total-ms` (default): client-observed total latency, today's behavior. `server-ms`: server-reported execution time — immune to client scheduling and network jitter; a cell whose server p50 is missing/invalid on either side is N/A and the op is named in an advisory warning (never a silent fallback to total-ms)"
+            help = "with --diff --regression: which latency metric's p50 median the budget verdicts gate on. `server-ms` (default): server-reported execution time — immune to client scheduling and network jitter; a cell whose server p50 is missing/invalid on either side is N/A and the op is named in an advisory warning (never a silent fallback). `total-ms` (explicit opt-in): client-observed total latency, including client scheduling and network time"
         )]
         gated_metric: Option<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -650,6 +650,14 @@ pub enum SyntheticCommands {
             help = "with --diff --regression: how a result divergence affects the verdict. `gate` (default): diverged op is 🔴 and fails the comparison. `advisory`: diverged op is ⚠, perf cells stay N/A, overall verdict caps at advisory — for cross-engine runs where engines legitimately differ"
         )]
         divergence_policy: Option<String>,
+        #[arg(
+            long = "gated-metric",
+            value_name = "METRIC",
+            value_parser = ["total-ms", "server-ms"],
+            requires = "regression",
+            help = "with --diff --regression: which latency metric's p50 median the budget verdicts gate on. `total-ms` (default): client-observed total latency, today's behavior. `server-ms`: server-reported execution time — immune to client scheduling and network jitter; a cell whose server p50 is missing/invalid on either side is N/A and the op is named in an advisory warning (never a silent fallback to total-ms)"
+        )]
+        gated_metric: Option<String>,
     },
 }
 
@@ -812,6 +820,32 @@ mod tests {
             "/tmp/does-not-matter",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn cli_gated_metric_flag_parses_known_values_and_requires_regression() {
+        use clap::Parser;
+        let report = |extra: &[&str]| {
+            let mut argv = vec![
+                "benchmark",
+                "synthetic",
+                "report",
+                "--diff",
+                "a.json",
+                "b.json",
+            ];
+            argv.extend_from_slice(extra);
+            Cli::try_parse_from(argv)
+        };
+        // Both known values parse; the flag is optional (default total-ms applies downstream).
+        assert!(report(&["--regression", "--gated-metric", "total-ms"]).is_ok());
+        assert!(report(&["--regression", "--gated-metric", "server-ms"]).is_ok());
+        assert!(report(&["--regression"]).is_ok());
+        // Unknown values are rejected by clap's value_parser.
+        assert!(report(&["--regression", "--gated-metric", "p50"]).is_err());
+        assert!(report(&["--regression", "--gated-metric", "server_ms"]).is_err());
+        // The flag is regression-only.
+        assert!(report(&["--gated-metric", "server-ms"]).is_err());
     }
 
     #[test]

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -23,12 +23,12 @@ use std::collections::{BTreeMap, BTreeSet};
 /// not a silent extension.
 pub const ANALYSIS_SCHEMA_VERSION: u32 = 2;
 
-/// The gated metric id carried in [`RegressionAnalysis::gated_metric`] under the default
+/// The gated metric id carried in [`RegressionAnalysis::gated_metric`] under the opt-in
 /// [`GatedMetric::TotalMs`]: the total-latency median is gated; every other metric is
 /// informational context.
 pub const GATED_METRIC: &str = "total_ms.p50";
 
-/// The gated metric id carried in [`RegressionAnalysis::gated_metric`] under
+/// The gated metric id carried in [`RegressionAnalysis::gated_metric`] under the default
 /// [`GatedMetric::ServerMs`]: the server-reported execution-time median is gated.
 pub const SERVER_GATED_METRIC: &str = "server_ms.p50";
 
@@ -36,15 +36,17 @@ pub const SERVER_GATED_METRIC: &str = "server_ms.p50";
 /// (`report --regression --gated-metric`). The budget is applied to this metric's p50 pair; the
 /// tails/throughput `context:` line follows the same metric so a cell never mixes clocks.
 /// Client scheduling + network jitter pollutes `total_ms`; gating on the server-reported
-/// execution time removes that noise entirely. There is **never** a silent fallback: a cell whose
+/// execution time removes that noise entirely, which is why **server-ms is the default gate**
+/// (maintainer decision: only the server execution time is measured; the total round trip is an
+/// explicit opt-in). There is **never** a silent fallback: a cell whose
 /// selected median is missing/invalid on either side gets a [`Verdict::NotApplicable`] and the op
 /// is named in one advisory warning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum GatedMetric {
-    /// Client-observed total latency (`total_ms.p50`) — the default, today's behavior.
-    #[default]
+    /// Client-observed total latency (`total_ms.p50`) — explicit opt-in escape hatch.
     TotalMs,
-    /// Server-reported execution time (`server_ms.p50`).
+    /// Server-reported execution time (`server_ms.p50`) — the default gate.
+    #[default]
     ServerMs,
 }
 
@@ -399,8 +401,8 @@ pub struct RegressionAnalysis {
     pub meta: AnalysisMeta,
     pub budget_profile: BudgetProfile,
     pub divergence_policy: DivergencePolicy,
-    /// The gated metric id ([`GatedMetric::id`] — [`GATED_METRIC`] by default,
-    /// [`SERVER_GATED_METRIC`] under `--gated-metric server-ms`); everything else is
+    /// The gated metric id ([`GatedMetric::id`] — [`SERVER_GATED_METRIC`] by default,
+    /// [`GATED_METRIC`] under the `--gated-metric total-ms` opt-in); everything else is
     /// informational.
     pub gated_metric: String,
     pub status: ComparisonStatus,
@@ -813,9 +815,10 @@ pub fn analyze(
         // Missing-data guard for the selectable metric: a cell measured on BOTH sides whose
         // server_ms median is missing/invalid (≤ 0 / non-finite — a report predating server-time
         // capture, or an engine that doesn't report execution time) is N/A, and the op is named
-        // in one warning below. `total_ms` is the always-captured wall clock, so the default
-        // gating stays byte-identical to today (no warning). Diverged/skipped ops are already
-        // N/A with their own, louder markers.
+        // in one loud warning below — this now triggers by default, since server-ms is the
+        // default gate. `total_ms` is the always-captured wall clock, so the opt-in total-ms
+        // gating never degrades (no warning). Diverged/skipped ops are already N/A with their
+        // own, louder markers.
         if options.gated_metric == GatedMetric::ServerMs
             && oa.correctness != Correctness::Diverged
             && oa.skipped_baseline.is_none()
@@ -869,9 +872,11 @@ pub fn analyze(
 
     if !metric_degraded.is_empty() {
         warnings.push(format!(
-            "gated metric {SERVER_GATED_METRIC} is missing/invalid on ≥1 side for {} op(s): {} — \
-             those cells have no verdict (N/A); the report predates server-time capture or the \
-             engine does not report execution time, and there is no fallback to total_ms",
+            "gated metric {SERVER_GATED_METRIC} (the default gate) is missing/invalid on ≥1 side \
+             for {} op(s): {} — those cells have NO verdict (N/A); the report predates \
+             server-time capture or the engine does not report execution time. There is no \
+             silent fallback to total_ms — re-run with `--gated-metric total-ms` to gate on the \
+             client-observed total latency instead",
             metric_degraded.len(),
             metric_degraded.join(", ")
         ));
@@ -916,7 +921,9 @@ mod tests {
         LevelMetrics {
             throughput_ops_per_sec: 1000.0,
             metrics: MetricSet {
-                server_ms: summ(median * 0.2),
+                // Both clocks carry the same medians so metric-agnostic tests behave identically
+                // under either gate; metric-disagreement tests override via `set_server_median`.
+                server_ms: summ(median),
                 total_ms: summ(median),
                 non_internal_ms: summ(median * 0.8),
                 cached_false_rate: 0.0,
@@ -998,7 +1005,8 @@ mod tests {
         )
     }
 
-    /// Analyze gating on the server-reported execution time (`--gated-metric server-ms`).
+    /// Analyze gating on the server-reported execution time — the default
+    /// (`--gated-metric server-ms`), spelled out for symmetry with [`total_gate`].
     fn server_gate(
         a: &Report,
         b: &Report,
@@ -1016,8 +1024,27 @@ mod tests {
         )
     }
 
+    /// Analyze gating on the client-observed total latency (the `--gated-metric total-ms`
+    /// opt-in escape hatch).
+    fn total_gate(
+        a: &Report,
+        b: &Report,
+    ) -> RegressionAnalysis {
+        let g = regression_guard(a, b);
+        analyze(
+            a,
+            b,
+            &g,
+            &Thresholds::builtin(),
+            &AnalysisOptions {
+                gated_metric: GatedMetric::TotalMs,
+                ..Default::default()
+            },
+        )
+    }
+
     /// Overwrite `op`'s cached C=1 `server_ms` summary (the fabricated reports have exactly one
-    /// level), decoupling it from the `metrics()` helper's fixed server = 0.2·total ratio.
+    /// level), decoupling it from the `metrics()` helper's shared server = total medians.
     fn set_server_median(
         rep: &mut Report,
         op: &str,
@@ -1470,7 +1497,7 @@ mod tests {
         assert_eq!(an.meta.baseline.warmup, 200);
         assert_eq!(an.meta.baseline.concurrency, vec![1]);
         assert_eq!(an.elapsed_secs, Some(12.5));
-        assert_eq!(an.gated_metric, "total_ms.p50");
+        assert_eq!(an.gated_metric, "server_ms.p50");
         assert_eq!(an.budget_profile, BudgetProfile::Strict);
         assert_eq!(an.divergence_policy, DivergencePolicy::Gate);
         // The thresholds echo carries the resolved default budget.
@@ -1631,7 +1658,7 @@ mod tests {
             "both".parse::<GatedMetric>().unwrap_err(),
             "unknown gated metric 'both' (expected 'total-ms' or 'server-ms')"
         );
-        assert_eq!(GatedMetric::default(), GatedMetric::TotalMs);
+        assert_eq!(GatedMetric::default(), GatedMetric::ServerMs);
         assert_eq!(GatedMetric::TotalMs.id(), GATED_METRIC);
         assert_eq!(GatedMetric::ServerMs.id(), SERVER_GATED_METRIC);
         for m in [GatedMetric::TotalMs, GatedMetric::ServerMs] {
@@ -1643,13 +1670,14 @@ mod tests {
     fn server_ms_gating_ignores_a_total_only_regression() {
         // The candidate doubles its client-observed total latency (+100 %, way over budget) but
         // its server-reported execution time grows only 5 % — pure client/network noise. The
-        // default gate regresses; `--gated-metric server-ms` passes, and the cells carry the
-        // server medians (and server tails in the context line), not the total ones.
-        let a = rpt("main", 42001, &[("match_by_index", 10.0, Some("d1"))]);
+        // opt-in total-ms gate regresses; the default (server-ms) passes, and the cells carry
+        // the server medians (and server tails in the context line), not the total ones.
+        let mut a = rpt("main", 42001, &[("match_by_index", 10.0, Some("d1"))]);
         let mut b = rpt("pr", 42002, &[("match_by_index", 20.0, Some("d1"))]);
-        set_server_median(&mut b, "match_by_index", 2.1); // baseline server = 10.0 * 0.2 = 2.0
+        set_server_median(&mut a, "match_by_index", 2.0);
+        set_server_median(&mut b, "match_by_index", 2.1);
 
-        let total = gate(&a, &b);
+        let total = total_gate(&a, &b);
         assert_eq!(total.verdict, OverallVerdict::Regressed);
         assert_eq!(total.gated_metric, GATED_METRIC);
         assert!(!total.gated_on_server_ms());
@@ -1684,12 +1712,13 @@ mod tests {
     #[test]
     fn server_ms_gating_catches_a_server_only_regression() {
         // Mirror image: totals stay within budget (+4 %, under the 0.5 ms floor too) while the
-        // server-reported execution time doubles. Only server-ms gating regresses.
-        let a = rpt("main", 42001, &[("match_by_index", 10.0, Some("d1"))]);
+        // server-reported execution time doubles. Only server-ms gating (the default) regresses.
+        let mut a = rpt("main", 42001, &[("match_by_index", 10.0, Some("d1"))]);
         let mut b = rpt("pr", 42002, &[("match_by_index", 10.4, Some("d1"))]);
-        set_server_median(&mut b, "match_by_index", 4.0); // baseline server = 2.0
+        set_server_median(&mut a, "match_by_index", 2.0);
+        set_server_median(&mut b, "match_by_index", 4.0);
 
-        assert_eq!(gate(&a, &b).verdict, OverallVerdict::Pass);
+        assert_eq!(total_gate(&a, &b).verdict, OverallVerdict::Pass);
         let server = server_gate(&a, &b);
         assert_eq!(server.verdict, OverallVerdict::Regressed);
         assert_eq!(server.regressed_cells, 1);
@@ -1701,9 +1730,10 @@ mod tests {
     #[test]
     fn missing_server_median_yields_na_cell_and_one_advisory_warning() {
         // One clean op and one whose candidate reports no usable server time (median 0 — e.g. an
-        // engine that doesn't report execution time). Under server-ms gating the degraded cell is
-        // N/A — never a silent fallback to total_ms — and ONE warning names exactly the affected
-        // op. The default total-ms gating of the same pair stays warning-free (byte-identical).
+        // engine that doesn't report execution time). Under the default server-ms gating the
+        // degraded cell is N/A — never a silent fallback to total_ms — and ONE loud warning names
+        // exactly the affected op and the escape hatch. The total-ms opt-in of the same pair
+        // stays warning-free.
         let a = rpt(
             "main",
             42001,
@@ -1746,9 +1776,13 @@ mod tests {
             !warning.contains("match_by_index"),
             "clean op not named: {warning}"
         );
-        assert!(warning.contains("no fallback to total_ms"), "{warning}");
+        assert!(warning.contains("no silent fallback to total_ms"), "{warning}");
+        assert!(
+            warning.contains("re-run with `--gated-metric total-ms`"),
+            "escape hatch named: {warning}"
+        );
 
-        let total = gate(&a, &b);
+        let total = total_gate(&a, &b);
         assert_eq!(total.verdict, OverallVerdict::Pass);
         assert_eq!(
             total.comparable_cells, 2,
@@ -1756,7 +1790,7 @@ mod tests {
         );
         assert!(
             total.warnings.iter().all(|w| !w.contains("gated metric")),
-            "no degraded-metric warning under the default gating: {:?}",
+            "no degraded-metric warning under the total-ms opt-in: {:?}",
             total.warnings
         );
     }

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -23,9 +23,72 @@ use std::collections::{BTreeMap, BTreeSet};
 /// not a silent extension.
 pub const ANALYSIS_SCHEMA_VERSION: u32 = 2;
 
-/// The gated metric id carried in [`RegressionAnalysis::gated_metric`]: only the total-latency
-/// median is gated; every other metric is informational context.
+/// The gated metric id carried in [`RegressionAnalysis::gated_metric`] under the default
+/// [`GatedMetric::TotalMs`]: the total-latency median is gated; every other metric is
+/// informational context.
 pub const GATED_METRIC: &str = "total_ms.p50";
+
+/// The gated metric id carried in [`RegressionAnalysis::gated_metric`] under
+/// [`GatedMetric::ServerMs`]: the server-reported execution-time median is gated.
+pub const SERVER_GATED_METRIC: &str = "server_ms.p50";
+
+/// Which latency metric's **median** drives the per-cell budget verdicts
+/// (`report --regression --gated-metric`). The budget is applied to this metric's p50 pair; the
+/// tails/throughput `context:` line follows the same metric so a cell never mixes clocks.
+/// Client scheduling + network jitter pollutes `total_ms`; gating on the server-reported
+/// execution time removes that noise entirely. There is **never** a silent fallback: a cell whose
+/// selected median is missing/invalid on either side gets a [`Verdict::NotApplicable`] and the op
+/// is named in one advisory warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GatedMetric {
+    /// Client-observed total latency (`total_ms.p50`) — the default, today's behavior.
+    #[default]
+    TotalMs,
+    /// Server-reported execution time (`server_ms.p50`).
+    ServerMs,
+}
+
+impl GatedMetric {
+    /// The stable lowercase id used in the `--gated-metric` flag.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GatedMetric::TotalMs => "total-ms",
+            GatedMetric::ServerMs => "server-ms",
+        }
+    }
+
+    /// The metric id carried in [`RegressionAnalysis::gated_metric`] and echoed by every renderer.
+    pub fn id(self) -> &'static str {
+        match self {
+            GatedMetric::TotalMs => GATED_METRIC,
+            GatedMetric::ServerMs => SERVER_GATED_METRIC,
+        }
+    }
+
+    /// The selected metric's [`Summary`] within one measured cell.
+    fn summary(
+        self,
+        m: &LevelMetrics,
+    ) -> &crate::synthetic::stats::Summary {
+        match self {
+            GatedMetric::TotalMs => &m.metrics.total_ms,
+            GatedMetric::ServerMs => &m.metrics.server_ms,
+        }
+    }
+}
+
+impl std::str::FromStr for GatedMetric {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "total-ms" => Ok(GatedMetric::TotalMs),
+            "server-ms" => Ok(GatedMetric::ServerMs),
+            other => Err(format!(
+                "unknown gated metric '{other}' (expected 'total-ms' or 'server-ms')"
+            )),
+        }
+    }
+}
 
 /// How a diverged op (differing per-op `result_digest`s) affects the verdicts (design §A3).
 /// Under **both** policies a diverged op's perf cells are N/A — diverged results mean the two
@@ -262,7 +325,9 @@ pub struct AnalysisMeta {
     pub thresholds: ThresholdsEcho,
 }
 
-/// One side's informational (never gated) tail/throughput context for a cell.
+/// One side's informational (never gated) tail/throughput context for a cell. The tails are read
+/// from the **selected gated metric's** summary (total-ms by default, server-ms under
+/// `--gated-metric server-ms`) so they always describe the same clock as the gated p50.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct CellContextSide {
     pub p90_ms: f64,
@@ -334,7 +399,9 @@ pub struct RegressionAnalysis {
     pub meta: AnalysisMeta,
     pub budget_profile: BudgetProfile,
     pub divergence_policy: DivergencePolicy,
-    /// The gated metric id ([`GATED_METRIC`]); everything else is informational.
+    /// The gated metric id ([`GatedMetric::id`] — [`GATED_METRIC`] by default,
+    /// [`SERVER_GATED_METRIC`] under `--gated-metric server-ms`); everything else is
+    /// informational.
     pub gated_metric: String,
     pub status: ComparisonStatus,
     /// Advisory notes (version/image), never comparability guards.
@@ -361,6 +428,8 @@ pub struct RegressionAnalysis {
 pub struct AnalysisOptions {
     pub budget_profile: BudgetProfile,
     pub divergence_policy: DivergencePolicy,
+    /// Which latency metric's median the budget verdicts gate on (default: total-ms).
+    pub gated_metric: GatedMetric,
     pub elapsed_secs: Option<f64>,
 }
 
@@ -415,6 +484,12 @@ impl RegressionAnalysis {
             .filter(|(_, o)| o.correctness == Correctness::Diverged)
             .map(|(name, _)| name.as_str())
             .collect()
+    }
+
+    /// Whether this comparison gated on the server-reported execution time
+    /// (`--gated-metric server-ms`) rather than the default client-observed total latency.
+    pub fn gated_on_server_ms(&self) -> bool {
+        self.gated_metric == SERVER_GATED_METRIC
     }
 
     /// Pretty-printed JSON — the `report --cells` artifact. Fallible so a serialization failure
@@ -519,8 +594,13 @@ fn level_metrics<'a>(
         .and_then(|lvl| mode.pick(lvl))
 }
 
-fn context_side(m: &LevelMetrics) -> CellContextSide {
-    let s = &m.metrics.total_ms;
+/// One side's informational tails/throughput, read from the **selected gated metric's** summary
+/// so a cell's primary p50 and its `context:` line always describe the same clock.
+fn context_side(
+    metric: GatedMetric,
+    m: &LevelMetrics,
+) -> CellContextSide {
+    let s = metric.summary(m);
     CellContextSide {
         p90_ms: s.p90,
         p95_ms: s.p95,
@@ -539,6 +619,7 @@ fn analyze_op(
     diverged: bool,
     thresholds: &Thresholds,
     policy: DivergencePolicy,
+    metric: GatedMetric,
 ) -> OpAnalysis {
     // Skip reasons (capability probe — design Phase 6 §3.5), per side. A skipped side recorded no
     // levels, so its cells are one-sided; forcing the verdict N/A below also covers a hand-crafted
@@ -563,8 +644,8 @@ fn analyze_op(
         for c in levels {
             let am = level_metrics(baseline, op, c, mode);
             let bm = level_metrics(candidate, op, c, mode);
-            let ap = am.map(|m| m.metrics.total_ms.median);
-            let bp = bm.map(|m| m.metrics.total_ms.median);
+            let ap = am.map(|m| metric.summary(m).median);
+            let bp = bm.map(|m| metric.summary(m).median);
             let budget = thresholds.resolve_by_name(op, c);
             // Perf verdict: N/A for every cell of a diverged op (different work ⇒ a latency
             // comparison is meaningless, under BOTH policies) and of a skipped op (one side never
@@ -595,8 +676,8 @@ fn analyze_op(
                 budget,
                 perf_verdict,
                 context: CellContext {
-                    baseline: am.map(context_side),
-                    candidate: bm.map(context_side),
+                    baseline: am.map(|m| context_side(metric, m)),
+                    candidate: bm.map(|m| context_side(metric, m)),
                 },
             });
         }
@@ -672,7 +753,7 @@ pub fn analyze(
         meta,
         budget_profile: options.budget_profile,
         divergence_policy: options.divergence_policy,
-        gated_metric: GATED_METRIC.to_string(),
+        gated_metric: options.gated_metric.id().to_string(),
         status: ComparisonStatus::Comparable,
         warnings: Vec::new(),
         elapsed_secs: options.elapsed_secs,
@@ -683,7 +764,7 @@ pub fn analyze(
         ops: BTreeMap::new(),
     };
 
-    let (diverged, warnings) = match guard {
+    let (diverged, mut warnings) = match guard {
         RegressionGuard::NotComparable { reason } => {
             return RegressionAnalysis {
                 status: ComparisonStatus::WorkloadMismatch { reason: reason.clone() },
@@ -711,6 +792,9 @@ pub fn analyze(
     let mut totals = OutcomeCounts::default();
     let mut comparable_cells = 0usize;
     let mut regressed_cells = 0usize;
+    // Ops whose selected metric was missing/invalid on ≥1 side of an otherwise-measured cell —
+    // surfaced as one advisory warning under server-ms gating (never a fallback to total_ms).
+    let mut metric_degraded: Vec<String> = Vec::new();
     let op_names: BTreeSet<&String> = baseline
         .operations
         .keys()
@@ -724,7 +808,27 @@ pub fn analyze(
             diverged.contains(op),
             thresholds,
             options.divergence_policy,
+            options.gated_metric,
         );
+        // Missing-data guard for the selectable metric: a cell measured on BOTH sides whose
+        // server_ms median is missing/invalid (≤ 0 / non-finite — a report predating server-time
+        // capture, or an engine that doesn't report execution time) is N/A, and the op is named
+        // in one warning below. `total_ms` is the always-captured wall clock, so the default
+        // gating stays byte-identical to today (no warning). Diverged/skipped ops are already
+        // N/A with their own, louder markers.
+        if options.gated_metric == GatedMetric::ServerMs
+            && oa.correctness != Correctness::Diverged
+            && oa.skipped_baseline.is_none()
+            && oa.skipped_candidate.is_none()
+            && oa.cells.iter().any(|c| {
+                matches!(
+                    (c.baseline_p50_ms, c.candidate_p50_ms),
+                    (Some(x), Some(y)) if !(x.is_finite() && x > 0.0 && y.is_finite() && y > 0.0)
+                )
+            })
+        {
+            metric_degraded.push(op.clone());
+        }
         for cell in &oa.cells {
             match cell.perf_verdict {
                 Verdict::Regressed => {
@@ -762,6 +866,16 @@ pub fn analyze(
     } else {
         OverallVerdict::Pass
     };
+
+    if !metric_degraded.is_empty() {
+        warnings.push(format!(
+            "gated metric {SERVER_GATED_METRIC} is missing/invalid on ≥1 side for {} op(s): {} — \
+             those cells have no verdict (N/A); the report predates server-time capture or the \
+             engine does not report execution time, and there is no fallback to total_ms",
+            metric_degraded.len(),
+            metric_degraded.join(", ")
+        ));
+    }
 
     RegressionAnalysis {
         warnings,
@@ -882,6 +996,39 @@ mod tests {
                 ..Default::default()
             },
         )
+    }
+
+    /// Analyze gating on the server-reported execution time (`--gated-metric server-ms`).
+    fn server_gate(
+        a: &Report,
+        b: &Report,
+    ) -> RegressionAnalysis {
+        let g = regression_guard(a, b);
+        analyze(
+            a,
+            b,
+            &g,
+            &Thresholds::builtin(),
+            &AnalysisOptions {
+                gated_metric: GatedMetric::ServerMs,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Overwrite `op`'s cached C=1 `server_ms` summary (the fabricated reports have exactly one
+    /// level), decoupling it from the `metrics()` helper's fixed server = 0.2·total ratio.
+    fn set_server_median(
+        rep: &mut Report,
+        op: &str,
+        median: f64,
+    ) {
+        rep.operations.get_mut(op).expect("op present").levels[0]
+            .cached
+            .as_mut()
+            .expect("cached level")
+            .metrics
+            .server_ms = summ(median);
     }
 
     #[test]
@@ -1466,6 +1613,236 @@ mod tests {
             let json = serde_json::to_string(&p).unwrap();
             assert_eq!(json, format!("\"{}\"", p.as_str()));
         }
+    }
+
+    #[test]
+    fn gated_metric_parses_ids_and_round_trips() {
+        assert_eq!(
+            "total-ms".parse::<GatedMetric>().unwrap(),
+            GatedMetric::TotalMs
+        );
+        assert_eq!(
+            "server-ms".parse::<GatedMetric>().unwrap(),
+            GatedMetric::ServerMs
+        );
+        assert!("server_ms".parse::<GatedMetric>().is_err());
+        assert!("p50".parse::<GatedMetric>().is_err());
+        assert_eq!(
+            "both".parse::<GatedMetric>().unwrap_err(),
+            "unknown gated metric 'both' (expected 'total-ms' or 'server-ms')"
+        );
+        assert_eq!(GatedMetric::default(), GatedMetric::TotalMs);
+        assert_eq!(GatedMetric::TotalMs.id(), GATED_METRIC);
+        assert_eq!(GatedMetric::ServerMs.id(), SERVER_GATED_METRIC);
+        for m in [GatedMetric::TotalMs, GatedMetric::ServerMs] {
+            assert_eq!(m.as_str().parse::<GatedMetric>().unwrap(), m);
+        }
+    }
+
+    #[test]
+    fn server_ms_gating_ignores_a_total_only_regression() {
+        // The candidate doubles its client-observed total latency (+100 %, way over budget) but
+        // its server-reported execution time grows only 5 % — pure client/network noise. The
+        // default gate regresses; `--gated-metric server-ms` passes, and the cells carry the
+        // server medians (and server tails in the context line), not the total ones.
+        let a = rpt("main", 42001, &[("match_by_index", 10.0, Some("d1"))]);
+        let mut b = rpt("pr", 42002, &[("match_by_index", 20.0, Some("d1"))]);
+        set_server_median(&mut b, "match_by_index", 2.1); // baseline server = 10.0 * 0.2 = 2.0
+
+        let total = gate(&a, &b);
+        assert_eq!(total.verdict, OverallVerdict::Regressed);
+        assert_eq!(total.gated_metric, GATED_METRIC);
+        assert!(!total.gated_on_server_ms());
+        assert_eq!(
+            total.ops["match_by_index"].cells[0].baseline_p50_ms,
+            Some(10.0)
+        );
+
+        let server = server_gate(&a, &b);
+        assert_eq!(server.verdict, OverallVerdict::Pass);
+        assert_eq!(server.gated_metric, SERVER_GATED_METRIC);
+        assert!(server.gated_on_server_ms());
+        assert_eq!(server.regressed_cells, 0);
+        assert_eq!(server.comparable_cells, 1);
+        let cell = &server.ops["match_by_index"].cells[0];
+        assert_eq!(cell.baseline_p50_ms, Some(2.0));
+        assert_eq!(cell.candidate_p50_ms, Some(2.1));
+        assert_eq!(cell.perf_verdict, Verdict::Ok);
+        assert!(cell.delta_pct.unwrap() > 4.9 && cell.delta_pct.unwrap() < 5.1);
+        // The context tails follow the gated metric (server p90 = 2.1 · 1.2), so the cell never
+        // mixes clocks.
+        let ctx = cell.context.candidate.unwrap();
+        assert!(
+            (ctx.p90_ms - 2.52).abs() < 1e-9,
+            "server tails expected, got {}",
+            ctx.p90_ms
+        );
+        // The budget resolves identically under both metrics — only the medians change.
+        assert_eq!(cell.budget, total.ops["match_by_index"].cells[0].budget);
+    }
+
+    #[test]
+    fn server_ms_gating_catches_a_server_only_regression() {
+        // Mirror image: totals stay within budget (+4 %, under the 0.5 ms floor too) while the
+        // server-reported execution time doubles. Only server-ms gating regresses.
+        let a = rpt("main", 42001, &[("match_by_index", 10.0, Some("d1"))]);
+        let mut b = rpt("pr", 42002, &[("match_by_index", 10.4, Some("d1"))]);
+        set_server_median(&mut b, "match_by_index", 4.0); // baseline server = 2.0
+
+        assert_eq!(gate(&a, &b).verdict, OverallVerdict::Pass);
+        let server = server_gate(&a, &b);
+        assert_eq!(server.verdict, OverallVerdict::Regressed);
+        assert_eq!(server.regressed_cells, 1);
+        let cell = &server.ops["match_by_index"].cells[0];
+        assert_eq!(cell.perf_verdict, Verdict::Regressed);
+        assert!((cell.delta_ms.unwrap() - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn missing_server_median_yields_na_cell_and_one_advisory_warning() {
+        // One clean op and one whose candidate reports no usable server time (median 0 — e.g. an
+        // engine that doesn't report execution time). Under server-ms gating the degraded cell is
+        // N/A — never a silent fallback to total_ms — and ONE warning names exactly the affected
+        // op. The default total-ms gating of the same pair stays warning-free (byte-identical).
+        let a = rpt(
+            "main",
+            42001,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("x1")),
+            ],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[
+                ("match_by_index", 1.05, Some("d1")),
+                ("aggregate_count", 1.05, Some("x1")),
+            ],
+        );
+        set_server_median(&mut b, "aggregate_count", 0.0);
+
+        let server = server_gate(&a, &b);
+        assert_eq!(
+            server.verdict,
+            OverallVerdict::Pass,
+            "the clean cell still compares"
+        );
+        assert_eq!(server.comparable_cells, 1);
+        let degraded = &server.ops["aggregate_count"];
+        assert_eq!(degraded.op_outcome, OpOutcome::NotApplicable);
+        assert_eq!(degraded.cells[0].perf_verdict, Verdict::NotApplicable);
+        assert!(
+            degraded.cells[0].delta_pct.is_none(),
+            "no delta from an invalid median"
+        );
+        let warning = server
+            .warnings
+            .iter()
+            .find(|w| w.contains("gated metric server_ms.p50"))
+            .expect("degraded-metric advisory present");
+        assert!(warning.contains("1 op(s): aggregate_count"), "{warning}");
+        assert!(
+            !warning.contains("match_by_index"),
+            "clean op not named: {warning}"
+        );
+        assert!(warning.contains("no fallback to total_ms"), "{warning}");
+
+        let total = gate(&a, &b);
+        assert_eq!(total.verdict, OverallVerdict::Pass);
+        assert_eq!(
+            total.comparable_cells, 2,
+            "total_ms is present — both cells compare"
+        );
+        assert!(
+            total.warnings.iter().all(|w| !w.contains("gated metric")),
+            "no degraded-metric warning under the default gating: {:?}",
+            total.warnings
+        );
+    }
+
+    #[test]
+    fn all_server_medians_invalid_is_advisory_with_warning_never_pass() {
+        // A baseline predating usable server time (NaN median) on the only op: every cell is N/A
+        // under server-ms gating ⇒ zero comparable cells ⇒ Advisory (never a silent green), plus
+        // the advisory warning.
+        let mut a = rpt("main", 42001, &[("match_by_index", 1.0, Some("d1"))]);
+        let b = rpt("pr", 42002, &[("match_by_index", 1.0, Some("d1"))]);
+        set_server_median(&mut a, "match_by_index", f64::NAN);
+        let an = server_gate(&a, &b);
+        assert_eq!(an.verdict, OverallVerdict::Advisory);
+        assert_eq!(an.comparable_cells, 0);
+        assert!(
+            an.warnings
+                .iter()
+                .any(|w| w.contains("gated metric server_ms.p50") && w.contains("match_by_index")),
+            "{:?}",
+            an.warnings
+        );
+        let (emoji, headline) = an.verdict_line();
+        assert_eq!(emoji, "⚠");
+        assert!(headline.starts_with("no comparable cells"), "{headline}");
+    }
+
+    #[test]
+    fn diverged_and_skipped_ops_never_join_the_degraded_metric_warning() {
+        // A diverged op and a skipped op are already N/A with their own louder markers; a missing
+        // server median on them must not add degraded-metric noise.
+        let a = rpt(
+            "main",
+            42001,
+            &[
+                ("match_by_index", 1.0, Some("d1")),
+                ("aggregate_count", 1.0, Some("x1")),
+            ],
+        );
+        let mut b = rpt(
+            "pr",
+            42002,
+            &[
+                ("match_by_index", 1.0, Some("d2")),
+                ("aggregate_count", 1.0, Some("x1")),
+            ],
+        );
+        set_server_median(&mut b, "match_by_index", 0.0); // diverged AND degraded
+        skip_op(
+            &mut b,
+            "aggregate_count",
+            "engine lacks procedure 'algo.maxFlow' (capability probe)",
+        );
+        let an = server_gate(&a, &b);
+        assert!(
+            an.warnings.iter().all(|w| !w.contains("gated metric")),
+            "diverged/skipped ops carry their own signal: {:?}",
+            an.warnings
+        );
+        assert_eq!(an.ops["match_by_index"].correctness, Correctness::Diverged);
+        assert_eq!(an.ops["aggregate_count"].op_outcome, OpOutcome::Skipped);
+    }
+
+    #[test]
+    fn server_gated_analysis_json_carries_the_metric_id() {
+        let a = rpt("main", 42001, &[("match_by_index", 1.0, Some("d1"))]);
+        let b = rpt("pr", 42002, &[("match_by_index", 1.0, Some("d1"))]);
+        let g = regression_guard(&a, &b);
+        let an = analyze(
+            &a,
+            &b,
+            &g,
+            &Thresholds::builtin(),
+            &AnalysisOptions {
+                gated_metric: GatedMetric::ServerMs,
+                ..Default::default()
+            },
+        );
+        let json = an.to_json().unwrap();
+        assert!(
+            json.contains("\"gated_metric\": \"server_ms.p50\""),
+            "{json}"
+        );
+        let back: RegressionAnalysis = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, an);
+        assert!(back.gated_on_server_ms());
     }
 
     #[test]

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -328,14 +328,20 @@ pub struct AnalysisMeta {
 }
 
 /// One side's informational (never gated) tail/throughput context for a cell. The tails are read
-/// from the **selected gated metric's** summary (total-ms by default, server-ms under
-/// `--gated-metric server-ms`) so they always describe the same clock as the gated p50.
+/// from the **selected gated metric's** summary (server-ms by default, total-ms under
+/// `--gated-metric total-ms`) so they always describe the same clock as the gated p50.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct CellContextSide {
     pub p90_ms: f64,
     pub p95_ms: f64,
     pub p99_ms: f64,
     pub throughput_ops_per_sec: f64,
+    /// The client-observed total-latency median (`total_ms.p50`), demoted to informational
+    /// context under the default server-ms gate: the benchmark measures server execution time,
+    /// so the wall clock stays visible but never drives a verdict. `None` under total-ms gating
+    /// (the primary p50 already is that clock) or when the side has no valid total median.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_p50_ms: Option<f64>,
 }
 
 /// Informational context for a cell (both sides optional — a side may not have measured it).
@@ -603,11 +609,17 @@ fn context_side(
     m: &LevelMetrics,
 ) -> CellContextSide {
     let s = metric.summary(m);
+    // Under the server-ms gate the wall clock rides along as demoted, informational context;
+    // under total-ms gating the primary p50 already is the wall clock, so nothing is duplicated.
+    let total = m.metrics.total_ms.median;
+    let total_p50_ms = (metric == GatedMetric::ServerMs && total.is_finite() && total > 0.0)
+        .then_some(total);
     CellContextSide {
         p90_ms: s.p90,
         p95_ms: s.p95,
         p99_ms: s.p99,
         throughput_ops_per_sec: m.throughput_ops_per_sec,
+        total_p50_ms,
     }
 }
 
@@ -1725,6 +1737,40 @@ mod tests {
         let cell = &server.ops["match_by_index"].cells[0];
         assert_eq!(cell.perf_verdict, Verdict::Regressed);
         assert!((cell.delta_ms.unwrap() - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn server_gate_demotes_total_p50_to_cell_context() {
+        // Under the default server-ms gate the client-observed total median stays visible as
+        // demoted, informational context; the total-ms opt-in carries no duplicate (its primary
+        // p50 already is the wall clock). The cells JSON mirrors that: the additive optional
+        // field is omitted entirely when absent, so total-ms analyses are byte-identical to
+        // before.
+        let mut a = rpt("main", 42001, &[("match_by_index", 10.0, Some("d1"))]);
+        let mut b = rpt("pr", 42002, &[("match_by_index", 10.4, Some("d1"))]);
+        set_server_median(&mut a, "match_by_index", 2.0);
+        set_server_median(&mut b, "match_by_index", 2.1);
+
+        let server = server_gate(&a, &b);
+        let cell = &server.ops["match_by_index"].cells[0];
+        assert_eq!(cell.baseline_p50_ms, Some(2.0), "primary p50 is the server median");
+        assert_eq!(cell.context.baseline.unwrap().total_p50_ms, Some(10.0));
+        assert_eq!(cell.context.candidate.unwrap().total_p50_ms, Some(10.4));
+        assert!(server.to_json().unwrap().contains("total_p50_ms"));
+
+        let total = total_gate(&a, &b);
+        let cell = &total.ops["match_by_index"].cells[0];
+        assert_eq!(cell.context.baseline.unwrap().total_p50_ms, None);
+        assert!(!total.to_json().unwrap().contains("total_p50_ms"));
+
+        // A side with no usable wall clock (total median 0) omits the context field; the
+        // server-gated verdict is untouched.
+        let mut c = rpt("pr", 42003, &[("match_by_index", 0.0, Some("d1"))]);
+        set_server_median(&mut c, "match_by_index", 2.1);
+        let server = server_gate(&a, &c);
+        let cell = &server.ops["match_by_index"].cells[0];
+        assert_eq!(cell.perf_verdict, Verdict::Ok);
+        assert_eq!(cell.context.candidate.unwrap().total_p50_ms, None);
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -8,7 +8,7 @@
 //! are computed once, there.
 
 use crate::synthetic::analysis::{
-    CacheMode, CellAnalysis, CellContextSide, Correctness, DivergencePolicy,
+    CacheMode, CellAnalysis, CellContextSide, Correctness, DivergencePolicy, GatedMetric,
     OpAnalysis, OpOutcome, OutcomeCounts, OverallVerdict, RegressionAnalysis,
 };
 use crate::synthetic::provenance::decode_module_version;
@@ -323,10 +323,11 @@ fn row2(
 // ==== Non-fatal regression report ===============================================================
 
 /// Render the **non-fatal** `report --regression` markdown from the [`RegressionAnalysis`] model:
-/// per-cell 🟢/🔴/N-A verdicts on p50 (total-latency median) against the threshold budget, with
-/// throughput shown for context. Diverged ops get a perf verdict of N/A — 🔴 under the `gate`
-/// divergence policy, ⚠ under `advisory`. A `NotComparable` status renders a single "not
-/// comparable" note. Never errors.
+/// per-cell 🟢/🔴/N-A verdicts on the gated p50 — the total-latency median by default, the
+/// server-reported execution-time median under `--gated-metric server-ms` — against the threshold
+/// budget, with throughput shown for context. Diverged ops get a perf verdict of N/A — 🔴 under
+/// the `gate` divergence policy, ⚠ under `advisory`. A `NotComparable` status renders a single
+/// "not comparable" note. Never errors.
 pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     let la = analysis.comparison.baseline_label.as_str();
     let lb = analysis.comparison.candidate_label.as_str();
@@ -381,6 +382,12 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     );
     head.push('\n');
     head.push_str(&meta.thresholds.settings_markdown());
+    if analysis.gated_on_server_ms() {
+        head.push_str(
+            "\n**Gated metric: `server_ms.p50`** — the server-reported execution time; \
+             client-observed total latency is not part of any verdict in this comparison.\n",
+        );
+    }
 
     if let Some(reason) = analysis.status.not_comparable_reason() {
         head.push_str(&format!(
@@ -448,18 +455,25 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     for w in &analysis.warnings {
         out.push_str(&format!("\n> ⚠ {}\n", md_cell(w)));
     }
-    out.push_str(match analysis.divergence_policy {
-        DivergencePolicy::Gate => {
+    // The legend names the gated metric under `--gated-metric server-ms`; the default (total-ms)
+    // wording stays byte-identical to the pre-flag report.
+    let metric_clause = if analysis.gated_on_server_ms() {
+        "Only **p50** of `server_ms` (server-reported execution time) is gated"
+    } else {
+        "Only **p50** is gated"
+    };
+    out.push_str(&match analysis.divergence_policy {
+        DivergencePolicy::Gate => format!(
             "\n🟢 = faster or within budget · 🔴 = slower than budget **or** results differ · \
-             N/A = no perf verdict. Only **p50** is gated — the `context:` line (p90/p95/p99 · throughput) \
+             N/A = no perf verdict. {metric_clause} — the `context:` line (p90/p95/p99 · throughput) \
              and `Δms` are informational, never part of the verdict. Non-blocking.\n"
-        }
-        DivergencePolicy::Advisory => {
+        ),
+        DivergencePolicy::Advisory => format!(
             "\n🟢 = faster or within budget · 🔴 = slower than budget · ⚠ = results differ \
              (advisory — the engines did different work, so perf is N/A) · N/A = no perf verdict. \
-             Only **p50** is gated — the `context:` line (p90/p95/p99 · throughput) and `Δms` are \
+             {metric_clause} — the `context:` line (p90/p95/p99 · throughput) and `Δms` are \
              informational, never part of the verdict. Non-blocking.\n"
-        }
+        ),
     });
     if analysis.totals.skipped > 0 {
         out.push_str(
@@ -601,7 +615,8 @@ pub struct SyntheticSummary {
     pub budget_profile: BudgetProfile,
     /// How divergences were treated (`gate` / `advisory`).
     pub divergence_policy: DivergencePolicy,
-    /// The gated metric id (`total_ms.p50`); everything else is informational.
+    /// The gated metric id (`total_ms.p50` by default, `server_ms.p50` under
+    /// `--gated-metric server-ms`); everything else is informational.
     pub gated_metric: String,
     /// Total wall-clock seconds the caller spent computing the check (`--elapsed-secs`), if given.
     pub elapsed_secs: Option<f64>,
@@ -728,6 +743,11 @@ impl SyntheticSummary {
             self.overall_verdict.emoji(),
             md_cell(&self.headline)
         ));
+        // Name a non-default gated metric; the default (total-ms) rendering stays byte-identical
+        // to the pre-flag comment.
+        if self.gated_metric == GatedMetric::ServerMs.id() {
+            out.push_str("\n_gated metric: `server_ms.p50` (server-reported execution time)_\n");
+        }
         if self.not_comparable_reason.is_some() {
             // NotComparable: the headline already carries the reason; there is nothing to tally.
             out.push_str(&format!("\n_report: {}_\n", self.slug));
@@ -819,6 +839,25 @@ mod tests {
         t: &Thresholds,
     ) -> SyntheticSummary {
         summarize(&analyze_gate(a, b, g, t))
+    }
+
+    /// Analyze under `--gated-metric server-ms` (gate divergence policy).
+    fn analyze_server(
+        a: &Report,
+        b: &Report,
+        g: &crate::synthetic::baseline::RegressionGuard,
+        t: &Thresholds,
+    ) -> RegressionAnalysis {
+        analyze(
+            a,
+            b,
+            g,
+            t,
+            &AnalysisOptions {
+                gated_metric: GatedMetric::ServerMs,
+                ..Default::default()
+            },
+        )
     }
 
     fn summ(median: f64) -> Summary {
@@ -1226,6 +1265,107 @@ mod tests {
         assert!(md.contains("10% AND 0.5 ms"), "guard cell: {md}");
         // Legend states the gate is p50-only.
         assert!(md.contains("Only **p50** is gated"), "{md}");
+    }
+
+    #[test]
+    fn regression_markdown_names_a_server_gated_metric_and_default_stays_silent() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        // +100 % total p50 (over budget) while the server p50 grows only +0.2 ms — over its 10 %
+        // budget but under the 0.5 ms floor, so server-ms gating passes.
+        let a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 2.0, 900.0);
+        let g = regression_guard(&a, &b);
+
+        // Default (total-ms): report byte-layout unchanged — no gated-metric header line, the
+        // pre-flag legend wording, and the total-latency verdict.
+        let md = regression_markdown(&analyze_gate(&a, &b, &g, &Thresholds::builtin()));
+        assert!(
+            !md.contains("Gated metric:"),
+            "default header must stay silent: {md}"
+        );
+        assert!(
+            md.contains("Only **p50** is gated — the `context:` line"),
+            "{md}"
+        );
+        assert!(
+            md.contains("🔴 1 of 1 comparable cell(s) over budget"),
+            "{md}"
+        );
+
+        // server-ms: the header and the legend both name the metric; the verdict follows the
+        // server medians (0.200 → 0.400), which the table now carries.
+        let md = regression_markdown(&analyze_server(&a, &b, &g, &Thresholds::builtin()));
+        assert!(md.contains("**Gated metric: `server_ms.p50`**"), "{md}");
+        assert!(
+            md.contains("Only **p50** of `server_ms` (server-reported execution time) is gated"),
+            "{md}"
+        );
+        assert!(
+            md.contains("🟢 no p50 regression beyond budget across 1 comparable cell(s)"),
+            "{md}"
+        );
+        assert!(
+            md.contains("0.200") && md.contains("0.400"),
+            "server medians in cells: {md}"
+        );
+    }
+
+    #[test]
+    fn regression_markdown_renders_the_degraded_server_metric_advisory() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        // The candidate carries no usable server time (all-zero summary): under server-ms gating
+        // the only cell is N/A, the overall verdict is Advisory, and the degraded-metric warning
+        // renders as a `> ⚠` line naming the op.
+        let a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        b.operations.get_mut("match_by_index").unwrap().levels[0]
+            .cached
+            .as_mut()
+            .unwrap()
+            .metrics
+            .server_ms = summ(0.0);
+        let g = regression_guard(&a, &b);
+        let md = regression_markdown(&analyze_server(&a, &b, &g, &Thresholds::builtin()));
+        assert!(
+            md.contains("> ⚠ gated metric server_ms.p50 is missing/invalid"),
+            "advisory line: {md}"
+        );
+        assert!(
+            md.contains("match_by_index — those cells have no verdict"),
+            "{md}"
+        );
+        assert!(md.contains("⚠ no comparable cells"), "{md}");
+    }
+
+    #[test]
+    fn summary_carries_and_renders_the_server_gated_metric() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 1.0, 1000.0);
+        let g = regression_guard(&a, &b);
+
+        let total = summarize_gate(&a, &b, &g, &Thresholds::builtin());
+        assert_eq!(total.gated_metric, "total_ms.p50");
+        assert!(
+            !total.to_markdown().contains("gated metric:"),
+            "default sticky comment stays byte-identical"
+        );
+
+        let server = summarize(&analyze_server(&a, &b, &g, &Thresholds::builtin()));
+        assert_eq!(server.gated_metric, "server_ms.p50");
+        let json = server.to_json().unwrap();
+        assert!(
+            json.contains("\"gated_metric\": \"server_ms.p50\""),
+            "{json}"
+        );
+        let md = server.to_markdown();
+        assert!(
+            md.contains("_gated metric: `server_ms.p50` (server-reported execution time)_"),
+            "{md}"
+        );
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -323,11 +323,11 @@ fn row2(
 // ==== Non-fatal regression report ===============================================================
 
 /// Render the **non-fatal** `report --regression` markdown from the [`RegressionAnalysis`] model:
-/// per-cell 🟢/🔴/N-A verdicts on the gated p50 — the total-latency median by default, the
-/// server-reported execution-time median under `--gated-metric server-ms` — against the threshold
-/// budget, with throughput shown for context. Diverged ops get a perf verdict of N/A — 🔴 under
-/// the `gate` divergence policy, ⚠ under `advisory`. A `NotComparable` status renders a single
-/// "not comparable" note. Never errors.
+/// per-cell 🟢/🔴/N-A verdicts on the gated p50 — the server-reported execution-time median by
+/// default, the total-latency median under the `--gated-metric total-ms` opt-in — against the
+/// threshold budget, with throughput shown for context. Diverged ops get a perf verdict of N/A —
+/// 🔴 under the `gate` divergence policy, ⚠ under `advisory`. A `NotComparable` status renders a
+/// single "not comparable" note. Never errors.
 pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     let la = analysis.comparison.baseline_label.as_str();
     let lb = analysis.comparison.candidate_label.as_str();
@@ -382,10 +382,18 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     );
     head.push('\n');
     head.push_str(&meta.thresholds.settings_markdown());
+    // The gated metric is always named — the default gate changed to server-ms (maintainer
+    // decision), so no reader should have to guess which clock the verdicts are on.
     if analysis.gated_on_server_ms() {
         head.push_str(
-            "\n**Gated metric: `server_ms.p50`** — the server-reported execution time; \
+            "\n**Gated metric: `server_ms.p50`** (default) — the server-reported execution time; \
              client-observed total latency is not part of any verdict in this comparison.\n",
+        );
+    } else {
+        head.push_str(
+            "\n**Gated metric: `total_ms.p50`** (opt-in) — the client-observed total latency, \
+             including client scheduling and network time; the default gate is the \
+             server-reported execution time (`server_ms.p50`).\n",
         );
     }
 
@@ -455,12 +463,12 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     for w in &analysis.warnings {
         out.push_str(&format!("\n> ⚠ {}\n", md_cell(w)));
     }
-    // The legend names the gated metric under `--gated-metric server-ms`; the default (total-ms)
-    // wording stays byte-identical to the pre-flag report.
+    // The legend always names the gated metric — server_ms by default, total_ms under the
+    // explicit opt-in.
     let metric_clause = if analysis.gated_on_server_ms() {
         "Only **p50** of `server_ms` (server-reported execution time) is gated"
     } else {
-        "Only **p50** is gated"
+        "Only **p50** of `total_ms` (client-observed total latency) is gated"
     };
     out.push_str(&match analysis.divergence_policy {
         DivergencePolicy::Gate => format!(
@@ -615,8 +623,8 @@ pub struct SyntheticSummary {
     pub budget_profile: BudgetProfile,
     /// How divergences were treated (`gate` / `advisory`).
     pub divergence_policy: DivergencePolicy,
-    /// The gated metric id (`total_ms.p50` by default, `server_ms.p50` under
-    /// `--gated-metric server-ms`); everything else is informational.
+    /// The gated metric id (`server_ms.p50` by default, `total_ms.p50` under the
+    /// `--gated-metric total-ms` opt-in); everything else is informational.
     pub gated_metric: String,
     /// Total wall-clock seconds the caller spent computing the check (`--elapsed-secs`), if given.
     pub elapsed_secs: Option<f64>,
@@ -743,10 +751,15 @@ impl SyntheticSummary {
             self.overall_verdict.emoji(),
             md_cell(&self.headline)
         ));
-        // Name a non-default gated metric; the default (total-ms) rendering stays byte-identical
-        // to the pre-flag comment.
+        // The sticky comment always names the gated metric — the default gate changed to
+        // server-ms (maintainer decision), so the clock is never ambiguous.
         if self.gated_metric == GatedMetric::ServerMs.id() {
             out.push_str("\n_gated metric: `server_ms.p50` (server-reported execution time)_\n");
+        } else {
+            out.push_str(
+                "\n_gated metric: `total_ms.p50` (client-observed total latency — opt-in; the \
+                 default gate is `server_ms.p50`)_\n",
+            );
         }
         if self.not_comparable_reason.is_some() {
             // NotComparable: the headline already carries the reason; there is nothing to tally.
@@ -841,7 +854,8 @@ mod tests {
         summarize(&analyze_gate(a, b, g, t))
     }
 
-    /// Analyze under `--gated-metric server-ms` (gate divergence policy).
+    /// Analyze under `--gated-metric server-ms` — the default, spelled out for symmetry with
+    /// [`analyze_total`] (gate divergence policy).
     fn analyze_server(
         a: &Report,
         b: &Report,
@@ -855,6 +869,25 @@ mod tests {
             t,
             &AnalysisOptions {
                 gated_metric: GatedMetric::ServerMs,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Analyze under the `--gated-metric total-ms` opt-in (gate divergence policy).
+    fn analyze_total(
+        a: &Report,
+        b: &Report,
+        g: &crate::synthetic::baseline::RegressionGuard,
+        t: &Thresholds,
+    ) -> RegressionAnalysis {
+        analyze(
+            a,
+            b,
+            g,
+            t,
+            &AnalysisOptions {
+                gated_metric: GatedMetric::TotalMs,
                 ..Default::default()
             },
         )
@@ -878,7 +911,9 @@ mod tests {
         LevelMetrics {
             throughput_ops_per_sec: tput,
             metrics: MetricSet {
-                server_ms: summ(median * 0.2),
+                // Both clocks carry the same medians so metric-agnostic tests behave identically
+                // under either gate; metric-specific tests overwrite one side explicitly.
+                server_ms: summ(median),
                 total_ms: summ(median),
                 non_internal_ms: summ(median * 0.8),
                 cached_false_rate: 0.0,
@@ -1231,8 +1266,9 @@ mod tests {
 
     // --- folded layout: per-line guard + non-gated p90/p99 context -----------------------------
 
-    /// Mutate the candidate's cached `total_ms` percentiles in place (keeping p50) so tests can
-    /// isolate tail behaviour from the gated p50.
+    /// Mutate the candidate's cached `server_ms` percentiles in place (keeping p50) so tests can
+    /// isolate tail behaviour from the gated p50 — the context tails follow the gated metric,
+    /// server_ms by default.
     fn set_tails(r: &mut Report, p90: f64, p99: f64) {
         let m = r
             .operations
@@ -1242,9 +1278,9 @@ mod tests {
             .cached
             .as_mut()
             .unwrap();
-        m.metrics.total_ms.p90 = p90;
-        m.metrics.total_ms.p95 = (p90 + p99) / 2.0;
-        m.metrics.total_ms.p99 = p99;
+        m.metrics.server_ms.p90 = p90;
+        m.metrics.server_ms.p95 = (p90 + p99) / 2.0;
+        m.metrics.server_ms.p99 = p99;
     }
 
     #[test]
@@ -1263,40 +1299,43 @@ mod tests {
         assert!(md.contains("<br><sub>context: p90 ") && md.contains("op/s</sub>"), "{md}");
         // The per-line guard shows the resolved default (10%) + floor.
         assert!(md.contains("10% AND 0.5 ms"), "guard cell: {md}");
-        // Legend states the gate is p50-only.
-        assert!(md.contains("Only **p50** is gated"), "{md}");
+        // Legend states the gate is p50-only, naming the default gated metric.
+        assert!(
+            md.contains("Only **p50** of `server_ms` (server-reported execution time) is gated"),
+            "{md}"
+        );
     }
 
     #[test]
-    fn regression_markdown_names_a_server_gated_metric_and_default_stays_silent() {
+    fn regression_markdown_names_the_gated_metric_for_both_gates() {
         use crate::synthetic::baseline::regression_guard;
         use crate::synthetic::thresholds::Thresholds;
         // +100 % total p50 (over budget) while the server p50 grows only +0.2 ms — over its 10 %
-        // budget but under the 0.5 ms floor, so server-ms gating passes.
-        let a = report(42001, 1.0, 1000.0);
-        let b = report(42002, 2.0, 900.0);
+        // budget but under the 0.5 ms floor, so the default (server-ms) gate passes while the
+        // total-ms opt-in regresses.
+        let mut a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 2.0, 900.0);
+        a.operations.get_mut("match_by_index").unwrap().levels[0]
+            .cached
+            .as_mut()
+            .unwrap()
+            .metrics
+            .server_ms = summ(0.2);
+        b.operations.get_mut("match_by_index").unwrap().levels[0]
+            .cached
+            .as_mut()
+            .unwrap()
+            .metrics
+            .server_ms = summ(0.4);
         let g = regression_guard(&a, &b);
 
-        // Default (total-ms): report byte-layout unchanged — no gated-metric header line, the
-        // pre-flag legend wording, and the total-latency verdict.
+        // Default (server-ms): the header and the legend both name the metric; the verdict
+        // follows the server medians (0.200 → 0.400), which the table carries.
         let md = regression_markdown(&analyze_gate(&a, &b, &g, &Thresholds::builtin()));
         assert!(
-            !md.contains("Gated metric:"),
-            "default header must stay silent: {md}"
-        );
-        assert!(
-            md.contains("Only **p50** is gated — the `context:` line"),
+            md.contains("**Gated metric: `server_ms.p50`** (default)"),
             "{md}"
         );
-        assert!(
-            md.contains("🔴 1 of 1 comparable cell(s) over budget"),
-            "{md}"
-        );
-
-        // server-ms: the header and the legend both name the metric; the verdict follows the
-        // server medians (0.200 → 0.400), which the table now carries.
-        let md = regression_markdown(&analyze_server(&a, &b, &g, &Thresholds::builtin()));
-        assert!(md.contains("**Gated metric: `server_ms.p50`**"), "{md}");
         assert!(
             md.contains("Only **p50** of `server_ms` (server-reported execution time) is gated"),
             "{md}"
@@ -1309,15 +1348,34 @@ mod tests {
             md.contains("0.200") && md.contains("0.400"),
             "server medians in cells: {md}"
         );
+
+        // total-ms opt-in: named as such, and the total-latency regression is caught.
+        let md = regression_markdown(&analyze_total(&a, &b, &g, &Thresholds::builtin()));
+        assert!(
+            md.contains("**Gated metric: `total_ms.p50`** (opt-in)"),
+            "{md}"
+        );
+        assert!(
+            md.contains("Only **p50** of `total_ms` (client-observed total latency) is gated"),
+            "{md}"
+        );
+        assert!(
+            md.contains("🔴 1 of 1 comparable cell(s) over budget"),
+            "{md}"
+        );
+        assert!(
+            md.contains("1.000") && md.contains("2.000"),
+            "total medians in cells: {md}"
+        );
     }
 
     #[test]
     fn regression_markdown_renders_the_degraded_server_metric_advisory() {
         use crate::synthetic::baseline::regression_guard;
         use crate::synthetic::thresholds::Thresholds;
-        // The candidate carries no usable server time (all-zero summary): under server-ms gating
-        // the only cell is N/A, the overall verdict is Advisory, and the degraded-metric warning
-        // renders as a `> ⚠` line naming the op.
+        // The candidate carries no usable server time (all-zero summary): under the default
+        // server-ms gating the only cell is N/A, the overall verdict is Advisory, and the loud
+        // degraded-metric warning renders as a `> ⚠` line naming the op and the escape hatch.
         let a = report(42001, 1.0, 1000.0);
         let mut b = report(42002, 1.0, 1000.0);
         b.operations.get_mut("match_by_index").unwrap().levels[0]
@@ -1329,12 +1387,16 @@ mod tests {
         let g = regression_guard(&a, &b);
         let md = regression_markdown(&analyze_server(&a, &b, &g, &Thresholds::builtin()));
         assert!(
-            md.contains("> ⚠ gated metric server_ms.p50 is missing/invalid"),
+            md.contains("> ⚠ gated metric server_ms.p50 (the default gate) is missing/invalid"),
             "advisory line: {md}"
         );
         assert!(
-            md.contains("match_by_index — those cells have no verdict"),
+            md.contains("match_by_index — those cells have NO verdict"),
             "{md}"
+        );
+        assert!(
+            md.contains("re-run with `--gated-metric total-ms`"),
+            "escape hatch named: {md}"
         );
         assert!(md.contains("⚠ no comparable cells"), "{md}");
     }
@@ -1347,14 +1409,8 @@ mod tests {
         let b = report(42002, 1.0, 1000.0);
         let g = regression_guard(&a, &b);
 
-        let total = summarize_gate(&a, &b, &g, &Thresholds::builtin());
-        assert_eq!(total.gated_metric, "total_ms.p50");
-        assert!(
-            !total.to_markdown().contains("gated metric:"),
-            "default sticky comment stays byte-identical"
-        );
-
-        let server = summarize(&analyze_server(&a, &b, &g, &Thresholds::builtin()));
+        // Default: server-ms — carried in the summary JSON and named in the sticky comment.
+        let server = summarize_gate(&a, &b, &g, &Thresholds::builtin());
         assert_eq!(server.gated_metric, "server_ms.p50");
         let json = server.to_json().unwrap();
         assert!(
@@ -1364,6 +1420,19 @@ mod tests {
         let md = server.to_markdown();
         assert!(
             md.contains("_gated metric: `server_ms.p50` (server-reported execution time)_"),
+            "{md}"
+        );
+
+        // total-ms opt-in: carried and named as the non-default escape hatch.
+        let total = summarize(&analyze_total(&a, &b, &g, &Thresholds::builtin()));
+        assert_eq!(total.gated_metric, "total_ms.p50");
+        let md = total.to_markdown();
+        assert!(
+            md.contains("_gated metric: `total_ms.p50` (client-observed total latency"),
+            "{md}"
+        );
+        assert!(
+            md.contains("the default gate is `server_ms.p50`"),
             "{md}"
         );
     }
@@ -1995,7 +2064,7 @@ mod tests {
         assert!(json.contains("\"overall_verdict\": \"regressed\""), "{json}");
         assert!(json.contains("\"budget_profile\": \"strict\""), "{json}");
         assert!(json.contains("\"divergence_policy\": \"gate\""), "{json}");
-        assert!(json.contains("\"gated_metric\": \"total_ms.p50\""), "{json}");
+        assert!(json.contains("\"gated_metric\": \"server_ms.p50\""), "{json}");
         // No `--elapsed-secs` ⇒ explicit null (the field is always present).
         assert!(json.contains("\"elapsed_secs\": null"), "{json}");
     }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -236,20 +236,26 @@ fn percentiles(m: &LevelMetrics) -> String {
     format!("{:.3} / {:.3} / {:.3} / {:.3}", s.median, s.p90, s.p95, s.p99)
 }
 
-/// A regression-table latency cell: the gated **p50** on the primary line, with p90/p95/p99 and
-/// throughput folded onto a smaller `context:` line (informational, never gated, appended only
-/// when the report carries it). `—` only when the side's p50 is absent. Values are
-/// fixed-precision measurements, so no operator-supplied text is interpolated (no `md_cell`
-/// escaping needed).
+/// A regression-table latency cell: the gated **p50** on the primary line, with p90/p95/p99,
+/// throughput and — under the server-ms gate — the demoted client-observed total p50 folded onto
+/// a smaller `context:` line (informational, never gated, appended only when the report carries
+/// it). `—` only when the side's p50 is absent. Values are fixed-precision measurements, so no
+/// operator-supplied text is interpolated (no `md_cell` escaping needed).
 fn latency_cell(
     p50: Option<f64>,
     ctx: Option<&CellContextSide>,
 ) -> String {
     match (p50, ctx) {
-        (Some(p50), Some(c)) => format!(
-            "{:.3}<br><sub>context: p90 {:.3} · p95 {:.3} · p99 {:.3} · {:.0} op/s</sub>",
-            p50, c.p90_ms, c.p95_ms, c.p99_ms, c.throughput_ops_per_sec
-        ),
+        (Some(p50), Some(c)) => {
+            let total = c
+                .total_p50_ms
+                .map(|t| format!(" · total p50 {t:.3}"))
+                .unwrap_or_default();
+            format!(
+                "{:.3}<br><sub>context: p90 {:.3} · p95 {:.3} · p99 {:.3} · {:.0} op/s{}</sub>",
+                p50, c.p90_ms, c.p95_ms, c.p99_ms, c.throughput_ops_per_sec, total
+            )
+        }
         (Some(p50), None) => format!("{p50:.3}"),
         (None, _) => "—".to_string(),
     }
@@ -387,7 +393,8 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     if analysis.gated_on_server_ms() {
         head.push_str(
             "\n**Gated metric: `server_ms.p50`** (default) — the server-reported execution time; \
-             client-observed total latency is not part of any verdict in this comparison.\n",
+             client-observed total latency is demoted to the `context:` line and is not part of \
+             any verdict in this comparison.\n",
         );
     } else {
         head.push_str(
@@ -470,16 +477,23 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     } else {
         "Only **p50** of `total_ms` (client-observed total latency) is gated"
     };
+    // The context descriptor matches what the cells actually fold in: under the server gate the
+    // client-observed total p50 rides along as demoted context.
+    let context_clause = if analysis.gated_on_server_ms() {
+        "the `context:` line (p90/p95/p99 · throughput · client-observed total p50)"
+    } else {
+        "the `context:` line (p90/p95/p99 · throughput)"
+    };
     out.push_str(&match analysis.divergence_policy {
         DivergencePolicy::Gate => format!(
             "\n🟢 = faster or within budget · 🔴 = slower than budget **or** results differ · \
-             N/A = no perf verdict. {metric_clause} — the `context:` line (p90/p95/p99 · throughput) \
+             N/A = no perf verdict. {metric_clause} — {context_clause} \
              and `Δms` are informational, never part of the verdict. Non-blocking.\n"
         ),
         DivergencePolicy::Advisory => format!(
             "\n🟢 = faster or within budget · 🔴 = slower than budget · ⚠ = results differ \
              (advisory — the engines did different work, so perf is N/A) · N/A = no perf verdict. \
-             {metric_clause} — the `context:` line (p90/p95/p99 · throughput) and `Δms` are \
+             {metric_clause} — {context_clause} and `Δms` are \
              informational, never part of the verdict. Non-blocking.\n"
         ),
     });
@@ -1295,8 +1309,12 @@ mod tests {
         assert!(md.contains("p50 (ms)") && md.contains("p50 guard (>% AND >ms)"), "{md}");
         // Δp50 carries the signed absolute ms delta so the floor is auditable.
         assert!(md.contains("(+0.100)"), "Δms missing: {md}");
-        // p90/p99 + throughput are folded onto the context line (not their own columns).
-        assert!(md.contains("<br><sub>context: p90 ") && md.contains("op/s</sub>"), "{md}");
+        // p90/p99 + throughput are folded onto the context line (not their own columns), with
+        // the demoted client-observed total p50 riding along under the default server gate.
+        assert!(
+            md.contains("<br><sub>context: p90 ") && md.contains("op/s · total p50 1.000</sub>"),
+            "{md}"
+        );
         // The per-line guard shows the resolved default (10%) + floor.
         assert!(md.contains("10% AND 0.5 ms"), "guard cell: {md}");
         // Legend states the gate is p50-only, naming the default gated metric.
@@ -1348,6 +1366,20 @@ mod tests {
             md.contains("0.200") && md.contains("0.400"),
             "server medians in cells: {md}"
         );
+        // The wall clock is demoted, not hidden: each side's total p50 rides on the context
+        // line, and the legend says so.
+        assert!(
+            md.contains("· total p50 1.000") && md.contains("· total p50 2.000"),
+            "demoted total p50 in context: {md}"
+        );
+        assert!(
+            md.contains("throughput · client-observed total p50)"),
+            "legend names the demoted total: {md}"
+        );
+        assert!(
+            md.contains("demoted to the `context:` line"),
+            "header states the demotion: {md}"
+        );
 
         // total-ms opt-in: named as such, and the total-latency regression is caught.
         let md = regression_markdown(&analyze_total(&a, &b, &g, &Thresholds::builtin()));
@@ -1367,6 +1399,9 @@ mod tests {
             md.contains("1.000") && md.contains("2.000"),
             "total medians in cells: {md}"
         );
+        // No duplicate: the primary p50 already is the wall clock, so the context line carries
+        // only tails + throughput.
+        assert!(!md.contains("· total p50"), "no demoted total under total-ms gating: {md}");
     }
 
     #[test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -3270,8 +3270,14 @@ mod tests {
         // while its SERVER p50 grows 5 % (within budget). The default gate (server-ms) passes;
         // the explicit `--gated-metric total-ms` opt-in regresses; every artifact (Markdown,
         // summary JSON, cells JSON) names the selected metric.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
         let dir = std::env::temp_dir();
-        let stem = format!("gm-{}", std::process::id());
+        let stem = format!(
+            "gm-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        );
         let write = |label: &str, total: f64, server: f64| -> String {
             let p = dir
                 .join(format!("{stem}-{label}.json"))

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -3265,11 +3265,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn report_regression_gates_on_server_ms_when_selected() {
-        // Hermetic end-to-end `--gated-metric`: the candidate doubles its TOTAL p50 (over budget)
-        // while its SERVER p50 grows 5 % (within budget). The default gate regresses; selecting
-        // `server-ms` passes, and every artifact (Markdown, summary JSON, cells JSON) names the
-        // selected metric.
+    async fn report_regression_gates_on_server_ms_by_default() {
+        // Hermetic end-to-end default flip: the candidate doubles its TOTAL p50 (over budget)
+        // while its SERVER p50 grows 5 % (within budget). The default gate (server-ms) passes;
+        // the explicit `--gated-metric total-ms` opt-in regresses; every artifact (Markdown,
+        // summary JSON, cells JSON) names the selected metric.
         let dir = std::env::temp_dir();
         let stem = format!("gm-{}", std::process::id());
         let write = |label: &str, total: f64, server: f64| -> String {
@@ -3322,7 +3322,7 @@ mod tests {
             (cmd, out, sum, cells)
         };
 
-        let (cmd, out, sum, cells) = run(Some("server-ms"), "srv");
+        let (cmd, out, sum, cells) = run(None, "srv");
         assert!(run_command(cmd).await.is_ok());
         let compact: diff::SyntheticSummary =
             serde_json::from_str(&std::fs::read_to_string(&sum).unwrap()).unwrap();
@@ -3341,13 +3341,16 @@ mod tests {
             let _ = std::fs::remove_file(p);
         }
 
-        // The identical pair under the default gate: the total-latency regression is caught.
-        let (cmd, out, sum, cells) = run(None, "tot");
+        // The identical pair under the explicit total-ms opt-in: the total-latency regression
+        // is caught, and the artifacts name total_ms.p50.
+        let (cmd, out, sum, cells) = run(Some("total-ms"), "tot");
         assert!(run_command(cmd).await.is_ok());
         let compact: diff::SyntheticSummary =
             serde_json::from_str(&std::fs::read_to_string(&sum).unwrap()).unwrap();
         assert_eq!(compact.overall_verdict, analysis::OverallVerdict::Regressed);
         assert_eq!(compact.gated_metric, "total_ms.p50");
+        let md = std::fs::read_to_string(&out).unwrap();
+        assert!(md.contains("**Gated metric: `total_ms.p50`** (opt-in)"), "{md}");
         for p in [a, b, out, sum, cells] {
             let _ = std::fs::remove_file(p);
         }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -1656,8 +1656,9 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             cells,
             budget_profile,
             divergence_policy,
+            gated_metric,
         } => {
-            // clap's value_parser restricts both to known names, so these parses cannot fail; map
+            // clap's value_parser restricts these to known names, so the parses cannot fail; map
             // errors anyway so a future drift fails loudly instead of silently defaulting.
             let budget_profile = budget_profile
                 .as_deref()
@@ -1668,6 +1669,12 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             let divergence_policy = divergence_policy
                 .as_deref()
                 .map(str::parse::<analysis::DivergencePolicy>)
+                .transpose()
+                .map_err(OtherError)?
+                .unwrap_or_default();
+            let gated_metric = gated_metric
+                .as_deref()
+                .map(str::parse::<analysis::GatedMetric>)
                 .transpose()
                 .map_err(OtherError)?
                 .unwrap_or_default();
@@ -1683,6 +1690,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                     cells,
                     budget_profile,
                     divergence_policy,
+                    gated_metric,
                 },
             )
             .await
@@ -1698,6 +1706,7 @@ struct RegressionOpts {
     cells: Option<String>,
     budget_profile: BudgetProfile,
     divergence_policy: analysis::DivergencePolicy,
+    gated_metric: analysis::GatedMetric,
 }
 
 /// `synthetic report`: re-render a saved report (`input`) to console + Markdown, or **diff** two
@@ -1753,6 +1762,7 @@ async fn report_command(
                 &analysis::AnalysisOptions {
                     budget_profile: opts.budget_profile,
                     divergence_policy: opts.divergence_policy,
+                    gated_metric: opts.gated_metric,
                     elapsed_secs: opts.elapsed_secs,
                 },
             );
@@ -2981,6 +2991,7 @@ mod tests {
             cells: None,
             budget_profile: None,
             divergence_policy: None,
+            gated_metric: None,
         })
         .await
         .expect_err("report with no args ⇒ error");
@@ -3035,6 +3046,7 @@ mod tests {
             cells: None,
             budget_profile: None,
             divergence_policy: None,
+            gated_metric: None,
         })
         .await
         .is_ok());
@@ -3051,6 +3063,7 @@ mod tests {
             cells: None,
             budget_profile: None,
             divergence_policy: None,
+            gated_metric: None,
         })
         .await
         .expect_err("workload_hash mismatch must abort");
@@ -3102,6 +3115,7 @@ mod tests {
             cells: None,
             budget_profile: None,
             divergence_policy: None,
+            gated_metric: None,
         })
         .await
         .is_ok());
@@ -3159,6 +3173,7 @@ mod tests {
             cells: Some(cells.clone()),
             budget_profile: None,
             divergence_policy: Some("advisory".to_string()),
+            gated_metric: None,
         })
         .await
         .is_ok());
@@ -3200,6 +3215,7 @@ mod tests {
             cells: None,
             budget_profile: Some("cross-engine".to_string()),
             divergence_policy: None,
+            gated_metric: None,
         })
         .await
         .expect_err("cross-engine without --thresholds must fail");
@@ -3237,6 +3253,7 @@ mod tests {
             cells: None,
             budget_profile: Some("cross-engine".to_string()),
             divergence_policy: None,
+            gated_metric: None,
         })
         .await
         .is_ok());
@@ -3245,6 +3262,120 @@ mod tests {
         for p in [rep, toml_path, out] {
             let _ = std::fs::remove_file(p);
         }
+    }
+
+    #[tokio::test]
+    async fn report_regression_gates_on_server_ms_when_selected() {
+        // Hermetic end-to-end `--gated-metric`: the candidate doubles its TOTAL p50 (over budget)
+        // while its SERVER p50 grows 5 % (within budget). The default gate regresses; selecting
+        // `server-ms` passes, and every artifact (Markdown, summary JSON, cells JSON) names the
+        // selected metric.
+        let dir = std::env::temp_dir();
+        let stem = format!("gm-{}", std::process::id());
+        let write = |label: &str, total: f64, server: f64| -> String {
+            let p = dir
+                .join(format!("{stem}-{label}.json"))
+                .to_string_lossy()
+                .into_owned();
+            let summ = |m: f64| {
+                format!(
+                    r#"{{"n":10,"removed":0,"min":{m},"mean":{m},"median":{m},"p90":{m},"p95":{m},"p99":{m},"max":{m},"stddev":0.0}}"#
+                )
+            };
+            let json = format!(
+                r#"{{"meta":{{"tool_version":"0.1.0","endpoint":"x","samples":1,"warmup":0,"concurrency":[1],"server_timeout_ms":5000,"client_deadline_ms":6000,"connection":"c","started_at_epoch_secs":0,"server":{{"module_graph_ver":42001}},"dataset":{{"seed":1,"nodes":10,"edges":20,"corpus_hash":"sha256:same"}},"label":"{label}"}},"operations":{{"match_by_index":{{"levels":[{{"concurrency":1,"cached":{{"throughput_ops_per_sec":1000.0,"metrics":{{"server_ms":{srv},"total_ms":{tot},"non_internal_ms":{ni},"cached_false_rate":0.0,"cached_unknown":0}}}}}}],"result_digest":"sha256:aa"}}}}}}"#,
+                srv = summ(server),
+                tot = summ(total),
+                ni = summ(total - server),
+            );
+            std::fs::write(&p, json).unwrap();
+            p
+        };
+        let a = write("main", 10.0, 2.0);
+        let b = write("pr", 20.0, 2.1);
+        let run = |gated: Option<&str>, suffix: &str| {
+            let out = dir
+                .join(format!("{stem}-{suffix}.md"))
+                .to_string_lossy()
+                .into_owned();
+            let sum = dir
+                .join(format!("{stem}-{suffix}-sum.json"))
+                .to_string_lossy()
+                .into_owned();
+            let cells = dir
+                .join(format!("{stem}-{suffix}-cells.json"))
+                .to_string_lossy()
+                .into_owned();
+            let cmd = crate::cli::SyntheticCommands::Report {
+                input: None,
+                regression: true,
+                thresholds: None,
+                diff: vec![a.clone(), b.clone()],
+                out: Some(out.clone()),
+                elapsed_secs: None,
+                summary: Some(sum.clone()),
+                cells: Some(cells.clone()),
+                budget_profile: None,
+                divergence_policy: None,
+                gated_metric: gated.map(str::to_string),
+            };
+            (cmd, out, sum, cells)
+        };
+
+        let (cmd, out, sum, cells) = run(Some("server-ms"), "srv");
+        assert!(run_command(cmd).await.is_ok());
+        let compact: diff::SyntheticSummary =
+            serde_json::from_str(&std::fs::read_to_string(&sum).unwrap()).unwrap();
+        assert_eq!(compact.overall_verdict, analysis::OverallVerdict::Pass);
+        assert_eq!(compact.gated_metric, "server_ms.p50");
+        let model: analysis::RegressionAnalysis =
+            serde_json::from_str(&std::fs::read_to_string(&cells).unwrap()).unwrap();
+        assert!(model.gated_on_server_ms());
+        assert_eq!(
+            model.ops["match_by_index"].cells[0].baseline_p50_ms,
+            Some(2.0)
+        );
+        let md = std::fs::read_to_string(&out).unwrap();
+        assert!(md.contains("**Gated metric: `server_ms.p50`**"), "{md}");
+        for p in [out, sum, cells] {
+            let _ = std::fs::remove_file(p);
+        }
+
+        // The identical pair under the default gate: the total-latency regression is caught.
+        let (cmd, out, sum, cells) = run(None, "tot");
+        assert!(run_command(cmd).await.is_ok());
+        let compact: diff::SyntheticSummary =
+            serde_json::from_str(&std::fs::read_to_string(&sum).unwrap()).unwrap();
+        assert_eq!(compact.overall_verdict, analysis::OverallVerdict::Regressed);
+        assert_eq!(compact.gated_metric, "total_ms.p50");
+        for p in [a, b, out, sum, cells] {
+            let _ = std::fs::remove_file(p);
+        }
+    }
+
+    #[tokio::test]
+    async fn report_regression_rejects_an_unknown_gated_metric() {
+        // clap's value_parser guards the real CLI; a directly-constructed command must fail
+        // loudly too (the parse happens before any report is read).
+        let err = run_command(crate::cli::SyntheticCommands::Report {
+            input: None,
+            regression: true,
+            thresholds: None,
+            diff: vec!["a.json".to_string(), "b.json".to_string()],
+            out: None,
+            elapsed_secs: None,
+            summary: None,
+            cells: None,
+            budget_profile: None,
+            divergence_policy: None,
+            gated_metric: Some("bogus".to_string()),
+        })
+        .await
+        .expect_err("unknown gated metric must fail");
+        assert!(
+            format!("{err}").contains("unknown gated metric 'bogus'"),
+            "got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What was done

`synthetic report --regression` now gates its p50 budget verdicts on the **server-reported execution time (`server_ms.p50`) by default** — per maintainer decision (*"server_ms is the only parameter I wish to measure, not the total round trip"*). A new **`--gated-metric <total-ms|server-ms>`** flag selects the gated metric; **`total-ms` remains selectable as an explicit opt-in escape hatch** that restores the old client-observed total-latency gate.

- New `GatedMetric` enum in `analysis.rs` (default `ServerMs`), plumbed `RegressionOpts → AnalysisOptions → analyze()/analyze_op()` — the one place verdicts are computed. The selected metric's median drives baseline/candidate p50 cells, `Δpct`/`Δms` and budget verdicts; the per-cell **context tails (p90/p95/p99) follow the selected metric** so a cell never mixes clocks.
- `RegressionAnalysis.gated_metric` (pre-existing string field — **no schema bump**) reflects the choice, and every renderer now **always names the gated metric** (Markdown header + legend, `--summary` sticky comment, `--cells` model): with the default changed, no reader should have to guess which clock the verdicts are on.
- **Server time is the primary presented metric** (maintainer: *"the benchmark is measuring the server time not the total time"*): regression-mode outputs (Markdown report, `--summary`, `--cells`) lead with the gated `server_ms` p50s, and the client-observed wall clock is **demoted, not hidden** — each cell's `context:` line now carries the informational `total p50` under the default gate (additive optional `total_p50_ms` on `CellContextSide`, omitted from the cells JSON when absent or when total-ms is itself the gate — still **no schema bump**). The Markdown header + legend state the demotion. `report --diff` and plain replay rendering are intentionally unchanged.
- ⚠ **Default changed** — this is a behavior change for existing pipelines: a regression that only shows up in the client-observed round trip no longer fails the gate unless you pass `--gated-metric total-ms`. Old reports without usable server time degrade loudly (below), never silently.
- **Missing-data handling (now on the default path):** if the server p50 is missing/invalid (≤ 0 / non-finite) on either side of a cell, that cell's verdict is **N/A** and one **loud advisory warning** names the affected ops, states there is **no silent fallback**, and names the `--gated-metric total-ms` escape hatch. Design decision — *warning + N/A cells* rather than a hard `NotComparable`: `MetricSet.server_ms` has been a required field since the report format's inception, so a report truly predating server-time capture fails deserialization on every path already; the realistic case is an engine/adapter reporting zero execution time, and failing the whole comparison over one op would be too strict. All-degraded still lands in the zero-comparable-cells **advisory** verdict — never a green pass.
- Docs: `readme.md` documents the flag + the changed default; both design docs annotated (history kept, marked as a later change); CLI help updated.

## Tests

`just ci` green (499 lib tests + 36 server-backed integration tests + doctests); patch coverage **100 %** (529/529 added coverable lines across all three commits, measured with `just coverage` against a live FalkorDB). Coverage of the behavior:

- `analysis.rs`: `GatedMetric::default()` is `ServerMs`; id/round-trip parsing; a **total-only regression passes the default gate** and a **server-only regression fails it while the `total-ms` opt-in passes** (medians disagree by construction); missing/invalid server median ⇒ N/A cell + exactly one advisory warning listing the ops **and the escape hatch**; all-invalid ⇒ advisory overall, never pass; diverged/skipped ops never join the degraded-metric warning; analysis JSON carries `server_ms.p50` by default.
- `diff.rs`: Markdown header + legend name the gated metric under **both** gates (`server_ms.p50` *(default)* / `total_ms.p50` *(opt-in)*); the degraded-metric advisory renders with the escape-hatch hint; the `--summary` JSON + sticky comment carry/render the metric under both gates; context tails follow the gated metric (tail-blow-up tests now mutate `server_ms` tails).
- Demotion: under the server gate each cell context carries `total_p50_ms` (asserted against fabricated medians where server ≠ total) and the Markdown folds `· total p50 x.xxx` into the context line + names it in the legend; under the `total-ms` opt-in there is **no duplicate** (field omitted from the cells JSON byte-identically to before, nothing in the context line); an invalid wall clock (total median 0) omits the field without touching the server-gated verdict.
- `mod.rs` (end-to-end through `run_command`): fabricated report pair where total p50 doubles but server p50 grows 5 % ⇒ **default passes**, `--gated-metric total-ms` regresses, all three artifacts naming their metric; unknown metric value rejected with a clear error.
- `cli.rs`: both values parse, flag optional, unknown values rejected, `requires = "regression"` enforced.
- Test fixtures now fabricate reports with **server == total medians** so every metric-agnostic test behaves identically under either gate; metric-disagreement tests pin both clocks explicitly.

## Measured improvement (A/A, ground truth = zero change)

**Methodology:** recorded a small 6-op read bundle (`match_by_index`, `expand_1_hop`, `expand_hops_5`, `aggregate_count`, `aggregate_group`, `shortest_path`; seed 7, 1 000 nodes / 5 000 edges) with `synthetic record`, then ran `synthetic run --recording` **K=8 times against the same FalkorDB container** (`falkordb/falkordb:latest`, Docker on macOS; load once, then `--no-load`), concurrency **1 and 8**, cached+uncached, 200 samples / 40 warmup per cell, release build. For each of the 7 consecutive run pairs, per-op |Δp50 %| computed from the report JSONs twice — from `total_ms.median` and from `server_ms.median` — giving n = 84 (op × cache-mode × pair) deltas per (C, metric) cell. Any nonzero delta is pure noise.

|Δp50 %| (relative noise):

| C | metric | median | p90 | worst |
|---|--------|-------:|----:|------:|
| 1 | total_ms | 2.72 % | 10.02 % | 21.84 % |
| 1 | server_ms | 2.71 % | 8.56 % | 24.58 % |
| 8 | total_ms | 1.80 % | 4.64 % | 10.93 % |
| 8 | **server_ms** | **1.54 %** | 5.71 % | **10.06 %** |

|Δp50| absolute (what the `floor_ms` noise guard sees):

| C | metric | median | worst |
|---|--------|-------:|------:|
| 1 | total_ms | 10.1 µs | 187.0 µs |
| 1 | **server_ms** | **3.4 µs** | **77.8 µs** |
| 8 | total_ms | 12.8 µs | 142.7 µs |
| 8 | **server_ms** | **2.7 µs** | **33.1 µs** |

- **A/A pairs breaching a 10 % budget** (would-be false 🔴 without the ms floor): C=1 **10/84 → 5/84**, C=8 **3/84 → 1/84** — 2–3× fewer false alarms.
- **Absolute jitter is 2.4–4.3× tighter** under server-ms (worst-case), so the 0.5 ms floor has ~an order of magnitude more headroom — a much tighter floor becomes viable later.
- **Why:** at C=8 a median **83 %** (up to 93 %) of the client-observed p50 for these ops is client scheduling + network, not server work (total 0.59–1.24 ms vs server 0.04–0.80 ms) — under closed-loop concurrency, total_ms mostly gates queueing noise. server-ms removes that component entirely.
- Per-op worst at C=8, heavier ops: `aggregate_count` 10.93 % → 5.52 %, `expand_hops_5` 10.50 % → 3.66 %.

**Honest caveats:** measured on macOS Docker Desktop (VM user-space networking inflates and jitters the client path — Linux CI will show a smaller client share, though CI noisy-neighbor scheduling is exactly the noise server-ms removes); the host concurrently ran another benchmark container (real contention, representative of shared CI runners). For **µs-scale ops** (`match_by_index` server p50 ≈ 40 µs) the server-reported time quantizes, so its *relative* noise can exceed total_ms (C=1 worst 24.58 % vs 21.84 %) even though its *absolute* jitter is far smaller — the ms floor absorbs this. A first 30-sample attempt was noisier in both metrics with the same qualitative ordering; the numbers above use 200 samples/cell. Small graph (1 k nodes), sub-ms ops.

## Recommendation

**server-ms IS the gate** — this PR makes it the default, per maintainer decision; no advisory phase. What a FalkorDB PR can regress is exactly the server execution time, and the A/A data shows the gated quantity's absolute jitter drops ~3–4× at C=8.

- The falkordb-rs-next-gen per-PR pipeline picks the new default up automatically on its next tool bump — no workflow change needed; the report header, legend and sticky comment all state `server_ms.p50` explicitly.
- The wall clock stays visible: every cell's `context:` line shows the demoted total p50, so client/driver-side drift is still spottable at a glance without gating on it.
- **`--gated-metric total-ms` is the escape hatch** for anyone who needs the old client-observed gate (e.g. investigating a client/driver-side regression, or comparing engines that don't report execution time — where the default degrades to N/A cells + a loud advisory naming the flag).
- Follow-up worth considering once real-PR data accumulates: tighten `floor_ms` (e.g. 0.5 ms → 0.2 ms) — the ~4× smaller absolute A/A jitter leaves room.

No schema bump anywhere: old `--cells`/`--summary` consumers keep working (`gated_metric` was already in both).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--gated-metric` to `synthetic report --regression`, with `server-ms` as the default and `total-ms` as an explicit opt-in.
  * Regression p50 verdicts and the related context tail percentiles now follow the selected metric consistently.
  * Report output and summary/cell JSON/Markdown include the selected gated metric.
  * When `server-ms` data is missing/invalid, affected cells show **N/A** with a clear advisory warning (no fallback to `total-ms`).
* **Documentation**
  * Updated the README and design docs to clarify defaults, metric definitions, and configuration behavior.
* **Tests**
  * Added/extended tests for CLI validation, gating behavior, and advisory warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
