### PR TITLE
chore(ci): pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Don't persist the GITHUB_TOKEN in .git/config (zizmor `artipacked`); the job only builds.
           persist-credentials: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Rust
         run: rustup update stable && rustup default stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # `just` is installed from a managed manifest; `lychee` (used by `just doc-links`) is not in
       # the manifest, so the action installs it via its cargo-binstall fallback from lychee's

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: lts/*
           cache: npm
@@ -39,7 +39,7 @@ jobs:
           PORT: 3000
         run: just ui-smoke
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: ${{ always() }}
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary
Pins every GitHub Actions `uses:` reference in this repository's workflows to a full 40-character commit SHA instead of a mutable tag or branch.

Mutable refs (`@v4`, `@main`, `@stable`, …) are re-pointable by the action owner or an attacker who compromises the action repo. Because these workflows run with repository secrets and write permissions, a moved tag is a direct supply-chain code-execution path. GitHub's own hardening guide and OpenSSF Scorecard both require full-SHA pinning.

## Changes
- Pinned **6** action reference(s) across **4** workflow file(s).
- Each SHA is the commit the original tag/branch resolved to at the time of this PR, so **behaviour is unchanged**.
- The original version is preserved as a trailing comment for readability and for Dependabot, e.g.
  ```yaml
  uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
  ```

Workflow files touched:
- `ci.yml`
- `coverage.yml`
- `docs.yml`
- `playwright.yml`

Resulting pinned references:
- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7`
- `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7`
- `actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6`

## Testing
- All modified workflow files were validated as parseable YAML.
- The diff is strictly 1-line-in / 1-line-out on `uses:` lines only — no jobs, steps, triggers, inputs, permissions or action *versions* were changed (verified via `git diff --shortstat`).
- Every SHA was resolved through the GitHub API (`GET /repos/{owner}/{repo}/commits/{ref}`) from the exact ref previously in use; no ref failed to resolve.
- Final verification is the CI run on this PR.

## Memory / Performance Impact
N/A — CI configuration only.

## Related Issues
N/A — part of an org-wide GitHub Actions supply-chain hardening pass across the FalkorDB organisation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned automated workflow actions to specific versions for more consistent and reliable CI, coverage, documentation, and Playwright runs.
  * Updated checkout, Node.js setup, and artifact upload steps while preserving their documented version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->