### PR TITLE
fix(synthetic): lead report --diff tables with server time; align sanity gate check

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -310,7 +310,7 @@ synthetic-sanity:
     grep -q '"budget_profile": "cross-engine"' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary lacks the cross-engine profile"; exit 1; }
     grep -q '"divergence_policy": "advisory"' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary lacks the advisory policy"; exit 1; }
     grep -q '"overall_verdict"' recordings/_sanity_a/summary.json || { echo "SANITY FAIL: summary lacks overall_verdict"; exit 1; }
-    grep -q '"gated_metric": "total_ms.p50"' recordings/_sanity_a/cells.json || { echo "SANITY FAIL: cells JSON lacks the gated metric"; exit 1; }
+    grep -q '"gated_metric": "server_ms.p50"' recordings/_sanity_a/cells.json || { echo "SANITY FAIL: cells JSON lacks the gated metric"; exit 1; }
     grep -q '"budget_pct": 150' recordings/_sanity_a/cells.json || { echo "SANITY FAIL: cells JSON did not apply the [cross-engine.op] override"; exit 1; }
     echo "regression artifacts OK (cross-engine profile + advisory policy + summary/cells)"
     echo "synthetic-sanity OK"

--- a/docs/design/synthetic-three-way-report.md
+++ b/docs/design/synthetic-three-way-report.md
@@ -106,7 +106,7 @@ RegressionAnalysis {
           concurrency: [usize] }, thresholds: ThresholdsEcho },
   budget_profile: "strict" | "cross-engine",
   divergence_policy: "gate" | "advisory",
-  gated_metric: "total_ms.p50",
+  gated_metric: "server_ms.p50",                     // default; "total_ms.p50" under --gated-metric total-ms
   status: Comparable | NotComparable { reason },     // workload-hash/config guard only —
                                                       // version mismatches are advisory warnings
                                                       // (as today), never comparability guards

--- a/readme.md
+++ b/readme.md
@@ -587,7 +587,8 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is
   expected and recorded), then writes a **Markdown diff** across every op × cache-mode × concurrency
   level (throughput + **server-time** p50/p90/p95/p99 with deltas; the client-observed total p50
-  rides along as an informational sub-line, and a report predating server-time capture degrades that
+  rides along as an informational sub-line, and a side without a valid server time — e.g. a report
+  predating server-time capture — degrades that
   latency cell to `—` — no silent fallback). The §6.3 **oracle attestation** is
   guarded the same way: a one-sided or differing `meta.oracle_verified` aborts (the runs did not run
   the same correctness tier — a re-hashed oracle→v2 downgrade looks exactly like this), the per-side

--- a/readme.md
+++ b/readme.md
@@ -586,7 +586,9 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   aborts unless the `workload_hash` **and** every op's `result_digest` match, so a version returning
   wrong/empty results faster can't masquerade as an improvement — the version difference itself is
   expected and recorded), then writes a **Markdown diff** across every op × cache-mode × concurrency
-  level (throughput + total-latency p50/p90/p95/p99 with deltas). The §6.3 **oracle attestation** is
+  level (throughput + **server-time** p50/p90/p95/p99 with deltas; the client-observed total p50
+  rides along as an informational sub-line, and a report predating server-time capture degrades that
+  latency cell to `—` — no silent fallback). The §6.3 **oracle attestation** is
   guarded the same way: a one-sided or differing `meta.oracle_verified` aborts (the runs did not run
   the same correctness tier — a re-hashed oracle→v2 downgrade looks exactly like this), the per-side
   attestation renders as an **outcome oracle** header row, and a pair of *un*-attested runs over

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -95,8 +95,11 @@ pub fn diff_markdown(
     );
 
     out.push_str(
-        "\n_Δ is 100·(candidate−baseline)/baseline. **Latency: lower is better** (a positive Δ = \
-         slower / regressed); **throughput: higher is better**. `—` = not measured in that run._\n",
+        "\n_Δ is 100·(candidate−baseline)/baseline. Latency percentiles and Δp50 are the \
+         **server-reported execution time** (`server_ms`); the client-observed total p50 rides \
+         along as an informational sub-line. **Latency: lower is better** (a positive Δ = \
+         slower / regressed); **throughput: higher is better**. `—` = not measured in that run \
+         (or, in a latency column, a report predating server-time capture)._\n",
     );
     for w in warnings {
         out.push_str(&format!("\n> ⚠ {w}\n"));
@@ -191,7 +194,7 @@ fn render_mode(
     let la = md_cell(&col_label(a, "A"));
     let lb = md_cell(&col_label(b, "B"));
     out.push_str(&format!(
-        "| C | {la} total p50/p90/p95/p99 (ms) | {lb} total p50/p90/p95/p99 (ms) | Δp50 | {la} tput (ops/s) | {lb} tput (ops/s) | Δtput |\n\
+        "| C | {la} server p50/p90/p95/p99 (ms) | {lb} server p50/p90/p95/p99 (ms) | Δp50 | {la} tput (ops/s) | {lb} tput (ops/s) | Δtput |\n\
          |---:|---|---|---:|---:|---:|---:|\n",
     ));
     for c in levels {
@@ -199,8 +202,8 @@ fn render_mode(
         let bm = level_metrics(b, op, c, mode);
         let a_pct = am.map(percentiles).unwrap_or_else(|| "—".to_string());
         let b_pct = bm.map(percentiles).unwrap_or_else(|| "—".to_string());
-        let dp50 = match (am, bm) {
-            (Some(x), Some(y)) => pct(x.metrics.total_ms.median, y.metrics.total_ms.median),
+        let dp50 = match (am.map(server_median), bm.map(server_median)) {
+            (Some(Some(x)), Some(Some(y))) => pct(x, y),
             _ => "—".to_string(),
         };
         let a_tp = am.map(|m| format!("{:.0}", m.throughput_ops_per_sec)).unwrap_or_else(|| "—".to_string());
@@ -231,9 +234,29 @@ fn level_metrics<'a>(
         .and_then(|lvl| mode.pick(lvl))
 }
 
+/// A side's valid server-time median: `Some` iff finite and positive (a non-positive or
+/// non-finite value means the report predates server-time capture — no silent fallback).
+fn server_median(m: &LevelMetrics) -> Option<f64> {
+    let v = m.metrics.server_ms.median;
+    (v.is_finite() && v > 0.0).then_some(v)
+}
+
+/// A diff-table latency cell: server-time percentiles on the primary line (`—` when the report
+/// predates server-time capture), with the client-observed total p50 demoted to a `sub` line
+/// whenever it is valid — mirroring the regression report's demotion.
 fn percentiles(m: &LevelMetrics) -> String {
-    let s = &m.metrics.total_ms;
-    format!("{:.3} / {:.3} / {:.3} / {:.3}", s.median, s.p90, s.p95, s.p99)
+    let primary = if server_median(m).is_some() {
+        let s = &m.metrics.server_ms;
+        format!("{:.3} / {:.3} / {:.3} / {:.3}", s.median, s.p90, s.p95, s.p99)
+    } else {
+        "—".to_string()
+    };
+    let t = m.metrics.total_ms.median;
+    if t.is_finite() && t > 0.0 {
+        format!("{primary}<br><sub>total p50 {t:.3}</sub>")
+    } else {
+        primary
+    }
 }
 
 /// A regression-table latency cell: the gated **p50** on the primary line, with p90/p95/p99,
@@ -1000,6 +1023,57 @@ mod tests {
     }
 
     #[test]
+    fn diff_gates_dp50_on_server_time_and_demotes_total() {
+        // Server clocks disagree with the wall clocks: Δp50 must follow server_ms (+50 %), not
+        // total_ms (+10 %), and each cell leads with server percentiles, total p50 demoted.
+        let mut a = report(42001, 1.000, 1000.0);
+        let mut b = report(42002, 1.100, 1000.0);
+        set_server_median(&mut a, 0.400);
+        set_server_median(&mut b, 0.600);
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("A server p50/p90/p95/p99"), "server-led header: {md}");
+        assert!(md.contains("+50.0%"), "Δp50 from server medians: {md}");
+        assert!(!md.contains("+10.0%"), "wall-clock Δ must not be gated: {md}");
+        assert!(
+            md.contains("<sub>total p50 1.000</sub>") && md.contains("<sub>total p50 1.100</sub>"),
+            "demoted totals: {md}"
+        );
+    }
+
+    #[test]
+    fn diff_degrades_to_na_when_server_time_is_missing() {
+        // A report predating server-time capture (zeroed server_ms): no silent fallback — the
+        // latency cell shows — (with the total demoted alongside) and Δp50 is —.
+        let mut a = report(42001, 1.000, 1000.0);
+        let b = report(42002, 1.100, 900.0);
+        set_server_median(&mut a, 0.0);
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(
+            md.contains("| —<br><sub>total p50 1.000</sub> |"),
+            "missing server side degrades to — with demoted total: {md}"
+        );
+        assert!(
+            md.contains("</sub> | — |"),
+            "Δp50 must be — when either server median is invalid: {md}"
+        );
+        assert!(md.contains("predating server-time capture"), "legend explains —: {md}");
+    }
+
+    /// Overwrite every level's `server_ms` summary median (fixtures default both clocks equal).
+    fn set_server_median(
+        r: &mut Report,
+        v: f64,
+    ) {
+        for op in r.operations.values_mut() {
+            for lvl in &mut op.levels {
+                for m in [&mut lvl.cached, &mut lvl.uncached].into_iter().flatten() {
+                    m.metrics.server_ms = summ(v);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn diff_uses_run_labels_as_headers() {
         let mut a = report(42001, 1.0, 1000.0);
         let mut b = report(42002, 1.1, 900.0);
@@ -1008,7 +1082,7 @@ mod tests {
         let md = diff_markdown(&a, &b, &[]);
         assert!(md.contains("diff — main → pr"), "title: {md}");
         assert!(md.contains("| main (baseline) | pr (candidate) |"), "header: {md}");
-        assert!(md.contains("main total p50") && md.contains("pr tput"), "op header: {md}");
+        assert!(md.contains("main server p50") && md.contains("pr tput"), "op header: {md}");
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -99,7 +99,8 @@ pub fn diff_markdown(
          **server-reported execution time** (`server_ms`); the client-observed total p50 rides \
          along as an informational sub-line. **Latency: lower is better** (a positive Δ = \
          slower / regressed); **throughput: higher is better**. `—` = not measured in that run \
-         (or, in a latency column, a report predating server-time capture)._\n",
+         (or, in a latency column, no valid server time on that side — e.g. a report predating \
+         server-time capture or an engine that doesn't report execution time)._\n",
     );
     for w in warnings {
         out.push_str(&format!("\n> ⚠ {w}\n"));
@@ -234,16 +235,17 @@ fn level_metrics<'a>(
         .and_then(|lvl| mode.pick(lvl))
 }
 
-/// A side's valid server-time median: `Some` iff finite and positive (a non-positive or
-/// non-finite value means the report predates server-time capture — no silent fallback).
+/// A side's valid server-time median: `Some` iff finite and positive. A non-positive or
+/// non-finite value means the side carries no usable server time (a report predating
+/// server-time capture, or an engine that doesn't report execution time) — no silent fallback.
 fn server_median(m: &LevelMetrics) -> Option<f64> {
     let v = m.metrics.server_ms.median;
     (v.is_finite() && v > 0.0).then_some(v)
 }
 
-/// A diff-table latency cell: server-time percentiles on the primary line (`—` when the report
-/// predates server-time capture), with the client-observed total p50 demoted to a `sub` line
-/// whenever it is valid — mirroring the regression report's demotion.
+/// A diff-table latency cell: server-time percentiles on the primary line (`—` when the side
+/// has no valid server time — see [`server_median`]), with the client-observed total p50
+/// demoted to a `sub` line whenever it is valid — mirroring the regression report's demotion.
 fn percentiles(m: &LevelMetrics) -> String {
     let primary = if server_median(m).is_some() {
         let s = &m.metrics.server_ms;


### PR DESCRIPTION
Follow-up to #273, completing the maintainer decision that **server_ms is the measured metric** (total round-trip is informational only).

## What was done
- `report --diff` per-op tables (the sticky verify comment + `diff.md` artifacts) still led with **total_ms**: column headers said `A total p50/p90/p95/p99`, and Δp50 was computed from the wall clock. They now render **`{label} server p50/p90/p95/p99`**, compute **Δp50 from `server_ms` medians**, demote the client-observed total p50 to an informational `<sub>` line, and degrade the latency cell to `—` (no silent fallback, matching #273's regression-report semantics) when a report predates server-time capture. Legend updated accordingly.
- **`just synthetic-sanity` was broken by #273's default flip**: it asserted `"gated_metric": "total_ms.p50"` in cells.json, which the new server-ms default fails. Now expects `server_ms.p50`. (CI was unaffected — the CI gate is `synthetic-verify`, digests only — but the local sanity recipe would have failed for anyone running it.)
- Three-way design doc example still named `total_ms.p50` as the gated id — annotated with the server-ms default.
- readme: `report --diff` bullet now documents server-time-led tables + the `—` degradation.

## Tests
- `diff_gates_dp50_on_server_time_and_demotes_total` — server clocks disagree with wall clocks: Δp50 must follow server_ms (+50 %), not total_ms (+10 %); each cell leads with server percentiles with the total demoted.
- `diff_degrades_to_na_when_server_time_is_missing` — zeroed server_ms side renders `—` (with the demoted total alongside) and Δp50 `—`.
- Existing label-header test updated (`main server p50`). Full `just ci` + `just doc-check` green.

## Impact
The verify sticky comment and `report --diff` artifacts now show the metric the project gates on; a server-side regression is no longer diluted by client/network time in the diff tables (locally 73–83 % of total_ms is client+network).

## Recommendation
Merge; tag v2.5.1 so the next-gen pin can pick it up. The in-flight #745 benchmark run is unaffected (its regression verdicts already gate on server_ms via v2.5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Synthetic benchmark diffs now use server-reported execution time for latency percentiles and p50 comparisons.
  * Client-observed total latency remains available as supplemental information.
* **Bug Fixes**
  * Reports with missing or invalid server-time data now display unavailable values instead of silently falling back to total latency.
* **Documentation**
  * Updated benchmark report guidance and synthetic report schema documentation to reflect server-time defaults and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->