### PR TITLE
feat(synthetic): pipelined reads (--pipeline-depth) and --client-threads for arrival-jitter-free server_ms

### DIFF
--- a/docs/synthetic-benchmark-architecture.md
+++ b/docs/synthetic-benchmark-architecture.md
@@ -124,7 +124,7 @@ requests in flight is gated **by construction of the workers**, not by any queue
 
 [`run_closed_loop`](../src/synthetic/engine.rs#L96) spawns one tokio task per worker into a
 [`JoinSet`](../src/synthetic/engine.rs#L115). Each worker owns its **own single connection** —
-[`open_graph`](../src/synthetic/mod.rs#L573) builds a dedicated client with
+[`open_graph`](../src/synthetic/mod.rs#L586) builds a dedicated client with
 `ConnectionStrategy::Pooled { size: 1 }` — and runs a **closed loop**: fire one command, await the
 reply (rows drained), only then fire the next. Warm-up invocations are discarded, then all `C`
 workers cross a shared [`Barrier`](../src/synthetic/engine.rs#L114) so the window opens with all
@@ -148,9 +148,9 @@ sequenceDiagram
 
 ### Depth `K > 1` (reads only): `C x K` resident, still only `C` executing
 
-With [`--pipeline-depth K`](../src/synthetic/mod.rs#L451), [`measure_level`
-fan-out](../src/synthetic/mod.rs#L1318-L1341) keeps the `C` connection slots but builds each one as
-a single **multiplexed** socket ([`open_graph_pipelined`](../src/synthetic/mod.rs#L600),
+With [`--pipeline-depth K`](../src/cli.rs#L517), [`measure_level`
+fan-out](../src/synthetic/mod.rs#L1315-L1338) keeps the `C` connection slots but builds each one as
+a single **multiplexed** socket ([`open_graph_pipelined`](../src/synthetic/mod.rs#L605),
 `ConnectionStrategy::Multiplexed { connections: 1 }`) whose handle is cheaply cloned into `K`
 closed-loop **lanes**. All `C x K` lanes are fed through the *unchanged*
 [`run_closed_loop`](../src/synthetic/engine.rs#L96) — each lane is still a closed loop, but the
@@ -190,37 +190,37 @@ What "gated" means per phase, precisely:
 
 | Phase | In-flight gate |
 |---|---|
-| Measured **read** levels | `C` connections x [`effective_pipeline_depth`](../src/synthetic/mod.rs#L627) lanes: `K` in flight per connection, `C` executing server-side. |
+| Measured **read** levels | `C` connections x [`effective_pipeline_depth`](../src/synthetic/mod.rs#L624) lanes: `K` in flight per connection, `C` executing server-side. |
 | Measured **write** levels | Always depth 1 — `C` connections, one in flight each, regardless of `--pipeline-depth`. |
-| Recorded-bundle dataset **load** | Untouched by `--pipeline-depth` (the flag reaches only [`measure_level`](../src/synthetic/mod.rs#L1290)); the load replays the recorded statements sequentially on one connection. |
+| Recorded-bundle dataset **load** | Untouched by `--pipeline-depth` (the flag reaches only [`measure_level`](../src/synthetic/mod.rs#L1287)); the load replays the recorded statements sequentially on one connection. |
 | **record** / **report** phases | Offline — no server, nothing in flight. |
 
 Bookkeeping that keeps depth-K comparable to depth-1 (and depth 1 byte-identical to the
 pre-pipelining behavior):
 
-- **Totals** — each lane measures [`ceil(samples / K)`](../src/synthetic/mod.rs#L641)
+- **Totals** — each lane measures [`ceil(samples / K)`](../src/synthetic/mod.rs#L638)
   invocations, so a level completes ≥ `C x samples` (exactly `C x samples` when `K` divides
   `--samples`; pick such a value).
-- **Uniqueness** — every lane claims a [disjoint uid block](../src/synthetic/mod.rs#L1294-L1296)
+- **Uniqueness** — every lane claims a [disjoint uid block](../src/synthetic/mod.rs#L1290-L1292)
   from the run-global allocator, so uncached query text (which embeds the uid) never collides
   across lanes, levels or ops.
 - **Decorrelation** — lane `l` of slot `w` starts its corpus cycle at offset
-  [`(w x K + l) % corpus.len()`](../src/synthetic/mod.rs#L651) — exactly today's `w %
+  [`(w x K + l) % corpus.len()`](../src/synthetic/mod.rs#L648) — exactly today's `w %
   corpus.len()` at `K = 1`.
 - **Digests** — the per-op `result_digest` comes from the replay's untimed single-flight
   [reference pass](../src/synthetic/replay.rs#L298), not from the measured lanes, so it is
   depth-independent by construction: a depth-1 and a depth-4 run of one bundle produce identical
   digests, and `report --diff` still guards them.
 - **Reporting** — the connection description in `meta`
-  ([`connection_description`](../src/synthetic/mod.rs#L664)) is informational and never guarded,
+  ([`connection_description`](../src/synthetic/mod.rs#L661)) is informational and never guarded,
   so depth-1 and depth-K reports of one workload stay diffable.
 
 ## Write operations
 
-Write ops always run the plain closed loop — [`effective_pipeline_depth`](../src/synthetic/mod.rs#L627)
+Write ops always run the plain closed loop — [`effective_pipeline_depth`](../src/synthetic/mod.rs#L624)
 returns 1 for `QueryType::Write` no matter what `--pipeline-depth` says (recorded writes measure
 with `kind: Write` even though they carry no write plan, so the gate is on the query kind). Two
-reasons, both visible in the [`GraphWorker` write choreography](../src/synthetic/mod.rs#L1075-L1131):
+reasons, both visible in the [`GraphWorker` write choreography](../src/synthetic/mod.rs#L1072-L1130):
 
 1. **Per-sample verification** — every measured write's reply is checked with `verify_mutation`
    (a silent no-op is an error), which pairs each request with *its* reply; a second in-flight
@@ -249,7 +249,7 @@ sequenceDiagram
 
 Each worker gets an **isolated `WriteScratch`** (its own key band sized to fit `i32`), setup runs
 untimed on the worker's own connection before the window, and the run's scratch is dropped
-afterward [on a fresh connection](../src/synthetic/mod.rs#L1231-L1251) whether or not the level
+afterward [on a fresh connection](../src/synthetic/mod.rs#L1231-L1247) whether or not the level
 succeeded — a failed write level never leaks scratch into the next one. On the success path a
 cleanup failure is surfaced; on the failure path cleanup is best-effort so it can't mask the
 original error.
@@ -343,11 +343,11 @@ Reading the tables:
 | Concern | Where |
 |---|---|
 | Closed-loop engine (barrier, JoinSet, fail-fast, window math) | [`src/synthetic/engine.rs`](../src/synthetic/engine.rs) — [`run_closed_loop`](../src/synthetic/engine.rs#L96) |
-| Single-flight connection (depth 1) | [`open_graph`](../src/synthetic/mod.rs#L573) — `Pooled { size: 1 }` |
-| Pipelined connection (depth K) | [`open_graph_pipelined`](../src/synthetic/mod.rs#L600) — `Multiplexed { connections: 1 }`, cloned into lanes |
-| Lane fan-out per level | [`measure_level`](../src/synthetic/mod.rs#L1268) (`if depth > 1` at [L1318](../src/synthetic/mod.rs#L1318)) |
-| Reads-only gating, lane math | [`effective_pipeline_depth`](../src/synthetic/mod.rs#L627), [`lane_samples`](../src/synthetic/mod.rs#L641), [`lane_corpus_offset`](../src/synthetic/mod.rs#L651) |
-| Write choreography (verify, reset, cleanup) | [`GraphWorker::invoke`](../src/synthetic/mod.rs#L1075) write arm |
+| Single-flight connection (depth 1) | [`open_graph`](../src/synthetic/mod.rs#L586) — `Pooled { size: 1 }` |
+| Pipelined connection (depth K) | [`open_graph_pipelined`](../src/synthetic/mod.rs#L605) — `Multiplexed { connections: 1 }`, cloned into lanes |
+| Lane fan-out per level | [`measure_level`](../src/synthetic/mod.rs#L1265) (`if depth > 1` at [L1318](../src/synthetic/mod.rs#L1315)) |
+| Reads-only gating, lane math | [`effective_pipeline_depth`](../src/synthetic/mod.rs#L624), [`lane_samples`](../src/synthetic/mod.rs#L638), [`lane_corpus_offset`](../src/synthetic/mod.rs#L648) |
+| Write choreography (verify, reset, cleanup) | [`GraphWorker::invoke`](../src/synthetic/mod.rs#L1072) write arm |
 | Replay: reference pass, digests, depth plumbing | [`src/synthetic/replay.rs`](../src/synthetic/replay.rs) ([`pipeline_depth`](../src/synthetic/replay.rs#L92-L93)) |
 | Runtime build (`--client-threads`) | [`build_runtime`](../src/main.rs#L203-L216) in `src/main.rs` |
 | CLI flags | [`--client-threads`](../src/cli.rs#L157) (global), [`--pipeline-depth`](../src/cli.rs#L517) (`synthetic run`) |

--- a/docs/synthetic-benchmark-architecture.md
+++ b/docs/synthetic-benchmark-architecture.md
@@ -1,0 +1,356 @@
+# Synthetic benchmark architecture
+
+How the synthetic per-operation benchmark is put together, in diagrams with links to the code:
+where **CPU pinning** happens, how **in-flight requests are gated** (one per connection vs `K`
+pipelined lanes), how **write operations** are handled, how **`--client-threads` relates to
+`--pipeline-depth`**, and what **run-to-run precision** the pinned + pipelined setup actually
+measures. Companion to the conceptual [synthetic benchmark
+tutorial](synthetic-benchmark-tutorial.md), the task-oriented
+[cookbook](synthetic-benchmark-cookbook.md), and the concurrency-model reference
+[`synthetic-benchmark.md`](../synthetic-benchmark.md).
+
+Everything below matches the code as of this document's commit; benchmark-repo links are relative,
+CI-script links are permalinks into
+[FalkorDB/falkordb-rs-next-gen](https://github.com/FalkorDB/falkordb-rs-next-gen) (where the CI
+that *runs* this tool lives).
+
+## The big picture: record, run, report
+
+Three verbs, three trust boundaries. `record` is a pure function of seed + knobs (no server);
+`run --recording` is the only phase that touches a server; `report` is offline again — so two
+`run`s of the same bundle against different builds are comparable by construction, and the diff
+can *guard* that claim (`workload_hash`, per-op `result_digest`) instead of assuming it.
+
+```mermaid
+flowchart LR
+    subgraph rec["record — offline, deterministic"]
+        R["synthetic record<br/>(seed + knobs)"] --> B["recordings/name/<br/>load script + measured commands<br/>+ workload_hash"]
+    end
+    subgraph runa["run --recording — engine A"]
+        A[("FalkorDB<br/>build A")]
+        RA["load graph, then measure:<br/>ops x concurrency sweep x cache modes"] --> A
+    end
+    subgraph runb["run --recording — engine B"]
+        Bb[("FalkorDB<br/>build B")]
+        RB["same bundle, same knobs"] --> Bb
+    end
+    subgraph rep["report — offline"]
+        D["report --diff / --regression<br/>guards workload_hash + result_digest,<br/>gates server_ms p50 vs per-op budget"]
+    end
+    B --> RA
+    B --> RB
+    RA -- "a.json" --> D
+    RB -- "b.json" --> D
+```
+
+The measured latencies are paired per invocation: `server_ms` (the engine's self-reported
+execution time) is what the regression gate compares; `total_ms` (client wall clock) is
+informational context. That split is why everything in this document optimizes for a clean,
+reproducible *arrival pattern at the server* rather than for pretty client-side numbers.
+
+## One CI run
+
+In CI (the [`synthetic`
+job](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/workflows/_benchmark.yml#L563-L626)
+of falkordb-rs-next-gen's benchmark pipeline) all of the above happens on **one fresh GCE VM per
+run** (x86 `n4-highcpu-16` or ARM `c4a-highcpu-16`, 16 vCPUs), driven by
+[`synthetic-run.sh`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-run.sh):
+record once, then measure the **PR image**, **main image** and the **production C engine** with
+the identical bundle, then compare three ways and publish.
+
+```mermaid
+flowchart TB
+    L["PR labeled benchmark-small"] --> VM["fresh GCE VM (16 vCPUs)<br/>one per run, destroyed after"]
+    VM --> R0["record bundle (offline)"]
+    R0 --> M1["run --recording vs PR image"]
+    M1 --> M2["run --recording vs main image"]
+    M2 --> M3["run --recording vs C engine"]
+    M3 --> C1["report --regression main-pr (the gate)"]
+    M3 --> C2["report c-pr / c-main (context)"]
+    C1 --> P["publish: GitHub Pages data.json + page,<br/>sticky PR comment with verdicts"]
+    C2 --> P
+```
+
+The **main-pr** comparison is the gate. On an A/A run (two identical-code images) its per-cell
+`delta_pct` is *pure measurement noise* — that property is what the [precision
+section](#run-to-run-precision) measures.
+
+## CPU pinning
+
+Pinning lives in the CI scripts of falkordb-rs-next-gen, not in this repo's binary — the binary
+just runs wherever it is placed. Every leg runs the measured server container **and** the
+closed-loop client on the *same* VM, so without partitioning the client's workers compete with the
+server's threads for the same CPUs and run-queue latency leaks into the measurements (worst at
+concurrency > 1).
+
+```mermaid
+flowchart LR
+    subgraph vm["GCE VM - 16 vCPUs"]
+        subgraph scpu["cpus 0-7: docker run --cpuset-cpus 0-7"]
+            F[("FalkorDB server container<br/>(the measured image)")]
+        end
+        subgraph ccpu["cpus 8-15: taskset -c 8-15"]
+            Bin["benchmark binary<br/>tokio multi_thread runtime"]
+        end
+    end
+    Bin -- "C connections<br/>GRAPH.RO_QUERY / GRAPH.QUERY" --> F
+```
+
+The split policy is a pure, deterministic function in
+[`synthetic-cpu-lib.sh`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-cpu-lib.sh#L14-L31):
+
+- **Default (auto-split)** — when the host has ≥ 4 CPUs, the server takes the **first half**
+  (rounded up: [`cpu_split_bound`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-cpu-lib.sh#L48-L54)),
+  the client the rest — `16 → 0-7 / 8-15`. Below 4 CPUs nothing is pinned.
+- **`SYNTH_CPU_PARTITION=0/false/no/off`** switches partitioning off entirely.
+- **`SYNTH_SERVER_CPUS` / `SYNTH_CLIENT_CPUS`** are honored verbatim when set (auto-split
+  disabled) — the escape hatch for topology-aware sets, e.g. keeping SMT siblings on one side.
+
+[`synthetic-measure-lib.sh`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-measure-lib.sh#L26-L28)
+applies it in exactly two places, for the **measured** replays only (offline record/report calls
+stay unpinned — nothing races them):
+
+- server: [`run_args+=(--cpuset-cpus "$SERVER_CPUS")`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-measure-lib.sh#L76)
+  on the measured container;
+- client: [`taskset -c "$CLIENT_CPUS" cargo run --release … --bin benchmark`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-measure-lib.sh#L45-L51)
+  (the spawned binary inherits the affinity).
+
+## In-flight gating: closed loop and pipelined lanes
+
+One measurement *level* = one (operation, concurrency `C`, cache mode) cell. The number of
+requests in flight is gated **by construction of the workers**, not by any queue-depth counter:
+
+### Depth 1 (the default): at most `C` in flight, one per connection
+
+[`run_closed_loop`](../src/synthetic/engine.rs#L96) spawns one tokio task per worker into a
+[`JoinSet`](../src/synthetic/engine.rs#L115). Each worker owns its **own single connection** —
+[`open_graph`](../src/synthetic/mod.rs#L573) builds a dedicated client with
+`ConnectionStrategy::Pooled { size: 1 }` — and runs a **closed loop**: fire one command, await the
+reply (rows drained), only then fire the next. Warm-up invocations are discarded, then all `C`
+workers cross a shared [`Barrier`](../src/synthetic/engine.rs#L114) so the window opens with all
+`C` active; the first worker error [aborts every other worker](../src/synthetic/engine.rs#L151-L167)
+(fail-fast — a half-run level never reports a misleading throughput).
+
+So at depth 1 the in-flight maximum is exactly `C` — *honest single-flight* per connection. The
+cost: every client-side scheduling gap (tokio wakeup latency, CPU contention) becomes a **gap in
+the server's arrival stream**, and at `C > 1` that jitter is what an A/A comparison sees as noise.
+
+```mermaid
+sequenceDiagram
+    participant W as worker w (1 of C, own connection)
+    participant S as server
+    W->>S: command n
+    Note over S: execute (server_ms)
+    S-->>W: reply n (drained)
+    Note over W: client turnaround gap - tokio wakeup,<br/>CPU contention: server sits idle on this connection
+    W->>S: command n+1
+```
+
+### Depth `K > 1` (reads only): `C x K` resident, still only `C` executing
+
+With [`--pipeline-depth K`](../src/synthetic/mod.rs#L451), [`measure_level`
+fan-out](../src/synthetic/mod.rs#L1318-L1341) keeps the `C` connection slots but builds each one as
+a single **multiplexed** socket ([`open_graph_pipelined`](../src/synthetic/mod.rs#L600),
+`ConnectionStrategy::Multiplexed { connections: 1 }`) whose handle is cheaply cloned into `K`
+closed-loop **lanes**. All `C x K` lanes are fed through the *unchanged*
+[`run_closed_loop`](../src/synthetic/engine.rs#L96) — each lane is still a closed loop, but the
+`K` lanes of one slot pipeline their in-flight commands over one socket (the vendored client's
+[`Multiplexed` strategy](../vendor/falkordb-rs/src/client/mod.rs#L44-L62) documents exactly this).
+
+Server-side concurrency **stays `C`**, by Redis semantics rather than by anything this repo does:
+FalkorDB is a Redis module, `GRAPH.QUERY`/`GRAPH.RO_QUERY` **block the client connection** while
+executing on the module's thread pool, and Redis **never parses the next command from a blocked
+connection** — per-connection execution is serial. Pipelining therefore does not add parallelism;
+it keeps each connection's input buffer non-empty so the server **self-paces**: the moment one
+command unblocks, the next is already there, and client scheduling jitter stops perturbing the
+arrival pattern.
+
+```mermaid
+flowchart LR
+    subgraph slot["connection slot w (of C=8), --pipeline-depth 4"]
+        L0["lane w.0"] --> MX["one multiplexed socket"]
+        L1["lane w.1"] --> MX
+        L2["lane w.2"] --> MX
+        L3["lane w.3"] --> MX
+    end
+    subgraph srv["server (FalkorDB = Redis module)"]
+        IB["conn w input buffer:<br/>up to 3 commands queued"]
+        EX["executing: 1 command per connection<br/>(blocked client is never parsed)"]
+        IB --> EX
+    end
+    MX -- "up to 4 in flight" --> IB
+```
+
+At `C=8, K=4`: **32 commands resident** on the server (8 executing + 24 queued in per-connection
+input buffers), **at most 8 executing** — the same execution concurrency as depth 1. The reported
+level keeps `concurrency = C`; lanes are an implementation detail of *how* the connection is kept
+busy.
+
+What "gated" means per phase, precisely:
+
+| Phase | In-flight gate |
+|---|---|
+| Measured **read** levels | `C` connections x [`effective_pipeline_depth`](../src/synthetic/mod.rs#L627) lanes: `K` in flight per connection, `C` executing server-side. |
+| Measured **write** levels | Always depth 1 — `C` connections, one in flight each, regardless of `--pipeline-depth`. |
+| Recorded-bundle dataset **load** | Untouched by `--pipeline-depth` (the flag reaches only [`measure_level`](../src/synthetic/mod.rs#L1290)); the load replays the recorded statements sequentially on one connection. |
+| **record** / **report** phases | Offline — no server, nothing in flight. |
+
+Bookkeeping that keeps depth-K comparable to depth-1 (and depth 1 byte-identical to the
+pre-pipelining behavior):
+
+- **Totals** — each lane measures [`ceil(samples / K)`](../src/synthetic/mod.rs#L641)
+  invocations, so a level completes ≥ `C x samples` (exactly `C x samples` when `K` divides
+  `--samples`; pick such a value).
+- **Uniqueness** — every lane claims a [disjoint uid block](../src/synthetic/mod.rs#L1294-L1296)
+  from the run-global allocator, so uncached query text (which embeds the uid) never collides
+  across lanes, levels or ops.
+- **Decorrelation** — lane `l` of slot `w` starts its corpus cycle at offset
+  [`(w x K + l) % corpus.len()`](../src/synthetic/mod.rs#L651) — exactly today's `w %
+  corpus.len()` at `K = 1`.
+- **Digests** — the per-op `result_digest` comes from the replay's untimed single-flight
+  [reference pass](../src/synthetic/replay.rs#L298), not from the measured lanes, so it is
+  depth-independent by construction: a depth-1 and a depth-4 run of one bundle produce identical
+  digests, and `report --diff` still guards them.
+- **Reporting** — the connection description in `meta`
+  ([`connection_description`](../src/synthetic/mod.rs#L664)) is informational and never guarded,
+  so depth-1 and depth-K reports of one workload stay diffable.
+
+## Write operations
+
+Write ops always run the plain closed loop — [`effective_pipeline_depth`](../src/synthetic/mod.rs#L627)
+returns 1 for `QueryType::Write` no matter what `--pipeline-depth` says (recorded writes measure
+with `kind: Write` even though they carry no write plan, so the gate is on the query kind). Two
+reasons, both visible in the [`GraphWorker` write choreography](../src/synthetic/mod.rs#L1075-L1131):
+
+1. **Per-sample verification** — every measured write's reply is checked with `verify_mutation`
+   (a silent no-op is an error), which pairs each request with *its* reply; a second in-flight
+   command on the same connection would break that pairing.
+2. **Untimed window-boundary resets** — at each `reset_every` boundary the worker runs the plan's
+   reset statements *untimed* to undo drift before reusing its key band; with pipelining, a reset
+   would land inside another lane's timed sample on the same socket.
+
+```mermaid
+sequenceDiagram
+    participant W as write worker w (own connection + own WriteScratch)
+    participant S as server
+    Note over W,S: untimed setup (plan.setup) before the window
+    W->>S: warm-up invocations (discarded)
+    Note over W: Barrier(C) - all workers enter the window together
+    loop each measured sample (seq)
+        opt window boundary: schedule().should_reset(seq)
+            W->>S: untimed reset statements (generous deadline)
+        end
+        W->>S: rendered write (timed)
+        S-->>W: reply + mutation counters
+        Note over W: verify_mutation - a silent no-op fails the level
+    end
+    Note over W,S: untimed cleanup on a FRESH connection,<br/>success or failure (scratch never leaks)
+```
+
+Each worker gets an **isolated `WriteScratch`** (its own key band sized to fit `i32`), setup runs
+untimed on the worker's own connection before the window, and the run's scratch is dropped
+afterward [on a fresh connection](../src/synthetic/mod.rs#L1231-L1251) whether or not the level
+succeeded — a failed write level never leaks scratch into the next one. On the success path a
+cleanup failure is surfaced; on the failure path cleanup is best-effort so it can't mask the
+original error.
+
+In the A/A precision data below, writes are therefore the **control group**: pipelining must not
+(and does not) change their noise band.
+
+## Client threads vs pipeline depth
+
+Two orthogonal knobs that are easy to conflate:
+
+| | [`--client-threads N`](../src/cli.rs#L157) (global) | [`--pipeline-depth K`](../src/cli.rs#L517) (`synthetic run`) |
+|---|---|---|
+| Controls | tokio **worker threads** — CPU parallelism for serialize/parse/wakeups | **in-flight commands per socket** — I/O concurrency, server-side queueing |
+| Does **not** control | the number of in-flight requests | CPU usage of the client |
+| Default | tokio default (one thread per core) | 1 (exact pre-pipelining closed loop) |
+| Scope | whole binary (loader, probes, replay) | measured **read** levels only |
+
+The key decoupling: a tokio task **awaiting I/O holds no thread**, so `N` does not cap in-flight
+commands — even one worker thread could keep all `C x K` lanes' commands in flight; threads only
+bound how much *CPU work* (request serialization, reply parsing, task wakeups) happens in
+parallel. [`build_runtime`](../src/main.rs#L203-L216) builds the runtime **before** any async work
+so the cap applies from the first task, and always uses the **multi-thread flavor even at
+`N=1`** — the vendored client [hard-errors on a current-thread
+runtime](../vendor/falkordb-rs/src/client/asynchronous.rs#L235-L236) (`RuntimeFlavor::CurrentThread`)
+because it uses `task::block_in_place`, so `N ≥ 1` means "multi_thread with N workers", never
+`current_thread`.
+
+The CI choice `--client-threads 3 --pipeline-depth 4` (8-CPU client partition, `C ≤ 8` ⇒ up to 32
+lanes) leaves headroom by design, and the saturation evidence confirms 3 threads comfortably
+drive 32 lanes: at `C=8` the depth-4 achieved read throughput was **≥ the depth-1 throughput in
+every cell locally (1.16–1.49x)** and a median **1.31x** in CI — removing arrival gaps can only
+add work per unit time; a drop would have meant the lanes serialize somewhere in the client.
+
+## Run-to-run precision
+
+All numbers below are **A/A noise**: the per-cell `delta_pct` of **`server_ms` p50** on the
+**main-pr** leg when both images run identical code — the ideal value is 0 everywhere, so the
+spread *is* the measurement error. Reads: n=50 cells per concurrency (25 ops x cached/uncached);
+writes: n=10 cells (write bundles pin `C=1` by recorded budget). σ is the population standard
+deviation of the *signed* per-cell Δ%; p90/worst are on |Δ%|. Sources: pr-745 run of
+falkordb-rs-next-gen (unpinned), the two pinning-evaluation runs of
+[#771](https://github.com/FalkorDB/falkordb-rs-next-gen/pull/771) plus one post-merge pinned run
+(depth 1), and the two runs of experiment PR
+[#773](https://github.com/FalkorDB/falkordb-rs-next-gen/pull/773)
+([run 1](https://github.com/FalkorDB/falkordb-rs-next-gen/actions/runs/30304708613),
+[run 2](https://github.com/FalkorDB/falkordb-rs-next-gen/actions/runs/30307252662)) which drove
+this PR's build with `--client-threads 3 --pipeline-depth 4`. All on the same runner class
+(x86 `n4-highcpu-16`, 16 vCPUs).
+
+**Reads, C=8** (the level pinning + pipelining target):
+
+| Setup | Runs | σ(Δ%) per run | p90 abs Δ% | worst abs Δ% |
+|---|---|---|---|---|
+| unpinned, depth 1 | 1 | 28.8 | 78.9 | 97.7 |
+| pinned, depth 1 | 3 | 3.0 / 6.8 / 2.2 | 4.2 / 15.6 / 3.8 | 13.5 / 25.3 / 6.4 |
+| pinned + pipelined (K=4, N=3) | 2 | **2.35 / 2.45** | **3.9 / 2.7** | 6.1 / 12.0 |
+
+**Reads, C=1** (single-flight — pipelining still smooths the turnaround):
+
+| Setup | Runs | σ(Δ%) per run | p90 abs Δ% | worst abs Δ% |
+|---|---|---|---|---|
+| unpinned, depth 1 | 1 | 16.4 | 29.6 | 65.5 |
+| pinned, depth 1 | 3 | 11.7 / 15.4 / 14.0 | 20.8 / 22.5 / 24.9 | 50.8 / 65.7 / 38.7 |
+| pinned + pipelined (K=4, N=3) | 2 | 12.6 / 7.4 | 17.5 / 12.8 | 70.9 / 25.1 |
+
+**Writes, C=1** (control — always depth 1, so pipelining must be a no-op): σ 9.4 unpinned;
+7.0 / 3.4 / 4.0 pinned; 3.9 / 5.3 pinned + pipelined — the same band, as expected.
+
+Reading the tables:
+
+- **From unpinned to pinned + pipelined, C=8 reads**: σ shrinks **~12x** (28.8 → ~2.4) and p90
+  |Δ%| **~20–29x** (78.9 → 2.7–3.9). The gate's noise floor at C=8 now sits where C=1's *best*
+  runs sit.
+- **What pipelining adds over pinning alone is stability**: pinned depth-1 swings run-to-run
+  (σ 2.2–6.8, p90 3.8–15.6 across three consecutive runs); pinned + pipelined held σ ≈ 2.4 and
+  p90 ≤ 4 in both runs. One outlier cell (12.0 worst in run 2) remains — sub-millisecond ops keep
+  a long relative-noise tail.
+- **C=1 reads** improve modestly; the large "worst" cells are sub-microsecond server times where
+  a tiny absolute wobble is a huge percentage.
+- **Not measured**: unpinned + pipelined — pinning ships unconditionally in the CI scripts; the
+  combination is measurable by setting `SYNTH_CPU_PARTITION=0` on a run if it's ever needed.
+- **Known costs**, both by design and both outside the gate: `total_ms` inflates under pipelining
+  (a reply queues behind up to `K−1` others — informational only), and a handful of compile-heavy
+  *uncached* C=8 cells complete at lower achieved throughput while their server p50 stays flat
+  (32 resident uncached queries convoy on a serialized server-side compile stage). Both A/A legs
+  measure identically, so comparability is unaffected.
+
+## Code map
+
+| Concern | Where |
+|---|---|
+| Closed-loop engine (barrier, JoinSet, fail-fast, window math) | [`src/synthetic/engine.rs`](../src/synthetic/engine.rs) — [`run_closed_loop`](../src/synthetic/engine.rs#L96) |
+| Single-flight connection (depth 1) | [`open_graph`](../src/synthetic/mod.rs#L573) — `Pooled { size: 1 }` |
+| Pipelined connection (depth K) | [`open_graph_pipelined`](../src/synthetic/mod.rs#L600) — `Multiplexed { connections: 1 }`, cloned into lanes |
+| Lane fan-out per level | [`measure_level`](../src/synthetic/mod.rs#L1268) (`if depth > 1` at [L1318](../src/synthetic/mod.rs#L1318)) |
+| Reads-only gating, lane math | [`effective_pipeline_depth`](../src/synthetic/mod.rs#L627), [`lane_samples`](../src/synthetic/mod.rs#L641), [`lane_corpus_offset`](../src/synthetic/mod.rs#L651) |
+| Write choreography (verify, reset, cleanup) | [`GraphWorker::invoke`](../src/synthetic/mod.rs#L1075) write arm |
+| Replay: reference pass, digests, depth plumbing | [`src/synthetic/replay.rs`](../src/synthetic/replay.rs) ([`pipeline_depth`](../src/synthetic/replay.rs#L92-L93)) |
+| Runtime build (`--client-threads`) | [`build_runtime`](../src/main.rs#L203-L216) in `src/main.rs` |
+| CLI flags | [`--client-threads`](../src/cli.rs#L157) (global), [`--pipeline-depth`](../src/cli.rs#L517) (`synthetic run`) |
+| Vendored connection strategies | [`vendor/falkordb-rs/src/client/mod.rs`](../vendor/falkordb-rs/src/client/mod.rs#L44-L62) (do not modify) |
+| CPU partition policy (CI) | [`synthetic-cpu-lib.sh`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-cpu-lib.sh) |
+| CPU partition application (CI) | [`synthetic-measure-lib.sh`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-measure-lib.sh) — [`--cpuset-cpus`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-measure-lib.sh#L76), [`taskset`](https://github.com/FalkorDB/falkordb-rs-next-gen/blob/8b01e59441669b61ed6dc3b1ae24bcb8c34f42cf/.github/scripts/benchmark/synthetic-measure-lib.sh#L45-L51) |

--- a/readme.md
+++ b/readme.md
@@ -227,7 +227,10 @@ metric is `server_ms` (as in the recorded-replay regression gate):
   multi-threaded even at `N=1`.
 
 See [`synthetic-benchmark.md`](synthetic-benchmark.md) for the concurrency model, the report schema
-(`operations[].levels[]`), and how to read the curve in depth.
+(`operations[].levels[]`), and how to read the curve in depth, and the [synthetic benchmark
+architecture](docs/synthetic-benchmark-architecture.md) for the full picture in diagrams — CPU
+pinning in CI, the in-flight gating model (closed loop vs pipelined lanes), the write choreography,
+threads-vs-depth, and the measured run-to-run precision.
 
 #### Operation catalog
 
@@ -461,8 +464,9 @@ load-script *and* the measured commands — then **run that identical bundle** a
 the commands each run), `run --recording` loads the recorded graph and measures the recorded commands
 through the closed-loop engine (the full concurrency sweep + cached/uncached modes), so the only
 variable is the FalkorDB version. See the full walkthrough in the
-[synthetic benchmark tutorial](docs/synthetic-benchmark-tutorial.md), and task-oriented recipes in
-the [synthetic benchmark cookbook](docs/synthetic-benchmark-cookbook.md).
+[synthetic benchmark tutorial](docs/synthetic-benchmark-tutorial.md), task-oriented recipes in
+the [synthetic benchmark cookbook](docs/synthetic-benchmark-cookbook.md), and the architecture
+in diagrams in the [synthetic benchmark architecture](docs/synthetic-benchmark-architecture.md).
 
 ```bash
 # 1. record a bundle OFFLINE (no server) into recordings/demo/

--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,30 @@ saturates, after which extra concurrency mostly inflates the tail — the highes
 flagged as the `<- knee`. A single-level sweep (`--concurrency 1`) reproduces the classic
 single-connection latency measurement plus its achieved throughput.
 
+##### Pipelined reads (`--pipeline-depth`) and `--client-threads`
+
+Two opt-in flags decouple **client scheduling jitter** from the server-side numbers when the gated
+metric is `server_ms` (as in the recorded-replay regression gate):
+
+- **`--pipeline-depth K`** (`synthetic run`; TOML `pipeline_depth`; default `1` = exactly the
+  closed loop described above). For **read** ops, each of the `C` connection slots becomes one
+  multiplexed socket carrying `K` closed-loop lanes, keeping `K` commands concurrently in flight
+  per connection. FalkorDB executes a connection's commands **serially** (a blocked connection is
+  never parsed for its next command), so server-side concurrency stays `C` — but the socket's input
+  buffer is never empty, so the server **self-paces**: a lane's next command is already queued when
+  the previous one finishes, and client-side scheduling gaps stop perturbing the arrival pattern.
+  Expect `total_ms` to inflate (a reply waits behind up to `K−1` others — informational only) while
+  `server_ms` tightens. Each lane measures `ceil(samples / K)` invocations, so a level still
+  completes ≥ `C × samples` (exactly `C × samples` when `K` divides `--samples` — pick such a
+  value). Uncached uid-uniqueness and the per-op `result_digest` (captured by the untimed reference
+  pass) are depth-independent, so depth-1 and depth-K runs of the same workload stay comparable
+  under `report --diff`. **Write** ops always run the plain closed loop regardless of `K` (their
+  per-sample verification and untimed window resets don't tolerate pipelining).
+- **`--client-threads N`** (global) caps the tokio worker threads of the whole binary (default:
+  one per core). On a machine that partitions CPUs between server and client, pinning the client
+  to a few dedicated threads removes runtime-scheduler migration noise. The runtime stays
+  multi-threaded even at `N=1`.
+
 See [`synthetic-benchmark.md`](synthetic-benchmark.md) for the concurrency model, the report schema
 (`operations[].levels[]`), and how to read the curve in depth.
 
@@ -533,7 +557,8 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   fails too). Capture is a record-time-only cost (the two
   full passes over the 1 000-node/5 000-edge repo-writes bundle take ~18 min); plain (oracle-free)
   v1/v2 bundles stay byte-identical.
-- **`benchmark synthetic run --recording <dir> [--concurrency … --cache …]`** drops + loads +
+- **`benchmark synthetic run --recording <dir> [--concurrency … --cache … --pipeline-depth …]`**
+  drops + loads +
   **count-verifies** the recorded graph, then measures the recorded commands across the concurrency
   sweep + cache modes, writing a report plus a per-op **`result_digest`** (a hash of the result
   values). It also **verifies results are identical at the highest concurrency** (an untimed

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,12 @@ impl clap::builder::TypedValueParser for OpSelectorValueParser {
 #[derive(Parser, Debug)]
 #[command(name = "benchmark", version, about="falkor benchmark tool", long_about = None, arg_required_else_help(true), propagate_version(true))]
 pub struct Cli {
+    #[arg(
+        long = "client-threads",
+        global = true,
+        help = "cap the tokio runtime at N worker threads (default: one per CPU core). Always a multi-threaded runtime, even for 1 — the FalkorDB client requires it."
+    )]
+    pub client_threads: Option<std::num::NonZeroUsize>,
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -504,6 +510,11 @@ pub enum SyntheticCommands {
             help = "with --recording: refuse to measure a write bundle that carries no outcome oracle (recording format < v3). Guards against re-hashed oracle-to-v2 downgrades; errors on read bundles (reads have no oracle)."
         )]
         require_oracle: bool,
+        #[arg(
+            long = "pipeline-depth",
+            help = "READ-op pipelining depth K (default 1 = today's closed loop): each of the C connections carries K concurrently in-flight commands over one multiplexed socket, so the server always has the next command queued (self-pacing; decouples client scheduling jitter from server_ms). FalkorDB executes a connection's commands serially, so server concurrency stays C. Write ops always run at depth 1. Each connection's K lanes measure ceil(samples/K) invocations each (pick --samples divisible by K for identical totals)."
+        )]
+        pipeline_depth: Option<std::num::NonZeroUsize>,
     },
     #[command(about = "list the available operations")]
     ListOps,
@@ -818,6 +829,58 @@ mod tests {
             "create_node",
             "--out-dir",
             "/tmp/does-not-matter",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn cli_client_threads_is_global_and_rejects_zero() {
+        use clap::Parser;
+        // Before the subcommand.
+        let cli =
+            Cli::try_parse_from(["benchmark", "--client-threads", "3", "synthetic", "list-ops"]).unwrap();
+        assert_eq!(cli.client_threads.map(std::num::NonZeroUsize::get), Some(3));
+        // Global flags also parse after the subcommand.
+        let cli =
+            Cli::try_parse_from(["benchmark", "synthetic", "list-ops", "--client-threads", "1"]).unwrap();
+        assert_eq!(cli.client_threads.map(std::num::NonZeroUsize::get), Some(1));
+        // Absent → None (tokio default).
+        let cli = Cli::try_parse_from(["benchmark", "synthetic", "list-ops"]).unwrap();
+        assert_eq!(cli.client_threads, None);
+        // Zero worker threads is impossible; clap's NonZeroUsize parser rejects it.
+        assert!(
+            Cli::try_parse_from(["benchmark", "--client-threads", "0", "synthetic", "list-ops"]).is_err()
+        );
+    }
+
+    #[test]
+    fn cli_pipeline_depth_parses_on_run_and_rejects_zero() {
+        use clap::Parser;
+        let depth_of = |cli: Cli| match cli.command {
+            Commands::Synthetic { command: SyntheticCommands::Run { pipeline_depth, .. } } => {
+                pipeline_depth.map(std::num::NonZeroUsize::get)
+            }
+            _ => panic!("expected synthetic run"),
+        };
+        let cli =
+            Cli::try_parse_from(["benchmark", "synthetic", "run", "--pipeline-depth", "4"]).unwrap();
+        assert_eq!(depth_of(cli), Some(4));
+        // Absent → None (config-file value or the depth-1 default applies downstream).
+        let cli = Cli::try_parse_from(["benchmark", "synthetic", "run"]).unwrap();
+        assert_eq!(depth_of(cli), None);
+        // Depth 0 is meaningless (no lanes at all) and rejected at parse time.
+        assert!(
+            Cli::try_parse_from(["benchmark", "synthetic", "run", "--pipeline-depth", "0"]).is_err()
+        );
+        // `record` has no --pipeline-depth: recording is untimed single-flight by design.
+        assert!(Cli::try_parse_from([
+            "benchmark",
+            "synthetic",
+            "record",
+            "--out-dir",
+            "x",
+            "--pipeline-depth",
+            "4",
         ])
         .is_err());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,10 +199,30 @@ fn worker_progress_batch_size(total_queries: usize) -> u32 {
     }
 }
 
-#[tokio::main]
-async fn main() -> BenchmarkResult<()> {
-    let mut cmd = Cli::command();
+/// Build the tokio runtime the whole binary runs on: multi-thread flavor, optionally capping the
+/// worker threads via `--client-threads N` (default: tokio's default, one per core). Always
+/// `new_multi_thread`, even for N=1 — the FalkorDB client rejects a current-thread runtime
+/// (`RuntimeFlavor::CurrentThread`) and uses `task::block_in_place`.
+fn build_runtime(client_threads: Option<std::num::NonZeroUsize>) -> BenchmarkResult<tokio::runtime::Runtime> {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    if let Some(threads) = client_threads {
+        builder.worker_threads(threads.get());
+    }
+    builder
+        .enable_all()
+        .build()
+        .map_err(|e| OtherError(format!("failed to build the tokio runtime: {e}")))
+}
+
+/// Entry point: parse the CLI synchronously, then run the async body on the manually built
+/// runtime so `--client-threads` is honored from the very first task.
+fn main() -> BenchmarkResult<()> {
     let cli = Cli::parse();
+    build_runtime(cli.client_threads)?.block_on(async_main(cli))
+}
+
+async fn async_main(cli: Cli) -> BenchmarkResult<()> {
+    let mut cmd = Cli::command();
 
     let filter = EnvFilter::from_default_env().add_directive(LevelFilter::INFO.into());
     let subscriber = fmt()
@@ -2311,4 +2331,26 @@ async fn init_memgraph(
 
     info!("---> Done");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_runtime;
+    use std::num::NonZeroUsize;
+
+    #[test]
+    fn build_runtime_caps_worker_threads_and_stays_multi_thread() {
+        // `--client-threads N` caps the pool exactly; the flavor stays multi_thread even for N=1
+        // (the FalkorDB client rejects a current-thread runtime and uses `block_in_place`).
+        for n in [1usize, 3] {
+            let rt = build_runtime(NonZeroUsize::new(n)).expect("runtime builds");
+            assert_eq!(rt.metrics().num_workers(), n);
+            // block_in_place is only legal on a multi-thread runtime — proves the flavor.
+            rt.block_on(async { tokio::task::block_in_place(|| ()) });
+        }
+        // Absent → tokio's default (one worker per core), and the runtime still runs futures.
+        let rt = build_runtime(None).expect("runtime builds");
+        assert!(rt.metrics().num_workers() >= 1);
+        assert_eq!(rt.block_on(async { 21 * 2 }), 42);
+    }
 }

--- a/src/synthetic/config.rs
+++ b/src/synthetic/config.rs
@@ -31,6 +31,8 @@ pub struct FileConfig {
     pub reset_every: Option<usize>,
     pub seed: Option<u64>,
     pub cache: Option<CacheSelection>,
+    /// READ-op pipelining depth `K` (default 1 = the plain closed loop; see `Config::pipeline_depth`).
+    pub pipeline_depth: Option<usize>,
     pub server_timeout_ms: Option<i64>,
     pub client_deadline_ms: Option<u64>,
     pub out: Option<String>,
@@ -97,6 +99,8 @@ pub struct CliOverrides {
     pub generate: bool,
     pub nodes: Option<usize>,
     pub edges: Option<usize>,
+    /// `--pipeline-depth` READ-op pipelining depth (`None` = not passed; must be ≥ 1).
+    pub pipeline_depth: Option<usize>,
 }
 
 /// Merge CLI overrides over an optional file config to produce the final [`Config`].
@@ -165,9 +169,22 @@ pub fn resolve(
         server_timeout_ms: default_server_timeout_ms,
         client_deadline_ms: default_client_deadline_ms,
         cache: default_cache,
+        pipeline_depth: default_pipeline_depth,
         out: default_out,
         ..
     } = defaults;
+
+    // The pipelining depth must be ≥ 1 wherever it came from (clap already enforces the CLI flag;
+    // the TOML file is validated here).
+    let pipeline_depth = cli
+        .pipeline_depth
+        .or(file.pipeline_depth)
+        .unwrap_or(default_pipeline_depth);
+    if pipeline_depth == 0 {
+        return Err(OtherError(
+            "pipeline_depth must be >= 1 (1 = no pipelining)".to_string(),
+        ));
+    }
 
     Ok(Config {
         endpoint: cli.endpoint.or(file.endpoint).unwrap_or(default_endpoint),
@@ -193,6 +210,7 @@ pub fn resolve(
             .or(file.client_deadline_ms)
             .unwrap_or(default_client_deadline_ms),
         cache: cli.cache.or(file.cache).unwrap_or(default_cache),
+        pipeline_depth,
         out: cli.out.or(file.out).unwrap_or(default_out),
         server_image: cli.server_image,
         label: cli.label,
@@ -310,6 +328,58 @@ mod tests {
         let cfg =
             FileConfig::from_toml("operations = [\"create_node\"]\nreset_every = 12345\n").unwrap();
         assert_eq!(cfg.reset_every, Some(12345));
+    }
+
+    #[test]
+    fn pipeline_depth_precedence_cli_over_file_over_default() {
+        // CLI wins over the file.
+        let file = FileConfig {
+            operations: Some(vec![OpName::MatchByIndex]),
+            pipeline_depth: Some(2),
+            ..Default::default()
+        };
+        let cli = CliOverrides {
+            pipeline_depth: Some(4),
+            ..Default::default()
+        };
+        assert_eq!(resolve(cli, Some(file.clone())).unwrap().pipeline_depth, 4);
+
+        // No CLI ⇒ the file's value.
+        assert_eq!(
+            resolve(CliOverrides::default(), Some(file))
+                .unwrap()
+                .pipeline_depth,
+            2
+        );
+
+        // Neither CLI nor file ⇒ depth 1, the plain closed loop (today's behaviour).
+        let bare = FileConfig {
+            operations: Some(vec![OpName::MatchByIndex]),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve(CliOverrides::default(), Some(bare))
+                .unwrap()
+                .pipeline_depth,
+            1
+        );
+        assert_eq!(Config::default().pipeline_depth, 1);
+    }
+
+    #[test]
+    fn pipeline_depth_parses_from_toml_and_rejects_zero() {
+        let cfg = FileConfig::from_toml("operations = [\"match_by_index\"]\npipeline_depth = 4\n")
+            .unwrap();
+        assert_eq!(cfg.pipeline_depth, Some(4));
+
+        // A zero depth in the file is rejected by resolve() (clap already rejects it on the CLI).
+        let zero = FileConfig {
+            operations: Some(vec![OpName::MatchByIndex]),
+            pipeline_depth: Some(0),
+            ..Default::default()
+        };
+        let err = resolve(CliOverrides::default(), Some(zero)).unwrap_err();
+        assert!(err.to_string().contains("pipeline_depth must be >= 1"));
     }
 
     #[test]

--- a/src/synthetic/engine.rs
+++ b/src/synthetic/engine.rs
@@ -3,7 +3,10 @@
 //! A *level* runs `C` worker tasks against a connection pool of size `C` (one connection per
 //! worker). Each worker fires an operation, awaits it to completion (row draining included), then
 //! fires the next from its pre-generated sequence — a **closed loop**: each worker keeps at most one
-//! outstanding request, so at most `C` are in flight. Because a new request is issued
+//! outstanding request, so at most `C` are in flight. (Under `--pipeline-depth K > 1`, read levels
+//! feed the same loop `C × K` lane workers that share `C` multiplexed sockets — see
+//! `synthetic::measure_level`; the engine itself is agnostic to how workers map to connections.)
+//! Because a new request is issued
 //! only after the previous one *completes*, the throughput it reports is **achieved** (what the
 //! server actually served), not **offered** (a target arrival rate), and it can't push past the
 //! server's own service rate. The measured latencies therefore describe behaviour *at that achieved

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -782,6 +782,13 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
     let uid_alloc = AtomicU64::new(0);
 
     let mut operations = BTreeMap::new();
+    // Write ops always measure at depth 1, so a run with no reads reports the plain pooled
+    // connection whatever depth was configured (computed before `ops` is consumed below).
+    let effective_meta_depth = if ops.iter().any(|op| op.kind() == QueryType::Read) {
+        config.pipeline_depth
+    } else {
+        1
+    };
     // Capture each op's corpus fingerprint (in execution order) so the corpus_hash reflects the
     // exact rendered workload — parameter values included — not just the op names.
     let mut op_fingerprints: Vec<(OpName, String)> = Vec::with_capacity(ops.len());
@@ -855,7 +862,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             corpus_size: CORPUS_SIZE,
             server_timeout_ms: config.server_timeout_ms,
             client_deadline_ms: config.client_deadline_ms,
-            connection: connection_description(config.pipeline_depth),
+            connection: connection_description(effective_meta_depth),
             started_at_epoch_secs,
             server,
             host: host::collect(),

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -566,6 +566,19 @@ pub(crate) fn redact_endpoint(endpoint: &str) -> String {
     }
 }
 
+/// Parse `endpoint` into a [`falkordb::FalkorConnectionInfo`] without ever echoing credentials:
+/// the error carries only the [redacted](redact_endpoint) endpoint. The underlying parse detail is
+/// deliberately dropped — the vendored client wraps the URL parser's own text
+/// (`FalkorDBError::InvalidConnectionInfo(String)`), which can quote the raw connection string.
+fn parse_endpoint(endpoint: &str) -> BenchmarkResult<falkordb::FalkorConnectionInfo> {
+    endpoint.try_into().map_err(|_| {
+        OtherError(format!(
+            "invalid endpoint '{}': connection string failed to parse",
+            redact_endpoint(endpoint)
+        ))
+    })
+}
+
 /// Open a single-connection [`falkordb::AsyncGraph`] handle for `endpoint` on graph `graph_name`.
 ///
 /// Uses a one-socket pool so latency is honest single-flight (the client otherwise defaults to 8
@@ -574,16 +587,8 @@ pub async fn open_graph(
     endpoint: &str,
     graph_name: &str,
 ) -> BenchmarkResult<falkordb::AsyncGraph> {
-    let connection_info = endpoint.try_into().map_err(|e| {
-        OtherError(format!(
-            "invalid endpoint '{}': {:?}",
-            redact_endpoint(endpoint),
-            e
-        ))
-    })?;
-
     let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
+        .with_connection_info(parse_endpoint(endpoint)?)
         .with_connection_strategy(ConnectionStrategy::Pooled {
             size: nonzero::nonzero!(1u8),
         })
@@ -601,16 +606,8 @@ async fn open_graph_pipelined(
     endpoint: &str,
     graph_name: &str,
 ) -> BenchmarkResult<falkordb::AsyncGraph> {
-    let connection_info = endpoint.try_into().map_err(|e| {
-        OtherError(format!(
-            "invalid endpoint '{}': {:?}",
-            redact_endpoint(endpoint),
-            e
-        ))
-    })?;
-
     let client = FalkorClientBuilder::new_async()
-        .with_connection_info(connection_info)
+        .with_connection_info(parse_endpoint(endpoint)?)
         .with_connection_strategy(ConnectionStrategy::Multiplexed {
             connections: nonzero::nonzero!(1u8),
         })
@@ -2594,6 +2591,19 @@ mod tests {
             Err(e) => e,
         };
         assert!(err.to_string().contains("invalid endpoint"));
+    }
+
+    #[test]
+    fn parse_endpoint_error_never_echoes_credentials() {
+        // The underlying parser's message can quote the raw connection string, so the mapped
+        // error must carry only the redacted endpoint — never the password.
+        let err = match parse_endpoint("falkor://user:hunter2@host:notaport") {
+            Ok(_) => panic!("malformed endpoint must fail"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("invalid endpoint"));
+        assert!(!msg.contains("hunter2"), "credential leaked: {msg}");
     }
 
     #[tokio::test]

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -440,6 +440,15 @@ pub struct Config {
     pub server_timeout_ms: i64,
     pub client_deadline_ms: u64,
     pub cache: CacheSelection,
+    /// READ-op pipelining depth `K` (default 1 = the plain closed loop). At `K > 1` each of a
+    /// level's `C` connections becomes one **multiplexed** socket carrying `K` closed-loop lanes,
+    /// keeping `K` commands in flight per connection so the server always has the next command
+    /// queued (self-pacing — client scheduling jitter can't perturb the arrival pattern). FalkorDB
+    /// executes a connection's commands serially, so server-side concurrency stays `C`; only
+    /// client-observed `total_ms` inflates (a command waits behind its lane-mates). Write ops
+    /// always measure at depth 1 (their per-sample verification and untimed resets are
+    /// closed-loop by design).
+    pub pipeline_depth: usize,
     pub out: String,
     pub server_image: Option<String>,
     /// Optional display name for this run (e.g. `pr`/`main`), recorded into the report.
@@ -463,6 +472,7 @@ impl Default for Config {
             server_timeout_ms: 5_000,
             client_deadline_ms: 6_000,
             cache: CacheSelection::Both,
+            pipeline_depth: 1,
             out: "synthetic-report.json".to_string(),
             server_image: None,
             label: None,
@@ -580,6 +590,86 @@ pub async fn open_graph(
         .build()
         .await?;
     Ok(client.select_graph(graph_name))
+}
+
+/// Open a **pipelining** [`falkordb::AsyncGraph`] handle: ONE multiplexed socket whose cheap
+/// clones share it, so `K` closed-loop lanes cloned from this handle keep `K` commands
+/// concurrently in flight on a single connection (the transport pipelines them; responses return
+/// in order). Backs `--pipeline-depth K > 1`; the default measurement path stays [`open_graph`]'s
+/// honest single-flight `Pooled { size: 1 }`.
+async fn open_graph_pipelined(
+    endpoint: &str,
+    graph_name: &str,
+) -> BenchmarkResult<falkordb::AsyncGraph> {
+    let connection_info = endpoint.try_into().map_err(|e| {
+        OtherError(format!(
+            "invalid endpoint '{}': {:?}",
+            redact_endpoint(endpoint),
+            e
+        ))
+    })?;
+
+    let client = FalkorClientBuilder::new_async()
+        .with_connection_info(connection_info)
+        .with_connection_strategy(ConnectionStrategy::Multiplexed {
+            connections: nonzero::nonzero!(1u8),
+        })
+        .build()
+        .await?;
+    Ok(client.select_graph(graph_name))
+}
+
+/// The effective pipelining depth for one measured op: reads honor the configured
+/// `--pipeline-depth` (min 1); writes always run the plain closed loop (depth 1) — their
+/// per-sample mutation verification and untimed window-boundary resets don't tolerate a second
+/// in-flight command on the connection. Recorded writes measure with `write: None` but
+/// `kind: Write`, so the gate is on the query kind, not the write plan.
+fn effective_pipeline_depth(
+    kind: QueryType,
+    configured: usize,
+) -> usize {
+    match kind {
+        QueryType::Read => configured.max(1),
+        QueryType::Write => 1,
+    }
+}
+
+/// Measured invocations per closed-loop lane at pipelining depth `depth`: each of a connection's
+/// `depth` lanes runs `ceil(samples / depth)` invocations, so a level completes **at least**
+/// `C × samples` invocations (exactly `C × samples` when `samples` divides evenly — pick such a
+/// `--samples` to keep totals identical across depths).
+fn lane_samples(
+    samples: usize,
+    depth: usize,
+) -> usize {
+    samples.div_ceil(depth.max(1))
+}
+
+/// The decorrelating corpus offset for one closed-loop lane: lanes globally index `w × depth + l`
+/// (worker slot `w`, lane `l`), so every lane starts its corpus cycle at a distinct offset —
+/// exactly today's `w % corpus.len()` when `depth == 1`.
+fn lane_corpus_offset(
+    worker: usize,
+    depth: usize,
+    lane: usize,
+    corpus_len: usize,
+) -> usize {
+    (worker * depth + lane) % corpus_len.max(1)
+}
+
+/// The report's human-readable connection description: the honest single-flight default, or the
+/// multiplexed lane fan-out under `--pipeline-depth K > 1` (informational — never guarded by the
+/// diff/regression comparability checks, so a depth-1 and a depth-K run of the same workload stay
+/// comparable on server_ms).
+pub(crate) fn connection_description(pipeline_depth: usize) -> String {
+    if pipeline_depth > 1 {
+        format!(
+            "multiplexed(1) per worker × {} pipelined read lanes",
+            pipeline_depth
+        )
+    } else {
+        "pool(size=1) per worker".to_string()
+    }
 }
 
 /// Run the probe: connect (single connection), collect server provenance, sample the graph to seed
@@ -765,7 +855,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
             corpus_size: CORPUS_SIZE,
             server_timeout_ms: config.server_timeout_ms,
             client_deadline_ms: config.client_deadline_ms,
-            connection: "pool(size=1) per worker".to_string(),
+            connection: connection_description(config.pipeline_depth),
             started_at_epoch_secs,
             server,
             host: host::collect(),
@@ -1156,6 +1246,12 @@ async fn run_scratch_cleanup(
 /// open `C` single-socket connections (one per worker), drive them to completion, and summarize the
 /// pooled samples plus the achieved throughput.
 ///
+/// At `pipeline_depth K > 1` (reads only — see [`effective_pipeline_depth`]) each of the `C`
+/// connection slots becomes one **multiplexed** socket fanned into `K` closed-loop lanes: the
+/// engine drives `C × K` lanes, each measuring [`lane_samples`] invocations, so at most `K`
+/// commands are in flight per connection while server-side concurrency stays `C` (FalkorDB
+/// executes a connection's commands serially). The reported level keeps `concurrency = C`.
+///
 /// For write ops each worker gets an isolated [`WriteScratch`] and its untimed setup runs before the
 /// window. The run's scratch is dropped afterward on a fresh connection whether or not the level
 /// errored, so a failed write level never leaks scratch into the next one. A cleanup failure on the
@@ -1181,9 +1277,15 @@ async fn measure_level(
         config.warmup
     };
 
-    // Each worker claims a disjoint id block wide enough for its warm-up + measured invocations, so
-    // no two workers (here or at any other level) ever render the same uncached query text.
-    let block = (effective_warmup + config.samples) as u64;
+    // Reads honor `--pipeline-depth`; writes always run the plain closed loop. At depth 1 every
+    // value below (lane count, per-lane samples, uid blocks, corpus offsets) is byte-identical to
+    // the pre-pipelining behaviour.
+    let depth = effective_pipeline_depth(target.kind, config.pipeline_depth);
+    let samples_per_lane = lane_samples(config.samples, depth);
+
+    // Each lane claims a disjoint id block wide enough for its warm-up + measured invocations, so
+    // no two lanes (here or at any other level) ever render the same uncached query text.
+    let block = (effective_warmup + samples_per_lane) as u64;
 
     // The untimed write hooks (setup/reset/cleanup) can touch a whole window of nodes, so give them
     // a generous deadline independent of the tight per-op measurement deadline.
@@ -1204,8 +1306,33 @@ async fn measure_level(
     // into a Result so a partway failure routes through the scratch cleanup below instead of leaking
     // the nodes earlier workers already created.
     let build_workers = async {
-        let mut workers = Vec::with_capacity(concurrency);
+        let mut workers = Vec::with_capacity(concurrency * depth);
         for w in 0..concurrency {
+            if depth > 1 {
+                // Pipelined reads: ONE multiplexed socket for this connection slot; its K cloned
+                // lanes pipeline their in-flight commands over it. Each lane claims its own
+                // disjoint uid block and a distinct decorrelating corpus offset.
+                let graph = open_graph_pipelined(&config.endpoint, &config.graph).await?;
+                for lane in 0..depth {
+                    let uid_base = uid_alloc.fetch_add(block, Ordering::Relaxed);
+                    workers.push(GraphWorker {
+                        graph: graph.clone(),
+                        kind: target.kind,
+                        mode,
+                        run_token,
+                        uid_base,
+                        server_timeout_ms: config.server_timeout_ms,
+                        client_deadline,
+                        hook_server_timeout_ms,
+                        hook_deadline,
+                        source: WorkerSource::Read {
+                            corpus: Arc::clone(corpus),
+                            corpus_offset: lane_corpus_offset(w, depth, lane, corpus.len()),
+                        },
+                    });
+                }
+                continue;
+            }
             let mut graph = open_graph(&config.endpoint, &config.graph).await?;
             let uid_base = uid_alloc.fetch_add(block, Ordering::Relaxed);
             let source = match &target.write {
@@ -1250,7 +1377,7 @@ async fn measure_level(
     // so the single cleanup path below runs for both outcomes (a partially set-up populated band
     // must never leak). The build/setup error is what we ultimately propagate.
     let run = match build_workers {
-        Ok(workers) => run_closed_loop(workers, effective_warmup, config.samples).await,
+        Ok(workers) => run_closed_loop(workers, effective_warmup, samples_per_lane).await,
         Err(e) => Err(e),
     };
 
@@ -1403,6 +1530,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
             recording,
             no_load,
             require_oracle,
+            pipeline_depth,
         } => {
             // Expand `--op all` / `--op '*'` to the concrete read ops before anything else.
             let ops = crate::cli::expand_op_selectors(&ops);
@@ -1436,6 +1564,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                     server_image,
                     label,
                     require_oracle,
+                    pipeline_depth: pipeline_depth.map_or(1, std::num::NonZeroUsize::get),
                 };
                 return replay::run_and_report(&replay_config).await;
             }
@@ -1468,6 +1597,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 generate,
                 nodes,
                 edges,
+                pipeline_depth: pipeline_depth.map(std::num::NonZeroUsize::get),
             };
             let file = config::FileConfig::load(config_path.as_deref())?;
             let config = config::resolve(overrides, file)?;
@@ -1529,6 +1659,7 @@ pub async fn run_command(command: crate::cli::SyntheticCommands) -> BenchmarkRes
                 generate: true,
                 nodes,
                 edges,
+                pipeline_depth: None,
             };
             let file = config::FileConfig::load(config_path.as_deref())?;
             let resolved = config::resolve(overrides, file)?;
@@ -1825,6 +1956,93 @@ async fn report_command(
 mod tests {
     use super::*;
     use crate::query::QueryBuilder;
+
+    #[test]
+    fn effective_pipeline_depth_pipelines_reads_only() {
+        // Reads honor the configured depth (with a ≥1 floor)…
+        assert_eq!(effective_pipeline_depth(QueryType::Read, 1), 1);
+        assert_eq!(effective_pipeline_depth(QueryType::Read, 4), 4);
+        assert_eq!(effective_pipeline_depth(QueryType::Read, 0), 1);
+        // …while writes always run the plain closed loop, whatever was configured (their
+        // per-sample verification + untimed resets don't tolerate pipelining).
+        assert_eq!(effective_pipeline_depth(QueryType::Write, 1), 1);
+        assert_eq!(effective_pipeline_depth(QueryType::Write, 4), 1);
+    }
+
+    #[test]
+    fn lane_samples_splits_evenly_and_rounds_up() {
+        // depth 1 = today's behaviour, verbatim.
+        assert_eq!(lane_samples(1000, 1), 1000);
+        // An even split keeps the level total exactly C × samples.
+        assert_eq!(lane_samples(1000, 4), 250);
+        // An uneven split rounds UP so a level never measures fewer than C × samples.
+        assert_eq!(lane_samples(1001, 4), 251);
+        assert_eq!(lane_samples(1, 8), 1);
+        // A zero depth is floored to 1 (defensive; effective_pipeline_depth already floors).
+        assert_eq!(lane_samples(10, 0), 10);
+    }
+
+    #[test]
+    fn lane_corpus_offset_is_todays_offset_at_depth_1_and_distinct_across_lanes() {
+        let corpus_len = 256;
+        // depth 1 reproduces the historical `w % corpus.len()` exactly.
+        for w in 0..40 {
+            assert_eq!(lane_corpus_offset(w, 1, 0, corpus_len), w % corpus_len);
+        }
+        // Lanes index globally (w × depth + lane): all C × K offsets are distinct while
+        // C × K ≤ corpus_len, so every lane starts its cycle somewhere different.
+        let depth = 4;
+        let concurrency = 8;
+        let mut seen = std::collections::HashSet::new();
+        for w in 0..concurrency {
+            for lane in 0..depth {
+                assert!(
+                    seen.insert(lane_corpus_offset(w, depth, lane, corpus_len)),
+                    "offset collision at worker {w} lane {lane}"
+                );
+            }
+        }
+        // Wraps modulo the corpus length…
+        assert_eq!(lane_corpus_offset(100, 4, 3, corpus_len), (100 * 4 + 3) % corpus_len);
+        // …and an empty corpus can't divide by zero (defensive floor).
+        assert_eq!(lane_corpus_offset(3, 4, 2, 0), 0);
+    }
+
+    #[test]
+    fn connection_description_reflects_pipeline_depth() {
+        // Depth 1 keeps the historical string byte-identical (report metadata compatibility).
+        assert_eq!(connection_description(1), "pool(size=1) per worker");
+        assert_eq!(connection_description(0), "pool(size=1) per worker");
+        assert_eq!(
+            connection_description(4),
+            "multiplexed(1) per worker × 4 pipelined read lanes"
+        );
+    }
+
+    /// Simulate `measure_level`'s uid-block claiming across lanes: every lane claims a disjoint
+    /// block sized for its warm-up + measured invocations, so no two lanes can ever render the
+    /// same uncached uid — the exact invariant uncached mode's plan-cache-miss guarantee needs.
+    #[test]
+    fn lane_uid_blocks_are_disjoint_across_a_pipelined_level() {
+        let warmup = 3usize;
+        let samples = 10usize;
+        let depth = 4usize;
+        let concurrency = 8usize;
+        let per_lane = lane_samples(samples, depth);
+        let block = (warmup + per_lane) as u64;
+        let uid_alloc = AtomicU64::new(0);
+        let mut all_uids = std::collections::HashSet::new();
+        for _lane in 0..concurrency * depth {
+            let uid_base = uid_alloc.fetch_add(block, Ordering::Relaxed);
+            for seq in 0..(warmup + per_lane) as u64 {
+                assert!(
+                    all_uids.insert(uid_base + seq),
+                    "uid collision at base {uid_base} seq {seq}"
+                );
+            }
+        }
+        assert_eq!(all_uids.len(), concurrency * depth * (warmup + per_lane));
+    }
 
     #[test]
     fn op_name_maps_are_consistent() {
@@ -2361,6 +2579,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn open_graph_pipelined_rejects_malformed_endpoint() {
+        // Same parse-time guard as `open_graph`, on the multiplexed path — no server needed.
+        // (`AsyncGraph` isn't `Debug`, so unwrap the error arm by hand.)
+        let err = match open_graph_pipelined("falkor://host:notaport", "g").await {
+            Ok(_) => panic!("malformed endpoint must fail"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("invalid endpoint"));
+    }
+
+    #[tokio::test]
     async fn run_command_list_ops_needs_no_server() {
         // The catalog path is pure output.
         assert!(run_command(crate::cli::SyntheticCommands::ListOps)
@@ -2405,6 +2634,7 @@ mod tests {
             recording: None,
             no_load: false,
             require_oracle: false,
+            pipeline_depth: None,
         };
         assert!(run_command(command).await.is_err());
         let _ = std::fs::remove_file(&cfg_path);
@@ -2588,6 +2818,7 @@ mod tests {
             server_image: None,
             label: None,
             require_oracle: false,
+            pipeline_depth: 1,
         };
         let err = crate::synthetic::replay::run(&replay_cfg).await.unwrap_err();
         assert!(
@@ -2901,6 +3132,7 @@ mod tests {
             recording: None,
             no_load: false,
             require_oracle: false,
+            pipeline_depth: None,
         };
         let err = run_command(command).await.expect_err("no ops ⇒ error");
         assert!(
@@ -2937,6 +3169,7 @@ mod tests {
             recording: Some("/nonexistent/rec".to_string()),
             no_load: false,
             require_oracle: false,
+            pipeline_depth: None,
         };
         let err = run_command(command).await.expect_err("recording + generate ⇒ error");
         assert!(format!("{err}").contains("--recording"), "got: {err}");
@@ -2970,6 +3203,7 @@ mod tests {
             recording: None,
             no_load: false,
             require_oracle: true,
+            pipeline_depth: None,
         };
         let err = run_command(command).await.expect_err("--require-oracle without --recording");
         assert!(

--- a/src/synthetic/oracle.rs
+++ b/src/synthetic/oracle.rs
@@ -123,6 +123,7 @@ pub async fn capture(
         server_image: None,
         label: None,
         require_oracle: false,
+        pipeline_depth: 1,
     };
     let graph_name = bundle.manifest.graph.clone();
     let dataset_spec = bundle.spec();

--- a/src/synthetic/recording.rs
+++ b/src/synthetic/recording.rs
@@ -2952,6 +2952,7 @@ mod tests {
             server_image: None,
             label: None,
             require_oracle: true,
+            pipeline_depth: 1,
         };
         let err = replay::run(&config).await.unwrap_err();
         let msg = format!("{err}");

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -88,6 +88,9 @@ pub struct ReplayConfig {
     /// format < v3). A re-hashed oracle→v2 strip is a perfectly legitimate-looking v2 bundle, so
     /// only the operator's *expectation* can catch the downgrade — this flag states it (§6.3).
     pub require_oracle: bool,
+    /// READ-op pipelining depth `K` (default 1 = the plain closed loop; see
+    /// [`Config::pipeline_depth`]). Recorded write bundles always measure at depth 1.
+    pub pipeline_depth: usize,
 }
 
 /// Replay `config`'s bundle: load the recorded graph, then measure the recorded commands through the
@@ -228,6 +231,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
         server_timeout_ms: config.server_timeout_ms,
         client_deadline_ms: config.client_deadline_ms,
         cache: config.cache,
+        pipeline_depth: config.pipeline_depth,
         out: config.out.clone(),
         server_image: config.server_image.clone(),
         label: config.label.clone(),
@@ -575,7 +579,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             corpus_size,
             server_timeout_ms: config.server_timeout_ms,
             client_deadline_ms: config.client_deadline_ms,
-            connection: "pool(size=1) per worker".to_string(),
+            connection: crate::synthetic::connection_description(config.pipeline_depth),
             started_at_epoch_secs,
             server,
             host: crate::synthetic::host::collect(),
@@ -1033,6 +1037,7 @@ mod tests {
             server_image: None,
             label: None,
             require_oracle: false,
+            pipeline_depth: 1,
         }
     }
 

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -579,7 +579,13 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             corpus_size,
             server_timeout_ms: config.server_timeout_ms,
             client_deadline_ms: config.client_deadline_ms,
-            connection: crate::synthetic::connection_description(config.pipeline_depth),
+            // A write bundle always measures at depth 1 (single-kind bundle ⇒ no read ever
+            // pipelines), so its report never claims pipelined read lanes.
+            connection: crate::synthetic::connection_description(if has_writes {
+                1
+            } else {
+                config.pipeline_depth
+            }),
             started_at_epoch_secs,
             server,
             host: crate::synthetic::host::collect(),

--- a/synthetic-bench.example.toml
+++ b/synthetic-bench.example.toml
@@ -29,6 +29,13 @@ cache = "both"              # cached | uncached | both
 # latency-vs-throughput curve. Each level opens that many dedicated connections.
 concurrency = [1, 2, 4, 8, 16, 32]
 
+# READ-op pipelining depth K (default 1 = the plain closed loop). K > 1 keeps K commands
+# concurrently in flight on each of the C connections (one multiplexed socket, K lanes), so the
+# server self-paces and client scheduling jitter stops perturbing server_ms. Server concurrency
+# stays C (FalkorDB executes a connection's commands serially); total_ms inflates (informational).
+# Write ops always run at depth 1. Pick `samples` divisible by K for identical totals.
+# pipeline_depth = 1
+
 # Write-op reset cadence: every `reset_every` operations each worker's scratch is reset (untimed)
 # so write drift is bounded to one sawtooth window. Ignored by read ops.
 reset_every = 50000

--- a/synthetic-benchmark.md
+++ b/synthetic-benchmark.md
@@ -46,6 +46,35 @@ which extra concurrency mostly inflates the tail. The highest-throughput level i
 `<- knee` in the console table. A single-level sweep (`--concurrency 1`) reproduces the classic
 single-connection latency measurement plus its achieved throughput.
 
+### Pipelined reads (`--pipeline-depth K`)
+
+By default (depth `1`) the loop above is **honest single-flight**: a worker's next command leaves
+the client only after the previous reply fully arrived, so client-side scheduling gaps (tokio
+wakeup jitter, CPU contention) become gaps in the server's arrival stream. When the metric that
+matters is **`server_ms`** (the regression gate's), `--pipeline-depth K` (K > 1, `synthetic run`;
+TOML `pipeline_depth`) removes those gaps for **read** ops: each of the `C` connection slots
+becomes one **multiplexed** socket carrying `K` cloned closed-loop lanes, keeping `K` commands
+concurrently in flight per connection. FalkorDB executes a connection's commands **serially** (a
+blocked connection is never parsed for its next command), so server-side concurrency stays `C`;
+the connection's input buffer just never runs dry — the server **self-paces**. Consequences:
+
+- `server_ms` stops seeing client arrival jitter; `total_ms` inflates (a reply queues behind up to
+  `K−1` earlier ones) and is informational only.
+- Each lane measures `ceil(samples / K)` invocations: a level completes ≥ `C × samples`, exactly
+  `C × samples` when `K` divides `--samples` (pick such a value for identical totals across
+  depths). Reported concurrency stays `C`; lanes are not extra levels.
+- Every lane claims its own disjoint uncached-uid block and a distinct corpus offset
+  (`w × K + lane`), so uncached mode still misses the plan cache on every invocation.
+- The per-op `result_digest` comes from the untimed single-flight reference pass, so digests are
+  depth-independent — depth-1 and depth-K runs of one workload stay comparable under
+  `report --diff`.
+- **Write** ops always run the plain closed loop regardless of `K`: their per-sample mutation
+  verification and untimed window-boundary resets don't tolerate a second in-flight command.
+
+The related global `--client-threads N` flag caps the binary's tokio worker threads (default: one
+per core; the runtime stays multi-threaded even at `N=1`), useful when the client is pinned to a
+dedicated CPU subset.
+
 ### Cache modes per level
 
 Every level is still measured under **both** plan-cache conditions, with the derived compilation

--- a/synthetic-benchmark.md
+++ b/synthetic-benchmark.md
@@ -73,7 +73,8 @@ the connection's input buffer just never runs dry — the server **self-paces**.
 
 The related global `--client-threads N` flag caps the binary's tokio worker threads (default: one
 per core; the runtime stays multi-threaded even at `N=1`), useful when the client is pinned to a
-dedicated CPU subset.
+dedicated CPU subset. The [architecture document](docs/synthetic-benchmark-architecture.md)
+diagrams the in-flight model, the threads-vs-depth relation, and the measured A/A precision.
 
 ### Cache modes per level
 

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -34,6 +34,7 @@ fn base_config(graph: &str) -> Config {
         server_timeout_ms: 5_000,
         client_deadline_ms: 6_000,
         cache: CacheSelection::Both,
+        pipeline_depth: 1,
         out: "synthetic-report.json".to_string(),
         server_image: None,
         label: None,
@@ -633,6 +634,114 @@ async fn concurrency_sweep_produces_per_level_throughput_and_percentiles() {
 
 #[tokio::test]
 #[ignore = "requires a running FalkorDB server"]
+async fn pipelined_reads_keep_totals_uniqueness_and_positive_throughput() {
+    // `pipeline_depth: 4`: each of the C connection slots carries 4 closed-loop lanes over one
+    // multiplexed socket. The level must still account for exactly C × samples invocations per
+    // cache mode (120 divides by 4), report positive throughput at the swept concurrencies (lanes
+    // are not extra levels), and keep uncached uid-uniqueness — every lane claims a disjoint uid
+    // block, so a collision would surface here as a cached plan hit in uncached mode.
+    let graph = "syn_it_pipelined";
+    seed_user_graph(graph, 200).await;
+
+    let samples = 120; // divisible by depth 4 ⇒ level totals stay exactly C × samples
+    let report = run(&Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::MatchByIndex],
+        samples,
+        warmup: 20,
+        concurrency: vec![1, 2],
+        cache: CacheSelection::Both,
+        pipeline_depth: 4,
+        ..base_config(graph)
+    })
+    .await
+    .expect("pipelined sweep should succeed");
+
+    assert!(
+        report.meta.connection.contains("pipelined read lanes"),
+        "meta.connection must reflect the lane fan-out, got '{}'",
+        report.meta.connection
+    );
+
+    let op = report.operations.get("match_by_index").expect("op present");
+    assert_eq!(
+        op.levels.iter().map(|l| l.concurrency).collect::<Vec<_>>(),
+        vec![1, 2],
+        "reported levels stay the swept concurrencies (lanes are not extra levels)"
+    );
+    for lvl in &op.levels {
+        let c = lvl.concurrency;
+        for (mode, lm) in [("cached", &lvl.cached), ("uncached", &lvl.uncached)] {
+            let lm = lm
+                .as_ref()
+                .unwrap_or_else(|| panic!("C={c} missing {mode} metrics"));
+            assert_eq!(
+                lm.metrics.server_ms.n + lm.metrics.server_ms.removed,
+                c * samples,
+                "C={c} {mode}: the lanes must measure exactly C × samples invocations in total"
+            );
+            assert!(
+                lm.throughput_ops_per_sec > 0.0,
+                "C={c} {mode}: throughput must be positive"
+            );
+        }
+        let uncached = &lvl.uncached.as_ref().unwrap().metrics;
+        assert!(
+            uncached.cached_false_rate > 0.5,
+            "C={c}: uncached mode must still miss the plan cache (uid uniqueness across lanes), got {}",
+            uncached.cached_false_rate
+        );
+    }
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn pipeline_depth_leaves_write_ops_on_the_plain_closed_loop() {
+    // With `pipeline_depth: 4` configured, write ops still run the plain closed loop (depth 1):
+    // a green run is itself the proof — the write path's per-sample `nodes_created == 1`
+    // verification and untimed window resets don't tolerate pipelined lanes — and the level still
+    // accounts for exactly C × samples with the run's scratch fully cleaned up.
+    let graph = "syn_it_pipelined_writes";
+    let seeded_users: i64 = 50;
+    seed_user_graph(graph, seeded_users).await;
+
+    let samples = 60;
+    let report = run(&Config {
+        graph: graph.to_string(),
+        ops: vec![OpName::CreateNode],
+        samples,
+        warmup: 10,
+        concurrency: vec![2],
+        reset_every: 50,
+        cache: CacheSelection::Cached,
+        pipeline_depth: 4,
+        ..base_config(graph)
+    })
+    .await
+    .expect("write sweep with a configured pipeline depth should still succeed at depth 1");
+
+    let op = report.operations.get("create_node").expect("op present");
+    let lvl = only_level(op);
+    let m = lvl.cached.as_ref().expect("cached metrics present");
+    assert_eq!(
+        m.metrics.server_ms.n + m.metrics.server_ms.removed,
+        lvl.concurrency * samples,
+        "writes ignore the pipeline depth: totals stay exactly C × samples"
+    );
+
+    // No scratch may leak (the seeded :User data is all that remains).
+    let mut g = open_graph(&endpoint(), graph).await.expect("reopen graph");
+    assert_eq!(
+        scalar_i64(&mut g, "MATCH (n) RETURN count(n)").await,
+        seeded_users,
+        "no scratch nodes may remain after the run's post-level cleanup"
+    );
+    drop_graph(graph).await;
+}
+
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
 async fn write_ops_run_isolated_sweep_and_clean_up() {
     // create_node + merge_miss at C=8 over several sawtooth windows. A green run is itself the
     // isolation proof: every sample verifies `nodes_created == 1`, so if two of the 8 workers ever
@@ -1085,6 +1194,7 @@ fn replay_config(dir: &std::path::Path, graph: &str, out: &str, load: bool) -> R
         server_image: None,
         label: None,
         require_oracle: false,
+        pipeline_depth: 1,
     }
 }
 
@@ -1548,6 +1658,7 @@ async fn record_and_replay_via_run_command() {
         recording: Some(out_dir),
         no_load: false,
         require_oracle: false,
+        pipeline_depth: None,
     })
     .await
     .expect("run --recording via run_command");
@@ -1557,6 +1668,111 @@ async fn record_and_replay_via_run_command() {
     assert!(written.contains("result_digest"));
     // The Markdown sibling is written too.
     assert!(std::path::Path::new(&report_out.replace(".json", ".md")).exists());
+
+    std::fs::remove_dir_all(&dir).ok();
+    drop_graph(graph).await;
+}
+
+/// Sanity-mirror: one recorded bundle, replayed at depth 1 and depth 4 with identical samples,
+/// must publish the **same** `workload_hash` and per-op `result_digest`s — the digest comes from
+/// the untimed single-flight reference pass, so pipelining the measured loop must not perturb it.
+/// This is the local `report --diff` comparability bar the pipelined mode has to clear.
+#[tokio::test]
+#[ignore = "requires a running FalkorDB server"]
+async fn replay_digests_are_identical_across_pipeline_depths() {
+    use benchmark::cli::SyntheticCommands;
+    use benchmark::synthetic::run_command;
+
+    let graph = "syn_it_depth_digests";
+    drop_graph(graph).await;
+    let dir = temp_bundle_dir("syn-it-depth");
+    let out_dir = dir.to_string_lossy().into_owned();
+
+    run_command(SyntheticCommands::Record {
+        config: None,
+        graph: Some(graph.to_string()),
+        ops: vec![
+            benchmark::cli::OpSelector::One(OpName::MatchByIndex),
+            benchmark::cli::OpSelector::One(OpName::AggregateCount),
+        ],
+        all_reads: false,
+        tier: None,
+        repo_reads: None,
+        repo_algorithms: false,
+        repo_writes: false,
+        seed: Some(23),
+        nodes: Some(400),
+        edges: Some(1200),
+        oracle: None,
+        out_dir: out_dir.clone(),
+    })
+    .await
+    .expect("record via run_command");
+
+    let replay = |depth: Option<usize>, out: String, load: bool| {
+        let out_dir = out_dir.clone();
+        async move {
+            run_command(SyntheticCommands::Run {
+                config: None,
+                endpoint: Some(endpoint()),
+                graph: None,
+                ops: vec![],
+                all_reads: false,
+                tier: None,
+                samples: Some(120), // divisible by 4 ⇒ identical totals at both depths
+                warmup: Some(10),
+                concurrency: vec![1, 2],
+                reset_every: None,
+                seed: None,
+                cache: Some(benchmark::synthetic::CacheSelection::Both),
+                server_timeout_ms: None,
+                client_deadline_ms: None,
+                out: Some(out),
+                server_image: None,
+                label: None,
+                generate: false,
+                nodes: None,
+                edges: None,
+                recording: Some(out_dir),
+                no_load: !load,
+                require_oracle: false,
+                pipeline_depth: depth.map(|d| std::num::NonZeroUsize::new(d).unwrap()),
+            })
+            .await
+        }
+    };
+
+    let out1 = dir.join("depth1.json").to_string_lossy().into_owned();
+    let out4 = dir.join("depth4.json").to_string_lossy().into_owned();
+    replay(None, out1.clone(), true)
+        .await
+        .expect("depth-1 replay");
+    // Second replay reuses the already-loaded graph (no_load) — same dataset, same digests.
+    replay(Some(4), out4.clone(), false)
+        .await
+        .expect("depth-4 replay");
+
+    let parse = |path: &str| -> serde_json::Value {
+        serde_json::from_str(&std::fs::read_to_string(path).expect("report exists"))
+            .expect("valid report JSON")
+    };
+    let (r1, r4) = (parse(&out1), parse(&out4));
+
+    // Identical workload identity…
+    let hash = |r: &serde_json::Value| r["meta"]["dataset"]["workload_hash"].as_str().unwrap().to_string();
+    assert_eq!(hash(&r1), hash(&r4), "workload_hash must not depend on pipeline depth");
+    // …and identical per-op result digests (both ops must actually carry one).
+    for op in ["match_by_index", "aggregate_count"] {
+        let digest = |r: &serde_json::Value| {
+            r["operations"][op]["result_digest"].as_str().map(str::to_owned)
+        };
+        let (d1, d4) = (digest(&r1), digest(&r4));
+        assert!(d1.is_some(), "{op}: depth-1 replay must publish a result digest");
+        assert_eq!(d1, d4, "{op}: result digest must not depend on pipeline depth");
+    }
+    // The pipelined run's metadata reflects the lane fan-out; the default run's doesn't.
+    assert!(r1["meta"]["connection"].as_str().unwrap().contains("pool(size=1)"));
+    assert!(r4["meta"]["connection"].as_str().unwrap().contains("pipelined read lanes"));
 
     std::fs::remove_dir_all(&dir).ok();
     drop_graph(graph).await;
@@ -2021,6 +2237,7 @@ async fn replay_concurrency_sweep_verifies_results_and_reports_levels() {
         server_image: None,
         label: None,
         require_oracle: false,
+        pipeline_depth: 1,
     };
     // If any op returned different results at C=4 vs the single-flight reference, run() errors here.
     // The two LIMIT ops (expand_hops_5, aggregate_group) are totally ordered, so their value digests

--- a/tests/synthetic_probe.rs
+++ b/tests/synthetic_probe.rs
@@ -721,6 +721,13 @@ async fn pipeline_depth_leaves_write_ops_on_the_plain_closed_loop() {
     .await
     .expect("write sweep with a configured pipeline depth should still succeed at depth 1");
 
+    // A write-only run never pipelines, so its metadata must say so too.
+    assert!(
+        !report.meta.connection.contains("pipelined"),
+        "write-only runs report the plain pooled connection, got '{}'",
+        report.meta.connection
+    );
+
     let op = report.operations.get("create_node").expect("op present");
     let lvl = only_level(op);
     let m = lvl.cached.as_ref().expect("cached metrics present");


### PR DESCRIPTION
## Motivation

The synthetic regression gate compares **server_ms p50** across FalkorDB versions (total_ms is informational). After CPU pinning (falkordb-rs-next-gen#771: server `--cpuset-cpus 0-7`, client `taskset -c 8-15`) took C=8 main-pr A/A noise from p90 |Δ%| ≈ 78.75% down to 4.12%/15.58%, the remaining hypothesis is **client scheduling jitter re-injected into the arrival pattern** by the closed loop: a worker's next command leaves the client only after the previous reply arrived, so tokio wakeup gaps become gaps in the server's arrival stream.

FalkorDB is a Redis module: `GRAPH.QUERY` blocks the client, and Redis never parses the next command from a blocked connection — **per-connection execution is serial**. Pipelining K≥2 commands per connection therefore does *not* raise server concurrency (still = #connections); it keeps each connection's input buffer non-empty so the server **self-paces** at a rock-steady C in flight, fully decoupling client jitter from server_ms. Reply-order/total_ms inflation is acceptable because only server_ms is gated.

## Design

- **`--pipeline-depth K`** (`synthetic run`, TOML `pipeline_depth`, default **1 = byte-identical to today**): for **read** levels, each of the C connection slots becomes one `Multiplexed{connections:1}` socket whose K cloned `AsyncGraph` lanes feed the unchanged closed-loop engine (C×K lane workers). Each lane measures `ceil(samples/K)` invocations (pick `--samples` divisible by K for identical totals) and claims its own disjoint uncached-uid block + corpus offset (`w×K+lane`) — uncached plan-cache-miss semantics and corpus decorrelation are preserved. **Write ops always run at depth 1** (their per-sample verification + untimed window resets don't tolerate pipelining). Reported concurrency stays C; `meta.connection` records the fan-out; the per-op `result_digest` comes from the untimed single-flight reference pass, so digests are **depth-independent** and depth-1 vs depth-K runs of one workload stay comparable under `report --diff`.
- **`--client-threads N`** (global): manual `new_multi_thread` tokio runtime capping worker threads (stays multi-thread even at N=1 — the vendored client rejects `RuntimeFlavor::CurrentThread`).
- Depth=1 default path is untouched (`Pooled{size:1}` per worker, same uid blocks/offsets/samples).

## Sanity evidence (local, recorded bundle, C=1,8, samples 400, same server)

- `workload_hash` **identical** across depth-1 vs depth-4 runs; **all per-op result digests identical**; `report --diff` exits 0.
- C=8 read throughput ratio depth4/depth1: **1.16–1.49×** (≥1 ⇒ no lane serialization); C=1: ~2× (client gaps removed).
- `just synthetic-sanity` (depth defaults to 1) — green, unchanged.
- `just ci`, `just doc-check`, `just coverage` (patch coverage ≈ 97% incl. 3 new integration tests) — green.

## Architecture document

[`docs/synthetic-benchmark-architecture.md`](https://github.com/FalkorDB/benchmark/blob/barakb/synthetic-pipelined-reads/docs/synthetic-benchmark-architecture.md) diagrams the whole picture (mermaid + code links): where CPU pinning lives in CI, the in-flight gating model (depth-1 closed loop vs C×K pipelined lanes, why server concurrency stays C), the write choreography, the client-threads vs pipeline-depth relation, and the measured run-to-run A/A precision (σ of per-cell server_ms p50 Δ%: C=8 reads 28.8 unpinned → 2.2–6.8 pinned → 2.35/2.45 pinned+pipelined).

## CI usage (follow-up experiment)

Stacked experiment PR FalkorDB/falkordb-rs-next-gen#773 passed `--client-threads 3 --pipeline-depth 4` to the measured `synthetic run --recording` invocations: across two GCE runs, C=8 main-pr A/A reads p90 |Δ%| held at **3.9 / 2.7** (pinned depth-1 baseline: 3.7–15.6 across three runs), digests identical, 0 false regressions — details in the PR #773 results comment and the architecture doc's precision section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--pipeline-depth <K>` for pipelined synthetic *read* runs (write operations still use non-pipelined behavior).
  - Added global `--client-threads <N>` to cap benchmark worker threads.
  - Added TOML/config support for `pipeline_depth` with clear precedence (CLI > file > default), and updated report metadata to reflect effective connection/pipelining mode.

- **Documentation**
  - Expanded synthetic benchmark docs, including a new pipelined-reads subsection, updated examples, and refreshed “Record / run / report” walkthrough references.

- **Tests**
  - Added/updated coverage for CLI parsing, precedence, and pipelined read vs write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
