### PR TITLE
feat(synthetic): paired interleaved A/B replay measurement

### DIFF
--- a/docs/synthetic-benchmark-cookbook.md
+++ b/docs/synthetic-benchmark-cookbook.md
@@ -105,6 +105,21 @@ _cached (plan reused — execution only)_
 `just synthetic-compare-versions A=falkor://…:6381 B=falkor://…:6382` wraps the two runs + the diff
 into a single recipe.
 
+**Noise-sensitive variant — one paired run instead of two sequential ones.** The two `run
+--recording` invocations above are minutes apart, so environment drift (thermal state, background
+load) lands on *different* ops in each run and pollutes per-op deltas. `--paired-endpoint` measures
+both versions in **one interleaved run**: each cache-mode × concurrency cell is measured on A and
+immediately after on B, so both sides of every compared cell see the same environment window. It
+writes the same two standard reports (read bundles only):
+
+```bash
+benchmark synthetic run --recording rec --endpoint falkor://127.0.0.1:6381 \
+  --paired-endpoint falkor://127.0.0.1:6382 \
+  --concurrency 1,2,4,8,16,32 --cache both \
+  --out runA.json --paired-out runB.json --label v4.2.0 --paired-label v4.2.1
+benchmark synthetic report --diff runA.json runB.json --out diff.md
+```
+
 ---
 
 <a id="story-2"></a>

--- a/readme.md
+++ b/readme.md
@@ -582,6 +582,25 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   never covered oracle data), pass **`--require-oracle`** whenever the bundle is *expected* to
   carry the correctness tier: the replay then refuses (offline, before any connection) a write
   bundle without an oracle, and errors on a read bundle (reads have none).
+- **`benchmark synthetic run --recording <dir> --paired-endpoint <endpoint-B> [--paired-graph g]
+  [--paired-out B.json] [--paired-label name]`** measures the same recorded bundle against **two**
+  endpoints **interleaved** instead of sequentially, so both sides of every per-op comparison cell
+  see the same environment window (thermal state, background load) and per-op deltas aren't
+  polluted by minutes of drift between two full runs. Both endpoints are set up identically (each
+  loads the recorded graph, runs its own untimed reference pass and digests, honors per-op
+  budgets), then for each op, for each cache-mode × concurrency cell, the cell is measured on the
+  primary endpoint and **immediately after** on the paired endpoint (A,B,A,B,…). Ops are never
+  interleaved with each other — per-op attribution stays strict, and an op skipped on either side
+  (capability) is skipped on both so the reports stay comparable. The run writes **two complete
+  standard reports** — primary → `--out`, paired → `--paired-out` (default: `<out>` with a `-b`
+  suffix, e.g. `report-b.json`) — that work unchanged with `report --diff`/`--regression`; each
+  report's `meta.paired_with` names the other side's endpoint as pairing provenance.
+  `--paired-label` names the B column like `--label` names A's. Paired mode is **read-bundle
+  only** (write bundles reset the base graph around every cell, which defeats interleaving; the
+  replay refuses them up front) and requires `--recording`; `--require-oracle` is likewise
+  refused. For an **A/A self-check** on a single server, pass the same endpoint twice with a
+  distinct `--paired-graph` — identical `workload_hash` + per-op digests and near-zero deltas are
+  the expected outcome.
 - **`benchmark synthetic report --diff <A.json> <B.json> [--out diff.md]`** **guards** the pair (it
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -504,6 +504,30 @@ pub enum SyntheticCommands {
             help = "with --recording: refuse to measure a write bundle that carries no outcome oracle (recording format < v3). Guards against re-hashed oracle-to-v2 downgrades; errors on read bundles (reads have no oracle)."
         )]
         require_oracle: bool,
+        #[arg(
+            long = "paired-endpoint",
+            requires = "recording",
+            help = "with --recording (READ bundles only): measure the bundle against this SECOND endpoint too, INTERLEAVED per cell — each op's cache-mode x concurrency cell runs on the primary endpoint then immediately here (A,B,A,B,...), so both sides of every per-op comparison share the same environment window. Both endpoints are set up identically (own graph load, reference pass, digests); two complete standard reports are written (--out / --paired-out) that work unchanged with `report --diff`/`--regression`. Refused for write bundles (their per-cell resets/restores don't interleave safely)."
+        )]
+        paired_endpoint: Option<String>,
+        #[arg(
+            long = "paired-graph",
+            requires = "paired_endpoint",
+            help = "with --paired-endpoint: the second side's graph key (default: same resolution as --graph). Give side B its own graph to pair two graphs on ONE server (an A/A self-check)."
+        )]
+        paired_graph: Option<String>,
+        #[arg(
+            long = "paired-out",
+            requires = "paired_endpoint",
+            help = "with --paired-endpoint: path for the second side's JSON report (default: --out with a `-b` suffix before the extension, e.g. synthetic-report-b.json)."
+        )]
+        paired_out: Option<String>,
+        #[arg(
+            long = "paired-label",
+            requires = "paired_endpoint",
+            help = "with --paired-endpoint: display name for the second side's run (like --label for the first), recorded into its report."
+        )]
+        paired_label: Option<String>,
     },
     #[command(about = "list the available operations")]
     ListOps,
@@ -889,5 +913,60 @@ mod tests {
             "benchmark", "synthetic", "run", "--require-oracle",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn cli_paired_flags_need_recording_and_paired_endpoint() {
+        use clap::Parser;
+        // The full paired flag set rides on `--recording`.
+        assert!(Cli::try_parse_from([
+            "benchmark",
+            "synthetic",
+            "run",
+            "--recording",
+            "rec",
+            "--paired-endpoint",
+            "falkor://127.0.0.1:6380",
+            "--paired-graph",
+            "g_b",
+            "--paired-out",
+            "b.json",
+            "--paired-label",
+            "pr",
+        ])
+        .is_ok());
+        // `--paired-endpoint` alone is enough (out/label/graph default).
+        assert!(Cli::try_parse_from([
+            "benchmark",
+            "synthetic",
+            "run",
+            "--recording",
+            "rec",
+            "--paired-endpoint",
+            "falkor://127.0.0.1:6380",
+        ])
+        .is_ok());
+        // …but is rejected without `--recording` (paired measurement replays a bundle).
+        assert!(Cli::try_parse_from([
+            "benchmark",
+            "synthetic",
+            "run",
+            "--paired-endpoint",
+            "falkor://127.0.0.1:6380",
+        ])
+        .is_err());
+        // The secondary knobs ride on `--paired-endpoint`, not on `--recording` alone.
+        for lone in [
+            vec!["--paired-graph", "g_b"],
+            vec!["--paired-out", "b.json"],
+            vec!["--paired-label", "pr"],
+        ] {
+            let mut argv = vec!["benchmark", "synthetic", "run", "--recording", "rec"];
+            argv.extend(lone);
+            assert!(
+                Cli::try_parse_from(argv.clone()).is_err(),
+                "expected missing --paired-endpoint for {argv:?}"
+            );
+        }
     }
 }

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -860,6 +860,7 @@ mod tests {
                 }),
                 label: Some(label.to_string()),
                 oracle_verified: None,
+                paired_with: None,
             },
             operations,
         }

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -979,6 +979,7 @@ mod regression_guard_tests {
                 }),
                 label: None,
                 oracle_verified: None,
+                paired_with: None,
             },
             operations,
         }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -891,6 +891,7 @@ mod tests {
                 }),
                 label: None,
                 oracle_verified: None,
+                paired_with: None,
             },
             operations,
         }
@@ -1429,6 +1430,7 @@ mod tests {
                 }),
                 label: Some(label.to_string()),
                 oracle_verified: None,
+                paired_with: None,
             },
             operations,
         }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -25,6 +25,7 @@ pub mod engine;
 pub mod host;
 pub mod op_runner;
 pub mod oracle;
+pub mod paired;
 pub mod provenance;
 pub mod recording;
 pub mod replay;
@@ -772,6 +773,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             dataset: dataset_info,
             label: config.label.clone(),
             oracle_verified: None,
+            paired_with: None,
         },
         operations,
     })
@@ -1403,6 +1405,10 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             recording,
             no_load,
             require_oracle,
+            paired_endpoint,
+            paired_graph,
+            paired_out,
+            paired_label,
         } => {
             // Expand `--op all` / `--op '*'` to the concrete read ops before anything else.
             let ops = crate::cli::expand_op_selectors(&ops);
@@ -1417,6 +1423,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                             .to_string(),
                     ));
                 }
+                let out = out.unwrap_or_else(|| "synthetic-report.json".to_string());
                 let replay_config = replay::ReplayConfig {
                     recording_dir: std::path::PathBuf::from(recording),
                     endpoint: endpoint.unwrap_or_else(|| "falkor://127.0.0.1:6379".to_string()),
@@ -1432,11 +1439,32 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                     cache: cache.unwrap_or(CacheSelection::Both),
                     server_timeout_ms: server_timeout_ms.unwrap_or(5_000),
                     client_deadline_ms: client_deadline_ms.unwrap_or(6_000),
-                    out: out.unwrap_or_else(|| "synthetic-report.json".to_string()),
+                    out: out.clone(),
                     server_image,
                     label,
                     require_oracle,
                 };
+                // A second endpoint switches to the PAIRED interleaved replay: same bundle, both
+                // endpoints, each per-op cell measured A-then-B back to back, two reports.
+                if let Some(paired_endpoint) = paired_endpoint {
+                    let paired_config = paired::PairedReplayConfig {
+                        base: replay_config,
+                        paired_endpoint,
+                        paired_graph,
+                        paired_out: paired_out.unwrap_or_else(|| paired::default_paired_out(&out)),
+                        paired_label,
+                    };
+                    return paired::run_and_report(&paired_config).await;
+                }
+                // clap enforces `--paired-* requires --paired-endpoint`; re-validate for directly
+                // constructed commands so the knobs can never silently no-op.
+                if paired_graph.is_some() || paired_out.is_some() || paired_label.is_some() {
+                    return Err(OtherError(
+                        "--paired-graph/--paired-out/--paired-label require --paired-endpoint \
+                         (they configure the paired replay's second side)"
+                            .to_string(),
+                    ));
+                }
                 return replay::run_and_report(&replay_config).await;
             }
             // clap enforces `--require-oracle requires --recording`; re-validate for directly
@@ -1445,6 +1473,20 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 return Err(OtherError(
                     "--require-oracle requires --recording: the outcome oracle lives in a \
                      recorded write bundle"
+                        .to_string(),
+                ));
+            }
+            // Same re-validation for the paired flags (clap ties them to --recording via
+            // --paired-endpoint): paired measurement is defined over a recorded bundle only.
+            if paired_endpoint.is_some()
+                || paired_graph.is_some()
+                || paired_out.is_some()
+                || paired_label.is_some()
+            {
+                return Err(OtherError(
+                    "--paired-endpoint (and --paired-graph/--paired-out/--paired-label) require \
+                     --recording: paired interleaved measurement replays a recorded bundle \
+                     against two endpoints"
                         .to_string(),
                 ));
             }
@@ -2395,6 +2437,10 @@ mod tests {
             recording: None,
             no_load: false,
             require_oracle: false,
+            paired_endpoint: None,
+            paired_graph: None,
+            paired_out: None,
+            paired_label: None,
         };
         assert!(run_command(command).await.is_err());
         let _ = std::fs::remove_file(&cfg_path);
@@ -2891,6 +2937,10 @@ mod tests {
             recording: None,
             no_load: false,
             require_oracle: false,
+            paired_endpoint: None,
+            paired_graph: None,
+            paired_out: None,
+            paired_label: None,
         };
         let err = run_command(command).await.expect_err("no ops ⇒ error");
         assert!(
@@ -2927,6 +2977,10 @@ mod tests {
             recording: Some("/nonexistent/rec".to_string()),
             no_load: false,
             require_oracle: false,
+            paired_endpoint: None,
+            paired_graph: None,
+            paired_out: None,
+            paired_label: None,
         };
         let err = run_command(command).await.expect_err("recording + generate ⇒ error");
         assert!(format!("{err}").contains("--recording"), "got: {err}");
@@ -2960,11 +3014,76 @@ mod tests {
             recording: None,
             no_load: false,
             require_oracle: true,
+            paired_endpoint: None,
+            paired_graph: None,
+            paired_out: None,
+            paired_label: None,
         };
         let err = run_command(command).await.expect_err("--require-oracle without --recording");
         assert!(
             format!("{err}").contains("--require-oracle requires --recording"),
             "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_command_rejects_paired_flags_without_recording() {
+        // clap ties the paired flags to --recording via --paired-endpoint; the handler
+        // re-validates for directly constructed commands so they can never silently no-op.
+        let command = |recording: Option<String>,
+                       paired_endpoint: Option<String>,
+                       paired_out: Option<String>| {
+            crate::cli::SyntheticCommands::Run {
+                config: None,
+                endpoint: None,
+                graph: None,
+                ops: vec![],
+                all_reads: false,
+                tier: None,
+                samples: None,
+                warmup: None,
+                concurrency: vec![],
+                reset_every: None,
+                seed: None,
+                cache: None,
+                server_timeout_ms: None,
+                client_deadline_ms: None,
+                out: None,
+                server_image: None,
+                label: None,
+                generate: false,
+                nodes: None,
+                edges: None,
+                recording,
+                no_load: false,
+                require_oracle: false,
+                paired_endpoint,
+                paired_graph: None,
+                paired_out,
+                paired_label: None,
+            }
+        };
+        // --paired-endpoint without --recording: paired measurement replays a bundle.
+        let err = run_command(command(
+            None,
+            Some("falkor://127.0.0.1:6380".to_string()),
+            None,
+        ))
+        .await
+        .expect_err("paired without --recording");
+        assert!(format!("{err}").contains("--recording"), "got: {err}");
+        assert!(format!("{err}").contains("--paired-endpoint"), "got: {err}");
+        // A secondary paired knob without --paired-endpoint is refused on the recording path too.
+        let err = run_command(command(
+            Some("/nonexistent/rec".to_string()),
+            None,
+            Some("b.json".to_string()),
+        ))
+        .await
+        .expect_err("--paired-out without --paired-endpoint");
+        assert!(
+            format!("{err}").contains("--paired-endpoint"),
+            "must name the missing flag: {err}"
         );
     }
 

--- a/src/synthetic/paired.rs
+++ b/src/synthetic/paired.rs
@@ -1,0 +1,1014 @@
+//! Backs `synthetic run --recording --paired-endpoint`: measure ONE recorded bundle against TWO
+//! FalkorDB endpoints **interleaved at per-op cell granularity**, so both sides of every
+//! comparison see the same environment window.
+//!
+//! A cross-version comparison built from two sequential [`crate::synthetic::replay`] runs leaves
+//! **minutes** between the moments the same op is measured on each side, so slow environment
+//! drift (thermal throttling, background load, page-cache churn) lands on *different* ops in each
+//! run and pollutes the per-op deltas. The paired replay instead sets both endpoints up
+//! identically (each loads the recorded graph and runs its own untimed reference pass and
+//! capability probe, honoring per-op budgets), then for each op, for each **cache mode ×
+//! concurrency cell**, measures the cell on endpoint A and *immediately* the same cell on
+//! endpoint B (A,B,A,B, … — see [`paired_schedule`]). Strict per-op attribution is preserved: an
+//! op's cells are never interleaved with another op's, and commands are never mixed between ops.
+//! Each endpoint's own cell subsequence is exactly the solo replay's order, so per-side behavior
+//! (plan-cache state, warm-up, cache-buster uniqueness) matches a solo run.
+//!
+//! The output is **two complete standard [`Report`]s** (side A → `--out`, side B →
+//! `--paired-out`) that work unchanged with `report --diff` / `report --regression`; pairing
+//! provenance is recorded additively in [`crate::synthetic::report::Meta::paired_with`] (each
+//! side names the other's redacted endpoint).
+//!
+//! **Scope: read bundles only.** A write bundle's replay resets the base graph before every
+//! measured cell and ends with an error-safe restore + content verification (Phase 7 §3.3/§3.5);
+//! interleaving two endpoints' reset/restore cycles would multiply those untimed reloads into the
+//! paired window and tangle the two sides' error-recovery paths, so paired mode **fails fast on a
+//! write bundle** — record reads and writes as separate bundles and pair only the reads.
+
+use crate::error::BenchmarkError::OtherError;
+use crate::error::BenchmarkResult;
+use crate::falkor::falkor_endpoint_to_redis_url;
+use crate::queries_repository::QueryType;
+use crate::synthetic::catalog::DEFAULT_RESET_EVERY;
+use crate::synthetic::dataset;
+use crate::synthetic::op_runner::ResultShape;
+use crate::synthetic::recording::{self, Bundle, OpEntry};
+use crate::synthetic::replay::{
+    bundle_corpus_size, capture_read_op_shapes, load_recorded_graph, op_result_digest,
+    probe_procedures, replay_meta, verify_concurrent, ReplayConfig,
+};
+use crate::synthetic::report::{
+    LevelMetrics, LevelReport, OperationReport, Report, ServerInfo, SCHEMA_VERSION,
+};
+use crate::synthetic::{
+    measure_op, normalize_concurrency, open_graph, provenance, redact_endpoint, validate_op_config,
+    write_report, CacheMode, CacheSelection, Config, MeasureTarget,
+};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{info, warn};
+
+/// How to replay one recorded bundle against two endpoints, interleaved per cell.
+#[derive(Debug, Clone)]
+pub struct PairedReplayConfig {
+    /// Side A: the standard replay knobs (endpoint, graph, sweep, cache, out, label, …). The
+    /// global measurement knobs (samples/warmup/concurrency/cache/timeouts) apply to **both**
+    /// sides — only endpoint/graph/out/label differ per side.
+    pub base: ReplayConfig,
+    /// Side B's FalkorDB endpoint.
+    pub paired_endpoint: String,
+    /// Side B's graph key. `None` ⇒ the same resolution as side A (the `--graph` override or the
+    /// bundle manifest's graph). Give B its own graph to pair two graphs on ONE server (an A/A
+    /// self-check).
+    pub paired_graph: Option<String>,
+    /// Where to write side B's JSON report (Markdown alongside as `<out>.md`).
+    pub paired_out: String,
+    /// Optional display name for side B (e.g. `pr`), recorded into B's report.
+    pub paired_label: Option<String>,
+}
+
+impl PairedReplayConfig {
+    /// The [`ReplayConfig`] view of one side: A is `base` verbatim; B swaps in the paired
+    /// endpoint/graph/out/label. B's `server_image` is cleared — the operator-supplied identity
+    /// describes the primary endpoint only (B's identity comes from its own provenance probe).
+    fn side_config(
+        &self,
+        side: Side,
+    ) -> ReplayConfig {
+        match side {
+            Side::A => self.base.clone(),
+            Side::B => ReplayConfig {
+                endpoint: self.paired_endpoint.clone(),
+                graph: self
+                    .paired_graph
+                    .clone()
+                    .or_else(|| self.base.graph.clone()),
+                out: self.paired_out.clone(),
+                label: self.paired_label.clone(),
+                server_image: None,
+                ..self.base.clone()
+            },
+        }
+    }
+}
+
+/// One side of a paired replay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Side {
+    A,
+    B,
+}
+
+/// The cell grid one op is measured across: its effective concurrency sweep × cache modes
+/// (per-op budget overlays applied).
+#[derive(Debug, Clone)]
+pub(crate) struct OpCells {
+    pub concurrency: Vec<usize>,
+    pub modes: Vec<CacheMode>,
+}
+
+/// One scheduled measurement: op `op_index`'s cell (`concurrency`, `mode`) on `side`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ScheduledCell {
+    pub op_index: usize,
+    pub concurrency: usize,
+    pub mode: CacheMode,
+    pub side: Side,
+}
+
+/// The paired measurement order (pure — the whole interleaving policy lives here): ops run **one
+/// at a time** in the given order (never interleaved with each other); within an op, cells follow
+/// the solo replay's order (concurrency outer, cache mode inner); and every cell is measured on
+/// side A then **immediately** on side B, so both sides of each per-op cell share the same
+/// environment window.
+pub(crate) fn paired_schedule(ops: &[OpCells]) -> Vec<ScheduledCell> {
+    let mut cells = Vec::new();
+    for (op_index, op) in ops.iter().enumerate() {
+        for &concurrency in &op.concurrency {
+            for &mode in &op.modes {
+                for side in [Side::A, Side::B] {
+                    cells.push(ScheduledCell {
+                        op_index,
+                        concurrency,
+                        mode,
+                        side,
+                    });
+                }
+            }
+        }
+    }
+    cells
+}
+
+/// The default `--paired-out` for a given `--out`: insert `-b` before the extension
+/// (`synthetic-report.json` → `synthetic-report-b.json`), or append `-b` when there is none.
+pub fn default_paired_out(out: &str) -> String {
+    let path = std::path::Path::new(out);
+    match (
+        path.file_stem().and_then(|s| s.to_str()),
+        path.extension().and_then(|e| e.to_str()),
+    ) {
+        (Some(stem), Some(ext)) => path
+            .with_file_name(format!("{stem}-b.{ext}"))
+            .to_string_lossy()
+            .into_owned(),
+        _ => format!("{out}-b"),
+    }
+}
+
+/// Everything one side carries out of setup and into the interleaved measurement phase.
+struct SideSetup {
+    config: ReplayConfig,
+    graph_name: String,
+    server: ServerInfo,
+    /// This side's capability-skip reasons (op name → reason), from its own procedure registry.
+    skipped: BTreeMap<String, String>,
+    /// Per op name: the reference shapes captured on THIS side — each side digests its own
+    /// results, so `report --diff` genuinely compares the two engines. Absent for a
+    /// capability-skipped op (never executed).
+    reference: BTreeMap<String, Vec<ResultShape>>,
+}
+
+/// Set up one side exactly as the solo replay does before measuring: open a connection, collect
+/// provenance (best-effort), load (or count-verify) the recorded graph, probe capabilities when
+/// any op requires one, and run the untimed reference pass. The connection is dropped on return
+/// so it never idles alongside the measurement workers.
+async fn setup_side(
+    config: ReplayConfig,
+    bundle: &Bundle,
+    op_entries: &HashMap<&str, &OpEntry>,
+) -> BenchmarkResult<SideSetup> {
+    let graph_name = resolve_graph(&config, bundle);
+    let client_deadline = Duration::from_millis(config.client_deadline_ms);
+    let mut graph = open_graph(&config.endpoint, &graph_name).await?;
+
+    let redis_url = falkor_endpoint_to_redis_url(Some(&config.endpoint));
+    let server = match provenance::collect(&redis_url, config.server_image.clone()).await {
+        Ok(info) => info,
+        Err(e) => fallback_server_info(&config, &e.to_string()),
+    };
+
+    if config.load {
+        load_recorded_graph(&mut graph, bundle, &graph_name, &bundle.spec(), &config).await?;
+    } else {
+        dataset::verify_counts(
+            &mut graph,
+            &bundle.spec(),
+            config.server_timeout_ms,
+            client_deadline,
+        )
+        .await
+        .map_err(no_load_hint)?;
+    }
+
+    // Capability probe (one registry query per side): each side skips the ops ITS engine lacks;
+    // the caller then unions the two skip sets so a cell is only ever measured on both sides.
+    let any_capability = bundle
+        .commands
+        .iter()
+        .any(|(op, _)| op_entries[op.name()].capability.is_some());
+    let available: Option<BTreeSet<String>> = if any_capability {
+        Some(probe_procedures(&mut graph, config.server_timeout_ms, client_deadline).await?)
+    } else {
+        None
+    };
+    let mut skipped = BTreeMap::new();
+    if let Some(available) = available.as_ref() {
+        for (op, _) in &bundle.commands {
+            let Some(procedure) = op_entries[op.name()].capability.as_deref() else {
+                continue;
+            };
+            if !available.contains(&procedure.to_lowercase()) {
+                let reason = format!("engine lacks procedure '{}' (capability probe)", procedure);
+                let side = redact_endpoint(&config.endpoint);
+                info!("paired side {side}: skipping op '{}': {reason}", op.name());
+                skipped.insert(op.name().to_string(), reason);
+            }
+        }
+    }
+
+    // Reference pass (untimed, single-flight, per-op budgeted timeouts) — this side's own result
+    // shapes. Capability-skipped ops are never executed, not even the fail-fast probe.
+    let mut reference = BTreeMap::new();
+    for (op, cyphers) in &bundle.commands {
+        if skipped.contains_key(op.name()) {
+            continue;
+        }
+        let entry = op_entries[op.name()];
+        let op_st = entry
+            .budget
+            .server_timeout_ms
+            .unwrap_or(config.server_timeout_ms);
+        let op_deadline = entry
+            .budget
+            .client_deadline_ms
+            .map(Duration::from_millis)
+            .unwrap_or(client_deadline);
+        let shapes = capture_read_op_shapes(
+            &mut graph,
+            op.name(),
+            cyphers,
+            entry.result_gated,
+            op_st,
+            op_deadline,
+        )
+        .await?;
+        reference.insert(op.name().to_string(), shapes);
+    }
+
+    Ok(SideSetup {
+        config,
+        graph_name,
+        server,
+        skipped,
+        reference,
+    })
+}
+
+/// Replay `config`'s bundle against both endpoints, interleaved per cell (module docs), and build
+/// the two [`Report`]s — `(side A, side B)`. Writing them is the caller's responsibility (see
+/// [`run_and_report`]).
+pub async fn run(config: &PairedReplayConfig) -> BenchmarkResult<(Report, Report)> {
+    if config.base.samples == 0 {
+        return Err(OtherError(
+            "run --recording --samples must be greater than 0".to_string(),
+        ));
+    }
+    if config.base.require_oracle {
+        return Err(OtherError(
+            "--require-oracle cannot be combined with --paired-endpoint: paired replay measures \
+             read bundles only, and reads carry no outcome oracle"
+                .to_string(),
+        ));
+    }
+    let concurrency = normalize_concurrency(&config.base.concurrency)?;
+    let bundle = recording::load(&config.base.recording_dir)?;
+
+    // Scope guard (offline, before any connection): paired mode measures READ bundles only. A
+    // write bundle's per-cell base resets + error-safe final restore (Phase 7) don't interleave
+    // safely — see the module docs.
+    if let Some((op, _)) = bundle
+        .commands
+        .iter()
+        .find(|(op, _)| op.kind() == QueryType::Write)
+    {
+        return Err(OtherError(format!(
+            "--paired-endpoint supports read bundles only, but op '{}' is a write — a write \
+             replay resets/restores the base graph around every measured cell, which does not \
+             interleave safely across two endpoints. Measure the write bundle with two solo \
+             `synthetic run --recording` runs instead",
+            op.name()
+        )));
+    }
+
+    let config_a = config.side_config(Side::A);
+    let config_b = config.side_config(Side::B);
+    // Two sides must be two distinct measurement targets: the same endpoint + graph would make
+    // the "pair" one graph measured twice, silently reloaded mid-flight by the second setup.
+    if config_a.endpoint == config_b.endpoint
+        && resolve_graph(&config_a, &bundle) == resolve_graph(&config_b, &bundle)
+    {
+        return Err(OtherError(format!(
+            "--paired-endpoint resolves to the same endpoint AND graph as the primary side \
+             ({} / '{}') — point it at a second server, or give side B its own graph with \
+             --paired-graph for an A/A self-check on one server",
+            redact_endpoint(&config_a.endpoint),
+            resolve_graph(&config_a, &bundle),
+        )));
+    }
+
+    // Manifest entry lookup, validated up front (mirrors the solo replay) so a corrupt bundle
+    // fails before either endpoint is touched.
+    let op_entries: HashMap<&str, &OpEntry> = bundle
+        .manifest
+        .ops
+        .iter()
+        .map(|e| (e.name.as_str(), e))
+        .collect();
+    validate_bundle_ops(&bundle, &op_entries)?;
+
+    let started_at_epoch_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    // Per-side engine configs (differ only in endpoint/graph/out/label) + offline validation of
+    // every op's resolved budget overlay, once — budgets and global knobs are shared, so a
+    // malformed manifest fails closed before either endpoint is touched.
+    let engine_config_a = engine_config(&config_a, &bundle, &concurrency);
+    let engine_config_b = engine_config(&config_b, &bundle, &concurrency);
+    for (op, _) in &bundle.commands {
+        let entry = op_entries[op.name()];
+        validate_op_config(
+            op.name(),
+            &engine_config_a.with_recorded_budget(&entry.budget),
+        )?;
+    }
+
+    // Set both sides up identically, A first (setup is untimed; measurement is what interleaves).
+    let a = Box::pin(setup_side(config_a, &bundle, &op_entries)).await?;
+    let b = Box::pin(setup_side(config_b, &bundle, &op_entries)).await?;
+
+    // Union skip semantics: a cell is measured on BOTH sides or on neither (a half-measured op
+    // would break the pairing this mode exists for). Each side's report entry records its own
+    // probe's reason when it has one, else names the peer that lacked the capability.
+    let mut skipped_union: BTreeSet<String> = a.skipped.keys().cloned().collect();
+    skipped_union.extend(b.skipped.keys().cloned());
+
+    let mut operations_a: BTreeMap<String, OperationReport> = BTreeMap::new();
+    let mut operations_b: BTreeMap<String, OperationReport> = BTreeMap::new();
+    for name in &skipped_union {
+        operations_a.insert(
+            name.clone(),
+            skipped_report(skip_reason(
+                a.skipped.get(name),
+                &b.config.endpoint,
+                b.skipped.get(name),
+            )),
+        );
+        operations_b.insert(
+            name.clone(),
+            skipped_report(skip_reason(
+                b.skipped.get(name),
+                &a.config.endpoint,
+                a.skipped.get(name),
+            )),
+        );
+    }
+
+    // The measured ops (present on both sides), in recorded order, with the shared cell grid the
+    // pure schedule below is built from.
+    let mut measured: Vec<MeasuredOp<'_>> = Vec::new();
+    let mut grid: Vec<OpCells> = Vec::new();
+    for (op, cyphers) in &bundle.commands {
+        if skipped_union.contains(op.name()) {
+            continue;
+        }
+        let entry = op_entries[op.name()];
+        let op_config_a = engine_config_a.with_recorded_budget(&entry.budget);
+        let op_config_b = engine_config_b.with_recorded_budget(&entry.budget);
+        let op_concurrency = normalize_concurrency(&op_config_a.concurrency)?;
+        let op_deadline = Duration::from_millis(op_config_a.client_deadline_ms);
+        grid.push(OpCells {
+            concurrency: op_concurrency.clone(),
+            modes: op_config_a.cache.modes().to_vec(),
+        });
+        measured.push(MeasuredOp {
+            name: op.name(),
+            corpus: Arc::new(cyphers.clone()),
+            entry,
+            op_config_a,
+            op_config_b,
+            op_concurrency,
+            op_deadline,
+        });
+    }
+
+    // Concurrency-correctness pass (untimed, per side, mirroring the solo replay): results must
+    // be IDENTICAL at each op's highest concurrency before any latency is trusted.
+    for m in &measured {
+        let op_max_c = m.op_concurrency.iter().copied().max().unwrap_or(1);
+        if op_max_c <= 1 || !m.entry.result_gated {
+            continue;
+        }
+        for side in [&a, &b] {
+            let shapes = &side.reference[m.name];
+            verify_concurrent(
+                &side.config.endpoint,
+                &side.graph_name,
+                &m.corpus,
+                shapes,
+                op_max_c,
+                m.op_config_a.server_timeout_ms,
+                m.op_deadline,
+            )
+            .await
+            .map_err(|e| {
+                let side_ep = redact_endpoint(&side.config.endpoint);
+                let msg = format!(
+                    "op '{}' returned different results at concurrency {op_max_c} on {side_ep}: {e}",
+                    m.name
+                );
+                OtherError(msg)
+            })?;
+        }
+    }
+
+    // The interleaved measurement itself: consume the pure schedule cell by cell — A then
+    // immediately B for every (op, concurrency, cache-mode) cell.
+    let run_token = rand::random_range(0..=u64::MAX);
+    let uid_alloc = AtomicU64::new(0);
+    let mut acc_a: Vec<OpAccumulator> = vec![BTreeMap::new(); measured.len()];
+    let mut acc_b: Vec<OpAccumulator> = vec![BTreeMap::new(); measured.len()];
+    for cell in paired_schedule(&grid) {
+        let m = &measured[cell.op_index];
+        let op_config = match cell.side {
+            Side::A => &m.op_config_a,
+            Side::B => &m.op_config_b,
+        };
+        let cell_config = Config {
+            cache: match cell.mode {
+                CacheMode::Cached => CacheSelection::Cached,
+                CacheMode::Uncached => CacheSelection::Uncached,
+            },
+            ..op_config.clone()
+        };
+        let cell_report = measure_op(
+            &cell_config,
+            &[cell.concurrency],
+            MeasureTarget::read(),
+            Arc::clone(&m.corpus),
+            run_token,
+            &uid_alloc,
+            m.op_deadline,
+        )
+        .await
+        .map_err(|e| {
+            let side_ep = redact_endpoint(&cell_config.endpoint);
+            let msg = format!(
+                "measuring op '{}' (C={}, {:?}) on {side_ep}: {e}",
+                m.name, cell.concurrency, cell.mode
+            );
+            OtherError(msg)
+        })?;
+        let level = cell_report
+            .levels
+            .into_iter()
+            .next()
+            .ok_or_else(|| OtherError(format!("op '{}' produced no level report", m.name)))?;
+        let acc = match cell.side {
+            Side::A => &mut acc_a[cell.op_index],
+            Side::B => &mut acc_b[cell.op_index],
+        };
+        let slot = acc.entry(cell.concurrency).or_insert((None, None));
+        match cell.mode {
+            CacheMode::Cached => slot.0 = level.cached,
+            CacheMode::Uncached => slot.1 = level.uncached,
+        }
+    }
+
+    // Assemble each side's per-op report from its accumulated cells + its OWN reference digests.
+    for (idx, m) in measured.iter().enumerate() {
+        let insert = |acc: &mut OpAccumulator,
+                      setup: &SideSetup,
+                      ops: &mut BTreeMap<String, OperationReport>| {
+            let shapes = &setup.reference[m.name];
+            ops.insert(
+                m.name.to_string(),
+                OperationReport {
+                    levels: assemble_levels(&m.op_concurrency, std::mem::take(acc)),
+                    result_digest: m
+                        .entry
+                        .result_gated
+                        .then(|| op_result_digest(m.name, shapes)),
+                    policy: (!m.entry.budget.is_inherit())
+                        .then(|| m.op_config_a.resolved_policy(&m.op_concurrency)),
+                    skipped: None,
+                },
+            );
+        };
+        insert(&mut acc_a[idx], &a, &mut operations_a);
+        insert(&mut acc_b[idx], &b, &mut operations_b);
+    }
+
+    let corpus_size = bundle_corpus_size(&bundle);
+    let build = |setup: &SideSetup, peer: &SideSetup, operations| -> Report {
+        Report {
+            schema_version: SCHEMA_VERSION,
+            meta: replay_meta(
+                &setup.config,
+                &bundle,
+                setup.graph_name.clone(),
+                concurrency.clone(),
+                corpus_size,
+                started_at_epoch_secs,
+                setup.server.clone(),
+                Some(redact_endpoint(&peer.config.endpoint)),
+            ),
+            operations,
+        }
+    };
+    let report_a = build(&a, &b, operations_a);
+    let report_b = build(&b, &a, operations_b);
+    Ok((report_a, report_b))
+}
+
+/// [`run`], then print both console summaries and write both JSON + Markdown reports
+/// (A → `base.out`, B → `paired_out`).
+pub async fn run_and_report(config: &PairedReplayConfig) -> BenchmarkResult<()> {
+    let (report_a, report_b) = run(config).await?;
+    println!("{}", report_a.to_console());
+    println!("{}", report_b.to_console());
+    write_report(&report_a, &config.base.out).await?;
+    write_report(&report_b, &config.paired_out).await
+}
+
+/// One measured op's shared measurement context (both sides).
+struct MeasuredOp<'b> {
+    name: &'b str,
+    corpus: Arc<Vec<String>>,
+    entry: &'b OpEntry,
+    op_config_a: Config,
+    op_config_b: Config,
+    /// The op's effective (normalized) sweep — identical on both sides by construction.
+    op_concurrency: Vec<usize>,
+    op_deadline: Duration,
+}
+
+/// One op's accumulated per-concurrency `(cached, uncached)` metrics on one side.
+type OpAccumulator = BTreeMap<usize, (Option<LevelMetrics>, Option<LevelMetrics>)>;
+
+/// Side-resolved graph name (the `--graph`/`--paired-graph` override or the bundle's).
+fn resolve_graph(
+    config: &ReplayConfig,
+    bundle: &Bundle,
+) -> String {
+    config
+        .graph
+        .clone()
+        .unwrap_or_else(|| bundle.manifest.graph.clone())
+}
+
+/// The skip reason recorded on a side's report for a union-skipped op: its own probe's reason
+/// when it has one, else a pointer at the peer that lacked the capability. Pure, so both the
+/// wiring and the message are unit-testable.
+fn skip_reason(
+    own_reason: Option<&String>,
+    peer_endpoint: &str,
+    peer_reason: Option<&String>,
+) -> String {
+    own_reason.cloned().unwrap_or_else(|| {
+        format!(
+            "paired endpoint {} skipped this op ({}) — paired cells run on both sides or neither",
+            redact_endpoint(peer_endpoint),
+            peer_reason.map(String::as_str).unwrap_or("no reason recorded")
+        )
+    })
+}
+
+/// Validate the bundle's op listing offline (before any connection is opened): every recorded
+/// command stream must have a manifest entry and at least one command — either failure means a
+/// corrupt bundle. Mirrors the solo replay's guards.
+fn validate_bundle_ops(
+    bundle: &Bundle,
+    op_entries: &HashMap<&str, &OpEntry>,
+) -> BenchmarkResult<()> {
+    for (op, cyphers) in &bundle.commands {
+        if !op_entries.contains_key(op.name()) {
+            return Err(OtherError(format!(
+                "op '{}' replayed without a manifest entry (corrupt bundle)",
+                op.name()
+            )));
+        }
+        if cyphers.is_empty() {
+            return Err(OtherError(format!(
+                "op '{}' has no recorded commands",
+                op.name()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// The provenance-collection fallback: warn and report only the operator-supplied image (the
+/// exact behavior of the solo replay when a side's `INFO`/`GRAPH.INFO` probes fail).
+fn fallback_server_info(config: &ReplayConfig, err: &str) -> ServerInfo {
+    warn!(
+        "could not collect server provenance for {}: {}",
+        redact_endpoint(&config.endpoint),
+        err
+    );
+    ServerInfo {
+        server_image: config.server_image.clone(),
+        ..Default::default()
+    }
+}
+
+/// Decorate a `--no-load` count-verification failure with the fix (load the recording first).
+fn no_load_hint(e: crate::error::BenchmarkError) -> crate::error::BenchmarkError {
+    OtherError(format!(
+        "{} — load the recording first (don't pass --no-load)",
+        e
+    ))
+}
+
+/// The shared closed-loop engine config for one side (mirrors the solo replay's, minus the op
+/// list, which the measurement path never reads).
+fn engine_config(
+    config: &ReplayConfig,
+    bundle: &Bundle,
+    concurrency: &[usize],
+) -> Config {
+    Config {
+        endpoint: config.endpoint.clone(),
+        graph: resolve_graph(config, bundle),
+        ops: Vec::new(),
+        samples: config.samples,
+        warmup: config.warmup,
+        concurrency: concurrency.to_vec(),
+        reset_every: DEFAULT_RESET_EVERY,
+        seed: bundle.manifest.corpus_seed,
+        server_timeout_ms: config.server_timeout_ms,
+        client_deadline_ms: config.client_deadline_ms,
+        cache: config.cache,
+        out: config.out.clone(),
+        server_image: config.server_image.clone(),
+        label: config.label.clone(),
+        dataset: None,
+    }
+}
+
+/// A skipped op's report entry: no levels, no digest, no policy — just the reason.
+fn skipped_report(reason: String) -> OperationReport {
+    OperationReport {
+        levels: Vec::new(),
+        result_digest: None,
+        policy: None,
+        skipped: Some(reason),
+    }
+}
+
+/// Fold one op's accumulated per-cell metrics into [`LevelReport`]s in sweep order, deriving the
+/// per-level compilation cost exactly as the solo path does.
+fn assemble_levels(
+    op_concurrency: &[usize],
+    mut acc: OpAccumulator,
+) -> Vec<LevelReport> {
+    let mut levels = Vec::with_capacity(op_concurrency.len());
+    for &c in op_concurrency {
+        let (cached, uncached) = acc.remove(&c).unwrap_or((None, None));
+        let compilation_ms_median = match (&cached, &uncached) {
+            (Some(cm), Some(um)) => Some(um.metrics.server_ms.median - cm.metrics.server_ms.median),
+            _ => None,
+        };
+        levels.push(LevelReport {
+            concurrency: c,
+            cached,
+            uncached,
+            compilation_ms_median,
+        });
+    }
+    levels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::synthetic::catalog::RecordedBudget;
+    use crate::synthetic::dataset::DatasetSpec;
+    use crate::synthetic::recording::{record_rendered, temp_bundle_dir, RecordedOp};
+    use crate::synthetic::OpKey;
+    use std::path::PathBuf;
+
+    fn base_replay_config() -> ReplayConfig {
+        ReplayConfig {
+            recording_dir: PathBuf::from("/nonexistent/recording"),
+            // Nothing should ever connect in these tests — a guard regression that reaches the
+            // network fails loudly on this closed port instead of hanging.
+            endpoint: "falkor://127.0.0.1:1".to_string(),
+            graph: None,
+            load: true,
+            samples: 5,
+            warmup: 0,
+            concurrency: vec![1],
+            cache: CacheSelection::Cached,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: "unused.json".to_string(),
+            server_image: None,
+            label: None,
+            require_oracle: false,
+        }
+    }
+
+    fn paired_config(base: ReplayConfig) -> PairedReplayConfig {
+        PairedReplayConfig {
+            base,
+            paired_endpoint: "falkor://127.0.0.2:1".to_string(),
+            paired_graph: None,
+            paired_out: "unused-b.json".to_string(),
+            paired_label: None,
+        }
+    }
+
+    /// Record a tiny single-op bundle of `kind` on disk (offline), returning its directory.
+    fn record_one_op(
+        tag: &str,
+        kind: QueryType,
+    ) -> PathBuf {
+        let dir = temp_bundle_dir(tag);
+        let spec = DatasetSpec {
+            seed: 7,
+            nodes: 10,
+            edges: 20,
+        };
+        let (name, command, budget) = match kind {
+            QueryType::Write => (
+                "w_op",
+                "CREATE (n:X)",
+                RecordedBudget {
+                    concurrency: Some(vec![1]),
+                    ..RecordedBudget::default()
+                },
+            ),
+            QueryType::Read => (
+                "r_op",
+                "MATCH (n) RETURN count(n)",
+                RecordedBudget::default(),
+            ),
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic(name, kind),
+            result_gated: kind == QueryType::Read,
+            budget,
+            capability: None,
+            commands: vec![command.to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 7, 64, &dir).expect("record bundle");
+        dir
+    }
+
+    #[test]
+    fn paired_schedule_alternates_sides_and_never_interleaves_ops() {
+        // Two ops with different grids: op 0 sweeps C=1,4 under both modes; op 1 is a budgeted
+        // C=1 cached-only op (the shape a recorded budget produces).
+        let ops = vec![
+            OpCells {
+                concurrency: vec![1, 4],
+                modes: vec![CacheMode::Cached, CacheMode::Uncached],
+            },
+            OpCells {
+                concurrency: vec![1],
+                modes: vec![CacheMode::Cached],
+            },
+        ];
+        let schedule = paired_schedule(&ops);
+
+        // Every (op, C, mode) cell appears exactly twice: A then immediately B.
+        assert_eq!(schedule.len(), 2 * (2 * 2 + 1));
+        for pair in schedule.chunks_exact(2) {
+            let (first, second) = (&pair[0], &pair[1]);
+            assert_eq!(first.side, Side::A, "each cell starts on side A");
+            assert_eq!(second.side, Side::B, "…and B follows immediately");
+            assert_eq!(
+                (first.op_index, first.concurrency, first.mode),
+                (second.op_index, second.concurrency, second.mode),
+                "adjacent A/B entries are the SAME cell"
+            );
+        }
+
+        // Ops are contiguous blocks (never interleaved with each other), in the given order.
+        let op_sequence: Vec<usize> = schedule.iter().map(|c| c.op_index).collect();
+        let mut deduped = op_sequence.clone();
+        deduped.dedup();
+        assert_eq!(deduped, vec![0, 1], "ops run one at a time, in order");
+
+        // Within an op, cells follow the solo replay's order: concurrency outer, mode inner.
+        let op0: Vec<(usize, CacheMode)> = schedule
+            .iter()
+            .filter(|c| c.op_index == 0 && c.side == Side::A)
+            .map(|c| (c.concurrency, c.mode))
+            .collect();
+        assert_eq!(
+            op0,
+            vec![
+                (1, CacheMode::Cached),
+                (1, CacheMode::Uncached),
+                (4, CacheMode::Cached),
+                (4, CacheMode::Uncached),
+            ]
+        );
+    }
+
+    #[test]
+    fn paired_schedule_of_no_ops_is_empty() {
+        assert!(paired_schedule(&[]).is_empty());
+    }
+
+    #[test]
+    fn default_paired_out_inserts_b_before_the_extension() {
+        assert_eq!(
+            default_paired_out("synthetic-report.json"),
+            "synthetic-report-b.json"
+        );
+        assert_eq!(
+            default_paired_out("recordings/demo/report.json"),
+            "recordings/demo/report-b.json"
+        );
+        // No extension: append.
+        assert_eq!(default_paired_out("report"), "report-b");
+    }
+
+    #[tokio::test]
+    async fn run_rejects_zero_samples() {
+        let mut base = base_replay_config();
+        base.samples = 0;
+        let err = run(&paired_config(base)).await.unwrap_err();
+        assert!(
+            format!("{err}").contains("samples must be greater than 0"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_rejects_require_oracle() {
+        // Paired replay is read-only, and reads carry no outcome oracle — the flag combination is
+        // operator error, refused before any disk/server access.
+        let mut base = base_replay_config();
+        base.require_oracle = true;
+        let err = run(&paired_config(base)).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("--require-oracle cannot be combined"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("read bundles only"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_rejects_a_write_bundle() {
+        // Scope cut (module docs): write bundles reset/restore the base graph around every cell,
+        // which doesn't interleave safely — fail fast, offline, naming the op.
+        let dir = record_one_op("paired-write-reject", QueryType::Write);
+        let mut base = base_replay_config();
+        base.recording_dir = dir.clone();
+        let err = run(&paired_config(base)).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("read bundles only"), "got: {msg}");
+        assert!(msg.contains("'w_op'"), "must name the write op: {msg}");
+        assert!(
+            msg.contains("two solo"),
+            "must point at the sequential path: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn run_rejects_the_same_endpoint_and_graph_on_both_sides() {
+        // A "pair" of one endpoint + one graph is a single measurement target: the second setup
+        // would silently reload the graph the first side just set up.
+        let dir = record_one_op("paired-same-target", QueryType::Read);
+        let mut base = base_replay_config();
+        base.recording_dir = dir.clone();
+        let mut config = paired_config(base.clone());
+        config.paired_endpoint = base.endpoint.clone();
+        let err = run(&config).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("same endpoint AND graph"), "got: {msg}");
+        assert!(
+            msg.contains("--paired-graph"),
+            "must suggest the A/A escape hatch: {msg}"
+        );
+
+        // …while the SAME endpoint with a DISTINCT --paired-graph is the supported A/A pairing:
+        // it must clear the offline guards and fail only on the (closed) connection attempt.
+        config.paired_graph = Some("g_b".to_string());
+        let err = run(&config).await.unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            !msg.contains("same endpoint AND graph"),
+            "distinct graphs must pass the target guard: {msg}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn skip_reason_prefers_the_side_s_own_probe_reason() {
+        let own = "engine lacks procedure 'algo.x' (capability probe)".to_string();
+        let peer = "engine lacks procedure 'algo.y' (capability probe)".to_string();
+        // A side with its own reason reports it verbatim…
+        assert_eq!(
+            skip_reason(Some(&own), "falkor://peer:6379", Some(&peer)),
+            own
+        );
+        // …a side skipped only by union names the peer and its reason…
+        let msg = skip_reason(None, "falkor://peer:6379", Some(&peer));
+        assert!(msg.contains("paired endpoint"), "got: {msg}");
+        assert!(msg.contains("algo.y"), "got: {msg}");
+        // …and a reason-less peer (defensive) still yields a self-explanatory message.
+        let msg = skip_reason(None, "falkor://peer:6379", None);
+        assert!(msg.contains("no reason recorded"), "got: {msg}");
+    }
+
+    #[test]
+    fn validate_bundle_ops_rejects_corrupt_bundles() {
+        let dir = record_one_op("paired-validate-ops", QueryType::Read);
+        let mut bundle = recording::load(&dir).expect("load");
+        std::fs::remove_dir_all(&dir).ok();
+
+        // The recorded bundle itself is valid.
+        let entries: HashMap<&str, &OpEntry> =
+            bundle.manifest.ops.iter().map(|e| (e.name.as_str(), e)).collect();
+        assert!(validate_bundle_ops(&bundle, &entries).is_ok());
+
+        // An op with a command stream but no manifest entry is corrupt…
+        let mut phantom = bundle.clone();
+        phantom
+            .commands
+            .push((OpKey::dynamic("phantom", QueryType::Read), vec!["RETURN 1".to_string()]));
+        let entries: HashMap<&str, &OpEntry> =
+            phantom.manifest.ops.iter().map(|e| (e.name.as_str(), e)).collect();
+        let msg = format!("{}", validate_bundle_ops(&phantom, &entries).unwrap_err());
+        assert!(msg.contains("phantom") && msg.contains("manifest"), "got: {msg}");
+
+        // …and so is an op with an empty command stream.
+        bundle.commands[0].1.clear();
+        let entries: HashMap<&str, &OpEntry> =
+            bundle.manifest.ops.iter().map(|e| (e.name.as_str(), e)).collect();
+        let msg = format!("{}", validate_bundle_ops(&bundle, &entries).unwrap_err());
+        assert!(msg.contains("no recorded commands"), "got: {msg}");
+    }
+
+    #[test]
+    fn fallback_server_info_reports_only_the_operator_supplied_image() {
+        let config = ReplayConfig {
+            server_image: Some("falkordb/falkordb:test".to_string()),
+            ..base_replay_config()
+        };
+        let info = fallback_server_info(&config, "connection refused");
+        assert_eq!(info.server_image.as_deref(), Some("falkordb/falkordb:test"));
+        assert_eq!(info.module_graph_ver, None, "everything else stays unknown");
+    }
+
+    #[test]
+    fn no_load_hint_names_the_fix() {
+        let msg = format!("{}", no_load_hint(OtherError("node count mismatch".to_string())));
+        assert!(msg.contains("node count mismatch"), "got: {msg}");
+        assert!(msg.contains("don't pass --no-load"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_rejects_an_invalid_recorded_budget_offline() {
+        // A per-op budget that zeroes samples must fail closed BEFORE either endpoint is touched
+        // (the recorded budget overlays the global config exactly as in the solo replay).
+        let dir = temp_bundle_dir("paired-bad-budget");
+        let spec = DatasetSpec {
+            seed: 7,
+            nodes: 10,
+            edges: 20,
+        };
+        let ops = vec![RecordedOp {
+            key: OpKey::dynamic("zero_samples", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget {
+                samples: Some(0),
+                ..RecordedBudget::default()
+            },
+            capability: None,
+            commands: vec!["RETURN 1".to_string()],
+        }];
+        record_rendered(&spec, "g", &ops, 7, 64, &dir).expect("record bundle");
+        let mut base = base_replay_config();
+        base.recording_dir = dir.clone();
+        let mut config = paired_config(base);
+        config.paired_graph = Some("g_b".to_string());
+        let msg = format!("{}", run(&config).await.unwrap_err());
+        std::fs::remove_dir_all(&dir).ok();
+        assert!(
+            msg.contains("zero_samples") && msg.contains("samples"),
+            "the offline budget validation must name the op: {msg}"
+        );
+    }
+}

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -325,19 +325,15 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                 reference.push((op.clone(), Arc::new(cyphers.clone()), Vec::new()));
                 continue;
             }
-            let to_capture: &[String] = if entry.result_gated { cyphers } else { &cyphers[..1] };
-            let mut shapes = Vec::with_capacity(to_capture.len());
-            for c in to_capture {
-                shapes.push(
-                    capture_result(&mut graph, c, op_st, op_deadline)
-                        .await
-                        .map_err(|e| OtherError(format!("capturing '{}': {}", op.name(), e)))?,
-                );
-            }
-            if !entry.result_gated {
-                // The probe shape is discarded: downstream code treats a shapeless op as result-N/A.
-                shapes.clear();
-            }
+            let shapes = capture_read_op_shapes(
+                &mut graph,
+                op.name(),
+                cyphers,
+                entry.result_gated,
+                op_st,
+                op_deadline,
+            )
+            .await?;
             reference.push((op.clone(), Arc::new(cyphers.clone()), shapes));
         }
         // Setup connection done; drop it so it isn't an idle extra connection during the sweep.
@@ -555,47 +551,77 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     // The corpus size is what the bundle actually recorded per op (not the compile-time constant) —
     // over every recorded op, including capability-skipped ones (it describes the bundle, not the
     // subset this engine could execute).
-    let corpus_size = bundle
-        .commands
-        .iter()
-        .map(|(_, cyphers)| cyphers.len())
-        .max()
-        .unwrap_or(0);
+    let corpus_size = bundle_corpus_size(&bundle);
 
     Ok(Report {
         schema_version: SCHEMA_VERSION,
-        meta: Meta {
-            tool_version: env!("CARGO_PKG_VERSION").to_string(),
-            endpoint: redact_endpoint(&config.endpoint),
-            graph: graph_name,
-            samples: config.samples,
-            warmup: config.warmup,
-            concurrency: concurrency.clone(),
-            seed: bundle.manifest.corpus_seed,
+        meta: replay_meta(
+            config,
+            &bundle,
+            graph_name,
+            concurrency,
             corpus_size,
-            server_timeout_ms: config.server_timeout_ms,
-            client_deadline_ms: config.client_deadline_ms,
-            connection: "pool(size=1) per worker".to_string(),
             started_at_epoch_secs,
             server,
-            host: crate::synthetic::host::collect(),
-            // The bundle's workload_hash attests the graph *and* the commands, so the guard compares
-            // replays of the same bundle safely.
-            dataset: Some(DatasetInfo {
-                seed: dataset_spec.seed,
-                nodes: dataset_spec.nodes,
-                edges: dataset_spec.edges,
-                workload_hash: bundle.manifest.workload_hash.clone(),
-            }),
-            label: config.label.clone(),
-            oracle_verified: if bundle.oracle.is_empty() {
-                None
-            } else {
-                Some(bundle.oracle.iter().map(|(op, v)| (op.clone(), v.len())).collect())
-            },
-        },
+            None,
+        ),
         operations,
     })
+}
+
+/// The bundle's recorded per-op corpus size (the maximum across ops — what the bundle actually
+/// recorded, not the compile-time constant), over every recorded op including capability-skipped
+/// ones (it describes the bundle, not the subset an engine could execute).
+pub(crate) fn bundle_corpus_size(bundle: &Bundle) -> usize {
+    bundle.commands.iter().map(|(_, cyphers)| cyphers.len()).max().unwrap_or(0)
+}
+
+/// Build the replay report's [`Meta`] block — shared by the solo replay and each side of the
+/// paired replay (see [`crate::synthetic::paired`]) so the two can't drift. `paired_with` is the
+/// redacted endpoint of the *other* side for a paired run, `None` for a solo one.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn replay_meta(
+    config: &ReplayConfig,
+    bundle: &Bundle,
+    graph_name: String,
+    concurrency: Vec<usize>,
+    corpus_size: usize,
+    started_at_epoch_secs: u64,
+    server: ServerInfo,
+    paired_with: Option<String>,
+) -> Meta {
+    let dataset_spec = bundle.spec();
+    Meta {
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        endpoint: redact_endpoint(&config.endpoint),
+        graph: graph_name,
+        samples: config.samples,
+        warmup: config.warmup,
+        concurrency,
+        seed: bundle.manifest.corpus_seed,
+        corpus_size,
+        server_timeout_ms: config.server_timeout_ms,
+        client_deadline_ms: config.client_deadline_ms,
+        connection: "pool(size=1) per worker".to_string(),
+        started_at_epoch_secs,
+        server,
+        host: crate::synthetic::host::collect(),
+        // The bundle's workload_hash attests the graph *and* the commands, so the guard compares
+        // replays of the same bundle safely.
+        dataset: Some(DatasetInfo {
+            seed: dataset_spec.seed,
+            nodes: dataset_spec.nodes,
+            edges: dataset_spec.edges,
+            workload_hash: bundle.manifest.workload_hash.clone(),
+        }),
+        label: config.label.clone(),
+        oracle_verified: if bundle.oracle.is_empty() {
+            None
+        } else {
+            Some(bundle.oracle.iter().map(|(op, v)| (op.clone(), v.len())).collect())
+        },
+        paired_with,
+    }
 }
 
 /// Replay, print the console summary, and write the JSON + Markdown report.
@@ -827,11 +853,40 @@ pub(crate) async fn restore_and_verify(
     Ok(())
 }
 
+/// Untimed single-flight reference capture for one **read** op (design §3.4): capture every
+/// command's [`ResultShape`] when the op is result-gated; otherwise probe only the first command
+/// (fail-fast on a broken recorded command) and discard the shape, so downstream code treats the
+/// op as result-N/A. Shared by the solo replay and each side of the paired replay
+/// ([`crate::synthetic::paired`]) so the capture semantics can't drift.
+pub(crate) async fn capture_read_op_shapes(
+    graph: &mut AsyncGraph,
+    op_name: &str,
+    cyphers: &[String],
+    result_gated: bool,
+    server_timeout_ms: i64,
+    client_deadline: Duration,
+) -> BenchmarkResult<Vec<ResultShape>> {
+    let to_capture: &[String] = if result_gated { cyphers } else { &cyphers[..1] };
+    let mut shapes = Vec::with_capacity(to_capture.len());
+    for c in to_capture {
+        shapes.push(
+            capture_result(graph, c, server_timeout_ms, client_deadline)
+                .await
+                .map_err(|e| OtherError(format!("capturing '{}': {}", op_name, e)))?,
+        );
+    }
+    if !result_gated {
+        // The probe shape is discarded: downstream code treats a shapeless op as result-N/A.
+        shapes.clear();
+    }
+    Ok(shapes)
+}
+
 /// Ask the engine which procedures it registers (`dbms.procedures()`), returning their
 /// **lowercased** names — the capability probe (design Phase 6 §3.5). One query per replay,
 /// mirroring the A/B driver's `detect_algorithm_capabilities` (matching is case-insensitive so a
 /// registry spelling change can't fake a missing capability).
-async fn probe_procedures(
+pub(crate) async fn probe_procedures(
     graph: &mut AsyncGraph,
     server_timeout_ms: i64,
     client_deadline: Duration,
@@ -906,7 +961,7 @@ pub(crate) async fn restore_base_on(
 }
 
 /// Drop `graph`, execute the bundle's recorded load statements, and verify the node/edge counts.
-async fn load_recorded_graph(
+pub(crate) async fn load_recorded_graph(
     graph: &mut AsyncGraph,
     bundle: &Bundle,
     graph_name: &str,
@@ -943,7 +998,7 @@ async fn load_recorded_graph(
 /// connections, run every command on each, and assert each command's [`ResultShape`] equals the
 /// single-flight reference. Untimed — a pure correctness check that concurrency didn't change
 /// results. Any mismatch (or error) fails the whole run.
-async fn verify_concurrent(
+pub(crate) async fn verify_concurrent(
     endpoint: &str,
     graph_name: &str,
     cyphers: &Arc<Vec<String>>,
@@ -984,7 +1039,7 @@ async fn verify_concurrent(
 /// row set), in command order. Deterministic given the same graph + recorded commands, and
 /// length-framed so it can't alias a different op's digest. Two versions returning different results
 /// for the same recorded command produce different digests.
-fn op_result_digest(
+pub(crate) fn op_result_digest(
     name: &str,
     shapes: &[ResultShape],
 ) -> String {

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -121,6 +121,13 @@ pub struct Meta {
     /// pre-§6.3 reports still deserialize.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oracle_verified: Option<std::collections::BTreeMap<String, usize>>,
+    /// Pairing provenance: the **redacted endpoint of the other side** when this report was
+    /// produced by a paired interleaved replay (`synthetic run --recording --paired-endpoint`),
+    /// where each per-op cell (cache mode × concurrency) was measured back-to-back on both
+    /// endpoints so the two sides shared the same environment window. Absent for a solo run.
+    /// `#[serde(default)]` so pre-paired reports still deserialize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paired_with: Option<String>,
 }
 
 /// Provenance for a synthetic dataset: its knobs and the `workload_hash` that identifies the whole
@@ -773,6 +780,7 @@ mod tests {
                 dataset: None,
                 label: None,
                 oracle_verified: None,
+                paired_with: None,
             },
             operations,
         }
@@ -819,6 +827,33 @@ mod tests {
         assert!(!json.contains("oracle_verified"), "None must not serialize: {json}");
         let back: Report = serde_json::from_str(&json).unwrap();
         assert_eq!(back.meta.oracle_verified, None);
+    }
+
+    #[test]
+    fn paired_with_round_trips_and_defaults_to_none() {
+        // A paired interleaved replay records the other side's redacted endpoint…
+        let mut report = sample_report();
+        report.meta.paired_with = Some("falkor://127.0.0.1:6380/".to_string());
+        let json = report.to_json().unwrap();
+        assert!(
+            json.contains("\"paired_with\""),
+            "pairing provenance serialized: {json}"
+        );
+        let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.meta.paired_with,
+            Some("falkor://127.0.0.1:6380/".to_string())
+        );
+        // …while solo runs omit the field entirely, and pre-paired reports (no field at all)
+        // still deserialize — schema compatibility is additive.
+        let plain = sample_report();
+        let json = plain.to_json().unwrap();
+        assert!(
+            !json.contains("paired_with"),
+            "None must not serialize: {json}"
+        );
+        let back: Report = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.meta.paired_with, None);
     }
 
     #[test]

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -1548,6 +1548,10 @@ async fn record_and_replay_via_run_command() {
         recording: Some(out_dir),
         no_load: false,
         require_oracle: false,
+        paired_endpoint: None,
+        paired_graph: None,
+        paired_out: None,
+        paired_label: None,
     })
     .await
     .expect("run --recording via run_command");
@@ -2528,4 +2532,287 @@ async fn re_recording_over_an_oracle_bundle_succeeds_with_and_without_oracle() {
 
     std::fs::remove_dir_all(&dir).ok();
     drop_graph(graph).await;
+}
+
+/// Paired interleaved replay (`--paired-endpoint`), exercised as a TRUE A/A pairing: ONE FalkorDB
+/// serves as both endpoints with distinct graph names, driven end-to-end through the real CLI
+/// `run` path (so the flag mapping + the default `--paired-out` derivation run too). Asserts the
+/// noise-reduction mode changes nothing about correctness or comparability:
+/// - both standard reports are written (side B at the derived `<out>-b.json` default);
+/// - the two sides carry the identical `workload_hash` and identical per-op `result_digest`s
+///   (same engine + same recorded commands ⇒ same results);
+/// - pairing provenance is recorded crosswise (`meta.paired_with` names the other side);
+/// - a capability-gated op the engine lacks is skipped on BOTH sides (union-skip semantics);
+/// - `report --diff` (strict guard) and `report --diff --regression` both complete clean on the
+///   pair — the paired reports are drop-in inputs for the existing comparison pipeline.
+///
+/// Multi-thread runtime: FalkorDB entity decoding uses `block_in_place`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires a running FalkorDB server"]
+async fn paired_replay_a_a_pairing_matches_digests_and_diffs_clean() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::catalog::RecordedBudget;
+    use benchmark::synthetic::recording::RecordedOp;
+    use benchmark::synthetic::report::Report;
+    use benchmark::synthetic::{run_command, OpKey};
+
+    let graph_a = "syn_it_paired_a";
+    let graph_b = "syn_it_paired_b";
+    drop_graph(graph_a).await;
+    drop_graph(graph_b).await;
+    let dir = temp_bundle_dir("syn-it-paired");
+    let spec = DatasetSpec {
+        seed: 9,
+        nodes: 300,
+        edges: 900,
+    };
+    let ops = vec![
+        RecordedOp {
+            key: OpKey::dynamic("point_read", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec![
+                "MATCH (u:User {id: 1}) RETURN u.id".to_string(),
+                "MATCH (u:User {id: 2}) RETURN u.id".to_string(),
+            ],
+        },
+        RecordedOp {
+            key: OpKey::dynamic("count_all", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["MATCH (n:User) RETURN count(n)".to_string()],
+        },
+        RecordedOp {
+            key: OpKey::dynamic("ghost_algo", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            // A procedure no engine registers: the capability probe must skip this op on BOTH
+            // sides (union-skip), and the skip must not disturb the paired measurement.
+            capability: Some("algo.doesNotExist123".to_string()),
+            commands: vec!["RETURN 1".to_string()],
+        },
+    ];
+    recording::record_rendered(&spec, graph_a, &ops, spec.seed, 256, &dir).expect("record");
+
+    // Drive the real CLI path: --recording + --paired-endpoint (+ --paired-graph for the A/A
+    // pairing on one server), leaving --paired-out at its derived default.
+    let out_a = dir.join("paired-a.json").to_string_lossy().into_owned();
+    let out_b_default = dir.join("paired-a-b.json").to_string_lossy().into_owned();
+    run_command(SyntheticCommands::Run {
+        config: None,
+        endpoint: Some(endpoint()),
+        graph: Some(graph_a.to_string()),
+        ops: vec![],
+        all_reads: false,
+        tier: None,
+        samples: Some(30),
+        warmup: Some(5),
+        concurrency: vec![1, 2],
+        reset_every: None,
+        seed: None,
+        cache: None, // defaults to Both
+        server_timeout_ms: None,
+        client_deadline_ms: None,
+        out: Some(out_a.clone()),
+        server_image: None,
+        label: Some("base".to_string()),
+        generate: false,
+        nodes: None,
+        edges: None,
+        recording: Some(dir.to_string_lossy().into_owned()),
+        no_load: false,
+        require_oracle: false,
+        paired_endpoint: Some(endpoint()),
+        paired_graph: Some(graph_b.to_string()),
+        paired_out: None, // exercise the `<out>-b.json` default
+        paired_label: Some("cand".to_string()),
+    })
+    .await
+    .expect("paired replay");
+
+    // Both reports written; both sides measured the identical workload.
+    let load = |path: &str| -> Report {
+        let text = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("parse {path}: {e}"))
+    };
+    let a = load(&out_a);
+    let b = load(&out_b_default);
+    assert_eq!(
+        a.meta.dataset.as_ref().expect("dataset a").workload_hash,
+        b.meta.dataset.as_ref().expect("dataset b").workload_hash,
+        "both sides replay the same bundle"
+    );
+    assert_eq!(a.meta.label.as_deref(), Some("base"));
+    assert_eq!(b.meta.label.as_deref(), Some("cand"));
+    assert_eq!(a.meta.graph, graph_a);
+    assert_eq!(b.meta.graph, graph_b);
+    // Pairing provenance is crosswise: each side names the other's (redacted) endpoint — the
+    // same normalization `meta.endpoint` uses, so they must match exactly.
+    assert_eq!(
+        a.meta.paired_with.as_deref(),
+        Some(b.meta.endpoint.as_str())
+    );
+    assert_eq!(
+        b.meta.paired_with.as_deref(),
+        Some(a.meta.endpoint.as_str())
+    );
+
+    // A true A/A pairing: same engine + same commands ⇒ identical per-op result digests, with
+    // every measured cell present on both sides (C=1,2 × cached+uncached).
+    for op in ["point_read", "count_all"] {
+        let op_a = &a.operations[op];
+        let op_b = &b.operations[op];
+        let da = op_a
+            .result_digest
+            .as_ref()
+            .unwrap_or_else(|| panic!("digest a for {op}"));
+        let db = op_b
+            .result_digest
+            .as_ref()
+            .unwrap_or_else(|| panic!("digest b for {op}"));
+        assert_eq!(da, db, "A/A digests must match for {op}");
+        for side in [op_a, op_b] {
+            let levels: Vec<usize> = side.levels.iter().map(|l| l.concurrency).collect();
+            assert_eq!(levels, vec![1, 2], "full sweep measured for {op}");
+            for level in &side.levels {
+                assert!(level.cached.is_some(), "cached cell for {op}");
+                assert!(level.uncached.is_some(), "uncached cell for {op}");
+            }
+        }
+    }
+    // The capability-gated op was skipped on BOTH sides, unmeasured, with the probe's reason.
+    for side in [&a, &b] {
+        let ghost = &side.operations["ghost_algo"];
+        let reason = ghost.skipped.as_ref().expect("ghost_algo skipped");
+        assert!(reason.contains("algo.doesNotExist123"), "got: {reason}");
+        assert!(ghost.levels.is_empty() && ghost.result_digest.is_none());
+    }
+
+    // The paired reports are drop-in inputs for the comparison pipeline: the strict diff guard
+    // (workload_hash + digests) passes, and the regression flavor renders clean too.
+    let diff_out = dir.join("diff.md").to_string_lossy().into_owned();
+    run_command(SyntheticCommands::Report {
+        input: None,
+        diff: vec![out_a.clone(), out_b_default.clone()],
+        regression: false,
+        thresholds: None,
+        out: Some(diff_out.clone()),
+        elapsed_secs: None,
+        summary: None,
+        cells: None,
+        budget_profile: None,
+        divergence_policy: None,
+    })
+    .await
+    .expect("report --diff on the paired pair");
+    assert!(std::path::Path::new(&diff_out).exists(), "diff.md written");
+    let regression_out = dir.join("regression.md").to_string_lossy().into_owned();
+    run_command(SyntheticCommands::Report {
+        input: None,
+        diff: vec![out_a, out_b_default],
+        regression: true,
+        thresholds: None,
+        out: Some(regression_out.clone()),
+        elapsed_secs: None,
+        summary: None,
+        cells: None,
+        budget_profile: None,
+        divergence_policy: None,
+    })
+    .await
+    .expect("report --diff --regression on the paired pair");
+    assert!(
+        std::path::Path::new(&regression_out).exists(),
+        "regression.md written"
+    );
+
+    // ---- Phase 2: paired `--no-load` over the already-loaded graphs (library API this time),
+    // with a bundle that has NO capability ops and ONE budgeted op — the second recorded shape
+    // paired mode must honor (per-op budgets narrow the cell grid, C=1 skips the concurrent
+    // verify pass, cached-only leaves the compilation column empty).
+    use benchmark::synthetic::paired::{self as paired_mod, PairedReplayConfig};
+
+    let dir2 = temp_bundle_dir("syn-it-paired-noload");
+    let tight = RecordedBudget {
+        samples: Some(5),
+        warmup: Some(0),
+        concurrency: Some(vec![1]),
+        cache: Some(benchmark::synthetic::CacheSelection::Cached),
+        ..RecordedBudget::default()
+    };
+    let ops2 = vec![
+        RecordedOp {
+            key: OpKey::dynamic("plain_read", QueryType::Read),
+            result_gated: true,
+            budget: RecordedBudget::default(),
+            capability: None,
+            commands: vec!["MATCH (u:User {id: 3}) RETURN u.id".to_string()],
+        },
+        RecordedOp {
+            key: OpKey::dynamic("tight_read", QueryType::Read),
+            result_gated: true,
+            budget: tight,
+            capability: None,
+            commands: vec!["MATCH (u:User {id: 4}) RETURN u.id".to_string()],
+        },
+    ];
+    recording::record_rendered(&spec, graph_a, &ops2, spec.seed, 128, &dir2).expect("record 2");
+    let paired_no_load = |graph_override: &str| PairedReplayConfig {
+        base: ReplayConfig {
+            recording_dir: dir2.to_path_buf(),
+            endpoint: endpoint(),
+            graph: Some(graph_override.to_string()),
+            load: false,
+            samples: 40,
+            warmup: 5,
+            concurrency: vec![1],
+            cache: benchmark::synthetic::CacheSelection::Cached,
+            server_timeout_ms: 5_000,
+            client_deadline_ms: 6_000,
+            out: dir2.join("nl-a.json").to_string_lossy().into_owned(),
+            server_image: None,
+            label: None,
+            require_oracle: false,
+        },
+        paired_endpoint: endpoint(),
+        paired_graph: Some(graph_b.to_string()),
+        paired_out: dir2.join("nl-b.json").to_string_lossy().into_owned(),
+        paired_label: None,
+    };
+    let (nl_a, nl_b) = paired_mod::run(&paired_no_load(graph_a))
+        .await
+        .expect("paired --no-load over the loaded graphs");
+    for report in [&nl_a, &nl_b] {
+        // The budgeted op measured its own narrowed grid (one C=1 cached cell) and carries the
+        // resolved policy; the plain op followed the global config; digests are gated on both.
+        let tight_op = &report.operations["tight_read"];
+        assert_eq!(tight_op.levels.len(), 1);
+        assert!(tight_op.levels[0].cached.is_some() && tight_op.levels[0].uncached.is_none());
+        let policy = tight_op.policy.as_ref().expect("budgeted op persists its policy");
+        assert_eq!((policy.samples, policy.warmup), (5, 0));
+        assert!(report.operations["plain_read"].policy.is_none());
+    }
+    for op in ["plain_read", "tight_read"] {
+        assert_eq!(
+            nl_a.operations[op].result_digest, nl_b.operations[op].result_digest,
+            "A/A digests must match for {op}"
+        );
+        assert!(nl_a.operations[op].result_digest.is_some());
+    }
+
+    // A paired `--no-load` against a graph that was never loaded fails closed with the fix.
+    let msg = format!(
+        "{}",
+        paired_mod::run(&paired_no_load("syn_it_paired_missing"))
+            .await
+            .expect_err("count-verify must fail on a missing graph")
+    );
+    assert!(msg.contains("don't pass --no-load"), "got: {msg}");
+
+    std::fs::remove_dir_all(&dir2).ok();
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph_a).await;
+    drop_graph(graph_b).await;
 }


### PR DESCRIPTION
## What was done

`synthetic run --recording <dir>` gains an optional **paired mode** that measures a recorded read bundle against **two endpoints interleaved at per-op cell granularity**, so both sides of every per-op comparison share the same environment window. Today, comparing two FalkorDB versions means two fully sequential runs, minutes apart — thermal ramps and background load land on *different* ops in each run and pollute per-op deltas. Paired mode turns that slow drift into a common-mode term that subtracts out of every A-vs-B cell comparison.

**New flags** (all only valid with `--recording`; rejected otherwise with a clear error):

- `--paired-endpoint <endpoint>` — the second server (B side).
- `--paired-graph <key>` — optional distinct graph key for B; enables a true A/A pairing on one server (defaults to `--graph`; the combination *same endpoint + same graph* is rejected with a hint to use this flag).
- `--paired-out <path>` — B-side report path; defaults to `<out>` with a `-b` suffix (`report.json` → `report-b.json`).
- `--paired-label <label>` — B-side report label.

**Semantics:**

- Both endpoints are set up identically: each loads the recorded graph (or count-verifies it under `--no-load`), runs its own untimed reference pass capturing per-command `ResultShape` digests, probes capabilities, and honors recorded per-op budgets.
- Measurement is interleaved by a pure scheduling function (`paired_schedule`): for each op, for each cache-mode × concurrency cell, the cell is measured on A then **immediately** on B (A,B,A,B,…). **Ops are never interleaved with each other** — strict per-op attribution is preserved; only the A/B sides of the *same* cell alternate.
- Ops unsupported on *either* side are skipped on **both** (union skip semantics) so the two reports stay structurally comparable; the skip reason names the side(s).
- Two complete, standard reports are emitted (A → `--out`, B → `--paired-out`) that work **unchanged** with `synthetic report --diff` / `--regression`.
- Pairing provenance is recorded in `Meta` via an additive `paired_with: Option<String>` field (`#[serde(default, skip_serializing_if = "Option::is_none")]`, same pattern as `policy`/`label`) — old reports without the field still deserialize; `BaselineKey` comparison is unaffected.
- Default behavior without the flags is byte-identical to today (solo path untouched; shared logic extracted into helpers reused by both paths).

**Scope cuts:**

- **Write bundles are rejected** in paired mode with an explicit error: their per-cell base resets/restores don't interleave safely (a reset for B while A measures would corrupt attribution). Read bundles only; documented in the CLI help, readme and cookbook.
- `--require-oracle` is likewise rejected (oracle verification is a write-bundle feature).

## Tests

Unit (in `src/synthetic/paired.rs`, `src/cli.rs`, `src/synthetic/mod.rs`, `src/synthetic/report.rs`):

- `cli_paired_flags_need_recording_and_paired_endpoint` — clap rejects `--paired-endpoint` without `--recording`, and `--paired-graph`/`--paired-out`/`--paired-label` without `--paired-endpoint`.
- `run_command_rejects_paired_flags_without_recording` — the same guards at the `run_command` dispatch layer (defense in depth for library callers).
- `paired_schedule_*` (3 tests) — the pure scheduler: cells alternate A/B within each op, ops are contiguous (never interleaved with each other), every cell appears exactly twice, deterministic order.
- `default_paired_out_*` — `-b` suffix derivation incl. extension-less and dotted paths.
- `paired_with_round_trips_and_defaults_to_none` — serde round-trip + backward compat with old JSON lacking the field.
- Offline rejection tests: write bundles, `require_oracle`, same-endpoint+same-graph (suggests `--paired-graph`), zero-sample recorded budgets, corrupt bundles (`validate_bundle_ops`), plus pure-helper tests (`skip_reason` branches, `fallback_server_info`, `no_load_hint`).

Integration (`tests/synthetic_probe.rs`, `#[ignore]`d like the existing ones, so `just coverage` runs them):

- `paired_replay_a_a_pairing_matches_digests_and_diffs_clean` — a true A/A pairing on ONE FalkorDB with distinct graph keys, driving the real CLI `run_command` path (default `--paired-out` derivation): asserts both reports are written, identical `workload_hash`, per-op `result_digest`s equal across the two reports, crosswise `paired_with` provenance, union skip of an unsupported op on both sides, and that `report --diff` (strict) and `report --regression` on the pair complete clean. A second phase re-pairs over the already-loaded graphs with `--no-load` + a recorded per-op budget (covers the budgeted-policy, capability-probe-absent, C=1-no-verify and cached-only paths) and asserts a paired `--no-load` against a missing graph fails with the load hint.

`just ci` green, `just doc-check` green, `just coverage` green (all 37 integration tests); `src/synthetic/paired.rs` line coverage **98.3%** (11 uncovered lines are A/A-unreachable error-path closures), well above the 90% patch gate.

## Measured improvement

> **Metric caveat (added after maintainer feedback):** the benchmark's regression gate is **`server_ms`** (server execution time; PR #273 defaults `--gated-metric server-ms`), not client round-trip. The tables below are **`total_ms`-based**: the raw report JSONs from this local A/A experiment were cleaned up before that decision landed, so per-op `server_ms` deltas could not be recomputed without rerunning the experiment (deliberately not redone). Every paired/solo report does capture `metrics.server_ms`, so the recommended CI-scale A/A validation below should compute its spread on `server_ms` directly. Directionally, `server_ms` excludes the client/NAT jitter that dominated this sub-millisecond local setup, so both protocols' deltas would likely shrink — while the drift-cancellation argument for pairing applies to either metric.

A/A ground truth experiment (Δ = 0 by construction): two identical local FalkorDB containers (same image), K=5 repeats per protocol, protocols alternated per repeat. Bundle: 3 read ops (`match_by_index`, `expand_1_hop`, `aggregate_count`), 5 000 nodes / 25 000 edges, 6 000 samples + 300 warmup per cell, C=1,4, cached+uncached (12 cells/op-side, ~36 s per leg). Per cell `|Δp50|% = 100·|p50_A − p50_B| / p50_A` on `total_ms`; per-op median and worst across all cells × repeats:

| op | sequential median \|Δp50\|% | sequential worst % | paired median \|Δp50\|% | paired worst % |
|---|---|---|---|---|
| aggregate_count | 1.29 | 2.81 | 1.26 | 4.29 |
| expand_1_hop | 0.66 | 4.42 | 1.87 | 24.35 |
| match_by_index | 1.28 | 7.39 | 1.88 | 13.29 |
| **all ops** | **1.11** | **7.39** | **1.68** | **24.35** |


**Honest read: no local improvement — paired measured slightly *worse* here.** Why, and why CI is still where it should pay off:

- **There was almost no drift to cancel.** Each leg took ~36 s, so the two sequential runs were only ~40 s apart — far from the minutes-apart CI scenario this feature targets. When inter-run drift is negligible, pairing has nothing to subtract.
- **The residual noise is fast noise, which pairing cannot cancel.** These ops are sub-millisecond over Docker-for-Mac NAT; per-cell medians are dominated by scheduler/VM jitter. All paired worst cases were isolated C=1 cells (single connection, most hiccup-sensitive), e.g. the 24.35 % outlier is one cell in one repeat.
- **Cell alternation idles each server ~50 % of the time**, which on a laptop VM plausibly costs frequency/cache warmth between cells — a small penalty that sequential back-to-back runs don't pay. On CI-scale runs (longer cells, hotter servers, millisecond+ ops) this effect shrinks while the drift pairing removes grows.
- A sibling workload was churning the shared Docker VM during the experiment (realistic noise, but it affects both protocols).

The mechanism argument stands: sequential comparison exposes each per-op delta to environment drift over the full run duration (minutes in CI), while paired mode bounds it to one cell (~seconds). The local experiment can't reproduce minutes-scale drift cheaply; a CI-scale A/A validation is the right next step (below).

## Recommendation

Adopt paired mode in the CI three-leg pipeline **after a CI-scale A/A validation**:

1. Run the existing per-PR verify matrix once with a paired A/A (same image twice) at real CI durations and compare per-op |Δp50|% spread against the current sequential three-leg baseline — the drift term CI actually suffers is minutes-scale, which the local experiment above cannot reproduce.
2. If the spread tightens as expected, switch `synthetic-compare-versions` to a single paired invocation (one `run --recording` with `--paired-endpoint` instead of two sequential runs) — it's also ~2× less wall-clock than two sequential legs and the reports feed `report --diff`/`--regression` unchanged.
3. Consider a follow-up for C=1 cells (e.g. a short re-warm ping before each side's measurement) if CI shows the idle-cooling effect observed locally.

Cost of standing still is low (flags are opt-in, solo path byte-identical), so this can merge independently of the CI decision.


