### PR TITLE
Add MongoDB as a benchmark engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -183,6 +205,18 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -199,6 +233,7 @@ dependencies = [
  "histogram",
  "hyper 0.14.32",
  "lazy_static",
+ "mongodb",
  "neo4rs",
  "nix",
  "nonzero",
@@ -224,9 +259,36 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -235,6 +297,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bson"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bitvec",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hex",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "rand 0.9.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -289,7 +374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -299,8 +384,10 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
  "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -344,7 +431,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -362,7 +449,7 @@ version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 3.0.4",
@@ -433,6 +520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +553,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
@@ -474,6 +576,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -493,6 +605,47 @@ checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -531,14 +684,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -548,7 +736,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -582,6 +770,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -685,6 +885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +979,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +1003,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -794,7 +1024,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -826,6 +1056,12 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -835,6 +1071,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "histogram"
@@ -848,11 +1090,20 @@ dependencies = [
 
 [[package]]
 name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -993,9 +1244,9 @@ dependencies = [
  "http 1.5.0",
  "hyper 1.11.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.43",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1005,7 +1256,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1022,6 +1273,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1108,6 +1383,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1437,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1190,7 +1495,7 @@ checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "simd_cesu8",
  "syn 2.0.119",
 ]
@@ -1257,6 +1562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1601,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,13 +1625,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1348,6 +1684,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "mongodb"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef206acb1b72389b49bc9985efe7eb1f8a9bb18e5680d262fac26c07f44025f1"
+dependencies = [
+ "async-trait",
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bson",
+ "chrono",
+ "derivative",
+ "derive_more",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hmac 0.12.1",
+ "lazy_static",
+ "md-5 0.10.6",
+ "pbkdf2",
+ "percent-encoding",
+ "rand 0.8.8",
+ "rustc_version_runtime",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha-1",
+ "sha2 0.10.9",
+ "socket2 0.4.10",
+ "stringprep",
+ "strsim 0.10.0",
+ "take_mut",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "trust-dns-proto",
+ "trust-dns-resolver",
+ "typed-builder",
+ "uuid",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
 name = "neo4rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,11 +1749,11 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "serde",
  "thiserror 1.0.69",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "url",
  "webpki-roots 0.26.11",
 ]
@@ -1391,7 +1774,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1486,7 +1869,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -1503,7 +1886,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -1606,6 +1989,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,15 +2078,15 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
- "md-5",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
  "memchr",
  "rand 0.10.2",
- "sha2",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
@@ -1821,7 +2213,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.43",
  "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
@@ -1843,7 +2235,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.20",
@@ -1877,9 +2269,21 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1888,8 +2292,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1914,12 +2328,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1973,7 +2406,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2011,7 +2444,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2028,12 +2461,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -2042,6 +2475,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "retain_mut"
@@ -2071,11 +2510,30 @@ checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d31b7153270ebf48bf91c65ae5b0c00e749c4cfad505f66530ac74950249582f"
+dependencies = [
+ "rustc_version 0.2.3",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2084,7 +2542,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2097,11 +2555,23 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -2114,7 +2584,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.15",
  "subtle",
  "zeroize",
 ]
@@ -2126,7 +2596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe 0.1.6",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -2142,6 +2612,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2174,10 +2653,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.43",
  "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.15",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2189,6 +2668,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2239,12 +2728,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -2257,7 +2756,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2276,9 +2775,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2288,6 +2802,16 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2316,11 +2840,34 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2337,10 +2884,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "sha2"
@@ -2349,8 +2918,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2390,7 +2959,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
  "simdutf8",
 ]
 
@@ -2417,6 +2986,16 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -2457,6 +3036,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -2485,7 +3070,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2498,7 +3083,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2584,7 +3169,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2598,6 +3183,18 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2773,11 +3370,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.43",
  "tokio",
 ]
 
@@ -2800,6 +3407,7 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "libc",
  "pin-project-lite",
@@ -2828,7 +3436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2918,10 +3526,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "rand 0.8.8",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ba72c2ea84515690c9fcef4c6c660bb9df3036ed1051686de84605b74fd558"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-builder"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "typenum"
@@ -2975,7 +3639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.1.0",
  "percent-encoding",
  "serde",
 ]
@@ -2993,10 +3657,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -3136,6 +3818,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
@@ -3176,6 +3864,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -3431,6 +4125,15 @@ name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ result_large_err = "allow"
 [dependencies]
 neo4rs = "0.8.0"
 tokio-postgres = "0.7"
+mongodb = { version = "2.8", default-features = false, features = ["tokio-runtime"] }
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = ["full", "tracing"] }
 futures = "0.3.31"

--- a/QUERY_EXPLANATIONS_AND_SAMPLES.md
+++ b/QUERY_EXPLANATIONS_AND_SAMPLES.md
@@ -718,7 +718,145 @@ SELECT
   )) AS dist
 ```
 
+## Mongo support
+Mongo is modeled as two collections, `users` and `friend_edges` (edge documents with `src`/`dst`
+fields), traversed with `$graphLookup`. Its own aggregation-pipeline catalog lives in
+`src/mongo_queries_repository.rs` rather than reusing `src/queries_repository.rs`.
+
+### Supported coverage profiles
+- `baseline` (default): the full set of baseline/phase-1 families that have an aggregation-pipeline translation.
+- `extended-core`: baseline + `exact_5_hop_traverse_count`, `exact_6_hop_traverse_count`, `temporal_spatial_roundtrip` (requires MongoDB 6.0+ for the `$documents` stage).
+- `fixture-dependent`: **not supported**. `--vendor mongo --query-profile fixture-dependent` is
+  rejected at startup because Mongo has no vector/fulltext index equivalent for the smoke queries.
+
+### Families excluded from every Mongo profile
+Same exclusions as Postgres (no aggregation-pipeline equivalent):
+- `algo_pagerank_summary`, `algo_max_flow_single_pair`, `algo_msf_summary`, `algo_harmonic_summary`
+- `vector_query_nodes_smoke`, `fulltext_query_nodes_smoke`, `fulltext_query_relationships_smoke`
+- `entity_path_introspection`
+
+### Additional families excluded (Postgres-only)
+`$graphLookup` returns an unordered, deduplicated reachable set per document with a first-seen
+`depthField` (BFS-like); this is usable for reachability/hop-count queries but cannot enumerate
+distinct paths or verify a full cyclic pattern's intermediate nodes, so these remain Postgres-only:
+`shortest_path`, `shortest_path_with_filter`, `all_shortest_paths_len`, `pattern_cycle`.
+
+### Mongo aggregation-pipeline templates (baseline, representative subset)
+```js
+// single_vertex_read
+db.users.findOne({ _id: id })
+
+// single_vertex_write (approximated as MERGE ... ON CREATE, no-op if already present)
+db.users.updateOne({ _id: id }, { $setOnInsert: { created_at: now } }, { upsert: true })
+
+// single_vertex_update
+db.users.updateOne({ _id: id }, { $set: { rpc_social_credit: value } })
+
+// single_edge_update ($sample + $merge is the standard Mongo idiom for "update a random doc")
+db.friend_edges.aggregate([
+  { $sample: { size: 1 } },
+  { $set: { color: value } },
+  { $merge: { into: "friend_edges", whenMatched: "merge", whenNotMatched: "discard" } },
+])
+
+// single_edge_write
+db.friend_edges.updateOne(
+  { src: from, dst: to },
+  { $setOnInsert: { bench_capacity: capacity }, $set: { touch: now } },
+  { upsert: true }
+)
+
+// aggregate_expansion_N[_with_filter] / neighbours_2[_with_filter]
+// Follow src -> dst edges via $graphLookup for (N-1) recursive hops, then filter to exactly
+// that depth (depth 0 == direct out-edges of the seed).
+db.users.aggregate([
+  { $match: { _id: seed } },
+  { $graphLookup: {
+      from: "friend_edges", startWith: "$_id",
+      connectFromField: "dst", connectToField: "src",
+      as: "reachable", maxDepth: hops - 1, depthField: "depth",
+  } },
+  { $unwind: "$reachable" },
+  { $match: { "reachable.depth": hops - 1 } },
+  // with_filter variant joins back to users and filters age >= 18:
+  { $lookup: { from: "users", localField: "reachable.dst", foreignField: "_id", as: "u" } },
+  { $unwind: "$u" },
+  { $match: { "u.age": { $gte: 18 } } },
+  { $project: { _id: "$u._id" } },
+])
+
+// value_join / value_join_cnt
+db.users.aggregate([
+  { $match: { _id: seed } },
+  { $lookup: {
+      from: "users", let: { age: "$age" },
+      pipeline: [ { $match: { $expr: { $eq: ["$age", "$$age"] } } } ],
+      as: "matches",
+  } },
+  { $unwind: "$matches" },
+  { $project: { _id: "$matches._id" } },
+])
+
+// union_all_ids / union_distinct_ids (via $unionWith; distinct adds a trailing $group)
+db.users.aggregate([
+  { $match: { _id: seed } },
+  { $project: { uid: "$_id" } },
+  { $unionWith: { coll: "users", pipeline: [
+      { $match: { _id: { $lt: 10 } } },
+      { $project: { uid: "$_id" } },
+  ] } },
+])
+
+// var_len_with_edge_where_filter (restrictSearchWithMatch filters the traversal itself)
+db.users.aggregate([
+  { $match: { _id: seed } },
+  { $graphLookup: {
+      from: "friend_edges", startWith: "$_id",
+      connectFromField: "dst", connectToField: "src",
+      as: "reachable", maxDepth: 2, depthField: "depth",
+      restrictSearchWithMatch: { bench_capacity: { $gte: min_capacity } },
+  } },
+  { $unwind: "$reachable" },
+  { $group: { _id: "$reachable.dst" } },
+  { $count: "cnt" },
+])
+
+// indexed_or_predicate / indexed_in_list_predicate
+db.users.find({ $or: [ { _id: id1 }, { _id: id2 } ] })
+db.users.find({ _id: { $in: [id1, id2, id3, id4] } })
+```
+
+### Mongo extended-core template
+```js
+// temporal_spatial_roundtrip
+// No $geoNear/PostGIS dependency: distance via the spherical law of cosines using Mongo's
+// trigonometry aggregation operators (MongoDB 4.2+); $documents (MongoDB 6.0+) seeds a single
+// input row without touching a real collection.
+db.users.aggregate([
+  { $documents: [ {} ] },
+  { $project: {
+      d: { $dateFromString: { dateString: "2024-01-01" } },
+      dur_hours: 51,
+      dist: { $multiply: [ 6371000, { $acos: { $add: [
+        { $multiply: [
+            { $cos: { $degreesToRadians: 32.1 } },
+            { $cos: { $degreesToRadians: 32.2 } },
+            { $cos: { $subtract: [ { $degreesToRadians: 34.9 }, { $degreesToRadians: 34.8 } ] } },
+        ] },
+        { $multiply: [ { $sin: { $degreesToRadians: 32.1 } }, { $sin: { $degreesToRadians: 32.2 } } ] },
+      ] } } ] },
+  } },
+])
+```
+
+### Mongo-specific limitations (documented, not fixed this phase)
+- `detach_delete_user`: Mongo has no FK/cascade concept; unlike Postgres's `ON DELETE CASCADE`,
+  deleting a user document does not remove `friend_edges` documents that reference it.
+- `remove_user_property_and_label` / `single_vertex_write` / `foreach_loop_mutation`: same
+  approximations as documented for Postgres (no label concept; single terminal assignment).
+
 ## Reference source
 - Canonical query definitions: `src/queries_repository.rs`
 - Postgres query definitions: `src/postgres_queries_repository.rs`
+- Mongo query definitions: `src/mongo_queries_repository.rs`
 - CLI profile/toggle options: `src/cli.rs` (`--query-profile` and `--enable-algo-*`)

--- a/readme.md
+++ b/readme.md
@@ -252,20 +252,22 @@ Options:
 - `cargo run --release --bin benchmark -- load --vendor neo4j -s small`
 - `cargo run --release --bin benchmark -- load --vendor memgraph -s small`
 - `cargo run --release --bin benchmark -- load --vendor postgres -s small`
+- `cargo run --release --bin benchmark -- load --vendor mongo -s small`
 
 NOTE: It is possible to use the load command with externally run vendor endpoint:
 - `cargo run --release --bin benchmark -- load --vendor falkor -s small --endpoint falkor://127.0.0.1:6379`
 - `cargo run --release --bin benchmark -- load --vendor neo4j -s small --endpoint neo4j://neo4j:benchmark123@127.0.0.1:7687`
 - `cargo run --release --bin benchmark -- load --vendor memgraph -s small --endpoint bolt://127.0.0.1:7687`
 - `cargo run --release --bin benchmark -- load --vendor postgres -s small --endpoint postgres://postgres:benchmark123@127.0.0.1:5432/postgres`
+- `cargo run --release --bin benchmark -- load --vendor mongo -s small --endpoint mongodb://127.0.0.1:27017/benchmark`
 
 Profile-aware loading (runs additional fixture/index setup when required):
 - `cargo run --release --bin benchmark -- load --vendor neo4j -s small --query-profile fixture-dependent`
 - `cargo run --release --bin benchmark -- load --vendor memgraph -s small --query-profile fixture-dependent`
 - `cargo run --release --bin benchmark -- load --vendor falkor -s small --query-profile fixture-dependent`
 
-NOTE: Postgres does not support the `fixture-dependent` profile (no vector/fulltext index
-equivalent); use `baseline` (default) or `extended-core` instead.
+NOTE: Postgres and Mongo do not support the `fixture-dependent` profile (no vector/fulltext
+index equivalent); use `baseline` (default) or `extended-core` instead.
 
 ##### create a set of queries to be used with the run command
 
@@ -282,6 +284,7 @@ Generate with a broader coverage profile:
 - `cargo run --release --bin benchmark -- generate-queries -s1000000 --dataset small --name=small-extended --write-ratio 0.0 --vendor neo4j --query-profile extended-core`
 - `cargo run --release --bin benchmark -- generate-queries -s1000000 --dataset small --name=small-fixtures --write-ratio 0.0 --vendor memgraph --query-profile fixture-dependent`
 - `cargo run --release --bin benchmark -- generate-queries -s1000000 --dataset small --name=small-readonly-postgres --write-ratio 0.0 --vendor postgres --query-profile baseline`
+- `cargo run --release --bin benchmark -- generate-queries -s1000000 --dataset small --name=small-readonly-mongo --write-ratio 0.0 --vendor mongo --query-profile baseline`
 
 ##### run the benchmarks
 
@@ -289,12 +292,14 @@ Generate with a broader coverage profile:
 - `cargo run --release --bin benchmark run --vendor neo4j --name small-readonly -p40 --mps 4000`
 - `cargo run --release --bin benchmark run --vendor memgraph --name small-readonly -p40 --mps 4000`
 - `cargo run --release --bin benchmark run --vendor postgres --name small-readonly-postgres -p40 --mps 4000`
+- `cargo run --release --bin benchmark run --vendor mongo --name small-readonly-mongo -p40 --mps 4000`
 
 NOTE: It is possible to use the run command externally run vendor endpoint:
 - `cargo run --release --bin benchmark run --vendor falkor --name small-readonly -p40 --mps 4000 --endpoint falkor://127.0.0.1:6379`
 - `cargo run --release --bin benchmark run --vendor neo4j --name small-readonly -p40 --mps 4000 --endpoint neo4j://neo4j:benchmark123@127.0.0.1:7687`
 - `cargo run --release --bin benchmark run --vendor memgraph --name small-readonly -p40 --mps 4000 --endpoint bolt://127.0.0.1:7687`
 - `cargo run --release --bin benchmark run --vendor postgres --name small-readonly-postgres -p40 --mps 4000 --endpoint postgres://postgres:benchmark123@127.0.0.1:5432/postgres`
+- `cargo run --release --bin benchmark run --vendor mongo --name small-readonly-mongo -p40 --mps 4000 --endpoint mongodb://127.0.0.1:27017/benchmark`
 
 Postgres connection parameters can also be supplied via environment variables
 (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`) when no
@@ -314,6 +319,25 @@ SQL equivalent and are always excluded from the Postgres catalog. See
 [QUERY_EXPLANATIONS_AND_SAMPLES.md](./QUERY_EXPLANATIONS_AND_SAMPLES.md) for the full capability
 matrix and SQL templates.
 
+Mongo connection parameters can also be supplied via environment variables (`MONGO_URI` for a
+full connection string, or `MONGO_HOST`/`MONGO_PORT`/`MONGO_USER`/`MONGO_PASSWORD`/`MONGO_DB`)
+when no `--endpoint` is given, defaulting to `127.0.0.1:27017` with database `benchmark`. A
+minimal local MongoDB for testing can be started with:
+
+```bash
+docker run --rm -d --name benchmark-mongo -p 27017:27017 mongo:7
+```
+
+Mongo is modeled as two collections, `users` and `friend_edges`, traversed with `$graphLookup`;
+most Cypher query families have a direct aggregation-pipeline translation, but `shortest_path`,
+`shortest_path_with_filter`, `all_shortest_paths_len`, and `pattern_cycle` are Postgres-only
+(`$graphLookup` returns an unordered reachable set and cannot enumerate distinct paths or verify
+cyclic patterns), and algorithm procedures plus vector/fulltext smoke queries have no aggregation
+equivalent and are always excluded from the Mongo catalog. `temporal_spatial_roundtrip` requires
+MongoDB 6.0+ (uses the `$documents` aggregation stage). See
+[QUERY_EXPLANATIONS_AND_SAMPLES.md](./QUERY_EXPLANATIONS_AND_SAMPLES.md) for the full capability
+matrix and aggregation-pipeline templates.
+
 ##### multi-vendor runs and per-vendor comparison reports (UI)
 
 The benchmark is designed to run the same workload against multiple vendors and then generate a **pairwise comparison report**.
@@ -324,6 +348,7 @@ The benchmark is designed to run the same workload against multiple vendors and 
 - `cargo run --release --bin benchmark -- run --vendor neo4j --name small-readonly -p40 --mps 4000 --results-dir Results-YYMMDD-HH:MM`
 - `cargo run --release --bin benchmark -- run --vendor memgraph --name small-readonly -p40 --mps 4000 --results-dir Results-YYMMDD-HH:MM`
 - `cargo run --release --bin benchmark -- run --vendor postgres --name small-readonly-postgres -p40 --mps 4000 --results-dir Results-YYMMDD-HH:MM`
+- `cargo run --release --bin benchmark -- run --vendor mongo --name small-readonly-mongo -p40 --mps 4000 --results-dir Results-YYMMDD-HH:MM`
 
 2) Aggregate into UI-ready JSON summaries:
 
@@ -334,6 +359,7 @@ This produces:
 - `ui/public/summaries/neo4j_vs_falkordb.json`
 - `ui/public/summaries/memgraph_vs_falkordb.json`
 - `ui/public/summaries/postgres_vs_falkordb.json`
+- `ui/public/summaries/mongo_vs_falkordb.json`
 
 AWS instance comparisons (e.g. Graviton vs Intel for FalkorDB runs stored under `aws-tests/`):
 
@@ -348,6 +374,7 @@ The comparison pages load only the relevant vendor pair:
 - `/neo4j` compares Neo4j vs FalkorDB
 - `/memgraph` compares Memgraph vs FalkorDB
 - `/postgres` compares Postgres vs FalkorDB
+- `/mongo` compares Mongo vs FalkorDB
 
 ##### per-query latency tracking (for the "single" view)
 

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -224,8 +224,15 @@ pub fn aggregate_results(
 
     // postgres vs falkor
     if let Ok(postgres) = load_vendor(&results_dir, Vendor::Postgres) {
-        let summary = make_summary(&[falkor, postgres])?;
+        let summary = make_summary(&[falkor.clone(), postgres])?;
         let out_path = out_dir.join("postgres_vs_falkordb.json");
+        write_summary(&out_path, &summary)?;
+    }
+
+    // mongo vs falkor
+    if let Ok(mongo) = load_vendor(&results_dir, Vendor::Mongo) {
+        let summary = make_summary(&[falkor, mongo])?;
+        let out_path = out_dir.join("mongo_vs_falkordb.json");
         write_summary(&out_path, &summary)?;
     }
 
@@ -726,6 +733,10 @@ fn build_ui_run_custom(v: &CustomRunArtifacts) -> BenchmarkResult<UiRun> {
             .get_single_value("postgres_store_size_bytes")
             .map(|v| v.round().max(0.0) as u64)
             .filter(|v| *v > 0),
+        Vendor::Mongo => metrics
+            .get_single_value("mongo_store_size_bytes")
+            .map(|v| v.round().max(0.0) as u64)
+            .filter(|v| *v > 0),
         _ => None,
     };
 
@@ -788,6 +799,7 @@ fn vendor_id(vendor: Vendor) -> String {
         Vendor::Neo4j => "neo4j".to_string(),
         Vendor::Memgraph => "memgraph".to_string(),
         Vendor::Postgres => "postgres".to_string(),
+        Vendor::Mongo => "mongo".to_string(),
     }
 }
 
@@ -889,6 +901,11 @@ impl MetricsIndex {
                 "postgres_latency_p95_us",
                 "postgres_latency_p99_us",
             ),
+            Vendor::Mongo => (
+                "mongo_latency_p50_us",
+                "mongo_latency_p95_us",
+                "mongo_latency_p99_us",
+            ),
         };
 
         let p50v = self.get_single_value(p50)?;
@@ -912,6 +929,7 @@ impl MetricsIndex {
             Vendor::Neo4j => "neo4j_query_latency_pct_us",
             Vendor::Memgraph => "memgraph_query_latency_pct_us",
             Vendor::Postgres => "postgres_query_latency_pct_us",
+            Vendor::Mongo => "mongo_query_latency_pct_us",
         };
         let timeout_metric_legacy = match vendor {
             Vendor::Memgraph => Some("memgraph_query_timeout_rate_pct"),
@@ -1005,6 +1023,7 @@ impl MetricsIndex {
             Vendor::Neo4j => "neo4j_query_latency_pct_us_by_size",
             Vendor::Memgraph => "memgraph_query_latency_pct_us_by_size",
             Vendor::Postgres => "postgres_query_latency_pct_us_by_size",
+            Vendor::Mongo => "mongo_query_latency_pct_us_by_size",
         };
 
         let samples = self.samples.get(metric).cloned().unwrap_or_default();
@@ -1217,6 +1236,7 @@ impl MetricsIndex {
             Vendor::Neo4j => "neo4j",
             Vendor::Memgraph => "memgraph",
             Vendor::Postgres => "postgres",
+            Vendor::Mongo => "mongo",
         };
 
         let base = match kind {
@@ -1299,8 +1319,9 @@ impl MetricsIndex {
             Vendor::Falkor => self.get_single_value("falkor_cpu_usage").unwrap_or(0.0),
             Vendor::Neo4j => self.get_single_value("neo4j_cpu_usage").unwrap_or(0.0),
             Vendor::Memgraph => self.get_single_value("memgraph_cpu_usage").unwrap_or(0.0),
-            // No local process management for Postgres (always an external endpoint).
+            // No local process management for Postgres/Mongo (always an external endpoint).
             Vendor::Postgres => 0.0,
+            Vendor::Mongo => 0.0,
         };
 
         // Prefer query-interface memory metrics when present.
@@ -1343,8 +1364,9 @@ impl MetricsIndex {
                 let mem_kib = self.get_single_value("neo4j_memory_usage").unwrap_or(0.0);
                 format_mem_from_kib(mem_kib)
             }
-            // No local process management for Postgres (always an external endpoint).
+            // No local process management for Postgres/Mongo (always an external endpoint).
             Vendor::Postgres => "0MB".to_string(),
+            Vendor::Mongo => "0MB".to_string(),
         };
 
         (cpu, mem_str)

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum BenchmarkError {
     FalkorDBError(#[from] FalkorDBError),
     #[error("Postgres error: {0}")]
     PostgresError(#[from] tokio_postgres::Error),
+    #[error("MongoDB error: {0}")]
+    MongoError(#[from] mongodb::error::Error),
     #[error("Redis error: {0}")]
     RedisError(#[from] redis::RedisError),
     #[error("Serde error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@ pub mod error;
 pub mod falkor;
 pub mod memgraph;
 pub mod memgraph_client;
+pub mod mongo;
+pub mod mongo_client;
+pub mod mongo_queries_repository;
+pub mod mongo_query;
 pub mod multi_benchmark;
 pub mod neo4j;
 pub mod neo4j_client;
@@ -444,6 +448,51 @@ lazy_static! {
     pub static ref POSTGRES_STORE_SIZE_BYTES: IntGauge = register_int_gauge!(
         "postgres_store_size_bytes",
         "Approximate size in bytes of Postgres users/friend_edges tables and their indexes"
+    )
+    .unwrap();
+
+    pub static ref MONGO_SUCCESS_REQUESTS_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "mongo_response_time_success_histogram",
+        "Response time histogram of the successful requests",
+        vec![0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,]
+    )
+    .unwrap();
+    pub static ref MONGO_ERROR_REQUESTS_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "mongo_response_time_error_histogram",
+        "Response time histogram of the error requests",
+        vec![0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,]
+    )
+    .unwrap();
+    pub static ref MONGO_MSG_DEADLINE_OFFSET_GAUGE: IntGauge = register_int_gauge!(
+        "mongo_msg_deadline_offset",
+        "offset of the message from the deadline",
+    )
+    .unwrap();
+    pub static ref MONGO_LATENCY_P50_US: IntGauge = register_int_gauge!(
+        "mongo_latency_p50_us",
+        "P50 latency in microseconds (computed in-process)"
+    )
+    .unwrap();
+    pub static ref MONGO_LATENCY_P95_US: IntGauge = register_int_gauge!(
+        "mongo_latency_p95_us",
+        "P95 latency in microseconds (computed in-process)"
+    )
+    .unwrap();
+    pub static ref MONGO_LATENCY_P99_US: IntGauge = register_int_gauge!(
+        "mongo_latency_p99_us",
+        "P99 latency in microseconds (computed in-process)"
+    )
+    .unwrap();
+    pub static ref MONGO_QUERY_LATENCY_PCT_US: IntGaugeVec = register_int_gauge_vec!(
+        "mongo_query_latency_pct_us",
+        "Latency percentile per query in microseconds (computed in-process)",
+        &["query", "pct"]
+    )
+    .unwrap();
+    // Combined collection + index size (bytes) for the `users`/`friend_edges` collections.
+    pub static ref MONGO_STORE_SIZE_BYTES: IntGauge = register_int_gauge!(
+        "mongo_store_size_bytes",
+        "Approximate size in bytes of Mongo users/friend_edges collections and their indexes"
     )
     .unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ use benchmark::falkor::{Falkor, FalkorAlgorithmCapabilities, Stopped};
 use benchmark::memgraph_client::{
     MemgraphAlgorithmCapabilities, MemgraphClient, MemgraphFixtureCapabilities,
 };
+use benchmark::mongo_client::MongoClient;
+use benchmark::mongo_queries_repository::MongoUsersQueriesRepository;
+use benchmark::mongo_query::PreparedMongoQuery;
 use benchmark::multi_benchmark::{load_scenario_config, rolling_windows, GraphDeploymentPlan};
 use benchmark::neo4j_client::{Neo4jAlgorithmCapabilities, Neo4jClient, Neo4jFixtureCapabilities};
 use benchmark::postgres_client::PostgresClient;
@@ -33,6 +36,8 @@ use benchmark::{
     MEMGRAPH_ERROR_REQUESTS_DURATION_HISTOGRAM, MEMGRAPH_LATENCY_P50_US, MEMGRAPH_LATENCY_P95_US,
     MEMGRAPH_LATENCY_P99_US, MEMGRAPH_QUERY_LATENCY_PCT_US, MEMGRAPH_QUERY_TIMEOUT_RATE_PCT,
     MEMGRAPH_STORAGE_BASE_DATASET_BYTES, MEMGRAPH_SUCCESS_REQUESTS_DURATION_HISTOGRAM,
+    MONGO_ERROR_REQUESTS_DURATION_HISTOGRAM, MONGO_LATENCY_P50_US, MONGO_LATENCY_P95_US,
+    MONGO_LATENCY_P99_US, MONGO_QUERY_LATENCY_PCT_US, MONGO_SUCCESS_REQUESTS_DURATION_HISTOGRAM,
     NEO4J_ERROR_REQUESTS_DURATION_HISTOGRAM, NEO4J_LATENCY_P50_US, NEO4J_LATENCY_P95_US,
     NEO4J_LATENCY_P99_US, NEO4J_QUERY_LATENCY_PCT_US, NEO4J_STORE_SIZE_BYTES,
     NEO4J_SUCCESS_REQUESTS_DURATION_HISTOGRAM,
@@ -333,6 +338,14 @@ async fn async_main(cli: Cli) -> BenchmarkResult<()> {
                         init_postgres(size, force, batch_size, endpoint, query_profile).await?;
                     }
                 }
+                Vendor::Mongo => {
+                    if dry_run {
+                        info!("Dry run");
+                        todo!()
+                    } else {
+                        init_mongo(size, force, batch_size, endpoint, query_profile).await?;
+                    }
+                }
             }
         }
         Commands::Run {
@@ -362,6 +375,9 @@ async fn async_main(cli: Cli) -> BenchmarkResult<()> {
                 }
                 Vendor::Postgres => {
                     run_postgres(parallel, name, mps, simulate, endpoint, results_dir).await?;
+                }
+                Vendor::Mongo => {
+                    run_mongo(parallel, name, mps, simulate, endpoint, results_dir).await?;
                 }
             }
         }
@@ -566,6 +582,14 @@ fn validate_query_coverage_profile_support(
             "Postgres does not support the 'fixture-dependent' query coverage profile \
              (vector/fulltext index queries have no SQL equivalent in this integration). \
              Use --query-profile baseline or extended-core instead."
+                .to_string(),
+        ));
+    }
+    if vendor == Vendor::Mongo && query_profile.includes_fixture_dependent() {
+        return Err(OtherError(
+            "Mongo does not support the 'fixture-dependent' query coverage profile \
+             (vector/fulltext index queries have no aggregation-pipeline equivalent in this \
+             integration). Use --query-profile baseline or extended-core instead."
                 .to_string(),
         ));
     }
@@ -927,6 +951,7 @@ impl PerQueryLatency {
             Vendor::Neo4j => "neo4j",
             Vendor::Memgraph => "memgraph",
             Vendor::Postgres => "postgres",
+            Vendor::Mongo => "mongo",
         }
     }
 
@@ -940,6 +965,7 @@ impl PerQueryLatency {
             Vendor::Neo4j => NEO4J_QUERY_LATENCY_PCT_US.reset(),
             Vendor::Memgraph => MEMGRAPH_QUERY_LATENCY_PCT_US.reset(),
             Vendor::Postgres => POSTGRES_QUERY_LATENCY_PCT_US.reset(),
+            Vendor::Mongo => MONGO_QUERY_LATENCY_PCT_US.reset(),
         }
         BENCHMARK_QUERY_TIMEOUT_RATE_PCT.reset();
         BENCHMARK_QUERY_FAILURE_RATE_PCT.reset();
@@ -1028,6 +1054,11 @@ impl PerQueryLatency {
                     }
                     Vendor::Postgres => {
                         POSTGRES_QUERY_LATENCY_PCT_US
+                            .with_label_values(&[entry.name.as_str(), pct_label.as_str()])
+                            .set(v);
+                    }
+                    Vendor::Mongo => {
+                        MONGO_QUERY_LATENCY_PCT_US
                             .with_label_values(&[entry.name.as_str(), pct_label.as_str()])
                             .set(v);
                     }
@@ -2592,6 +2623,269 @@ async fn spawn_postgres_worker(
     Ok(handle)
 }
 
+async fn init_mongo(
+    size: Size,
+    force: bool,
+    batch_size: usize,
+    endpoint: Option<String>,
+    query_profile: QueryCoverageProfile,
+) -> BenchmarkResult<()> {
+    validate_query_coverage_profile_support(Vendor::Mongo, query_profile)?;
+    let spec = Spec::new(benchmark::scenario::Name::Users, size, Vendor::Mongo);
+
+    let (uri, dbname) = if let Some(ref endpoint_str) = endpoint {
+        info!(
+            "Using external Mongo endpoint for data loading: {}",
+            redact_endpoint(endpoint_str)
+        );
+        parse_mongo_endpoint(endpoint_str)?
+    } else {
+        benchmark::mongo::default_connection_params()
+    };
+
+    let client = MongoClient::connect(&uri, &dbname).await?;
+    info!("client connected to mongo");
+
+    if force {
+        info!("Clearing existing Mongo collections (--force)");
+        benchmark::mongo::clear_schema(&client).await?;
+    }
+
+    benchmark::mongo::create_schema(&client).await?;
+
+    let (node_count, relation_count) = client.graph_size().await?;
+    info!(
+        "node count: {}, relation count: {}",
+        format_number(node_count),
+        format_number(relation_count)
+    );
+    if node_count != 0 || relation_count != 0 {
+        error!(
+            "Mongo database is not empty, node count: {}, relation count: {}",
+            node_count, relation_count
+        );
+        return Err(OtherError(
+            "Database is not empty. Use --force to clear it first.".to_string(),
+        ));
+    }
+
+    let mut histogram = Histogram::new(7, 64)?;
+    let data_stream = spec.init_data_iterator().await?;
+    info!("importing data (bulk insertMany) in batches of {}", batch_size);
+    let start = Instant::now();
+    let total_processed =
+        benchmark::mongo::load_from_cypher_import(&client, data_stream, batch_size, &mut histogram)
+            .await?;
+    info!(
+        "Processed {} records via bulk-insertMany batches",
+        format_number(total_processed as u64)
+    );
+
+    let (node_count, relation_count) = client.graph_size().await?;
+    info!(
+        "{} nodes and {} relations were imported at {:?}",
+        format_number(node_count),
+        format_number(relation_count),
+        start.elapsed()
+    );
+
+    info!("---> histogram");
+    show_historgam(histogram);
+
+    info!("---> Done");
+    Ok(())
+}
+
+async fn run_mongo(
+    parallel: usize,
+    file_name: String,
+    mps: usize,
+    simulate: Option<usize>,
+    endpoint: Option<String>,
+    results_dir: Option<String>,
+) -> BenchmarkResult<()> {
+    let queries_file = file_name.clone();
+    let (queries_metadata, queries) = read_mongo_queries(file_name).await?;
+    validate_query_coverage_profile_support(Vendor::Mongo, queries_metadata.query_profile)?;
+
+    let (uri, dbname) = if let Some(ref endpoint_str) = endpoint {
+        info!(
+            "Using external Mongo endpoint: {}",
+            redact_endpoint(endpoint_str)
+        );
+        parse_mongo_endpoint(endpoint_str)?
+    } else {
+        benchmark::mongo::default_connection_params()
+    };
+
+    let client = MongoClient::connect(&uri, &dbname).await?;
+    info!("client connected to mongo");
+    let engine_version = client.detect_engine_version().await.ok().flatten();
+
+    // Best-effort store sizing.
+    client.collect_store_size_metrics().await;
+
+    let number_of_queries = queries.len();
+    let worker_progress_every = worker_progress_batch_size(number_of_queries);
+    let (node_count, relation_count) = client.graph_size().await?;
+
+    info!(
+        "graph has {} nodes and {} relations",
+        format_number(node_count),
+        format_number(relation_count)
+    );
+    info!(
+        "running {} queries",
+        format_number(number_of_queries as u64)
+    );
+    info!(
+        "worker query spread batch set to {} (total queries: {})",
+        worker_progress_every,
+        format_number(number_of_queries as u64)
+    );
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Msg<PreparedMongoQuery>>(20 * parallel);
+    let rx: Arc<Mutex<Receiver<Msg<PreparedMongoQuery>>>> = Arc::new(Mutex::new(rx));
+    let scheduler_handle =
+        scheduler::spawn_scheduler::<PreparedMongoQuery>(mps, tx.clone(), queries);
+    let mut workers_handles = Vec::with_capacity(parallel);
+
+    let latency_hist = Arc::new(tokio::sync::Mutex::new(histogram::Histogram::new(7, 64)?));
+    let per_query = Arc::new(PerQueryLatency::new(queries_metadata.catalog.clone())?);
+
+    let started_at = SystemTime::now();
+    let start = Instant::now();
+    for spawn_id in 0..parallel {
+        let handle = spawn_mongo_worker(
+            client.clone(),
+            spawn_id,
+            &rx,
+            simulate,
+            latency_hist.clone(),
+            per_query.clone(),
+            worker_progress_every,
+        )
+        .await?;
+        workers_handles.push(handle);
+    }
+    let _ = scheduler_handle.await;
+    drop(tx);
+
+    for handle in workers_handles {
+        let _ = handle.await;
+    }
+
+    let elapsed = start.elapsed();
+    let finished_at = SystemTime::now();
+
+    info!(
+        "running {} queries took {:?}",
+        format_number(number_of_queries as u64),
+        elapsed
+    );
+
+    {
+        let hist = latency_hist.lock().await;
+        MONGO_LATENCY_P50_US.set(percentile_us(&hist, 50.0) as i64);
+        MONGO_LATENCY_P95_US.set(percentile_us(&hist, 95.0) as i64);
+        MONGO_LATENCY_P99_US.set(percentile_us(&hist, 99.0) as i64);
+    }
+
+    per_query.export_to_prometheus(Vendor::Mongo);
+
+    write_run_results(
+        results_dir,
+        Vendor::Mongo,
+        queries_metadata.dataset,
+        &queries_file,
+        parallel,
+        mps,
+        simulate,
+        &endpoint,
+        number_of_queries,
+        started_at,
+        finished_at,
+        elapsed,
+        engine_version,
+    )
+    .await?;
+
+    info!("Using external endpoint, skipping Mongo process management");
+    Ok(())
+}
+
+async fn spawn_mongo_worker(
+    client: MongoClient,
+    worker_id: usize,
+    receiver: &Arc<Mutex<Receiver<Msg<PreparedMongoQuery>>>>,
+    simulate: Option<usize>,
+    latency_hist: Arc<tokio::sync::Mutex<histogram::Histogram>>,
+    per_query: Arc<PerQueryLatency>,
+    worker_progress_every: u32,
+) -> BenchmarkResult<JoinHandle<()>> {
+    info!("spawning worker");
+    let receiver = Arc::clone(receiver);
+    let handle = tokio::spawn(async move {
+        let worker_id = worker_id.to_string();
+        let worker_id_str = worker_id.as_str();
+        let mut counter = 0u32;
+        let client = client.clone();
+        loop {
+            let received = receiver.lock().await.recv().await;
+
+            match received {
+                Some(prepared_query) => {
+                    let start_time = Instant::now();
+
+                    let r = client
+                        .execute_prepared_query(worker_id_str, &prepared_query, &simulate)
+                        .await;
+                    let duration = start_time.elapsed();
+                    match r {
+                        Ok(_) => {
+                            MONGO_SUCCESS_REQUESTS_DURATION_HISTOGRAM
+                                .observe(duration.as_secs_f64());
+                            {
+                                let mut h = latency_hist.lock().await;
+                                let _ = h.increment(duration.as_micros() as u64);
+                            }
+                            per_query.record_success_us(
+                                prepared_query.payload.q_id,
+                                duration.as_micros() as u64,
+                            );
+                            counter += 1;
+                            if counter.is_multiple_of(worker_progress_every) {
+                                info!("worker {} processed {} queries", worker_id, counter);
+                            }
+                        }
+                        Err(e) => {
+                            MONGO_ERROR_REQUESTS_DURATION_HISTOGRAM
+                                .observe(duration.as_secs_f64());
+                            if is_timeout_error(&e) {
+                                per_query.record_timeout(prepared_query.payload.q_id);
+                            } else {
+                                per_query.record_failure(prepared_query.payload.q_id);
+                            }
+                            let seconds_wait = 3u64;
+                            info!(
+                                "worker {} failed to process query, not sleeping for {} seconds {:?}",
+                                worker_id, seconds_wait, e
+                            );
+                        }
+                    }
+                }
+                None => {
+                    info!("worker {} received None, exiting", worker_id);
+                    break;
+                }
+            }
+        }
+        info!("worker {} finished", worker_id);
+    });
+
+    Ok(handle)
+}
+
 fn print_completions<G: Generator>(
     gen: G,
     cmd: &mut Command,
@@ -2629,6 +2923,16 @@ async fn prepare_queries(
         )
         .await;
     }
+    if vendor == Vendor::Mongo {
+        return prepare_mongo_queries(
+            dataset,
+            size,
+            file_name,
+            write_ratio,
+            query_profile,
+        )
+        .await;
+    }
 
     let start = Instant::now();
 
@@ -2642,6 +2946,7 @@ async fn prepare_queries(
         Vendor::Neo4j => Flavour::Neo4j,
         Vendor::Memgraph => Flavour::Memgraph,
         Vendor::Postgres => unreachable!("handled above via prepare_postgres_queries"),
+        Vendor::Mongo => unreachable!("handled above via prepare_mongo_queries"),
     };
 
     let queries_repository = benchmark::queries_repository::UsersQueriesRepository::new(
@@ -2872,6 +3177,104 @@ fn parse_postgres_endpoint(
     };
 
     Ok((host, port, user, password, dbname))
+}
+
+/// Mongo analogue of `prepare_postgres_queries`, writing `PreparedMongoQuery` lines instead of
+/// SQL `PreparedSqlQuery` lines.
+async fn prepare_mongo_queries(
+    dataset: Size,
+    size: usize,
+    file_name: String,
+    write_ratio: f32,
+    query_profile: QueryCoverageProfile,
+) -> BenchmarkResult<()> {
+    let start = Instant::now();
+    let spec = Spec::new(Users, dataset, Vendor::Mongo);
+    let vertices = spec.vertices as i32;
+    let edges = spec.edges as i32;
+
+    let queries_repository = MongoUsersQueriesRepository::new(vertices, edges, query_profile);
+    let catalog = queries_repository.catalog();
+
+    let metadata = PrepareQueriesMetadata {
+        size,
+        dataset,
+        query_profile,
+        catalog,
+    };
+
+    let file = File::create(file_name).await?;
+    let mut writer = BufWriter::new(file);
+    let metadata_line = serde_json::to_string(&metadata)?;
+    writer.write_all(metadata_line.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+
+    for query in queries_repository.random_queries(size, write_ratio) {
+        let json_string = serde_json::to_string(&query)?;
+        writer.write_all(json_string.as_bytes()).await?;
+        writer.write_all(b"\n").await?;
+    }
+    writer.flush().await?;
+
+    let duration = start.elapsed();
+    info!("Time taken to prepare Mongo queries: {:?}", duration);
+    Ok(())
+}
+
+async fn read_mongo_queries(
+    file_name: String
+) -> BenchmarkResult<(PrepareQueriesMetadata, Vec<PreparedMongoQuery>)> {
+    let start = Instant::now();
+    let file = File::open(file_name).await?;
+    let mut reader = BufReader::new(file);
+
+    let mut metadata_line = String::new();
+    reader.read_line(&mut metadata_line).await?;
+
+    match serde_json::from_str::<PrepareQueriesMetadata>(&metadata_line) {
+        Ok(metadata) => {
+            let size = metadata.size;
+            let mut queries = Vec::with_capacity(size);
+            let mut lines = reader.lines();
+
+            while let Some(line) = lines.next_line().await? {
+                let query: PreparedMongoQuery = serde_json::from_str(&line)?;
+                queries.push(query);
+            }
+            let duration = start.elapsed();
+            info!("Reading {} Mongo queries took {:?}", size, duration);
+            Ok((metadata, queries))
+        }
+        Err(e) => Err(OtherError(format!("Error parsing metadata: {}", e))),
+    }
+}
+
+/// Parse a Mongo endpoint string into (uri, dbname). Supports full connection strings like
+/// `mongodb://user:pass@host:27017/dbname` or `mongodb+srv://...`; the whole endpoint string is
+/// passed through as the URI (the Mongo driver understands both schemes natively), and the
+/// database name is extracted from the URL path (falling back to `MONGO_DB`).
+fn parse_mongo_endpoint(endpoint: &str) -> BenchmarkResult<(String, String)> {
+    let url = Url::parse(endpoint)
+        .map_err(|e| OtherError(format!("Invalid Mongo endpoint URL '{}': {}", endpoint, e)))?;
+
+    match url.scheme() {
+        "mongodb" | "mongodb+srv" => {}
+        scheme => {
+            return Err(OtherError(format!(
+                "Unsupported Mongo scheme '{}'. Use mongodb:// or mongodb+srv://",
+                scheme
+            )));
+        }
+    }
+
+    let dbname = url.path().trim_start_matches('/');
+    let dbname = if dbname.is_empty() {
+        std::env::var("MONGO_DB").unwrap_or_else(|_| "benchmark".to_string())
+    } else {
+        dbname.to_string()
+    };
+
+    Ok((endpoint.to_string(), dbname))
 }
 
 async fn run_memgraph(

--- a/src/mongo.rs
+++ b/src/mongo.rs
@@ -1,0 +1,192 @@
+use crate::data_prep::bench_capacity;
+use crate::error::BenchmarkError::MongoError;
+use crate::error::BenchmarkResult;
+use crate::mongo_client::MongoClient;
+use crate::pokec_cypher_parser::{parse_edge_line, parse_node_line, EdgeRecord, NodeRecord};
+use futures::StreamExt;
+use histogram::Histogram;
+use mongodb::bson::{doc, Document};
+use mongodb::options::InsertManyOptions;
+use std::io;
+use tokio::time::Instant;
+use tracing::{error, info};
+
+/// Resolve a Mongo connection URI + database name from environment variables, with sane local
+/// defaults. `MONGO_URI` takes priority (allows full connection strings, e.g. `mongodb+srv://...`
+/// or replica-set/auth options); otherwise a URI is built from host/port/user/password.
+pub fn default_connection_params() -> (String, String) {
+    let dbname = std::env::var("MONGO_DB").unwrap_or_else(|_| "benchmark".to_string());
+
+    if let Ok(uri) = std::env::var("MONGO_URI") {
+        return (uri, dbname);
+    }
+
+    let host = std::env::var("MONGO_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let port = std::env::var("MONGO_PORT").unwrap_or_else(|_| "27017".to_string());
+    let user = std::env::var("MONGO_USER").unwrap_or_default();
+    let password = std::env::var("MONGO_PASSWORD").unwrap_or_default();
+
+    let uri = if user.is_empty() {
+        format!("mongodb://{}:{}", host, port)
+    } else {
+        format!("mongodb://{}:{}@{}:{}", user, password, host, port)
+    };
+
+    (uri, dbname)
+}
+
+pub async fn clear_schema(client: &MongoClient) -> BenchmarkResult<()> {
+    client.drop_collections().await
+}
+
+pub async fn create_schema(client: &MongoClient) -> BenchmarkResult<()> {
+    client.create_schema().await
+}
+
+fn node_to_document(n: &NodeRecord) -> Document {
+    doc! {
+        "_id": n.id,
+        "completion_percentage": n.completion_percentage,
+        "gender": n.gender.clone(),
+        "age": n.age,
+    }
+}
+
+fn edge_to_document(e: &EdgeRecord) -> Document {
+    doc! {
+        "src": e.src,
+        "dst": e.dst,
+        "bench_capacity": bench_capacity(e.src as u64, e.dst as u64) as i32,
+    }
+}
+
+async fn flush_nodes(
+    client: &MongoClient,
+    nodes: &mut Vec<NodeRecord>,
+    histogram: &mut Histogram,
+    batch_count: &mut usize,
+) -> BenchmarkResult<()> {
+    if nodes.is_empty() {
+        return Ok(());
+    }
+    *batch_count += 1;
+
+    let docs: Vec<Document> = nodes.iter().map(node_to_document).collect();
+    let start = Instant::now();
+    let options = InsertManyOptions::builder().ordered(false).build();
+    if let Err(e) = client.users_collection().insert_many(docs, options).await {
+        // Ignore duplicate-key errors (E11000) so re-running against a partially loaded
+        // collection behaves like Postgres's `ON CONFLICT (id) DO NOTHING`.
+        if !e.to_string().contains("E11000") {
+            return Err(MongoError(e));
+        }
+    }
+    histogram.increment(start.elapsed().as_micros() as u64)?;
+    nodes.clear();
+    Ok(())
+}
+
+async fn flush_edges(
+    client: &MongoClient,
+    edges: &mut Vec<EdgeRecord>,
+    histogram: &mut Histogram,
+    batch_count: &mut usize,
+) -> BenchmarkResult<()> {
+    if edges.is_empty() {
+        return Ok(());
+    }
+    *batch_count += 1;
+
+    let docs: Vec<Document> = edges.iter().map(edge_to_document).collect();
+    let start = Instant::now();
+    let options = InsertManyOptions::builder().ordered(false).build();
+    if let Err(e) = client.friend_edges_collection().insert_many(docs, options).await {
+        if !e.to_string().contains("E11000") {
+            return Err(MongoError(e));
+        }
+    }
+    histogram.increment(start.elapsed().as_micros() as u64)?;
+    edges.clear();
+    Ok(())
+}
+
+/// Fast-path loader for the Pokec "Users" dataset, mirroring `postgres::load_from_cypher_import`'s
+/// batching strategy but emitting `insertMany` calls instead of bulk-insert SQL.
+pub async fn load_from_cypher_import<S>(
+    client: &MongoClient,
+    mut stream: S,
+    batch_size: usize,
+    histogram: &mut Histogram,
+) -> BenchmarkResult<usize>
+where
+    S: StreamExt<Item = Result<String, io::Error>> + Unpin,
+{
+    info!(
+        "Processing Pokec Users import into MongoDB in batches of {}",
+        batch_size
+    );
+
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    enum Phase {
+        Nodes,
+        Edges,
+    }
+
+    let mut phase = Phase::Nodes;
+    let mut nodes: Vec<NodeRecord> = Vec::with_capacity(batch_size);
+    let mut edges: Vec<EdgeRecord> = Vec::with_capacity(batch_size);
+
+    let mut total_processed: usize = 0;
+    let mut batch_count: usize = 0;
+
+    while let Some(item_result) = stream.next().await {
+        let line = match item_result {
+            Ok(v) => v,
+            Err(e) => {
+                error!("Error reading import line: {:?}", e);
+                continue;
+            }
+        };
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed == ";" || trimmed.starts_with("//") {
+            continue;
+        }
+
+        if phase == Phase::Nodes && trimmed.starts_with("MATCH") {
+            flush_nodes(client, &mut nodes, histogram, &mut batch_count).await?;
+            phase = Phase::Edges;
+        }
+
+        match phase {
+            Phase::Nodes => {
+                if let Some(node) = parse_node_line(trimmed) {
+                    nodes.push(node);
+                    total_processed += 1;
+                }
+                if nodes.len() >= batch_size {
+                    flush_nodes(client, &mut nodes, histogram, &mut batch_count).await?;
+                }
+            }
+            Phase::Edges => {
+                if let Some(edge) = parse_edge_line(trimmed) {
+                    edges.push(edge);
+                    total_processed += 1;
+                }
+                if edges.len() >= batch_size {
+                    flush_edges(client, &mut edges, histogram, &mut batch_count).await?;
+                }
+            }
+        }
+    }
+
+    flush_nodes(client, &mut nodes, histogram, &mut batch_count).await?;
+    flush_edges(client, &mut edges, histogram, &mut batch_count).await?;
+
+    info!(
+        "Pokec Users import into MongoDB completed: {} records batched into {} insertMany calls",
+        total_processed, batch_count
+    );
+
+    Ok(total_processed)
+}

--- a/src/mongo_client.rs
+++ b/src/mongo_client.rs
@@ -1,0 +1,298 @@
+use crate::error::BenchmarkError::{MongoError, OtherError};
+use crate::error::BenchmarkResult;
+use crate::mongo_query::{MongoOperation, PreparedMongoQuery};
+use crate::scheduler::Msg;
+use crate::{MONGO_MSG_DEADLINE_OFFSET_GAUGE, MONGO_STORE_SIZE_BYTES, OPERATION_COUNTER};
+use futures::TryStreamExt;
+use mongodb::bson::{doc, Document};
+use mongodb::options::UpdateOptions;
+use mongodb::{Client, Database};
+use std::time::Duration;
+use tracing::{info, warn};
+
+fn mongo_query_timeout_from_env() -> Duration {
+    const DEFAULT_TIMEOUT_MS: u64 = 900_000;
+
+    match std::env::var("MONGO_QUERY_TIMEOUT_MS") {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(ms) if ms > 0 => Duration::from_millis(ms),
+            _ => {
+                warn!(
+                    "Invalid MONGO_QUERY_TIMEOUT_MS='{}', using default {}ms",
+                    raw, DEFAULT_TIMEOUT_MS
+                );
+                Duration::from_millis(DEFAULT_TIMEOUT_MS)
+            }
+        },
+        Err(_) => Duration::from_millis(DEFAULT_TIMEOUT_MS),
+    }
+}
+
+/// Thin wrapper around a `mongodb::Database` handle. `mongodb::Client` (and the `Database`
+/// handles derived from it) already manage an internal connection pool and are cheap to clone,
+/// mirroring how `PostgresClient` shares a single connection across benchmark workers.
+#[derive(Clone)]
+pub struct MongoClient {
+    db: Database,
+    query_timeout: Duration,
+}
+
+/// Algorithm (graph-procedure) capabilities. MongoDB has no equivalent to the Cypher algorithm
+/// procedures (pageRank, maxFlow, MSF, harmonic centrality), so all flags are always `false`.
+/// This exists purely so call sites that check vendor capabilities compile uniformly.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MongoAlgorithmCapabilities {
+    pub has_pagerank: bool,
+    pub has_max_flow: bool,
+    pub has_msf: bool,
+    pub has_harmonic: bool,
+}
+
+/// Fixture-dependent (vector / fulltext index) capabilities. Mongo support for these query
+/// families is out of scope; all flags are always `false`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MongoFixtureCapabilities {
+    pub has_vector_query_nodes: bool,
+    pub has_fulltext_query_nodes: bool,
+    pub has_fulltext_query_relationships: bool,
+}
+
+impl MongoClient {
+    pub async fn connect(
+        uri: &str,
+        dbname: &str,
+    ) -> BenchmarkResult<Self> {
+        let client = Client::with_uri_str(uri).await.map_err(MongoError)?;
+        let db = client.database(dbname);
+
+        let query_timeout = mongo_query_timeout_from_env();
+        info!(
+            "Mongo per-query timeout configured to {}ms",
+            query_timeout.as_millis()
+        );
+
+        Ok(MongoClient { db, query_timeout })
+    }
+
+    fn collection(
+        &self,
+        name: &str,
+    ) -> mongodb::Collection<Document> {
+        self.db.collection::<Document>(name)
+    }
+
+    /// Exposed for the bulk `insertMany`-based dataset loader (`mongo::load_from_cypher_import`),
+    /// which needs direct collection handles rather than going through `execute_prepared_query`.
+    pub fn users_collection(&self) -> mongodb::Collection<Document> {
+        self.collection("users")
+    }
+
+    pub fn friend_edges_collection(&self) -> mongodb::Collection<Document> {
+        self.collection("friend_edges")
+    }
+
+    pub async fn drop_collections(&self) -> BenchmarkResult<()> {
+        self.collection("friend_edges").drop(None).await.map_err(MongoError)?;
+        self.collection("users").drop(None).await.map_err(MongoError)?;
+        Ok(())
+    }
+
+    /// Create indexes on `friend_edges` (src/dst lookups + a unique compound index to dedupe
+    /// edges) and `users` (age, used by several filtered-expansion query families).
+    pub async fn create_schema(&self) -> BenchmarkResult<()> {
+        use mongodb::options::IndexOptions;
+        use mongodb::IndexModel;
+
+        let friend_edges = self.collection("friend_edges");
+        friend_edges
+            .create_index(IndexModel::builder().keys(doc! {"src": 1}).build(), None)
+            .await
+            .map_err(MongoError)?;
+        friend_edges
+            .create_index(IndexModel::builder().keys(doc! {"dst": 1}).build(), None)
+            .await
+            .map_err(MongoError)?;
+        friend_edges
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! {"src": 1, "dst": 1})
+                    .options(IndexOptions::builder().unique(true).build())
+                    .build(),
+                None,
+            )
+            .await
+            .map_err(MongoError)?;
+
+        let users = self.collection("users");
+        users
+            .create_index(IndexModel::builder().keys(doc! {"age": 1}).build(), None)
+            .await
+            .map_err(MongoError)?;
+
+        Ok(())
+    }
+
+    pub async fn detect_engine_version(&self) -> BenchmarkResult<Option<String>> {
+        let result = self
+            .db
+            .run_command(doc! {"buildInfo": 1}, None)
+            .await
+            .map_err(MongoError)?;
+        Ok(result
+            .get_str("version")
+            .ok()
+            .map(|v| format!("MongoDB {}", v)))
+    }
+
+    pub async fn graph_size(&self) -> BenchmarkResult<(u64, u64)> {
+        let users_count = self
+            .collection("users")
+            .estimated_document_count(None)
+            .await
+            .map_err(MongoError)?;
+        let edges_count = self
+            .collection("friend_edges")
+            .estimated_document_count(None)
+            .await
+            .map_err(MongoError)?;
+        Ok((users_count, edges_count))
+    }
+
+    pub async fn store_size_bytes(&self) -> BenchmarkResult<u64> {
+        let stats = self
+            .db
+            .run_command(doc! {"dbStats": 1}, None)
+            .await
+            .map_err(MongoError)?;
+        let bytes = stats.get_f64("storageSize").unwrap_or(0.0)
+            + stats.get_f64("indexSize").unwrap_or(0.0);
+        Ok(bytes.max(0.0) as u64)
+    }
+
+    /// Best-effort: query MongoDB for combined collection+index size and write it into the
+    /// corresponding Prometheus gauge.
+    pub async fn collect_store_size_metrics(&self) {
+        MONGO_STORE_SIZE_BYTES.set(0);
+        match self.store_size_bytes().await {
+            Ok(bytes) => MONGO_STORE_SIZE_BYTES.set(bytes.min(i64::MAX as u64) as i64),
+            Err(e) => {
+                tracing::debug!("Failed collecting Mongo store size: {}", e);
+            }
+        }
+    }
+
+    /// MongoDB has no algorithm procedures; these are always unsupported.
+    pub fn algorithm_capabilities(&self) -> MongoAlgorithmCapabilities {
+        MongoAlgorithmCapabilities::default()
+    }
+
+    /// MongoDB has no vector/fulltext index procedures in this integration; always unsupported.
+    pub fn fixture_capabilities(&self) -> MongoFixtureCapabilities {
+        MongoFixtureCapabilities::default()
+    }
+
+    async fn run_operation(
+        &self,
+        operation: &MongoOperation,
+    ) -> BenchmarkResult<()> {
+        match operation {
+            MongoOperation::Find { collection, filter } => {
+                self.collection(collection)
+                    .find_one(filter.clone(), None)
+                    .await
+                    .map_err(MongoError)?;
+            }
+            MongoOperation::Aggregate { collection, pipeline } => {
+                let mut cursor = self
+                    .collection(collection)
+                    .aggregate(pipeline.clone(), None)
+                    .await
+                    .map_err(MongoError)?;
+                // Drain the cursor so the aggregation actually executes end-to-end.
+                while cursor.try_next().await.map_err(MongoError)?.is_some() {}
+            }
+            MongoOperation::InsertOne { collection, document } => {
+                // Ignore duplicate-key errors so re-running the same generated workload against
+                // an already-populated collection behaves like Postgres's `ON CONFLICT DO NOTHING`.
+                if let Err(e) = self.collection(collection).insert_one(document.clone(), None).await {
+                    if !is_duplicate_key_error(&e) {
+                        return Err(MongoError(e));
+                    }
+                }
+            }
+            MongoOperation::UpdateOne {
+                collection,
+                filter,
+                update,
+                upsert,
+            } => {
+                let options = UpdateOptions::builder().upsert(*upsert).build();
+                self.collection(collection)
+                    .update_one(filter.clone(), update.clone(), options)
+                    .await
+                    .map_err(MongoError)?;
+            }
+            MongoOperation::DeleteOne { collection, filter } => {
+                self.collection(collection)
+                    .delete_one(filter.clone(), None)
+                    .await
+                    .map_err(MongoError)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn execute_prepared_query<S: AsRef<str>>(
+        &self,
+        worker_id: S,
+        msg: &Msg<PreparedMongoQuery>,
+        simulate: &Option<usize>,
+    ) -> BenchmarkResult<()> {
+        let worker_id = worker_id.as_ref();
+        let q_name = msg.payload.q_name.as_str();
+        let timeout = self.query_timeout;
+        let offset = msg.compute_offset_ms();
+
+        MONGO_MSG_DEADLINE_OFFSET_GAUGE.set(offset);
+        if offset > 0 {
+            tokio::time::sleep(Duration::from_millis(offset as u64)).await;
+        }
+
+        if let Some(delay) = simulate {
+            if *delay > 0 {
+                tokio::time::sleep(Duration::from_millis(*delay as u64)).await;
+            }
+            return Ok(());
+        }
+
+        let result = tokio::time::timeout(timeout, self.run_operation(&msg.payload.operation)).await;
+
+        OPERATION_COUNTER
+            .with_label_values(&["mongo", worker_id, "", q_name, "", ""])
+            .inc();
+
+        match result {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => {
+                OPERATION_COUNTER
+                    .with_label_values(&["mongo", worker_id, "error", q_name, "", ""])
+                    .inc();
+                Err(e)
+            }
+            Err(_) => {
+                OPERATION_COUNTER
+                    .with_label_values(&["mongo", worker_id, "timeout", q_name, "", ""])
+                    .inc();
+                Err(OtherError(format!(
+                    "Timeout after {}ms",
+                    timeout.as_millis()
+                )))
+            }
+        }
+    }
+}
+
+fn is_duplicate_key_error(err: &mongodb::error::Error) -> bool {
+    use mongodb::error::ErrorKind;
+    matches!(err.kind.as_ref(), ErrorKind::Write(_)) && err.to_string().contains("E11000")
+}

--- a/src/mongo_queries_repository.rs
+++ b/src/mongo_queries_repository.rs
@@ -1,0 +1,880 @@
+use crate::mongo_query::{MongoOperation, PreparedMongoQuery};
+use crate::queries_repository::{QueryCatalogEntry, QueryCoverageProfile, QueryType};
+use mongodb::bson::{doc, Bson, Document};
+use rand::prelude::IndexedRandom;
+use std::collections::HashMap;
+
+type MongoOperationFn = Box<dyn Fn() -> MongoOperation + Send + Sync>;
+type MongoOperationEntry = (String, QueryType, MongoOperationFn);
+
+struct RandomUtil {
+    vertices: i32,
+}
+
+impl RandomUtil {
+    fn random_vertex(&self) -> i32 {
+        rand::random_range(1..=self.vertices)
+    }
+
+    fn random_path(&self) -> (i32, i32) {
+        let start = self.random_vertex();
+        let mut end = self.random_vertex();
+        while end == start {
+            end = self.random_vertex();
+        }
+        (start, end)
+    }
+}
+
+struct MongoOperationGenerator {
+    query_type: QueryType,
+    generator: MongoOperationFn,
+}
+
+impl MongoOperationGenerator {
+    fn generate(&self) -> MongoOperation {
+        (self.generator)()
+    }
+}
+
+/// Mongo analogue of `postgres_queries_repository::PostgresQueriesRepository`. There is no
+/// `Flavour` concept (single aggregation-pipeline dialect) and no algorithm-query sub-pool
+/// (Mongo has no equivalent procedures).
+pub struct MongoQueriesRepository {
+    read_queries: HashMap<String, MongoOperationGenerator>,
+    write_queries: HashMap<String, MongoOperationGenerator>,
+    read_query_names: Vec<String>,
+    write_query_names: Vec<String>,
+    name_to_id: HashMap<String, u16>,
+    catalog: Vec<QueryCatalogEntry>,
+}
+
+impl MongoQueriesRepository {
+    fn new() -> Self {
+        MongoQueriesRepository {
+            read_queries: HashMap::new(),
+            write_queries: HashMap::new(),
+            read_query_names: Vec::new(),
+            write_query_names: Vec::new(),
+            name_to_id: HashMap::new(),
+            catalog: Vec::new(),
+        }
+    }
+
+    fn add_with_id(
+        &mut self,
+        id: u16,
+        name: String,
+        query_type: QueryType,
+        generator: MongoOperationFn,
+    ) {
+        self.name_to_id.insert(name.clone(), id);
+        self.catalog.push(QueryCatalogEntry {
+            id,
+            name: name.clone(),
+            q_type: query_type,
+        });
+
+        match query_type {
+            QueryType::Read => {
+                self.read_query_names.push(name.clone());
+                self.read_queries
+                    .insert(name, MongoOperationGenerator { query_type, generator });
+            }
+            QueryType::Write => {
+                self.write_query_names.push(name.clone());
+                self.write_queries
+                    .insert(name, MongoOperationGenerator { query_type, generator });
+            }
+        }
+    }
+
+    pub fn catalog(&self) -> Vec<QueryCatalogEntry> {
+        self.catalog.clone()
+    }
+
+    fn random_query_from_pool(
+        &self,
+        queries: &HashMap<String, MongoOperationGenerator>,
+        query_names: &[String],
+    ) -> Option<PreparedMongoQuery> {
+        let mut rng = rand::rng();
+        let key = query_names.choose(&mut rng)?;
+        let generator = queries.get(key)?;
+        let q_id = *self.name_to_id.get(key).unwrap_or(&0);
+        Some(PreparedMongoQuery::new(
+            q_id,
+            key.clone(),
+            generator.query_type,
+            generator.generate(),
+        ))
+    }
+
+    pub fn random_query(
+        &self,
+        query_type: QueryType,
+    ) -> Option<PreparedMongoQuery> {
+        let (queries, query_names) = match query_type {
+            QueryType::Read => (&self.read_queries, &self.read_query_names),
+            QueryType::Write => (&self.write_queries, &self.write_query_names),
+        };
+        self.random_query_from_pool(queries, query_names)
+    }
+}
+
+struct MongoQueriesRepositoryBuilder {
+    vertices: i32,
+    queries: Vec<MongoOperationEntry>,
+}
+
+impl MongoQueriesRepositoryBuilder {
+    fn new(vertices: i32) -> Self {
+        MongoQueriesRepositoryBuilder {
+            vertices,
+            queries: Vec::new(),
+        }
+    }
+
+    fn add_query<F>(
+        mut self,
+        name: impl Into<String>,
+        query_type: QueryType,
+        generator: F,
+    ) -> Self
+    where
+        F: Fn(&RandomUtil) -> MongoOperation + Send + Sync + 'static,
+    {
+        let vertices = self.vertices;
+        self.queries.push((
+            name.into(),
+            query_type,
+            Box::new(move || {
+                let random = RandomUtil { vertices };
+                generator(&random)
+            }),
+        ));
+        self
+    }
+
+    fn build(self) -> MongoQueriesRepository {
+        let mut repo = MongoQueriesRepository::new();
+        for (idx, (name, query_type, generator)) in self.queries.into_iter().enumerate() {
+            repo.add_with_id(idx as u16, name, query_type, generator);
+        }
+        repo
+    }
+}
+
+/// Traverse `friend_edges` starting from `seed`, following `src -> dst` edges up to `max_depth`
+/// recursive hops (depth 0 = direct edges out of `seed`). Mirrors the shape of a Cypher
+/// `(seed)-->()...-->(n)` chain, using `$graphLookup`'s BFS-like traversal.
+fn graph_lookup_stage(
+    max_depth: i32,
+    restrict_with_match: Option<Document>,
+) -> Document {
+    let mut stage = doc! {
+        "from": "friend_edges",
+        "startWith": "$_id",
+        "connectFromField": "dst",
+        "connectToField": "src",
+        "as": "reachable",
+        "maxDepth": max_depth,
+        "depthField": "depth",
+    };
+    if let Some(restrict) = restrict_with_match {
+        stage.insert("restrictSearchWithMatch", restrict);
+    }
+    doc! { "$graphLookup": stage }
+}
+
+/// Expansion pipeline: from `seed`, follow exactly `hops` edges (`hops - 1` recursive
+/// `$graphLookup` steps), optionally joining back to `users` to apply an `age >= 18` filter.
+/// Mirrors `aggregate_expansion_N[_with_filter]` / `neighbours_2[_with_filter]`.
+fn expansion_pipeline(
+    seed: i32,
+    hops: i32,
+    with_filter: bool,
+    distinct: bool,
+) -> Vec<Document> {
+    let mut pipeline = vec![
+        doc! { "$match": { "_id": seed } },
+        graph_lookup_stage(hops - 1, None),
+        doc! { "$unwind": "$reachable" },
+        doc! { "$match": { "reachable.depth": hops - 1 } },
+    ];
+
+    if with_filter {
+        pipeline.push(doc! {
+            "$lookup": {
+                "from": "users",
+                "localField": "reachable.dst",
+                "foreignField": "_id",
+                "as": "u",
+            }
+        });
+        pipeline.push(doc! { "$unwind": "$u" });
+        pipeline.push(doc! { "$match": { "u.age": { "$gte": 18 } } });
+        pipeline.push(doc! { "$project": { "_id": "$u._id" } });
+    } else {
+        pipeline.push(doc! { "$project": { "_id": "$reachable.dst" } });
+    }
+
+    if distinct {
+        pipeline.push(doc! { "$group": { "_id": "$_id" } });
+    }
+
+    pipeline
+}
+
+fn expansion_with_data_pipeline(
+    seed: i32,
+    hops: i32,
+    with_filter: bool,
+) -> Vec<Document> {
+    let mut pipeline = vec![
+        doc! { "$match": { "_id": seed } },
+        graph_lookup_stage(hops - 1, None),
+        doc! { "$unwind": "$reachable" },
+        doc! { "$match": { "reachable.depth": hops - 1 } },
+        doc! {
+            "$lookup": {
+                "from": "users",
+                "localField": "reachable.dst",
+                "foreignField": "_id",
+                "as": "u",
+            }
+        },
+        doc! { "$unwind": "$u" },
+    ];
+    if with_filter {
+        pipeline.push(doc! { "$match": { "u.age": { "$gte": 18 } } });
+    }
+    pipeline.push(doc! { "$replaceRoot": { "newRoot": "$u" } });
+    pipeline
+}
+
+/// Mongo analogue of `postgres_queries_repository::PostgresUsersQueriesRepository`.
+pub struct MongoUsersQueriesRepository {
+    repo: MongoQueriesRepository,
+}
+
+impl MongoUsersQueriesRepository {
+    pub fn catalog(&self) -> Vec<QueryCatalogEntry> {
+        self.repo.catalog()
+    }
+
+    pub fn random_queries(
+        self,
+        count: usize,
+        write_ratio: f32,
+    ) -> Box<dyn Iterator<Item = PreparedMongoQuery> + Send + Sync> {
+        Box::new((0..count).filter_map(move |_| self.random_query(write_ratio)))
+    }
+
+    pub fn random_query(
+        &self,
+        write_ratio: f32,
+    ) -> Option<PreparedMongoQuery> {
+        let write_ratio = write_ratio.clamp(0.0, 1.0);
+        if rand::random::<f32>() < write_ratio {
+            self.repo
+                .random_query(QueryType::Write)
+                .or_else(|| self.repo.random_query(QueryType::Read))
+        } else {
+            self.repo
+                .random_query(QueryType::Read)
+                .or_else(|| self.repo.random_query(QueryType::Write))
+        }
+    }
+
+    /// Build the Mongo query catalog. Algorithm queries (pagerank/max-flow/MSF/harmonic), vector
+    /// /fulltext smoke queries, and `entity_path_introspection` have no aggregation-pipeline
+    /// equivalent and are always omitted, same as Postgres. Additionally, `shortest_path`,
+    /// `shortest_path_with_filter`, `all_shortest_paths_len`, and `pattern_cycle` are omitted:
+    /// `$graphLookup` returns an unordered, deduplicated reachable set (first-seen depth per
+    /// node), which can answer reachability/hop-count questions but cannot enumerate distinct
+    /// paths (needed for true shortest-path) or verify a full cyclic pattern's intermediate
+    /// nodes -- these remain Postgres-only per the capability matrix in
+    /// `QUERY_EXPLANATIONS_AND_SAMPLES.md`. Callers are expected to reject the
+    /// `fixture-dependent` profile for Mongo before reaching this constructor.
+    pub fn new(
+        vertices: i32,
+        _edges: i32,
+        query_coverage_profile: QueryCoverageProfile,
+    ) -> MongoUsersQueriesRepository {
+        let mut builder = MongoQueriesRepositoryBuilder::new(vertices)
+            .add_query("single_vertex_read", QueryType::Read, |random| {
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                }
+            })
+            .add_query("single_vertex_write", QueryType::Write, |random| {
+                MongoOperation::UpdateOne {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                    update: doc! { "$setOnInsert": { "created_at": Bson::from(chrono_now()) } },
+                    upsert: true,
+                }
+            })
+            .add_query("single_vertex_update", QueryType::Write, |random| {
+                MongoOperation::UpdateOne {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                    update: doc! { "$set": { "rpc_social_credit": random.random_vertex() } },
+                    upsert: false,
+                }
+            })
+            .add_query("single_edge_update", QueryType::Write, |random| {
+                // No SQL-style "ORDER BY random() LIMIT 1" equivalent for a single update
+                // command; `$sample` + `$merge` is the standard Mongo idiom for "update a
+                // randomly chosen document" via an aggregation pipeline.
+                MongoOperation::Aggregate {
+                    collection: "friend_edges".to_string(),
+                    pipeline: vec![
+                        doc! { "$sample": { "size": 1 } },
+                        doc! { "$set": { "color": random.random_vertex() } },
+                        doc! { "$merge": { "into": "friend_edges", "whenMatched": "merge", "whenNotMatched": "discard" } },
+                    ],
+                }
+            })
+            .add_query("single_edge_write", QueryType::Write, |random| {
+                let (from, to) = random.random_path();
+                MongoOperation::UpdateOne {
+                    collection: "friend_edges".to_string(),
+                    filter: doc! { "src": from, "dst": to },
+                    update: doc! {
+                        "$setOnInsert": { "bench_capacity": bench_capacity_placeholder(from, to) },
+                        "$set": { "touch": Bson::from(chrono_now()) },
+                    },
+                    upsert: true,
+                }
+            })
+            .add_query("aggregate_expansion_1", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 1, false, false),
+                }
+            })
+            .add_query("aggregate_expansion_1_with_filter", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 1, true, false),
+                }
+            })
+            .add_query("aggregate_expansion_2", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 2, false, true),
+                }
+            })
+            .add_query("aggregate_expansion_2_with_filter", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 2, true, true),
+                }
+            })
+            .add_query("aggregate_expansion_3", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 3, false, true),
+                }
+            })
+            .add_query("aggregate_expansion_3_with_filter", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 3, true, true),
+                }
+            })
+            .add_query("aggregate_expansion_4", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 4, false, true),
+                }
+            })
+            .add_query("aggregate_expansion_4_with_filter", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 4, true, true),
+                }
+            })
+            .add_query("aggregate_age", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![doc! { "$group": { "_id": Bson::Null, "avg_age": { "$avg": "$age" } } }],
+                }
+            })
+            .add_query("aggregate_age_distinct", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$group": { "_id": "$age" } },
+                        doc! { "$count": "distinct_ages" },
+                    ],
+                }
+            })
+            .add_query("aggregate_age_filtered", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "age": { "$gte": 18 } } },
+                        doc! { "$group": { "_id": Bson::Null, "avg_age": { "$avg": "$age" } } },
+                    ],
+                }
+            })
+            .add_query("aggregate_count_users", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![doc! { "$count": "cnt" }],
+                }
+            })
+            .add_query("aggregate_age_min_max_avg", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![doc! { "$group": {
+                        "_id": Bson::Null,
+                        "min_age": { "$min": "$age" },
+                        "max_age": { "$max": "$age" },
+                        "avg_age": { "$avg": "$age" },
+                    } }],
+                }
+            })
+            .add_query("neighbours_2", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 2, false, false),
+                }
+            })
+            .add_query("neighbours_2_with_filter", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_pipeline(random.random_vertex(), 2, true, false),
+                }
+            })
+            .add_query("neighbours_2_with_data", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_with_data_pipeline(random.random_vertex(), 2, false),
+                }
+            })
+            .add_query("neighbours_2_with_data_and_filter", QueryType::Read, |random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: expansion_with_data_pipeline(random.random_vertex(), 2, true),
+                }
+            })
+            .add_query("pattern_long", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        graph_lookup_stage(3, None),
+                        doc! { "$unwind": "$reachable" },
+                        doc! { "$match": { "reachable.depth": 3 } },
+                        doc! { "$project": { "a_id": seed, "b_id": "$reachable.dst" } },
+                    ],
+                }
+            })
+            .add_query("pattern_short", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        graph_lookup_stage(1, None),
+                        doc! { "$unwind": "$reachable" },
+                        doc! { "$match": { "reachable.depth": 1 } },
+                        doc! { "$project": { "a_id": seed, "b_id": "$reachable.dst" } },
+                    ],
+                }
+            })
+            .add_query("vertex_on_label_property", QueryType::Read, |random| {
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                }
+            })
+            .add_query("vertex_on_label_property_index", QueryType::Read, |random| {
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                }
+            })
+            .add_query("vertex_on_property", QueryType::Read, |random| {
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                }
+            })
+            .add_query("value_join", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        doc! { "$lookup": {
+                            "from": "users",
+                            "let": { "age": "$age" },
+                            "pipeline": [ doc! { "$match": { "$expr": { "$eq": ["$age", "$$age"] } } } ],
+                            "as": "matches",
+                        } },
+                        doc! { "$unwind": "$matches" },
+                        doc! { "$project": { "_id": "$matches._id" } },
+                    ],
+                }
+            })
+            .add_query("value_join_cnt", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        doc! { "$lookup": {
+                            "from": "users",
+                            "let": { "age": "$age" },
+                            "pipeline": [ doc! { "$match": { "$expr": { "$eq": ["$age", "$$age"] } } } ],
+                            "as": "matches",
+                        } },
+                        doc! { "$project": { "cnt": { "$size": "$matches" } } },
+                    ],
+                }
+            })
+            .add_query("order_by_age", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$sort": { "age": 1, "_id": 1 } },
+                        doc! { "$project": { "_id": 1, "age": 1 } },
+                    ],
+                }
+            })
+            .add_query("unwind_rows", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        doc! { "$project": { "vals": [seed, seed + 1, seed + 2] } },
+                        doc! { "$unwind": "$vals" },
+                    ],
+                }
+            })
+            .add_query("var_len_friends", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        graph_lookup_stage(1, None),
+                        doc! { "$unwind": "$reachable" },
+                        doc! { "$group": { "_id": "$reachable.dst" } },
+                    ],
+                }
+            })
+            .add_query("optional_friend", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        doc! { "$lookup": { "from": "friend_edges", "localField": "_id", "foreignField": "src", "as": "edges" } },
+                        doc! { "$unwind": { "path": "$edges", "preserveNullAndEmptyArrays": true } },
+                        doc! { "$project": { "a_id": "$_id", "b_id": "$edges.dst" } },
+                    ],
+                }
+            })
+            .add_query("call_subquery", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        doc! { "$lookup": { "from": "friend_edges", "localField": "_id", "foreignField": "src", "as": "sub" } },
+                        doc! { "$unwind": "$sub" },
+                        doc! { "$project": { "bid": "$sub.dst" } },
+                    ],
+                }
+            })
+            .add_query("id_seek", QueryType::Read, |random| {
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                }
+            })
+            .add_query("id_range_scan", QueryType::Read, |random| {
+                let start = random.random_vertex();
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": { "$gte": start, "$lt": start + 100 } },
+                }
+            })
+            .add_query("merge_user_insert_path", QueryType::Write, |random| {
+                let insert_id = random.vertices.saturating_add(random.random_vertex());
+                MongoOperation::UpdateOne {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": insert_id },
+                    update: doc! { "$setOnInsert": {
+                        "created_at": Bson::from(chrono_now()),
+                        "age": random.random_vertex(),
+                    } },
+                    upsert: true,
+                }
+            })
+            .add_query("merge_user_upsert_existing", QueryType::Write, |random| {
+                MongoOperation::UpdateOne {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                    update: doc! {
+                        "$set": { "age": random.random_vertex(), "last_seen": Bson::from(chrono_now()) },
+                        "$setOnInsert": { "created_at": Bson::from(chrono_now()) },
+                    },
+                    upsert: true,
+                }
+            })
+            .add_query("merge_friend_edge_upsert", QueryType::Write, |random| {
+                let (from, to) = random.random_path();
+                MongoOperation::UpdateOne {
+                    collection: "friend_edges".to_string(),
+                    filter: doc! { "src": from, "dst": to },
+                    update: doc! {
+                        "$setOnInsert": { "since": Bson::from(chrono_now()), "bench_capacity": bench_capacity_placeholder(from, to) },
+                        "$set": { "touch": Bson::from(chrono_now()) },
+                    },
+                    upsert: true,
+                }
+            })
+            .add_query("detach_delete_user", QueryType::Write, |random| {
+                // Mongo has no FK/cascade concept: unlike Postgres's `ON DELETE CASCADE`, this
+                // only removes the user document; any `friend_edges` referencing it are left in
+                // place (documented limitation, see QUERY_EXPLANATIONS_AND_SAMPLES.md).
+                MongoOperation::DeleteOne {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                }
+            })
+            .add_query("remove_user_property_and_label", QueryType::Write, |random| {
+                // Mongo has no label concept; this drops only the property-removal semantics.
+                MongoOperation::UpdateOne {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                    update: doc! { "$unset": { "rpc_social_credit": "" } },
+                    upsert: false,
+                }
+            })
+            .add_query("foreach_loop_mutation", QueryType::Write, |random| {
+                // Approximated as a single terminal assignment (equivalent end state to the
+                // Cypher `FOREACH (x IN [1,2,3] | SET u.loop_counter = x)`).
+                MongoOperation::UpdateOne {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": random.random_vertex() },
+                    update: doc! { "$set": { "loop_counter": 3 } },
+                    upsert: false,
+                }
+            })
+            .add_query("union_all_ids", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        doc! { "$project": { "uid": "$_id" } },
+                        doc! { "$unionWith": { "coll": "users", "pipeline": [
+                            doc! { "$match": { "_id": { "$lt": 10 } } },
+                            doc! { "$project": { "uid": "$_id" } },
+                        ] } },
+                    ],
+                }
+            })
+            .add_query("union_distinct_ids", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        doc! { "$project": { "uid": "$_id" } },
+                        doc! { "$unionWith": { "coll": "users", "pipeline": [
+                            doc! { "$match": { "_id": seed } },
+                            doc! { "$project": { "uid": "$_id" } },
+                        ] } },
+                        doc! { "$group": { "_id": "$uid" } },
+                    ],
+                }
+            })
+            .add_query("var_len_with_edge_where_filter", QueryType::Read, |random| {
+                let seed = random.random_vertex();
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![
+                        doc! { "$match": { "_id": seed } },
+                        graph_lookup_stage(2, Some(doc! { "bench_capacity": { "$gte": 1 } })),
+                        doc! { "$unwind": "$reachable" },
+                        doc! { "$group": { "_id": "$reachable.dst" } },
+                        doc! { "$count": "cnt" },
+                    ],
+                }
+            })
+            .add_query("count_users_plain", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "users".to_string(),
+                    pipeline: vec![doc! { "$count": "cnt" }],
+                }
+            })
+            .add_query("count_friend_edges_plain", QueryType::Read, |_random| {
+                MongoOperation::Aggregate {
+                    collection: "friend_edges".to_string(),
+                    pipeline: vec![doc! { "$count": "cnt" }],
+                }
+            })
+            .add_query("indexed_or_predicate", QueryType::Read, |random| {
+                let (id1, id2) = random.random_path();
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "$or": [ { "_id": id1 }, { "_id": id2 } ] },
+                }
+            })
+            .add_query("indexed_in_list_predicate", QueryType::Read, |random| {
+                let id1 = random.random_vertex();
+                let id2 = random.random_vertex();
+                let id3 = random.random_vertex();
+                let id4 = random.random_vertex();
+                MongoOperation::Find {
+                    collection: "users".to_string(),
+                    filter: doc! { "_id": { "$in": [id1, id2, id3, id4] } },
+                }
+            });
+
+        if query_coverage_profile.includes_extended_core() {
+            builder = builder
+                .add_query("exact_5_hop_traverse_count", QueryType::Read, |random| {
+                    let seed = random.random_vertex();
+                    MongoOperation::Aggregate {
+                        collection: "users".to_string(),
+                        pipeline: vec![
+                            doc! { "$match": { "_id": seed } },
+                            graph_lookup_stage(4, None),
+                            doc! { "$unwind": "$reachable" },
+                            doc! { "$match": { "reachable.depth": 4 } },
+                            doc! { "$count": "cnt" },
+                        ],
+                    }
+                })
+                .add_query("exact_6_hop_traverse_count", QueryType::Read, |random| {
+                    let seed = random.random_vertex();
+                    MongoOperation::Aggregate {
+                        collection: "users".to_string(),
+                        pipeline: vec![
+                            doc! { "$match": { "_id": seed } },
+                            graph_lookup_stage(5, None),
+                            doc! { "$unwind": "$reachable" },
+                            doc! { "$match": { "reachable.depth": 5 } },
+                            doc! { "$count": "cnt" },
+                        ],
+                    }
+                })
+                .add_query("temporal_spatial_roundtrip", QueryType::Read, |_random| {
+                    // No `$geoNear`/PostGIS-style dependency: distance is computed manually via
+                    // the spherical law of cosines using Mongo's trigonometry aggregation
+                    // operators ($sin/$cos/$acos/$degreesToRadians, added in MongoDB 4.2), and
+                    // `$documents` (MongoDB 6.0+) seeds a single input row without touching a
+                    // real collection.
+                    MongoOperation::Aggregate {
+                        collection: "users".to_string(),
+                        pipeline: vec![
+                            doc! { "$documents": [ {} ] },
+                            doc! { "$project": {
+                                "d": { "$dateFromString": { "dateString": "2024-01-01" } },
+                                "dur_hours": 51,
+                                "dist": {
+                                    "$multiply": [
+                                        6371000,
+                                        { "$acos": {
+                                            "$add": [
+                                                { "$multiply": [
+                                                    { "$cos": { "$degreesToRadians": 32.1 } },
+                                                    { "$cos": { "$degreesToRadians": 32.2 } },
+                                                    { "$cos": { "$subtract": [
+                                                        { "$degreesToRadians": 34.9 },
+                                                        { "$degreesToRadians": 34.8 },
+                                                    ] } },
+                                                ] },
+                                                { "$multiply": [
+                                                    { "$sin": { "$degreesToRadians": 32.1 } },
+                                                    { "$sin": { "$degreesToRadians": 32.2 } },
+                                                ] },
+                                            ],
+                                        } },
+                                    ],
+                                },
+                            } },
+                        ],
+                    }
+                });
+        }
+
+        let repo = builder.build();
+        MongoUsersQueriesRepository { repo }
+    }
+}
+
+/// Deterministic placeholder mirroring `data_prep::bench_capacity`, kept local to avoid a
+/// dependency cycle; values only need to be a stable function of (src, dst) for benchmark
+/// purposes.
+fn bench_capacity_placeholder(
+    src: i32,
+    dst: i32,
+) -> i32 {
+    crate::data_prep::bench_capacity(src as u64, dst as u64) as i32
+}
+
+/// Best-effort "now" as an RFC3339 string wrapped in a BSON `DateTime`-compatible value. Uses
+/// `mongodb::bson::DateTime::now()` to avoid pulling in a separate `chrono` dependency.
+fn chrono_now() -> mongodb::bson::DateTime {
+    mongodb::bson::DateTime::now()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_catalog_excludes_unsupported_families() {
+        let repo = MongoUsersQueriesRepository::new(1000, 10000, QueryCoverageProfile::Baseline);
+        let names: Vec<String> = repo.catalog().into_iter().map(|c| c.name).collect();
+        assert!(!names.contains(&"algo_pagerank_summary".to_string()));
+        assert!(!names.contains(&"vector_query_nodes_smoke".to_string()));
+        assert!(!names.contains(&"entity_path_introspection".to_string()));
+        assert!(!names.contains(&"shortest_path".to_string()));
+        assert!(!names.contains(&"shortest_path_with_filter".to_string()));
+        assert!(!names.contains(&"all_shortest_paths_len".to_string()));
+        assert!(!names.contains(&"pattern_cycle".to_string()));
+        assert!(names.contains(&"aggregate_expansion_2".to_string()));
+        assert!(!names.contains(&"exact_5_hop_traverse_count".to_string()));
+    }
+
+    #[test]
+    fn extended_core_adds_extra_queries() {
+        let repo = MongoUsersQueriesRepository::new(1000, 10000, QueryCoverageProfile::ExtendedCore);
+        let names: Vec<String> = repo.catalog().into_iter().map(|c| c.name).collect();
+        assert!(names.contains(&"exact_5_hop_traverse_count".to_string()));
+        assert!(names.contains(&"exact_6_hop_traverse_count".to_string()));
+        assert!(names.contains(&"temporal_spatial_roundtrip".to_string()));
+    }
+
+    #[test]
+    fn random_query_generation_produces_operations() {
+        let repo = MongoUsersQueriesRepository::new(1000, 10000, QueryCoverageProfile::Baseline);
+        for _ in 0..50 {
+            let q = repo.random_query(0.5).expect("expected a query");
+            match q.operation {
+                MongoOperation::Find { collection, .. }
+                | MongoOperation::Aggregate { collection, .. }
+                | MongoOperation::InsertOne { collection, .. }
+                | MongoOperation::UpdateOne { collection, .. }
+                | MongoOperation::DeleteOne { collection, .. } => {
+                    assert!(!collection.is_empty());
+                }
+            }
+        }
+    }
+}

--- a/src/mongo_query.rs
+++ b/src/mongo_query.rs
@@ -1,0 +1,55 @@
+use crate::queries_repository::QueryType;
+use mongodb::bson::Document;
+use serde::{Deserialize, Serialize};
+
+/// A prepared MongoDB operation. Unlike `SqlQuery` (which carries positional placeholders
+/// resolved at execution time), operations here are fully resolved at generation time: any
+/// random ids/values are baked into the `Document`/pipeline, mirroring how `generate-queries`
+/// already persists one concrete, ready-to-run query per line for every vendor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MongoOperation {
+    /// `db.<collection>.findOne(filter)`
+    Find { collection: String, filter: Document },
+    /// `db.<collection>.aggregate(pipeline)`
+    Aggregate {
+        collection: String,
+        pipeline: Vec<Document>,
+    },
+    /// `db.<collection>.insertOne(document)`
+    InsertOne { collection: String, document: Document },
+    /// `db.<collection>.updateOne(filter, update, {upsert})`
+    UpdateOne {
+        collection: String,
+        filter: Document,
+        update: Document,
+        upsert: bool,
+    },
+    /// `db.<collection>.deleteOne(filter)`
+    DeleteOne { collection: String, filter: Document },
+}
+
+/// A prepared MongoDB query with a stable catalog id, mirroring `sql_query::PreparedSqlQuery`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreparedMongoQuery {
+    #[serde(default)]
+    pub q_id: u16,
+    pub q_name: String,
+    pub q_type: QueryType,
+    pub operation: MongoOperation,
+}
+
+impl PreparedMongoQuery {
+    pub fn new(
+        q_id: u16,
+        q_name: String,
+        q_type: QueryType,
+        operation: MongoOperation,
+    ) -> Self {
+        Self {
+            q_id,
+            q_name,
+            q_type,
+            operation,
+        }
+    }
+}

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -37,6 +37,7 @@ pub enum Vendor {
     Falkor,
     Memgraph,
     Postgres,
+    Mongo,
 }
 
 #[derive(Debug, Clone)]
@@ -60,9 +61,11 @@ impl Spec<'_> {
             Vendor::Neo4j => "https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/dataset/pokec/benchmark/neo4j.cypher",
             Vendor::Falkor => "https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/dataset/pokec/benchmark/falkordb.cypher",
             Vendor::Memgraph => "https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/dataset/pokec/benchmark/memgraph.cypher",
-            // Postgres creates its own schema/indexes directly (see `postgres::create_schema`);
-            // this URL is unused in practice but kept so `Spec::new` stays exhaustive.
+            // Postgres and Mongo create their own schema/indexes directly (see
+            // `postgres::create_schema`/`mongo::create_schema`); this URL is unused in practice
+            // but kept so `Spec::new` stays exhaustive.
             Vendor::Postgres => "https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/dataset/pokec/benchmark/neo4j.cypher",
+            Vendor::Mongo => "https://s3.eu-west-1.amazonaws.com/deps.memgraph.io/dataset/pokec/benchmark/neo4j.cypher",
         };
 
         match (name, size) {

--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -551,6 +551,8 @@ export default function DashBoard({
         ? "--Memgraph-color"
         : key === "postgres" || key === "postgresql"
         ? "--Postgres-color"
+        : key === "mongo" || key === "mongodb"
+        ? "--Mongo-color"
         : key === "intel" || key === "x86" || key.startsWith("r7i")
         ? "--Intel-color"
         : key === "graviton" || key === "arm" || key.startsWith("r8g")

--- a/ui/app/data/sideBarData.ts
+++ b/ui/app/data/sideBarData.ts
@@ -36,6 +36,7 @@ export const sidebarConfig: {
         { id: "neo4j", label: "Neo4j" },
         { id: "memgraph", label: "Memgraph" },
         { id: "postgres", label: "Postgres" },
+        { id: "mongo", label: "Mongo" },
       ],
     },
     {

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -55,6 +55,7 @@ body {
     --Neo4j-color: #0A6190;
     --Memgraph-color: #ff2b4a;
     --Postgres-color: #336791;
+    --Mongo-color: #13AA52;
 
     /* AWS instance comparison colors */
     --Intel-color: #1f77b4;
@@ -82,6 +83,9 @@ body {
 
     --Postgres-gradient-start: #336791;
     --Postgres-gradient-end: #a9c2d6;
+
+    --Mongo-gradient-start: #13AA52;
+    --Mongo-gradient-end: #b8f2d0;
   }
 
   .dark {

--- a/ui/app/lib/vendorColors.ts
+++ b/ui/app/lib/vendorColors.ts
@@ -1,4 +1,4 @@
-export type VendorKey = "falkordb" | "falkordb2" | "neo4j" | "memgraph" | "postgres" | "unknown";
+export type VendorKey = "falkordb" | "falkordb2" | "neo4j" | "memgraph" | "postgres" | "mongo" | "unknown";
 
 type GradientStops = { offset: number; color: string }[];
 
@@ -24,6 +24,7 @@ export function normalizeVendor(vendor: string): VendorKey {
   if (k === "neo4j") return "neo4j";
   if (k === "memgraph") return "memgraph";
   if (k === "postgres" || k === "postgresql") return "postgres";
+  if (k === "mongo" || k === "mongodb") return "mongo";
   return "unknown";
 }
 
@@ -78,6 +79,12 @@ function getStops(vendor: VendorKey): GradientStops {
       return [
         { offset: 0.0, color: cssVar("--Postgres-gradient-start", "#336791") },
         { offset: 1.0, color: cssVar("--Postgres-gradient-end", "#a9c2d6") },
+      ];
+    case "mongo":
+      // MongoDB brand green gradient
+      return [
+        { offset: 0.0, color: cssVar("--Mongo-gradient-start", "#13AA52") },
+        { offset: 1.0, color: cssVar("--Mongo-gradient-end", "#b8f2d0") },
       ];
     default:
       return [{ offset: 0.0, color: "#191919" }];

--- a/ui/app/mongo/page.tsx
+++ b/ui/app/mongo/page.tsx
@@ -1,0 +1,32 @@
+import DashBoard from "../components/dashboard";
+import { Header } from "../components/header";
+import BenchmarkMetricsCrawlerTable from "../components/BenchmarkMetricsCrawlerTable";
+import { loadBenchmarkSummary, loadRunsManifest } from "../lib/benchmark-data.server";
+
+export default async function MongoVsFalkor() {
+  const dataUrl = "/summaries/mongo_vs_falkordb.json";
+  const [initialData, initialManifest] = await Promise.all([
+    loadBenchmarkSummary(dataUrl),
+    loadRunsManifest(),
+  ]);
+  return (
+    <main className="min-h-screen md:h-screen flex flex-col">
+      <Header />
+      <DashBoard
+        dataUrl={dataUrl}
+        initialData={initialData}
+        initialManifest={initialManifest}
+        comparisonVendors={["falkordb", "mongo"]}
+        initialSelectedOptions={{
+          "Workload Type": ["concurrent"],
+          Vendors: ["falkordb", "mongo"],
+        }}
+      />
+      <BenchmarkMetricsCrawlerTable
+        data={initialData}
+        dataUrl={dataUrl}
+        title="Mongo vs FalkorDB"
+      />
+    </main>
+  );
+}

--- a/ui/components/ui/app-sidebar.tsx
+++ b/ui/components/ui/app-sidebar.tsx
@@ -67,6 +67,7 @@ export function AppSidebar({
       if (lower === "neo4j") return "Neo4j";
       if (lower === "memgraph") return "Memgraph";
       if (lower === "postgres" || lower === "postgresql") return "Postgres";
+      if (lower === "mongo" || lower === "mongodb") return "Mongo";
       if (lower === "intel") return "Intel";
       if (lower === "graviton") return "Graviton";
       // Generic fallback: Title Case

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -24,6 +24,7 @@ module.exports = {
 			Neo4j: 'var(--Neo4j-color)',
 			Memgraph: 'var(--Memgraph-color)',
 			Postgres: 'var(--Postgres-color)',
+			Mongo: 'var(--Mongo-color)',
   			background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',
   			card: {


### PR DESCRIPTION
## Summary
Adds MongoDB as a benchmark engine alongside FalkorDB, Neo4j, Memgraph, and Postgres. Mongo is modeled as two collections, `users` and `friend_edges` (edge documents with `src`/`dst`), traversed via `$graphLookup` aggregation pipelines.

## Changes
- **New modules**: `src/mongo_client.rs` (connection/execution via the official `mongodb` driver), `src/mongo.rs` (schema/index setup + bulk `insertMany` loader), `src/mongo_queries_repository.rs` (aggregation-pipeline query catalog), `src/mongo_query.rs` (`MongoOperation`/`PreparedMongoQuery` types).
- **CLI**: `--vendor mongo` wired through `load`, `generate-queries`, and `run`, including `--endpoint mongodb://...` and env-var fallback (`MONGO_URI` or `MONGO_HOST/PORT/USER/PASSWORD/DB`).
- **Query coverage**: same exclusions as Postgres (algorithm procedures, vector/fulltext smoke queries, `entity_path_introspection`) plus `shortest_path`, `shortest_path_with_filter`, `all_shortest_paths_len`, and `pattern_cycle`, which remain Postgres-only since `$graphLookup` returns an unordered reachable set and can't enumerate distinct paths or verify cyclic patterns. The `fixture-dependent` profile is rejected for Mongo with a clear error.
- **Aggregation/metrics**: new `mongo_vs_falkordb.json` summary output and Mongo-labeled Prometheus metrics.
- **UI**: new `/mongo` comparison page plus sidebar/color wiring (MongoDB-green branding).
- **Docs**: `readme.md` CLI usage examples and `QUERY_EXPLANATIONS_AND_SAMPLES.md` capability matrix + aggregation-pipeline templates.

## Validation
- `cargo build` succeeds
- `cargo test --lib` — all 26 tests pass (including 3 new Mongo query-catalog tests)
- `cargo clippy --all-targets` — no new warnings

## Notes
This branch was rebased onto `master` (post #307 merge) to pick up the Postgres engine and subsequent dependency/runtime updates.

Generated with [Warp](https://warp.dev)

Co-Authored-By: Warp <agent@warp.dev>
