### PR TITLE
feat(synthetic): per-cell n/σ/CV stats and per-op example queries in reports

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -618,7 +618,15 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   level (throughput + **server-time** p50/p90/p95/p99 with deltas; the client-observed total p50
   rides along as an informational sub-line, and a side without a valid server time — e.g. a report
   predating server-time capture — degrades that
-  latency cell to `—` — no silent fallback). The §6.3 **oracle attestation** is
+  latency cell to `—` — no silent fallback). Each side also gets a compact **`n / σ (ms) / CV`**
+  column with its **within-run** dispersion of `server_ms`: `n` = samples retained after
+  severe-outlier removal (pooled across the C workers), `σ` = their **sample** standard deviation
+  (n−1 denominator), `CV` = 100·σ/mean — dispersion *within* that run, not run-to-run noise; σ/CV
+  degrade to `—` alongside the server latency columns. Every op section opens with a **collapsed
+  `example query`** block showing the op's deterministic first measured command (cached-mode base
+  text, truncated past 600 chars; recorded repo-read shapes are documented in
+  [`QUERY_EXPLANATIONS_AND_SAMPLES.md`](QUERY_EXPLANATIONS_AND_SAMPLES.md)). The §6.3 **oracle
+  attestation** is
   guarded the same way: a one-sided or differing `meta.oracle_verified` aborts (the runs did not run
   the same correctness tier — a re-hashed oracle→v2 downgrade looks exactly like this), the per-side
   attestation renders as an **outcome oracle** header row, and a pair of *un*-attested runs over
@@ -642,9 +650,11 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   passes **`--elapsed-secs <n>`** — a compute-time line (benchmark + reporting) for the run. Each cell
   row also prints the **effective `p50 guard`** applied to it (e.g. `15% AND 0.5 ms`, per-op×C
   overrides included) and the absolute `Δms`, and folds **p90/p99 + throughput** onto a smaller,
-  clearly non-gated `context:` line — under the default server-ms gate that line also carries the
+  clearly non-gated `context:` line — with each side's **within-run `n/σ/CV`** of `server_ms`
+  (same definitions as the `--diff` columns) and, under the default server-ms gate, the
   **demoted client-observed total p50** — the verdict stays **p50-only**. Each op's tables are wrapped in
-  a **collapsed `<details>`** (with the op's 🟢/🔴 verdict on the summary row) so the PR sticky
+  a **collapsed `<details>`** (with the op's 🟢/🔴 verdict on the summary row, and a nested
+  collapsed `example query` block showing its deterministic first measured command) so the PR sticky
   comment stays compact — the reader expands only the ops they care about.
 - Every regression comparison is computed **once** into a single analysis model and rolled up into a
   four-state **overall verdict**: **not comparable** (workload/config mismatch — nothing else
@@ -672,6 +682,12 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
     attestation when present, thresholds echo) plus every
     op × cache-mode × concurrency cell with baseline/candidate p50, `delta_pct`/`delta_ms`, the
     resolved budget and the per-cell verdict — source material for an interactive report page.
+    Each cell's per-side `context` also carries the within-run measurement stats — `n` (retained
+    samples; `0` in files written before the field existed), `n_server` (server-timed cohort,
+    omitted when the side has no valid server time), `server_stddev_ms`/`server_cv_pct` and
+    `total_stddev_ms`/`total_cv_pct` (sample σ, n−1; omitted when undefined) — and each op an
+    additive `example_query` (its deterministic first measured command, candidate's when both
+    sides carry one; omitted when neither does).
     Skipped ops carry their reason in `skipped_baseline`/`skipped_candidate` (omitted otherwise).
   - **`--divergence-policy <gate|advisory>`** (default `gate`) sets how a result divergence lands:
     under `gate` a diverged op is 🔴 and fails the comparison; under `advisory` (for cross-engine

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -342,6 +342,39 @@ pub struct CellContextSide {
     /// (the primary p50 already is that clock) or when the side has no valid total median.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_p50_ms: Option<f64>,
+    /// Number of pooled measured samples this side's cell retains after severe-outlier removal
+    /// (the `total_ms` cohort — the wall clock is captured on every sample), i.e. the samples the
+    /// dispersion stats describe. `0` on a cells JSON written before this field existed.
+    #[serde(default)]
+    pub n: usize,
+    /// Retained sample count backing the **server_ms** dispersion stats. `None` when the side
+    /// carries no valid server time (a report predating server-time capture, or an engine that
+    /// doesn't report execution time) — the same degradation rule as every server column. It can
+    /// differ from [`n`](Self::n) only on such foreign/older reports; this tool's own pipeline
+    /// filters the two clocks as a paired cohort.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub n_server: Option<usize>,
+    /// **Sample** standard deviation (n−1 denominator — see
+    /// [`Summary::sample_stddev`](crate::synthetic::stats::Summary::sample_stddev)) of this
+    /// side's retained `server_ms` samples, in ms: **within-run** dispersion (how spread this
+    /// run's own samples are), not run-to-run noise. `None` when the side has no valid server
+    /// time or fewer than 2 samples.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_stddev_ms: Option<f64>,
+    /// Coefficient of variation of `server_ms`, percent (`100·σ/mean`, sample σ) — within-run
+    /// dispersion relative to the cell's own scale. `None` under the same conditions as
+    /// [`server_stddev_ms`](Self::server_stddev_ms).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_cv_pct: Option<f64>,
+    /// Sample standard deviation of the retained `total_ms` samples, in ms — carried for
+    /// machine consumers (the interactive page / analyzer scripts); the Markdown tables show
+    /// only the server-clock dispersion. `None` with fewer than 2 samples.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_stddev_ms: Option<f64>,
+    /// Coefficient of variation of `total_ms`, percent — machine-consumer counterpart of
+    /// [`server_cv_pct`](Self::server_cv_pct). `None` when undefined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_cv_pct: Option<f64>,
 }
 
 /// Informational context for a cell (both sides optional — a side may not have measured it).
@@ -395,6 +428,13 @@ pub struct OpAnalysis {
     /// Why the **candidate** run skipped this op, or `None` when it measured it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skipped_candidate: Option<String>,
+    /// The op's deterministic representative Cypher text
+    /// ([`OperationReport::example_query`](crate::synthetic::report::OperationReport::example_query)),
+    /// preferring the **candidate** run's text (the run under test), falling back to the
+    /// baseline's — a comparable pair measured the same workload, so the two are normally
+    /// identical. `None` when neither report carries one (both predate the field).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub example_query: Option<String>,
     pub cells: Vec<CellAnalysis>,
 }
 
@@ -603,7 +643,9 @@ fn level_metrics<'a>(
 }
 
 /// One side's informational tails/throughput, read from the **selected gated metric's** summary
-/// so a cell's primary p50 and its `context:` line always describe the same clock.
+/// so a cell's primary p50 and its `context:` line always describe the same clock — plus the
+/// within-run dispersion stats (sample counts, sample σ, CV%) computed from each clock's own
+/// summary, clock-named so they are unambiguous under either gate.
 fn context_side(
     metric: GatedMetric,
     m: &LevelMetrics,
@@ -614,12 +656,25 @@ fn context_side(
     let total = m.metrics.total_ms.median;
     let total_p50_ms = (metric == GatedMetric::ServerMs && total.is_finite() && total > 0.0)
         .then_some(total);
+    // Server-clock stats degrade exactly like every other server column: absent whenever the
+    // side has no valid server time (same finite-and-positive-median rule as the p50 columns).
+    let server = &m.metrics.server_ms;
+    let server_valid = server.median.is_finite() && server.median > 0.0;
+    // Derived dispersion stats are rounded to 6 decimals: sub-nanosecond precision is noise,
+    // and short decimals keep the cells JSON compact and byte-stable across serde round-trips.
+    let round6 = |v: Option<f64>| v.map(|x| (x * 1e6).round() / 1e6);
     CellContextSide {
         p90_ms: s.p90,
         p95_ms: s.p95,
         p99_ms: s.p99,
         throughput_ops_per_sec: m.throughput_ops_per_sec,
         total_p50_ms,
+        n: m.metrics.total_ms.n,
+        n_server: server_valid.then_some(server.n),
+        server_stddev_ms: round6(if server_valid { server.sample_stddev() } else { None }),
+        server_cv_pct: round6(if server_valid { server.cv_pct() } else { None }),
+        total_stddev_ms: round6(m.metrics.total_ms.sample_stddev()),
+        total_cv_pct: round6(m.metrics.total_ms.cv_pct()),
     }
 }
 
@@ -738,6 +793,11 @@ fn analyze_op(
         op_outcome,
         skipped_baseline,
         skipped_candidate,
+        // Candidate first (the run under test), baseline as the fallback — deterministic, and
+        // normally identical on both sides of a comparable pair (same workload_hash).
+        example_query: [candidate, baseline]
+            .iter()
+            .find_map(|r| r.operations.get(op).and_then(|o| o.example_query.clone())),
         cells,
     }
 }
@@ -965,6 +1025,7 @@ mod tests {
                     result_digest: digest.map(str::to_string),
                     policy: None,
                     skipped: None,
+                    example_query: None,
                 },
             );
         }
@@ -1771,6 +1832,94 @@ mod tests {
         let cell = &server.ops["match_by_index"].cells[0];
         assert_eq!(cell.perf_verdict, Verdict::Ok);
         assert_eq!(cell.context.candidate.unwrap().total_p50_ms, None);
+    }
+
+    #[test]
+    fn cell_context_carries_within_run_dispersion_stats() {
+        // Each side's context carries the within-run sample count and dispersion of both
+        // clocks: n (retained total_ms cohort), n_server, sample σ (n−1) and CV% — all rounded
+        // to 6 decimals so the cells JSON stays compact and byte-stable across serde round-trips.
+        let a = rpt("main", 42001, &[("match_by_index", 2.0, Some("d1"))]);
+        let b = rpt("pr", 42002, &[("match_by_index", 2.0, Some("d1"))]);
+        let an = server_gate(&a, &b);
+        let side = an.ops["match_by_index"].cells[0].context.baseline.unwrap();
+        assert_eq!(side.n, 100);
+        assert_eq!(side.n_server, Some(100));
+        // summ(2.0): population σ = 0.2 over n = 100 ⇒ sample σ = 0.2·√(100/99) ≈ 0.201008.
+        assert_eq!(side.server_stddev_ms, Some(0.201008));
+        assert_eq!(side.server_cv_pct, Some(10.050378));
+        // Both fixture clocks share the same summary, so the total_ms stats match.
+        assert_eq!(side.total_stddev_ms, Some(0.201008));
+        assert_eq!(side.total_cv_pct, Some(10.050378));
+    }
+
+    #[test]
+    fn dispersion_stats_degrade_with_invalid_server_median() {
+        // No valid server time on a side (median 0/NaN — a report predating server-time
+        // capture): its server-clock stats and n_server are absent, exactly like the server p50
+        // columns; the wall-clock stats survive because total_ms is always captured.
+        let a = rpt("main", 42001, &[("match_by_index", 2.0, Some("d1"))]);
+        let mut b = rpt("pr", 42002, &[("match_by_index", 2.0, Some("d1"))]);
+        set_server_median(&mut b, "match_by_index", 0.0);
+        let an = server_gate(&a, &b);
+        let side = an.ops["match_by_index"].cells[0].context.candidate.unwrap();
+        assert_eq!(side.n, 100, "the wall-clock cohort is still counted");
+        assert_eq!(side.n_server, None);
+        assert_eq!(side.server_stddev_ms, None);
+        assert_eq!(side.server_cv_pct, None);
+        assert_eq!(side.total_stddev_ms, Some(0.201008));
+        assert_eq!(side.total_cv_pct, Some(10.050378));
+    }
+
+    #[test]
+    fn example_query_prefers_candidate_and_falls_back_to_baseline() {
+        // The op-level example query is additive context: the candidate's recorded text wins
+        // (it reflects what THIS run measured), an older candidate report without the field
+        // falls back to the baseline's, and the field is omitted when neither side carries one.
+        let mut a = rpt("main", 42001, &[("match_by_index", 1.0, Some("d1"))]);
+        let mut b = rpt("pr", 42002, &[("match_by_index", 1.0, Some("d1"))]);
+        a.operations.get_mut("match_by_index").unwrap().example_query =
+            Some("MATCH (old) RETURN old".to_string());
+        b.operations.get_mut("match_by_index").unwrap().example_query =
+            Some("MATCH (new) RETURN new".to_string());
+        let an = gate(&a, &b);
+        assert_eq!(
+            an.ops["match_by_index"].example_query.as_deref(),
+            Some("MATCH (new) RETURN new"),
+            "candidate wins"
+        );
+        assert!(an.to_json().unwrap().contains("\"example_query\""));
+
+        b.operations.get_mut("match_by_index").unwrap().example_query = None;
+        let an = gate(&a, &b);
+        assert_eq!(
+            an.ops["match_by_index"].example_query.as_deref(),
+            Some("MATCH (old) RETURN old"),
+            "baseline fallback"
+        );
+
+        a.operations.get_mut("match_by_index").unwrap().example_query = None;
+        let an = gate(&a, &b);
+        assert_eq!(an.ops["match_by_index"].example_query, None);
+        assert!(!an.to_json().unwrap().contains("example_query"), "omitted when absent");
+    }
+
+    #[test]
+    fn old_cells_json_without_dispersion_fields_still_deserializes() {
+        // Cells JSON written before the dispersion stats existed (schema v2, additive change):
+        // the new fields default — n = 0 (meaning "not recorded", which renderers omit) and the
+        // optional stats stay None.
+        let side: CellContextSide = serde_json::from_str(
+            r#"{"p90_ms":1.2,"p95_ms":1.3,"p99_ms":1.5,"throughput_ops_per_sec":1000.0}"#,
+        )
+        .unwrap();
+        assert_eq!(side.n, 0);
+        assert_eq!(side.n_server, None);
+        assert_eq!(side.server_stddev_ms, None);
+        assert_eq!(side.server_cv_pct, None);
+        assert_eq!(side.total_stddev_ms, None);
+        assert_eq!(side.total_cv_pct, None);
+        assert_eq!(side.total_p50_ms, None);
     }
 
     #[test]

--- a/src/synthetic/baseline.rs
+++ b/src/synthetic/baseline.rs
@@ -947,6 +947,7 @@ mod regression_guard_tests {
                     result_digest: dig.map(|s| s.to_string()),
                     policy: None,
                     skipped: None,
+                    example_query: None,
                 },
             );
         }

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -98,9 +98,16 @@ pub fn diff_markdown(
         "\n_Δ is 100·(candidate−baseline)/baseline. Latency percentiles and Δp50 are the \
          **server-reported execution time** (`server_ms`); the client-observed total p50 rides \
          along as an informational sub-line. **Latency: lower is better** (a positive Δ = \
-         slower / regressed); **throughput: higher is better**. `—` = not measured in that run \
-         (or, in a latency column, no valid server time on that side — e.g. a report predating \
-         server-time capture or an engine that doesn't report execution time)._\n",
+         slower / regressed); **throughput: higher is better**. Each side's `n / σ (ms) / CV` \
+         describes its own **within-run** dispersion of `server_ms` (not run-to-run noise): \
+         `n` = samples retained after severe-outlier removal (pooled across the C workers), \
+         `σ` = their **sample** standard deviation (n−1 denominator), `CV` = 100·σ/mean; when \
+         only part of the retained cohort carries a server time (older engines), `n (server m)` \
+         names both counts. `—` = not measured in that run (or, in a latency/σ/CV column, no \
+         valid server time on that side — e.g. a report predating server-time capture or an \
+         engine that doesn't report execution time). Each op's `example query` block shows its \
+         first measured command (cached-mode base text; uncached appends a unique cache-buster \
+         comment)._\n",
     );
     for w in warnings {
         out.push_str(&format!("\n> ⚠ {w}\n"));
@@ -122,6 +129,15 @@ pub fn diff_markdown(
         // (design Phase 6 §3.5), per side; reasons are manifest content, hence HTML-escaped.
         if let Some(note) = diff_skip_note(baseline, candidate, op, &la, &lb) {
             out.push_str(&format!("\n_{}_\n", md_cell(&md_inline(&html_escape(&note)))));
+        }
+        // The op's deterministic representative query, collapsed so the diff stays compact.
+        // Both sides of a comparable pair measured the same workload; candidate (the run under
+        // test) wins when both carry a text.
+        if let Some(example) = [candidate, baseline]
+            .iter()
+            .find_map(|r| r.operations.get(op).and_then(|o| o.example_query.as_deref()))
+        {
+            out.push_str(&example_query_block(example));
         }
         for mode in [Mode::Cached, Mode::Uncached] {
             render_mode(&mut out, baseline, candidate, op, mode);
@@ -195,14 +211,16 @@ fn render_mode(
     let la = md_cell(&col_label(a, "A"));
     let lb = md_cell(&col_label(b, "B"));
     out.push_str(&format!(
-        "| C | {la} server p50/p90/p95/p99 (ms) | {lb} server p50/p90/p95/p99 (ms) | Δp50 | {la} tput (ops/s) | {lb} tput (ops/s) | Δtput |\n\
-         |---:|---|---|---:|---:|---:|---:|\n",
+        "| C | {la} server p50/p90/p95/p99 (ms) | {la} n / σ (ms) / CV | {lb} server p50/p90/p95/p99 (ms) | {lb} n / σ (ms) / CV | Δp50 | {la} tput (ops/s) | {lb} tput (ops/s) | Δtput |\n\
+         |---:|---|---:|---|---:|---:|---:|---:|---:|\n",
     ));
     for c in levels {
         let am = level_metrics(a, op, c, mode);
         let bm = level_metrics(b, op, c, mode);
         let a_pct = am.map(percentiles).unwrap_or_else(|| "—".to_string());
         let b_pct = bm.map(percentiles).unwrap_or_else(|| "—".to_string());
+        let a_disp = am.map(dispersion_cell).unwrap_or_else(|| "—".to_string());
+        let b_disp = bm.map(dispersion_cell).unwrap_or_else(|| "—".to_string());
         let dp50 = match (am.map(server_median), bm.map(server_median)) {
             (Some(Some(x)), Some(Some(y))) => pct(x, y),
             _ => "—".to_string(),
@@ -214,7 +232,7 @@ fn render_mode(
             _ => "—".to_string(),
         };
         out.push_str(&format!(
-            "| {c} | {a_pct} | {b_pct} | {dp50} | {a_tp} | {b_tp} | {dtp} |\n"
+            "| {c} | {a_pct} | {a_disp} | {b_pct} | {b_disp} | {dp50} | {a_tp} | {b_tp} | {dtp} |\n"
         ));
     }
 }
@@ -261,24 +279,108 @@ fn percentiles(m: &LevelMetrics) -> String {
     }
 }
 
+/// A diff-table `n / σ (ms) / CV` cell: the retained-sample count with the **within-run**
+/// sample standard deviation and coefficient of variation of `server_ms` — see
+/// [`format_dispersion`]. σ/CV degrade to `—` exactly like the server latency columns when the
+/// side carries no valid server time.
+fn dispersion_cell(m: &LevelMetrics) -> String {
+    let server_valid = server_median(m).is_some();
+    let server = &m.metrics.server_ms;
+    format_dispersion(
+        " / ",
+        m.metrics.total_ms.n,
+        server_valid.then_some(server.n),
+        if server_valid { server.sample_stddev() } else { None },
+        if server_valid { server.cv_pct() } else { None },
+    )
+}
+
+/// Format one side's within-run dispersion stats (`n`, sample σ of `server_ms` in ms, CV%),
+/// joined by `sep`. `n` is the retained `total_ms` cohort (the always-captured wall clock);
+/// when the server-time cohort exists but differs — possible only on foreign/older reports —
+/// both counts are named (`n (server m)`). Undefined σ/CV (no valid server time, or n < 2)
+/// render `—`, mirroring the server latency columns.
+fn format_dispersion(
+    sep: &str,
+    n: usize,
+    n_server: Option<usize>,
+    stddev_ms: Option<f64>,
+    cv_pct: Option<f64>,
+) -> String {
+    let n_cell = match n_server {
+        Some(ns) if ns != n => format!("{n} (server {ns})"),
+        _ => n.to_string(),
+    };
+    let sd = stddev_ms.map(|s| format!("{s:.3}")).unwrap_or_else(|| "—".to_string());
+    let cv = cv_pct.map(|c| format!("{c:.1}%")).unwrap_or_else(|| "—".to_string());
+    format!("{n_cell}{sep}{sd}{sep}{cv}")
+}
+
+/// Maximum number of characters of an example query rendered into the Markdown reports. The
+/// full corpus is ~64 ops and the regression report doubles as a sticky PR comment capped at
+/// ~65 KB by GitHub, so very long recorded texts are cut with an explicit truncation note.
+const EXAMPLE_QUERY_MAX_CHARS: usize = 600;
+
+/// A collapsed `<details>` block showing an op's deterministic example query as a fenced
+/// `cypher` code block. The fence is made longer than any backtick run inside the text (Cypher
+/// identifiers may be backtick-quoted, and a recorded text could otherwise close the fence), and
+/// texts beyond [`EXAMPLE_QUERY_MAX_CHARS`] are truncated with a note naming both lengths.
+/// Rendering is pure — the same text always produces the same block.
+fn example_query_block(text: &str) -> String {
+    let total = text.chars().count();
+    let (shown, truncated): (String, bool) = if total > EXAMPLE_QUERY_MAX_CHARS {
+        (text.chars().take(EXAMPLE_QUERY_MAX_CHARS).collect(), true)
+    } else {
+        (text.to_string(), false)
+    };
+    // A fenced block is delimited by a backtick run at least as long as any inside it.
+    let longest_run = shown
+        .split(|ch| ch != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    let fence = "`".repeat((longest_run + 1).max(3));
+    let mut out = format!(
+        "\n<details><summary>example query</summary>\n\n{fence}cypher\n{shown}\n{fence}\n",
+    );
+    if truncated {
+        out.push_str(&format!(
+            "\n_truncated — showing the first {EXAMPLE_QUERY_MAX_CHARS} of {total} characters_\n"
+        ));
+    }
+    out.push_str("\n</details>\n");
+    out
+}
+
 /// A regression-table latency cell: the gated **p50** on the primary line, with p90/p95/p99,
-/// throughput and — under the server-ms gate — the demoted client-observed total p50 folded onto
-/// a smaller `context:` line (informational, never gated, appended only when the report carries
-/// it). `—` only when the side's p50 is absent. Values are fixed-precision measurements, so no
-/// operator-supplied text is interpolated (no `md_cell` escaping needed).
+/// throughput, the within-run `n`/σ/CV of `server_ms` and — under the server-ms gate — the
+/// demoted client-observed total p50 folded onto a smaller `context:` line (informational, never
+/// gated, appended only when the report carries it). `—` only when the side's p50 is absent.
+/// Values are fixed-precision measurements, so no operator-supplied text is interpolated (no
+/// `md_cell` escaping needed).
 fn latency_cell(
     p50: Option<f64>,
     ctx: Option<&CellContextSide>,
 ) -> String {
     match (p50, ctx) {
         (Some(p50), Some(c)) => {
+            // A zero `n` means the model predates the dispersion stats (deserialized old cells
+            // JSON) — omit the segment rather than claim zero samples.
+            let disp = if c.n > 0 {
+                format!(
+                    " · n/σ/CV {}",
+                    format_dispersion("/", c.n, c.n_server, c.server_stddev_ms, c.server_cv_pct)
+                )
+            } else {
+                String::new()
+            };
             let total = c
                 .total_p50_ms
                 .map(|t| format!(" · total p50 {t:.3}"))
                 .unwrap_or_default();
             format!(
-                "{:.3}<br><sub>context: p90 {:.3} · p95 {:.3} · p99 {:.3} · {:.0} op/s{}</sub>",
-                p50, c.p90_ms, c.p95_ms, c.p99_ms, c.throughput_ops_per_sec, total
+                "{:.3}<br><sub>context: p90 {:.3} · p95 {:.3} · p99 {:.3} · {:.0} op/s{}{}</sub>",
+                p50, c.p90_ms, c.p95_ms, c.p99_ms, c.throughput_ops_per_sec, disp, total
             )
         }
         (Some(p50), None) => format!("{p50:.3}"),
@@ -456,6 +558,12 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
         if op_body.trim().is_empty() {
             continue;
         }
+        // The op's deterministic representative query, nested-collapsed so the sticky PR comment
+        // stays compact. Appended only to ops that render a section anyway — an example alone
+        // never resurrects a section for a cell-less op.
+        if let Some(example) = &oa.example_query {
+            op_body.push_str(&example_query_block(example));
+        }
         let diverged_note = if oa.correctness == Correctness::Diverged {
             match analysis.divergence_policy {
                 DivergencePolicy::Gate => " — ⚠ results differ (perf verdict N/A)",
@@ -505,21 +613,28 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
     // The context descriptor matches what the cells actually fold in: under the server gate the
     // client-observed total p50 rides along as demoted context.
     let context_clause = if analysis.gated_on_server_ms() {
-        "the `context:` line (p90/p95/p99 · throughput · client-observed total p50)"
+        "the `context:` line (p90/p95/p99 · throughput · within-run n/σ/CV of `server_ms` · \
+         client-observed total p50)"
     } else {
-        "the `context:` line (p90/p95/p99 · throughput)"
+        "the `context:` line (p90/p95/p99 · throughput · within-run n/σ/CV of `server_ms`)"
     };
+    // The dispersion stats' one-line definition, shared by both policies' legends.
+    let stats_clause = "n = samples retained after severe-outlier removal (pooled across the C \
+                        workers; `n (server m)` when only `m` carry a server time); σ = their \
+                        **sample** standard deviation (n−1) of `server_ms` **within this run** — \
+                        not run-to-run noise; CV = 100·σ/mean.";
     out.push_str(&match analysis.divergence_policy {
         DivergencePolicy::Gate => format!(
             "\n🟢 = faster or within budget · 🔴 = slower than budget **or** results differ · \
              N/A = no perf verdict. {metric_clause} — {context_clause} \
-             and `Δms` are informational, never part of the verdict. Non-blocking.\n"
+             and `Δms` are informational, never part of the verdict. {stats_clause} \
+             Non-blocking.\n"
         ),
         DivergencePolicy::Advisory => format!(
             "\n🟢 = faster or within budget · 🔴 = slower than budget · ⚠ = results differ \
              (advisory — the engines did different work, so perf is N/A) · N/A = no perf verdict. \
              {metric_clause} — {context_clause} and `Δms` are \
-             informational, never part of the verdict. Non-blocking.\n"
+             informational, never part of the verdict. {stats_clause} Non-blocking.\n"
         ),
     });
     if analysis.totals.skipped > 0 {
@@ -974,6 +1089,7 @@ mod tests {
                 result_digest: Some("sha256:aa".to_string()),
                 policy: None,
                 skipped: None,
+                example_query: Some("MATCH (u:User {id: $id}) RETURN u".to_string()),
             },
         );
         Report {
@@ -1051,14 +1167,150 @@ mod tests {
         set_server_median(&mut a, 0.0);
         let md = diff_markdown(&a, &b, &[]);
         assert!(
-            md.contains("| —<br><sub>total p50 1.000</sub> |"),
-            "missing server side degrades to — with demoted total: {md}"
+            md.contains("| —<br><sub>total p50 1.000</sub> | 100 / — / — |"),
+            "missing server side degrades to — with demoted total and — σ/CV: {md}"
         );
         assert!(
-            md.contains("</sub> | — |"),
+            md.contains("10.1% | — |"),
             "Δp50 must be — when either server median is invalid: {md}"
         );
         assert!(md.contains("predating server-time capture"), "legend explains —: {md}");
+    }
+
+    #[test]
+    fn diff_renders_dispersion_columns_and_example_query() {
+        let a = report(42001, 1.000, 1000.0);
+        let b = report(42002, 1.100, 900.0);
+        let md = diff_markdown(&a, &b, &[]);
+        // One combined `n / σ (ms) / CV` column per side, right of its percentile column.
+        assert!(
+            md.contains("| A n / σ (ms) / CV |") && md.contains("| B n / σ (ms) / CV |"),
+            "dispersion headers: {md}"
+        );
+        // summ(median): population σ = median·0.1 over n = 100 ⇒ sample σ = ·√(100/99).
+        assert!(md.contains("| 100 / 0.101 / 10.1% |"), "A cell (median 1.0): {md}");
+        assert!(md.contains("| 100 / 0.111 / 10.1% |"), "B cell (median 1.1): {md}");
+        // The op's example query renders as a collapsed details block with a cypher fence.
+        assert!(md.contains("<details><summary>example query</summary>"), "{md}");
+        assert!(
+            md.contains("```cypher\nMATCH (u:User {id: $id}) RETURN u\n```"),
+            "fenced example text: {md}"
+        );
+        // The legend explains the new columns and their within-run scope.
+        assert!(md.contains("**within-run** dispersion"), "{md}");
+        assert!(md.contains("**sample** standard deviation (n−1 denominator)"), "{md}");
+        assert!(md.contains("`n (server m)`"), "{md}");
+    }
+
+    #[test]
+    fn diff_example_query_prefers_the_candidate_text() {
+        let mut a = report(42001, 1.0, 1000.0);
+        let mut b = report(42002, 1.0, 1000.0);
+        a.operations.get_mut("match_by_index").unwrap().example_query =
+            Some("MATCH (base) RETURN base".to_string());
+        b.operations.get_mut("match_by_index").unwrap().example_query =
+            Some("MATCH (cand) RETURN cand".to_string());
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("MATCH (cand) RETURN cand"), "candidate text wins: {md}");
+        assert!(!md.contains("MATCH (base) RETURN base"), "{md}");
+        // An older candidate report without the field falls back to the baseline's text.
+        b.operations.get_mut("match_by_index").unwrap().example_query = None;
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(md.contains("MATCH (base) RETURN base"), "baseline fallback: {md}");
+        // Neither side carries one (both reports predate the field): no details block at all.
+        a.operations.get_mut("match_by_index").unwrap().example_query = None;
+        let md = diff_markdown(&a, &b, &[]);
+        assert!(!md.contains("<details><summary>example query</summary>"), "{md}");
+    }
+
+    #[test]
+    fn example_query_block_is_deterministic_and_outruns_inner_backticks() {
+        let text = "MATCH (n:`weird``label`) WHERE n.x = ``` RETURN n";
+        let block = example_query_block(text);
+        assert_eq!(block, example_query_block(text), "pure and deterministic");
+        // The fence must be longer than the longest inner backtick run (3) — 4 backticks.
+        assert!(block.contains("\n````cypher\n"), "{block}");
+        assert!(block.contains("\n````\n"), "{block}");
+        assert!(!block.contains("truncated"), "{block}");
+        // GitHub only renders Markdown inside HTML <details> after a blank line.
+        assert!(block.contains("</summary>\n\n"), "{block}");
+    }
+
+    #[test]
+    fn example_query_block_truncates_very_long_texts() {
+        let text = "x".repeat(700);
+        let block = example_query_block(&text);
+        assert!(block.contains(&"x".repeat(600)), "{block}");
+        assert!(!block.contains(&"x".repeat(601)), "{block}");
+        assert!(
+            block.contains("_truncated — showing the first 600 of 700 characters_"),
+            "{block}"
+        );
+    }
+
+    #[test]
+    fn format_dispersion_names_a_differing_server_cohort() {
+        // In this tool's own reports both cohorts always match (paired capture); a foreign or
+        // older report may carry fewer server-timed samples — both counts are then named.
+        assert_eq!(
+            format_dispersion(" / ", 100, Some(100), Some(0.5), Some(10.0)),
+            "100 / 0.500 / 10.0%"
+        );
+        assert_eq!(
+            format_dispersion(" / ", 100, Some(80), Some(0.5), Some(10.0)),
+            "100 (server 80) / 0.500 / 10.0%"
+        );
+        assert_eq!(format_dispersion("/", 100, None, None, None), "100/—/—");
+    }
+
+    #[test]
+    fn latency_cell_omits_dispersion_for_pre_stats_cells() {
+        use crate::synthetic::analysis::CellContextSide;
+        // n = 0 marks a context deserialized from cells JSON written before the dispersion
+        // stats existed — the segment is omitted rather than claiming zero samples.
+        let old = CellContextSide {
+            p90_ms: 1.2,
+            p95_ms: 1.3,
+            p99_ms: 1.5,
+            throughput_ops_per_sec: 1000.0,
+            total_p50_ms: Some(1.0),
+            n: 0,
+            n_server: None,
+            server_stddev_ms: None,
+            server_cv_pct: None,
+            total_stddev_ms: None,
+            total_cv_pct: None,
+        };
+        let cell = latency_cell(Some(1.0), Some(&old));
+        assert!(!cell.contains("n/σ/CV"), "{cell}");
+        assert!(cell.contains("· total p50 1.000"), "{cell}");
+        // A populated context folds the stats between throughput and the demoted total.
+        let new = CellContextSide {
+            n: 100,
+            n_server: Some(100),
+            server_stddev_ms: Some(0.1),
+            server_cv_pct: Some(10.0),
+            ..old
+        };
+        let cell = latency_cell(Some(1.0), Some(&new));
+        assert!(
+            cell.contains("op/s · n/σ/CV 100/0.100/10.0% · total p50 1.000"),
+            "{cell}"
+        );
+    }
+
+    #[test]
+    fn regression_report_nests_the_example_query_per_op() {
+        use crate::synthetic::baseline::regression_guard;
+        use crate::synthetic::thresholds::Thresholds;
+        let a = report(42001, 1.0, 1000.0);
+        let b = report(42002, 1.0, 1000.0);
+        let g = regression_guard(&a, &b);
+        let md = regression_md(&a, &b, &g, &Thresholds::builtin(), None);
+        assert!(md.contains("<details><summary>example query</summary>"), "{md}");
+        assert!(md.contains("MATCH (u:User {id: $id}) RETURN u"), "{md}");
+        // The legend defines the context-line stats.
+        assert!(md.contains("n = samples retained after severe-outlier removal"), "{md}");
     }
 
     /// Overwrite every level's `server_ms` summary median (fixtures default both clocks equal).
@@ -1386,9 +1638,11 @@ mod tests {
         // Δp50 carries the signed absolute ms delta so the floor is auditable.
         assert!(md.contains("(+0.100)"), "Δms missing: {md}");
         // p90/p99 + throughput are folded onto the context line (not their own columns), with
-        // the demoted client-observed total p50 riding along under the default server gate.
+        // the within-run n/σ/CV and the demoted client-observed total p50 riding along under
+        // the default server gate.
         assert!(
-            md.contains("<br><sub>context: p90 ") && md.contains("op/s · total p50 1.000</sub>"),
+            md.contains("<br><sub>context: p90 ")
+                && md.contains("op/s · n/σ/CV 100/0.101/10.1% · total p50 1.000</sub>"),
             "{md}"
         );
         // The per-line guard shows the resolved default (10%) + floor.
@@ -1449,7 +1703,7 @@ mod tests {
             "demoted total p50 in context: {md}"
         );
         assert!(
-            md.contains("throughput · client-observed total p50)"),
+            md.contains("throughput · within-run n/σ/CV of `server_ms` · client-observed total p50)"),
             "legend names the demoted total: {md}"
         );
         assert!(
@@ -1633,6 +1887,7 @@ mod tests {
                     result_digest: Some("sha256:aa".to_string()),
                     policy: None,
                     skipped: None,
+                    example_query: None,
                 },
             );
         }
@@ -1718,6 +1973,7 @@ mod tests {
                     result_digest: Some((*digest).to_string()),
                     policy: None,
                     skipped: None,
+                    example_query: None,
                 },
             );
         }

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -49,7 +49,7 @@ use crate::synthetic::report::{
     DatasetInfo, LevelMetrics, LevelReport, Meta, OperationReport, OpPolicy, Report,
 };
 use crate::synthetic::thresholds::BudgetProfile;
-use crate::synthetic::writes::{verify_mutation, WritePlan, WriteScratch};
+use crate::synthetic::writes::{verify_mutation, WritePlan, WriteScratch, CANONICAL_SCRATCH_LABEL};
 use clap::ValueEnum;
 use falkordb::{AsyncGraph, ConnectionStrategy, FalkorClientBuilder};
 use futures::StreamExt;
@@ -416,6 +416,28 @@ fn render_cypher(
         // timed path); only uncached allocates to append its unique cache-buster comment.
         CacheMode::Cached => Cow::Borrowed(base),
         CacheMode::Uncached => Cow::Owned(format!("{} /* co{:x}-{} */", base, run_token, uid)),
+    }
+}
+
+/// The deterministic representative Cypher text a generated run records as the op's
+/// [`OperationReport::example_query`] — the **cached-mode base text** of its first invocation.
+/// Reads use their first pre-rendered corpus query verbatim. A catalog write renders invocation 0
+/// against a **canonical scratch** (run-token 0, worker 0), then swaps its label for the
+/// run-independent [`CANONICAL_SCRATCH_LABEL`]: a real worker's label folds in the run's random
+/// nonce, so rendering with the live scratch would make otherwise-identical reports differ
+/// byte-for-byte run to run — only that label differs from the measured text.
+fn example_query(
+    op_spec: &OperationSpec,
+    rendered: &[String],
+    reset_every: usize,
+) -> BenchmarkResult<Option<String>> {
+    match &op_spec.write {
+        Some(plan) => {
+            let scratch = WriteScratch::new(0, 0, reset_every)?;
+            let text = (plan.render)(&scratch, 0)?.to_cypher();
+            Ok(Some(text.replace(&scratch.label(), CANONICAL_SCRATCH_LABEL)))
+        }
+        None => Ok(rendered.first().cloned()),
     }
 }
 
@@ -814,6 +836,9 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         // render per-invocation, so this is unused for them). This is the same string a recorded
         // bundle stores, so a generated run and a `--recording` run measure identically.
         let rendered: Arc<Vec<String>> = Arc::new(corpus.iter().map(|q| q.to_cypher()).collect());
+        // Extracted before the measurement (which consumes the corpus): the op's deterministic
+        // representative query for the report.
+        let example = example_query(&op_spec, &rendered, config.reset_every)?;
         let mut op_report = measure_op(
             &op_config,
             &op_concurrency,
@@ -828,6 +853,7 @@ pub async fn run(config: &Config) -> BenchmarkResult<Report> {
         // global knob (all-INHERIT today), so a cross-run comparison can guard it per-op.
         op_report.policy =
             (op_spec.budget != OpBudget::INHERIT).then(|| op_config.resolved_policy(&op_concurrency));
+        op_report.example_query = example;
         operations.insert(op.as_str().to_string(), op_report);
     }
 
@@ -1212,6 +1238,7 @@ pub(crate) async fn measure_op(
         result_digest: None,
         policy: None,
         skipped: None,
+        example_query: None,
     })
 }
 
@@ -2046,6 +2073,36 @@ mod tests {
             }
         }
         assert_eq!(all_uids.len(), concurrency * depth * (warmup + per_lane));
+    }
+
+    #[test]
+    fn example_query_uses_the_first_rendered_read() {
+        let op_spec = spec(OpName::MatchByIndex);
+        let rendered = vec!["MATCH (one) RETURN one".to_string(), "MATCH (two)".to_string()];
+        let ex = example_query(&op_spec, &rendered, 512).unwrap();
+        assert_eq!(ex.as_deref(), Some("MATCH (one) RETURN one"), "first corpus query verbatim");
+        // Defensive: an empty corpus (impossible via build_corpus) yields no example, not a panic.
+        assert_eq!(example_query(&op_spec, &[], 512).unwrap(), None);
+    }
+
+    #[test]
+    fn example_query_renders_writes_with_the_canonical_label() {
+        // A catalog write renders invocation 0 against the canonical scratch and swaps the label
+        // for the run-independent placeholder, so identical runs report identical examples.
+        for op in [OpName::CreateNode, OpName::CreateEdge, OpName::DeleteNode] {
+            let op_spec = spec(op);
+            let first = example_query(&op_spec, &[], 512).unwrap().unwrap();
+            let second = example_query(&op_spec, &[], 512).unwrap().unwrap();
+            assert_eq!(first, second, "{op:?}: deterministic across calls");
+            assert!(
+                first.contains(CANONICAL_SCRATCH_LABEL),
+                "{op:?}: canonical placeholder label: {first}"
+            );
+            assert!(
+                !first.contains("BenchScratch_0"),
+                "{op:?}: raw run-token-0 label must be canonicalized: {first}"
+            );
+        }
     }
 
     #[test]

--- a/src/synthetic/replay.rs
+++ b/src/synthetic/replay.rs
@@ -278,8 +278,13 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
     let mut operations = BTreeMap::new();
     // Skipped ops get an empty-levels entry carrying the skip reason (BTreeMap renders by key),
     // so the report keeps the full recorded op set and the diff/regression guards can tell
-    // "skipped" from "not recorded".
+    // "skipped" from "not recorded". The example query still shows what *would* have run.
     for (name, reason) in &skipped {
+        let example = bundle
+            .commands
+            .iter()
+            .find(|(op, _)| op.name() == name)
+            .and_then(|(_, cyphers)| cyphers.first().cloned());
         operations.insert(
             name.clone(),
             crate::synthetic::report::OperationReport {
@@ -287,6 +292,7 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
                 result_digest: None,
                 policy: None,
                 skipped: Some(reason.clone()),
+                example_query: example,
             },
         );
     }
@@ -539,6 +545,9 @@ pub async fn run(config: &ReplayConfig) -> BenchmarkResult<Report> {
             // runs that measured the same workload under different per-op conditions.
             op_report.policy =
                 (!entry.budget.is_inherit()).then(|| op_config.resolved_policy(&op_concurrency));
+            // The op's first recorded command — its cached-mode measured text — is the report's
+            // deterministic representative query.
+            op_report.example_query = corpus.first().cloned();
             operations.insert(op.name().to_string(), op_report);
         }
         Ok(())
@@ -756,6 +765,9 @@ async fn measure_write_op(
         // diff/baseline guards always refuse cross-policy comparisons of write cells.
         policy: Some(op_config.resolved_policy(op_concurrency)),
         skipped: None,
+        // The first recorded write command — its cached-mode measured text — is the report's
+        // deterministic representative query.
+        example_query: corpus.first().cloned(),
     })
 }
 

--- a/src/synthetic/report.rs
+++ b/src/synthetic/report.rs
@@ -242,6 +242,17 @@ pub struct OperationReport {
     /// policy; the diff/regression guards treat it as **neither a pass nor a divergence**.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skipped: Option<String>,
+    /// A deterministic representative Cypher text for this op: its **first** measured command —
+    /// the first recorded command for a `--recording` run, the first rendered corpus query for a
+    /// generated read, and a canonical rendering (run-token 0, worker 0, seq 0, with the
+    /// run-independent `BenchScratch_RUN` placeholder label) for a catalog write, whose real
+    /// per-run scratch label carries a random nonce. This is the **cached-mode base text**;
+    /// uncached mode appends a per-invocation cache-buster comment. Extraction is deterministic
+    /// (never sampled), so the same inputs always yield the same text. A capability-skipped op
+    /// still carries its first recorded command (what *would* have run). `None` on reports
+    /// written before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub example_query: Option<String>,
 }
 
 impl OperationReport {
@@ -737,6 +748,7 @@ mod tests {
                 result_digest: None,
                 policy: None,
                 skipped: None,
+                example_query: Some("RETURN 1".to_string()),
             },
         );
         Report {
@@ -1056,6 +1068,7 @@ mod tests {
                 result_digest: None,
                 policy: None,
                 skipped: None,
+                example_query: None,
             },
         );
         ops.insert(
@@ -1070,6 +1083,7 @@ mod tests {
                 result_digest: None,
                 policy: None,
                 skipped: None,
+                example_query: None,
             },
         );
         ops.insert(
@@ -1093,6 +1107,7 @@ mod tests {
                 result_digest: None,
                 policy: None,
                 skipped: None,
+                example_query: None,
             },
         );
         r.operations = ops;

--- a/src/synthetic/stats.rs
+++ b/src/synthetic/stats.rs
@@ -25,6 +25,36 @@ pub struct Summary {
     pub stddev: f64,
 }
 
+impl Summary {
+    /// **Sample** standard deviation of the retained samples — Bessel-corrected (n−1 denominator):
+    /// `s = stddev · √(n/(n−1))`, exact because the stored [`Self::stddev`] is the population σ
+    /// over the same `n` values. The n−1 denominator is deliberate: the retained samples are a
+    /// *sample* of the operation's latency distribution, and the population formula would
+    /// understate its dispersion (most at small `n`). `None` when `n < 2` (dispersion of a single
+    /// sample is undefined) or the result is non-finite — never a NaN/∞ that could poison a
+    /// report.
+    pub fn sample_stddev(&self) -> Option<f64> {
+        if self.n < 2 {
+            return None;
+        }
+        let s = self.stddev * (self.n as f64 / (self.n as f64 - 1.0)).sqrt();
+        s.is_finite().then_some(s)
+    }
+
+    /// Coefficient of variation, in percent: `100 · sample_stddev / mean` — the dispersion of the
+    /// retained samples relative to their own scale, so cells of very different magnitudes are
+    /// comparable at a glance. `None` whenever [`Self::sample_stddev`] is undefined or the mean is
+    /// non-finite or non-positive (a ratio to a ≤ 0 denominator is meaningless for latencies).
+    pub fn cv_pct(&self) -> Option<f64> {
+        let s = self.sample_stddev()?;
+        if !(self.mean.is_finite() && self.mean > 0.0) {
+            return None;
+        }
+        let cv = s / self.mean * 100.0;
+        cv.is_finite().then_some(cv)
+    }
+}
+
 /// The Tukey multiplier that classifies a *severe* outlier (`3·IQR`); mild would be `1.5`.
 const SEVERE_IQR_MULTIPLIER: f64 = 3.0;
 
@@ -217,5 +247,47 @@ mod tests {
     fn stddev_of_constant_is_zero() {
         let s = summarize(&[5.0, 5.0, 5.0, 5.0, 5.0]).unwrap();
         assert!(approx(s.stddev, 0.0));
+    }
+
+    #[test]
+    fn sample_stddev_applies_bessel_correction() {
+        // For [2, 4, 4, 4, 5, 5, 7, 9]: population σ = 2, sample s = √(32/7) ≈ 2.13809.
+        let s = summarize(&[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]).unwrap();
+        assert!(approx(s.stddev, 2.0));
+        assert!(approx(s.sample_stddev().unwrap(), (32.0f64 / 7.0).sqrt()));
+    }
+
+    #[test]
+    fn sample_stddev_undefined_below_two_samples() {
+        // n = 1: the n−1 denominator would divide by zero — must be None, not a panic/NaN.
+        let s = summarize(&[42.0]).unwrap();
+        assert_eq!(s.n, 1);
+        assert_eq!(s.sample_stddev(), None);
+        assert_eq!(s.cv_pct(), None);
+        // A synthetic n = 0 summary (never produced by `summarize`, but reachable through serde).
+        let zero = Summary { n: 0, ..s };
+        assert_eq!(zero.sample_stddev(), None);
+        assert_eq!(zero.cv_pct(), None);
+    }
+
+    #[test]
+    fn cv_pct_is_relative_sample_dispersion() {
+        // mean = 5, sample s = √(32/7) → CV = 100·s/5 ≈ 42.76%.
+        let s = summarize(&[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]).unwrap();
+        assert!(approx(s.cv_pct().unwrap(), (32.0f64 / 7.0).sqrt() / 5.0 * 100.0));
+        // A constant series has zero dispersion → CV 0%.
+        let flat = summarize(&[5.0, 5.0, 5.0, 5.0]).unwrap();
+        assert!(approx(flat.cv_pct().unwrap(), 0.0));
+    }
+
+    #[test]
+    fn cv_pct_undefined_for_nonpositive_or_nonfinite_mean() {
+        let base = summarize(&[1.0, 2.0, 3.0]).unwrap();
+        // Zeroed/negative means (an invalid server-time summary) must not divide.
+        assert_eq!(Summary { mean: 0.0, ..base.clone() }.cv_pct(), None);
+        assert_eq!(Summary { mean: -1.0, ..base.clone() }.cv_pct(), None);
+        assert_eq!(Summary { mean: f64::NAN, ..base.clone() }.cv_pct(), None);
+        // A non-finite stored σ (hand-crafted/corrupt) degrades to None, never NaN.
+        assert_eq!(Summary { stddev: f64::NAN, ..base }.sample_stddev(), None);
     }
 }

--- a/src/synthetic/stats.rs
+++ b/src/synthetic/stats.rs
@@ -31,10 +31,11 @@ impl Summary {
     /// over the same `n` values. The n−1 denominator is deliberate: the retained samples are a
     /// *sample* of the operation's latency distribution, and the population formula would
     /// understate its dispersion (most at small `n`). `None` when `n < 2` (dispersion of a single
-    /// sample is undefined) or the result is non-finite — never a NaN/∞ that could poison a
-    /// report.
+    /// sample is undefined) or the stored σ is negative (impossible from this tool — only a
+    /// corrupted/foreign report) or the result is non-finite — never a nonsensical value that
+    /// could poison a report.
     pub fn sample_stddev(&self) -> Option<f64> {
-        if self.n < 2 {
+        if self.n < 2 || self.stddev < 0.0 {
             return None;
         }
         let s = self.stddev * (self.n as f64 / (self.n as f64 - 1.0)).sqrt();
@@ -268,6 +269,10 @@ mod tests {
         let zero = Summary { n: 0, ..s };
         assert_eq!(zero.sample_stddev(), None);
         assert_eq!(zero.cv_pct(), None);
+        // A negative stored σ (corrupted/foreign report): invalid, not a negative "deviation".
+        let corrupt = Summary { n: 4, stddev: -1.0, ..s };
+        assert_eq!(corrupt.sample_stddev(), None);
+        assert_eq!(corrupt.cv_pct(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

A `Δp50` alone is hard to judge: without knowing **how many samples** produced each median and **how dispersed** they were, a +3 % delta could be solid signal or pure noise. And op names like `match_by_index` don't tell a reviewer what Cypher was actually measured. This PR enriches the synthetic reports (maintainer request) with:

1. an **example query** per op (the actual measured Cypher text),
2. **std dev**, 3. **CV %**, and 4. **sample count `n`** per measurement cell (op × cache-mode × concurrency, per side).

All new data is **informational — gating semantics are untouched** (still Δp50 on `server_ms` medians with `budget_pct` + `floor_ms`).

## What changed

### `report --diff` markdown
- One combined **`n / σ (ms) / CV`** column per side (kept as a single column so the 9-column table stays readable in the ~65 KB sticky-comment budget).
- Legend explains: `n` = samples retained after severe-outlier removal, pooled across the C workers; `σ` = **sample** standard deviation (n−1 denominator) of `server_ms` **within this run** (not run-to-run noise); `CV` = 100·σ/mean; `n (server m)` names both cohorts when they differ (foreign/older reports).
- σ/CV degrade to `—` exactly like the server latency columns (no valid server time ⇒ no server stats; `n` from the always-captured wall clock still shows).
- Each op section opens with a collapsed **`example query`** `<details>` block — fenced `cypher` code block whose fence outruns any inner backtick run, truncated past 600 chars with an explicit note.

### Regression report
- The per-cell `context:` line folds in `n/σ/CV` between throughput and the demoted total p50; both policy legends define the stats.
- The example-query block nests inside the op's collapsed `<details>` (appended only to ops that render a section anyway).

### `--cells` JSON (additive only, schema v2 unchanged)
- `ops.<op>.cells[].context.{baseline,candidate}` gains: `n`, `n_server`, `server_stddev_ms`, `server_cv_pct`, `total_stddev_ms`, `total_cv_pct` (total-clock stats are JSON-only, keeping the markdown single-clock).
- `ops.<op>.example_query` (candidate's text wins, baseline fallback; omitted when neither side carries one).
- Old cells files still deserialize (serde defaults; renderers omit the stats segment when `n == 0` rather than claim zero samples).

## Design choices

- **No report-schema change for the stats**: reports already store the population σ and `n` per summary, so the sample σ is derived exactly (`s = σ·√(n/(n−1))`) via new `Summary::sample_stddev()`/`cv_pct()` — old reports gain the stats retroactively. `n < 2` or a nonpositive/non-finite mean degrade to `None` (never panic / divide by zero).
- **Derived stats rounded to 6 decimals** in the cells JSON — sub-nanosecond precision is noise, and short decimals keep serde round-trips byte-stable.
- **Deterministic example extraction** (never sampled): first recorded command for `--recording` runs (skipped ops keep what *would* have run); first rendered corpus query for generated reads; catalog writes render invocation 0 against a canonical scratch and swap the per-run random label for the existing run-independent `BenchScratch_RUN` placeholder, so identical runs report byte-identical examples. Cached-mode base text; the legend notes uncached appends a cache-buster comment.

## Before / after (regression cell, real `synthetic-sanity` output)

Before:
```
| 1 | 0.043<br><sub>context: p90 0.049 · p95 0.052 · p99 0.055 · 2673 op/s · total p50 0.364</sub> | … |
```

After:
```
| 1 | 0.043<br><sub>context: p90 0.049 · p95 0.052 · p99 0.055 · 2673 op/s · n/σ/CV 284/0.007/17.7% · total p50 0.364</sub> | … |
```

New `--diff` table shape:

| C | A server p50/p90/p95/p99 (ms) | A n / σ (ms) / CV | B server p50/p90/p95/p99 (ms) | B n / σ (ms) / CV | Δp50 | A tput (ops/s) | B tput (ops/s) | Δtput |
|---:|---|---:|---|---:|---:|---:|---:|---:|
| 1 | 0.043 / 0.049 / 0.052 / 0.055<br><sub>total p50 0.364</sub> | 284 / 0.007 / 17.7% | 0.043 / 0.050 / 0.054 / 0.057<br><sub>total p50 0.321</sub> | 251 / 0.005 / 12.2% | +0.1% | 2673 | 3056 | +14.3% |

Per-op example block (collapsed):

<details><summary>example query</summary>

```cypher
CYPHER id = 834 MATCH (n:User {id: $id}) RETURN n.id
```

</details>

## Validation

- `just ci` (build + clippy + test): green, 518 unit tests (13 new: σ/CV math incl. n=0/1/non-finite edges, table rendering + `—` degradation + `n (server m)`, example-block determinism/fencing/truncation, candidate-first fallback, old-cells-JSON compatibility, canonical write labels).
- `just doc-check`: green.
- `just coverage` (against a live FalkorDB, `--include-ignored`): **patch coverage 100 %** (340/340 changed lines).
- `just synthetic-sanity`: green end-to-end (record → run → report with the new columns/blocks).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced synthetic benchmark diff and regression reports with within-run sample counts, standard deviation, and coefficient of variation.
  - Added collapsed, deterministic example-query sections for each operation, including truncation for long queries.
  - Expanded `--cells` JSON output with detailed dispersion metrics and retained sample counts.
  - Added representative example queries to benchmark and replay reports.

- **Bug Fixes**
  - Reports now gracefully omit server-time statistics when server latency data is unavailable or invalid.
  - Older cells JSON remains compatible with the updated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Consumer

The interactive per-PR page renders these new fields in FalkorDB/falkordb-rs-next-gen#774 (feature-detected — older data.json files render unchanged there until the pipeline pins a benchmark build that includes this PR).
