### PR TITLE
refactor(synthetic): report per-cell dispersion stats on server_ms only

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -619,9 +619,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
   rides along as an informational sub-line, and a side without a valid server time — e.g. a report
   predating server-time capture — degrades that
   latency cell to `—` — no silent fallback). Each side also gets a compact **`n / σ (ms) / CV`**
-  column with its **within-run** dispersion of `server_ms`: `n` = samples retained after
-  severe-outlier removal (pooled across the C workers), `σ` = their **sample** standard deviation
-  (n−1 denominator), `CV` = 100·σ/mean — dispersion *within* that run, not run-to-run noise; σ/CV
+  column with its **within-run** dispersion of `server_ms` — the gated distribution: `n` = retained
+  samples that actually carried a server-reported time (severe outliers removed, pooled across the
+  C workers), `σ` = their **sample** standard deviation (n−1 denominator), `CV` = 100·σ/mean —
+  dispersion *within* that run, not run-to-run noise; all three
   degrade to `—` alongside the server latency columns. Every op section opens with a **collapsed
   `example query`** block showing the op's deterministic first measured command (cached-mode base
   text, truncated past 600 chars; recorded repo-read shapes are documented in
@@ -682,10 +683,10 @@ just synthetic-compare-versions demo falkor://127.0.0.1:6379 falkor://127.0.0.1:
     attestation when present, thresholds echo) plus every
     op × cache-mode × concurrency cell with baseline/candidate p50, `delta_pct`/`delta_ms`, the
     resolved budget and the per-cell verdict — source material for an interactive report page.
-    Each cell's per-side `context` also carries the within-run measurement stats — `n` (retained
-    samples; `0` in files written before the field existed), `n_server` (server-timed cohort,
-    omitted when the side has no valid server time), `server_stddev_ms`/`server_cv_pct` and
-    `total_stddev_ms`/`total_cv_pct` (sample σ, n−1; omitted when undefined) — and each op an
+    Each cell's per-side `context` also carries the within-run measurement stats of `server_ms` —
+    the gated distribution: `server_n` (retained samples that actually carried a server-reported
+    time; omitted when the side has no valid server time) and `server_stddev_ms`/`server_cv_pct`
+    (sample σ, n−1, and 100·σ/mean; omitted when undefined, i.e. n < 2) — and each op an
     additive `example_query` (its deterministic first measured command, candidate's when both
     sides carry one; omitted when neither does).
     Skipped ops carry their reason in `skipped_baseline`/`skipped_candidate` (omitted otherwise).

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -342,18 +342,13 @@ pub struct CellContextSide {
     /// (the primary p50 already is that clock) or when the side has no valid total median.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total_p50_ms: Option<f64>,
-    /// Number of pooled measured samples this side's cell retains after severe-outlier removal
-    /// (the `total_ms` cohort — the wall clock is captured on every sample), i.e. the samples the
-    /// dispersion stats describe. `0` on a cells JSON written before this field existed.
-    #[serde(default)]
-    pub n: usize,
-    /// Retained sample count backing the **server_ms** dispersion stats. `None` when the side
-    /// carries no valid server time (a report predating server-time capture, or an engine that
-    /// doesn't report execution time) — the same degradation rule as every server column. It can
-    /// differ from [`n`](Self::n) only on such foreign/older reports; this tool's own pipeline
-    /// filters the two clocks as a paired cohort.
+    /// Number of retained measured samples that actually carried a **server-reported execution
+    /// time** — the cohort every dispersion stat (and the gated server p50) describes, counted
+    /// after severe-outlier removal and pooled across the C workers. `None` when the side has no
+    /// valid server time (a report predating server-time capture, or an engine that doesn't
+    /// report execution time) — the same degradation rule as every server column.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub n_server: Option<usize>,
+    pub server_n: Option<usize>,
     /// **Sample** standard deviation (n−1 denominator — see
     /// [`Summary::sample_stddev`](crate::synthetic::stats::Summary::sample_stddev)) of this
     /// side's retained `server_ms` samples, in ms: **within-run** dispersion (how spread this
@@ -366,15 +361,6 @@ pub struct CellContextSide {
     /// [`server_stddev_ms`](Self::server_stddev_ms).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_cv_pct: Option<f64>,
-    /// Sample standard deviation of the retained `total_ms` samples, in ms — carried for
-    /// machine consumers (the interactive page / analyzer scripts); the Markdown tables show
-    /// only the server-clock dispersion. `None` with fewer than 2 samples.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub total_stddev_ms: Option<f64>,
-    /// Coefficient of variation of `total_ms`, percent — machine-consumer counterpart of
-    /// [`server_cv_pct`](Self::server_cv_pct). `None` when undefined.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub total_cv_pct: Option<f64>,
 }
 
 /// Informational context for a cell (both sides optional — a side may not have measured it).
@@ -644,8 +630,8 @@ fn level_metrics<'a>(
 
 /// One side's informational tails/throughput, read from the **selected gated metric's** summary
 /// so a cell's primary p50 and its `context:` line always describe the same clock — plus the
-/// within-run dispersion stats (sample counts, sample σ, CV%) computed from each clock's own
-/// summary, clock-named so they are unambiguous under either gate.
+/// within-run dispersion stats (`server_n`, sample σ, CV%), all computed on **`server_ms`**:
+/// the distribution whose p50 is gated. Field names carry the clock so they stay unambiguous.
 fn context_side(
     metric: GatedMetric,
     m: &LevelMetrics,
@@ -669,12 +655,9 @@ fn context_side(
         p99_ms: s.p99,
         throughput_ops_per_sec: m.throughput_ops_per_sec,
         total_p50_ms,
-        n: m.metrics.total_ms.n,
-        n_server: server_valid.then_some(server.n),
+        server_n: server_valid.then_some(server.n),
         server_stddev_ms: round6(if server_valid { server.sample_stddev() } else { None }),
         server_cv_pct: round6(if server_valid { server.cv_pct() } else { None }),
-        total_stddev_ms: round6(m.metrics.total_ms.sample_stddev()),
-        total_cv_pct: round6(m.metrics.total_ms.cv_pct()),
     }
 }
 
@@ -1836,39 +1819,33 @@ mod tests {
 
     #[test]
     fn cell_context_carries_within_run_dispersion_stats() {
-        // Each side's context carries the within-run sample count and dispersion of both
-        // clocks: n (retained total_ms cohort), n_server, sample σ (n−1) and CV% — all rounded
-        // to 6 decimals so the cells JSON stays compact and byte-stable across serde round-trips.
+        // Each side's context carries the within-run dispersion of `server_ms` — the gated
+        // distribution: server_n (samples that actually carried a server time), sample σ (n−1)
+        // and CV% — all rounded to 6 decimals so the cells JSON stays compact and byte-stable
+        // across serde round-trips.
         let a = rpt("main", 42001, &[("match_by_index", 2.0, Some("d1"))]);
         let b = rpt("pr", 42002, &[("match_by_index", 2.0, Some("d1"))]);
         let an = server_gate(&a, &b);
         let side = an.ops["match_by_index"].cells[0].context.baseline.unwrap();
-        assert_eq!(side.n, 100);
-        assert_eq!(side.n_server, Some(100));
+        assert_eq!(side.server_n, Some(100));
         // summ(2.0): population σ = 0.2 over n = 100 ⇒ sample σ = 0.2·√(100/99) ≈ 0.201008.
         assert_eq!(side.server_stddev_ms, Some(0.201008));
         assert_eq!(side.server_cv_pct, Some(10.050378));
-        // Both fixture clocks share the same summary, so the total_ms stats match.
-        assert_eq!(side.total_stddev_ms, Some(0.201008));
-        assert_eq!(side.total_cv_pct, Some(10.050378));
     }
 
     #[test]
     fn dispersion_stats_degrade_with_invalid_server_median() {
         // No valid server time on a side (median 0/NaN — a report predating server-time
-        // capture): its server-clock stats and n_server are absent, exactly like the server p50
-        // columns; the wall-clock stats survive because total_ms is always captured.
+        // capture): every dispersion stat is absent, exactly like the server p50 columns —
+        // there is deliberately no wall-clock fallback.
         let a = rpt("main", 42001, &[("match_by_index", 2.0, Some("d1"))]);
         let mut b = rpt("pr", 42002, &[("match_by_index", 2.0, Some("d1"))]);
         set_server_median(&mut b, "match_by_index", 0.0);
         let an = server_gate(&a, &b);
         let side = an.ops["match_by_index"].cells[0].context.candidate.unwrap();
-        assert_eq!(side.n, 100, "the wall-clock cohort is still counted");
-        assert_eq!(side.n_server, None);
+        assert_eq!(side.server_n, None);
         assert_eq!(side.server_stddev_ms, None);
         assert_eq!(side.server_cv_pct, None);
-        assert_eq!(side.total_stddev_ms, Some(0.201008));
-        assert_eq!(side.total_cv_pct, Some(10.050378));
     }
 
     #[test]
@@ -1907,18 +1884,14 @@ mod tests {
     #[test]
     fn old_cells_json_without_dispersion_fields_still_deserializes() {
         // Cells JSON written before the dispersion stats existed (schema v2, additive change):
-        // the new fields default — n = 0 (meaning "not recorded", which renderers omit) and the
-        // optional stats stay None.
+        // the optional server-clock stats default to None, which renderers omit.
         let side: CellContextSide = serde_json::from_str(
             r#"{"p90_ms":1.2,"p95_ms":1.3,"p99_ms":1.5,"throughput_ops_per_sec":1000.0}"#,
         )
         .unwrap();
-        assert_eq!(side.n, 0);
-        assert_eq!(side.n_server, None);
+        assert_eq!(side.server_n, None);
         assert_eq!(side.server_stddev_ms, None);
         assert_eq!(side.server_cv_pct, None);
-        assert_eq!(side.total_stddev_ms, None);
-        assert_eq!(side.total_cv_pct, None);
         assert_eq!(side.total_p50_ms, None);
     }
 

--- a/src/synthetic/analysis.rs
+++ b/src/synthetic/analysis.rs
@@ -346,8 +346,10 @@ pub struct CellContextSide {
     /// time** — the cohort every dispersion stat (and the gated server p50) describes, counted
     /// after severe-outlier removal and pooled across the C workers. `None` when the side has no
     /// valid server time (a report predating server-time capture, or an engine that doesn't
-    /// report execution time) — the same degradation rule as every server column.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// report execution time) — the same degradation rule as every server column. Accepts the
+    /// transient v2.7 name `n_server` on deserialization (the same server-timed cohort) so cells
+    /// JSON written by that release keeps its count.
+    #[serde(default, alias = "n_server", skip_serializing_if = "Option::is_none")]
     pub server_n: Option<usize>,
     /// **Sample** standard deviation (n−1 denominator — see
     /// [`Summary::sample_stddev`](crate::synthetic::stats::Summary::sample_stddev)) of this
@@ -1893,6 +1895,19 @@ mod tests {
         assert_eq!(side.server_stddev_ms, None);
         assert_eq!(side.server_cv_pct, None);
         assert_eq!(side.total_p50_ms, None);
+
+        // A v2.7 payload (the short-lived wall-clock schema): the removed keys `n`,
+        // `total_stddev_ms` and `total_cv_pct` are ignored, and `n_server` — the same
+        // server-timed cohort — still feeds `server_n` through its serde alias.
+        let side: CellContextSide = serde_json::from_str(
+            r#"{"p90_ms":1.2,"p95_ms":1.3,"p99_ms":1.5,"throughput_ops_per_sec":1000.0,
+                "n":300,"n_server":297,"server_stddev_ms":0.05,"server_cv_pct":12.0,
+                "total_stddev_ms":0.06,"total_cv_pct":13.0}"#,
+        )
+        .unwrap();
+        assert_eq!(side.server_n, Some(297));
+        assert_eq!(side.server_stddev_ms, Some(0.05));
+        assert_eq!(side.server_cv_pct, Some(12.0));
     }
 
     #[test]

--- a/src/synthetic/diff.rs
+++ b/src/synthetic/diff.rs
@@ -100,14 +100,13 @@ pub fn diff_markdown(
          along as an informational sub-line. **Latency: lower is better** (a positive Δ = \
          slower / regressed); **throughput: higher is better**. Each side's `n / σ (ms) / CV` \
          describes its own **within-run** dispersion of `server_ms` (not run-to-run noise): \
-         `n` = samples retained after severe-outlier removal (pooled across the C workers), \
-         `σ` = their **sample** standard deviation (n−1 denominator), `CV` = 100·σ/mean; when \
-         only part of the retained cohort carries a server time (older engines), `n (server m)` \
-         names both counts. `—` = not measured in that run (or, in a latency/σ/CV column, no \
-         valid server time on that side — e.g. a report predating server-time capture or an \
-         engine that doesn't report execution time). Each op's `example query` block shows its \
-         first measured command (cached-mode base text; uncached appends a unique cache-buster \
-         comment)._\n",
+         `n` = retained samples that carried a server-reported time (severe outliers removed, \
+         pooled across the C workers), `σ` = their **sample** standard deviation (n−1 \
+         denominator), `CV` = 100·σ/mean. `—` = not measured in that run (or, in a \
+         latency/n/σ/CV column, no valid server time on that side — e.g. a report predating \
+         server-time capture or an engine that doesn't report execution time). Each op's \
+         `example query` block shows its first measured command (cached-mode base text; \
+         uncached appends a unique cache-buster comment)._\n",
     );
     for w in warnings {
         out.push_str(&format!("\n> ⚠ {w}\n"));
@@ -279,38 +278,32 @@ fn percentiles(m: &LevelMetrics) -> String {
     }
 }
 
-/// A diff-table `n / σ (ms) / CV` cell: the retained-sample count with the **within-run**
-/// sample standard deviation and coefficient of variation of `server_ms` — see
-/// [`format_dispersion`]. σ/CV degrade to `—` exactly like the server latency columns when the
-/// side carries no valid server time.
+/// A diff-table `n / σ (ms) / CV` cell: the within-run dispersion of **`server_ms`** — the
+/// gated distribution — where `n` counts the retained samples that actually carried a server
+/// time. All three degrade to `—` together exactly like the server latency columns when the
+/// side carries no valid server time — see [`format_dispersion`].
 fn dispersion_cell(m: &LevelMetrics) -> String {
     let server_valid = server_median(m).is_some();
     let server = &m.metrics.server_ms;
     format_dispersion(
         " / ",
-        m.metrics.total_ms.n,
         server_valid.then_some(server.n),
         if server_valid { server.sample_stddev() } else { None },
         if server_valid { server.cv_pct() } else { None },
     )
 }
 
-/// Format one side's within-run dispersion stats (`n`, sample σ of `server_ms` in ms, CV%),
-/// joined by `sep`. `n` is the retained `total_ms` cohort (the always-captured wall clock);
-/// when the server-time cohort exists but differs — possible only on foreign/older reports —
-/// both counts are named (`n (server m)`). Undefined σ/CV (no valid server time, or n < 2)
-/// render `—`, mirroring the server latency columns.
+/// Format one side's within-run dispersion stats of `server_ms` (`n`, sample σ in ms, CV%),
+/// joined by `sep`. `n` counts the retained samples carrying a server-reported time; it renders
+/// `—` (like every server column) when the side has no valid server time, and σ/CV additionally
+/// render `—` when undefined (n < 2).
 fn format_dispersion(
     sep: &str,
-    n: usize,
-    n_server: Option<usize>,
+    n: Option<usize>,
     stddev_ms: Option<f64>,
     cv_pct: Option<f64>,
 ) -> String {
-    let n_cell = match n_server {
-        Some(ns) if ns != n => format!("{n} (server {ns})"),
-        _ => n.to_string(),
-    };
+    let n_cell = n.map(|v| v.to_string()).unwrap_or_else(|| "—".to_string());
     let sd = stddev_ms.map(|s| format!("{s:.3}")).unwrap_or_else(|| "—".to_string());
     let cv = cv_pct.map(|c| format!("{c:.1}%")).unwrap_or_else(|| "—".to_string());
     format!("{n_cell}{sep}{sd}{sep}{cv}")
@@ -364,12 +357,12 @@ fn latency_cell(
 ) -> String {
     match (p50, ctx) {
         (Some(p50), Some(c)) => {
-            // A zero `n` means the model predates the dispersion stats (deserialized old cells
-            // JSON) — omit the segment rather than claim zero samples.
-            let disp = if c.n > 0 {
+            // Absent server_n means the side carries no server-clock stats (deserialized old
+            // cells JSON, or a side without valid server time) — omit the segment entirely.
+            let disp = if c.server_n.is_some() {
                 format!(
                     " · n/σ/CV {}",
-                    format_dispersion("/", c.n, c.n_server, c.server_stddev_ms, c.server_cv_pct)
+                    format_dispersion("/", c.server_n, c.server_stddev_ms, c.server_cv_pct)
                 )
             } else {
                 String::new()
@@ -619,10 +612,10 @@ pub fn regression_markdown(analysis: &RegressionAnalysis) -> String {
         "the `context:` line (p90/p95/p99 · throughput · within-run n/σ/CV of `server_ms`)"
     };
     // The dispersion stats' one-line definition, shared by both policies' legends.
-    let stats_clause = "n = samples retained after severe-outlier removal (pooled across the C \
-                        workers; `n (server m)` when only `m` carry a server time); σ = their \
-                        **sample** standard deviation (n−1) of `server_ms` **within this run** — \
-                        not run-to-run noise; CV = 100·σ/mean.";
+    let stats_clause = "n = retained samples that carried a server-reported time (severe \
+                        outliers removed, pooled across the C workers); σ = their **sample** \
+                        standard deviation (n−1) of `server_ms` **within this run** — not \
+                        run-to-run noise; CV = 100·σ/mean.";
     out.push_str(&match analysis.divergence_policy {
         DivergencePolicy::Gate => format!(
             "\n🟢 = faster or within budget · 🔴 = slower than budget **or** results differ · \
@@ -1167,8 +1160,8 @@ mod tests {
         set_server_median(&mut a, 0.0);
         let md = diff_markdown(&a, &b, &[]);
         assert!(
-            md.contains("| —<br><sub>total p50 1.000</sub> | 100 / — / — |"),
-            "missing server side degrades to — with demoted total and — σ/CV: {md}"
+            md.contains("| —<br><sub>total p50 1.000</sub> | — / — / — |"),
+            "missing server side degrades to — with demoted total and a dashed n/σ/CV: {md}"
         );
         assert!(
             md.contains("10.1% | — |"),
@@ -1199,7 +1192,7 @@ mod tests {
         // The legend explains the new columns and their within-run scope.
         assert!(md.contains("**within-run** dispersion"), "{md}");
         assert!(md.contains("**sample** standard deviation (n−1 denominator)"), "{md}");
-        assert!(md.contains("`n (server m)`"), "{md}");
+        assert!(md.contains("`n` = retained samples that carried a server-reported time"), "{md}");
     }
 
     #[test]
@@ -1249,45 +1242,39 @@ mod tests {
     }
 
     #[test]
-    fn format_dispersion_names_a_differing_server_cohort() {
-        // In this tool's own reports both cohorts always match (paired capture); a foreign or
-        // older report may carry fewer server-timed samples — both counts are then named.
+    fn format_dispersion_renders_server_counts_and_degrades_together() {
+        // n counts the server-timed samples — the gated distribution's cohort. A side without
+        // valid server time degrades all three stats to `—` like every server column.
         assert_eq!(
-            format_dispersion(" / ", 100, Some(100), Some(0.5), Some(10.0)),
+            format_dispersion(" / ", Some(100), Some(0.5), Some(10.0)),
             "100 / 0.500 / 10.0%"
         );
-        assert_eq!(
-            format_dispersion(" / ", 100, Some(80), Some(0.5), Some(10.0)),
-            "100 (server 80) / 0.500 / 10.0%"
-        );
-        assert_eq!(format_dispersion("/", 100, None, None, None), "100/—/—");
+        assert_eq!(format_dispersion("/", Some(1), None, None), "1/—/—");
+        assert_eq!(format_dispersion("/", None, None, None), "—/—/—");
     }
 
     #[test]
     fn latency_cell_omits_dispersion_for_pre_stats_cells() {
         use crate::synthetic::analysis::CellContextSide;
-        // n = 0 marks a context deserialized from cells JSON written before the dispersion
-        // stats existed — the segment is omitted rather than claiming zero samples.
+        // An absent server_n marks a context deserialized from cells JSON written before the
+        // dispersion stats existed (or a side with no valid server time) — the segment is
+        // omitted rather than rendering a fully dashed triple.
         let old = CellContextSide {
             p90_ms: 1.2,
             p95_ms: 1.3,
             p99_ms: 1.5,
             throughput_ops_per_sec: 1000.0,
             total_p50_ms: Some(1.0),
-            n: 0,
-            n_server: None,
+            server_n: None,
             server_stddev_ms: None,
             server_cv_pct: None,
-            total_stddev_ms: None,
-            total_cv_pct: None,
         };
         let cell = latency_cell(Some(1.0), Some(&old));
         assert!(!cell.contains("n/σ/CV"), "{cell}");
         assert!(cell.contains("· total p50 1.000"), "{cell}");
         // A populated context folds the stats between throughput and the demoted total.
         let new = CellContextSide {
-            n: 100,
-            n_server: Some(100),
+            server_n: Some(100),
             server_stddev_ms: Some(0.1),
             server_cv_pct: Some(10.0),
             ..old
@@ -1310,7 +1297,7 @@ mod tests {
         assert!(md.contains("<details><summary>example query</summary>"), "{md}");
         assert!(md.contains("MATCH (u:User {id: $id}) RETURN u"), "{md}");
         // The legend defines the context-line stats.
-        assert!(md.contains("n = samples retained after severe-outlier removal"), "{md}");
+        assert!(md.contains("n = retained samples that carried a server-reported time"), "{md}");
     }
 
     /// Overwrite every level's `server_ms` summary median (fixtures default both clocks equal).

--- a/src/synthetic/mod.rs
+++ b/src/synthetic/mod.rs
@@ -2075,6 +2075,45 @@ mod tests {
         assert_eq!(all_uids.len(), concurrency * depth * (warmup + per_lane));
     }
 
+    /// The dispersion cohort under pipelining: a depth-K level drives `C × K` lanes, each
+    /// measuring `lane_samples(samples, K)`, and the engine pools every lane's samples into one
+    /// vector — so the summarized `server_ms` cohort (`Summary.n`, which `context_side` surfaces
+    /// as the cell's `server_n`) counts every lane-measured sample exactly once: no lane dropped,
+    /// none double-counted, and never fewer than the requested `samples` per worker slot.
+    #[tokio::test]
+    async fn pipelined_lanes_pool_into_one_dispersion_cohort() {
+        struct ConstEcho;
+        impl crate::synthetic::engine::OpInvoker for ConstEcho {
+            async fn invoke(
+                &mut self,
+                _seq: u64,
+            ) -> BenchmarkResult<OpSample> {
+                Ok(OpSample {
+                    server_ms: 1.0,
+                    total_ms: 2.0,
+                    rows: 1,
+                    cached: Some(true),
+                    mutations: crate::synthetic::writes::MutationStats::default(),
+                })
+            }
+        }
+
+        let (concurrency, depth, samples, warmup) = (3usize, 4usize, 10usize, 2usize);
+        let per_lane = lane_samples(samples, depth); // 10.div_ceil(4) = 3 — an uneven split
+        let workers: Vec<ConstEcho> = (0..concurrency * depth).map(|_| ConstEcho).collect();
+        let run = run_closed_loop(workers, warmup, per_lane).await.unwrap();
+
+        let pooled = concurrency * depth * per_lane;
+        assert_eq!(run.samples.len(), pooled, "every lane's samples pooled exactly once");
+        assert!(pooled >= concurrency * samples, "round-up never under-measures a level");
+
+        // Constant latencies ⇒ no severe outliers ⇒ the retained server cohort is the pooled
+        // count, and its median is valid — exactly what analysis reports as server_n.
+        let metrics = summarize_samples(&run.samples).unwrap();
+        assert_eq!(metrics.server_ms.n, pooled);
+        assert_eq!(metrics.server_ms.median, 1.0);
+    }
+
     #[test]
     fn example_query_uses_the_first_rendered_read() {
         let op_spec = spec(OpName::MatchByIndex);


### PR DESCRIPTION
Follow-up to #277, per maintainer clarification: **all** per-cell measurement statistics describe **`server_ms`** — the sample distribution whose p50 is the gated metric — and the wall-clock extras leave the schema.

## What changed

- **Headline count is `server_n`** — the retained samples that actually carried a server-reported execution time (the cohort σ/CV and the gated p50 describe). The old pair `n` (wall-clock cohort) + optional `n_server` is gone; if some samples lack server time, the count that matters is the server one.
- **`total_stddev_ms` / `total_cv_pct` dropped** from the cells JSON (they were never rendered in Markdown; removed everywhere while the fields are days old and unconsumed — the page PR consuming them is unmerged and updated in lockstep).
- **Markdown `n / σ (ms) / CV` cells** now degrade all three together to `—` when a side has no valid server time (previously the wall-clock `n` survived), and the `n (server m)` dual form disappears. Legends updated: *n = retained samples that carried a server-reported time…*
- Docs (`readme.md` `--diff` / `--cells` sections) aligned.

Cells-JSON context side is now:

```json
"context": { "baseline": { "p90_ms": …, "p95_ms": …, "p99_ms": …, "throughput_ops_per_sec": …,
  "total_p50_ms": …, "server_n": 38, "server_stddev_ms": 0.008062, "server_cv_pct": 23.859566 } }
```

Rendered regression cell (unchanged shape, server-only semantics):

> 0.084<br><sub>context: p90 0.101 · p95 0.108 · p99 0.133 · 2298 op/s · n/σ/CV 38/0.014/15.7% · total p50 0.407</sub>

## Compatibility

- Additive relative to every released consumer: pre-#277 cells JSON never carried any of these fields; `server_n`/σ/CV keep `skip_serializing_if` + `default`, so old files still deserialize (covered by test).
- Gating semantics untouched — all fields remain informational.

## Validation

- `just ci` green (529 lib tests), `just doc-check` green, `just synthetic-sanity` green.
- `just coverage-local`: touched files at 100% line coverage.
- End-to-end: record → run ×2 → `report --diff --regression --cells` against a throwaway FalkorDB produced the JSON/Markdown snippets above.

Consumer page update: FalkorDB/falkordb-rs-next-gen#774 reads `server_n` in lockstep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `--diff` and `--regression` dispersion statistics, including sample counts, standard deviation, coefficient of variation, and missing-data behavior.
  * Updated regression JSON documentation to reflect server-timing statistics and omission rules.

* **Bug Fixes**
  * Improved benchmark reports when server timing data is missing or invalid.
  * Dispersion values now show as unavailable, or are omitted where appropriate, instead of displaying misleading results.
  * Standardized dispersion labels and output across Markdown and JSON reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->