### PR TITLE
Add multi-engine comparison support (up to 5 engines)

### DIFF
--- a/dashboards/MULTI_ENGINE.md
+++ b/dashboards/MULTI_ENGINE.md
@@ -1,0 +1,5 @@
+# Multi-engine comparison
+
+Use the Next.js page `/multi-engine` which loads `ui/public/summaries/multi_engine_compare.json`.
+
+Scripts `run_{small,medium,large}_benchmark.sh` write this file when 2+ engine result folders exist (max 5 series).

--- a/scripts/run_large_benchmark.sh
+++ b/scripts/run_large_benchmark.sh
@@ -68,6 +68,12 @@ RUN_NEO4J=${RUN_NEO4J:-0}
 # Enable Memgraph by default for large benchmark comparisons (can be overridden via env).
 RUN_MEMGRAPH=${RUN_MEMGRAPH:-0}
 
+POSTGRES_ENDPOINT=${POSTGRES_ENDPOINT:-"postgres://postgres:postgres@127.0.0.1:5432/postgres"}
+RUN_POSTGRES=${RUN_POSTGRES:-0}
+
+MONGO_ENDPOINT=${MONGO_ENDPOINT:-"mongodb://127.0.0.1:27017"}
+RUN_MONGO=${RUN_MONGO:-0}
+
 BATCH_SIZE=${BATCH_SIZE:-10000}
 PARALLEL=${PARALLEL:-10}
 MPS=${MPS:-200}
@@ -107,6 +113,8 @@ QUERIES_FILE_BASE="${QUERIES_FILE}"
 FALKOR_QUERIES_FILE="${QUERIES_FILE_BASE}-falkor"
 NEO4J_QUERIES_FILE="${QUERIES_FILE_BASE}-neo4j"
 MEMGRAPH_QUERIES_FILE="${QUERIES_FILE_BASE}-memgraph"
+POSTGRES_QUERIES_FILE="${QUERIES_FILE}-postgres"
+MONGO_QUERIES_FILE="${QUERIES_FILE}-mongo"
 
 # Use a single shared results directory for all vendors so `benchmark aggregate` can
 # generate neo4j-vs-falkordb and memgraph-vs-falkordb UI summaries from one run.
@@ -670,6 +678,95 @@ else
   fi
   echo "==> Aggregating UI summaries to $SCRIPT_DIR/../ui/public/summaries"
   cargo run --release --bin benchmark -- aggregate --results-dir "$RESULTS_DIR" --out-dir "$SCRIPT_DIR/../ui/public/summaries"
+fi
+
+
+# ---------- Postgres ----------
+if [[ "${RUN_POSTGRES:-0}" == "1" ]]; then
+  echo "==> Preparing Postgres (large)"
+  cargo run --release --bin benchmark -- load --vendor postgres --size large \
+    --endpoint "$POSTGRES_ENDPOINT" -b "$BATCH_SIZE" --force --query-profile "$QUERY_PROFILE" || {
+      echo "Postgres load failed; continuing without Postgres results" >&2
+    }
+  echo "==> Generating Postgres query file"
+  cargo run --release --bin benchmark -- generate-queries \
+    --vendor postgres \
+    --dataset large \
+    --size "$QUERIES_COUNT" \
+    --name "$POSTGRES_QUERIES_FILE" \
+    --write-ratio "$WRITE_RATIO" \
+    --query-profile "$QUERY_PROFILE" || true
+  echo "==> Running Postgres workload"
+  cargo run --release --bin benchmark -- run \
+    --vendor postgres \
+    --name "$POSTGRES_QUERIES_FILE" \
+    --parallel "$PARALLEL" \
+    --mps "$MPS" \
+    --endpoint "$POSTGRES_ENDPOINT" \
+    --results-dir "$RESULTS_DIR" || true
+fi
+
+
+# ---------- MongoDB ----------
+if [[ "${RUN_MONGO:-0}" == "1" ]]; then
+  echo "==> Preparing MongoDB (large)"
+  cargo run --release --bin benchmark -- load --vendor mongo --size large \
+    --endpoint "$MONGO_ENDPOINT" -b "$BATCH_SIZE" --force --query-profile "$QUERY_PROFILE" || {
+      echo "MongoDB load failed; continuing without Mongo results" >&2
+    }
+  echo "==> Generating MongoDB query file"
+  cargo run --release --bin benchmark -- generate-queries \
+    --vendor mongo \
+    --dataset large \
+    --size "$QUERIES_COUNT" \
+    --name "$MONGO_QUERIES_FILE" \
+    --write-ratio "$WRITE_RATIO" \
+    --query-profile "$QUERY_PROFILE" || true
+  echo "==> Running MongoDB workload"
+  cargo run --release --bin benchmark -- run \
+    --vendor mongo \
+    --name "$MONGO_QUERIES_FILE" \
+    --parallel "$PARALLEL" \
+    --mps "$MPS" \
+    --endpoint "$MONGO_ENDPOINT" \
+    --results-dir "$RESULTS_DIR" || true
+fi
+
+
+# ---------- Aggregate multi-engine comparison (up to 5) ----------
+MULTI_SUMMARY="$SCRIPT_DIR/../ui/public/summaries/multi_engine_compare.json"
+PAIRWISE_OUT_DIR="$SCRIPT_DIR/../ui/public/summaries"
+mkdir -p "$PAIRWISE_OUT_DIR"
+
+if [[ "${RUN_FALKOR_2:-0}" == "1" && -d "$RESULTS_DIR/${FALKOR_2_NAME:-falkordb-rs}" ]]; then
+  echo "==> Secondary Falkor results available as $RESULTS_DIR/${FALKOR_2_NAME:-falkordb-rs}"
+fi
+
+echo "==> Aggregating multi-engine comparison into $MULTI_SUMMARY"
+if cargo run --release --bin benchmark -- aggregate-aws-tests \
+  --aws-tests-dir "$RESULTS_DIR" \
+  --out-path "$MULTI_SUMMARY"; then
+  echo "==> Multi-engine summary written"
+else
+  echo "Multi-engine labeled aggregate failed; falling back to pairwise aggregate" >&2
+fi
+
+# Pairwise summaries for dedicated UI pages (neo4j/memgraph/postgres vs falkor).
+# Primary Falkor may have been renamed to $FALKOR_NAME; restore a falkor/ view for the pairwise aggregator.
+if [[ ! -d "$RESULTS_DIR/falkor" ]]; then
+  for cand in "${FALKOR_NAME:-falkordb-c}" falkordb falkordb1; do
+    if [[ -d "$RESULTS_DIR/$cand" ]]; then
+      ln -sfn "$cand" "$RESULTS_DIR/falkor"
+      echo "==> Linked $RESULTS_DIR/falkor -> $cand for pairwise aggregate"
+      break
+    fi
+  done
+fi
+if [[ -d "$RESULTS_DIR/falkor" ]]; then
+  echo "==> Aggregating pairwise vendor summaries into $PAIRWISE_OUT_DIR"
+  cargo run --release --bin benchmark -- aggregate \
+    --results-dir "$RESULTS_DIR" \
+    --out-dir "$PAIRWISE_OUT_DIR" || true
 fi
 
 echo "==> Done"

--- a/scripts/run_medium_benchmark.sh
+++ b/scripts/run_medium_benchmark.sh
@@ -64,6 +64,12 @@ RUN_FALKOR_2=${RUN_FALKOR_2:-1}
 RUN_NEO4J=${RUN_NEO4J:-0}
 RUN_MEMGRAPH=${RUN_MEMGRAPH:-0}
 
+POSTGRES_ENDPOINT=${POSTGRES_ENDPOINT:-"postgres://postgres:postgres@127.0.0.1:5432/postgres"}
+RUN_POSTGRES=${RUN_POSTGRES:-0}
+
+MONGO_ENDPOINT=${MONGO_ENDPOINT:-"mongodb://127.0.0.1:27017"}
+RUN_MONGO=${RUN_MONGO:-0}
+
 BATCH_SIZE=${BATCH_SIZE:-5000}
 PARALLEL=${PARALLEL:-8}
 MPS=${MPS:-2000}
@@ -98,6 +104,8 @@ QUERIES_FILE_BASE="${QUERIES_FILE}"
 FALKOR_QUERIES_FILE="${QUERIES_FILE_BASE}-falkor"
 NEO4J_QUERIES_FILE="${QUERIES_FILE_BASE}-neo4j"
 MEMGRAPH_QUERIES_FILE="${QUERIES_FILE_BASE}-memgraph"
+POSTGRES_QUERIES_FILE="${QUERIES_FILE}-postgres"
+MONGO_QUERIES_FILE="${QUERIES_FILE}-mongo"
 
 # Use a single shared results directory for all vendors so `benchmark aggregate` can
 # generate neo4j-vs-falkordb and memgraph-vs-falkordb UI summaries from one run.
@@ -363,6 +371,95 @@ else
   fi
   echo "==> Aggregating UI summaries to $SCRIPT_DIR/../ui/public/summaries"
   cargo run --release --bin benchmark -- aggregate --results-dir "$RESULTS_DIR" --out-dir "$SCRIPT_DIR/../ui/public/summaries"
+fi
+
+
+# ---------- Postgres ----------
+if [[ "${RUN_POSTGRES:-0}" == "1" ]]; then
+  echo "==> Preparing Postgres (medium)"
+  cargo run --release --bin benchmark -- load --vendor postgres --size medium \
+    --endpoint "$POSTGRES_ENDPOINT" -b "$BATCH_SIZE" --force --query-profile "$QUERY_PROFILE" || {
+      echo "Postgres load failed; continuing without Postgres results" >&2
+    }
+  echo "==> Generating Postgres query file"
+  cargo run --release --bin benchmark -- generate-queries \
+    --vendor postgres \
+    --dataset medium \
+    --size "$QUERIES_COUNT" \
+    --name "$POSTGRES_QUERIES_FILE" \
+    --write-ratio "$WRITE_RATIO" \
+    --query-profile "$QUERY_PROFILE" || true
+  echo "==> Running Postgres workload"
+  cargo run --release --bin benchmark -- run \
+    --vendor postgres \
+    --name "$POSTGRES_QUERIES_FILE" \
+    --parallel "$PARALLEL" \
+    --mps "$MPS" \
+    --endpoint "$POSTGRES_ENDPOINT" \
+    --results-dir "$RESULTS_DIR" || true
+fi
+
+
+# ---------- MongoDB ----------
+if [[ "${RUN_MONGO:-0}" == "1" ]]; then
+  echo "==> Preparing MongoDB (medium)"
+  cargo run --release --bin benchmark -- load --vendor mongo --size medium \
+    --endpoint "$MONGO_ENDPOINT" -b "$BATCH_SIZE" --force --query-profile "$QUERY_PROFILE" || {
+      echo "MongoDB load failed; continuing without Mongo results" >&2
+    }
+  echo "==> Generating MongoDB query file"
+  cargo run --release --bin benchmark -- generate-queries \
+    --vendor mongo \
+    --dataset medium \
+    --size "$QUERIES_COUNT" \
+    --name "$MONGO_QUERIES_FILE" \
+    --write-ratio "$WRITE_RATIO" \
+    --query-profile "$QUERY_PROFILE" || true
+  echo "==> Running MongoDB workload"
+  cargo run --release --bin benchmark -- run \
+    --vendor mongo \
+    --name "$MONGO_QUERIES_FILE" \
+    --parallel "$PARALLEL" \
+    --mps "$MPS" \
+    --endpoint "$MONGO_ENDPOINT" \
+    --results-dir "$RESULTS_DIR" || true
+fi
+
+
+# ---------- Aggregate multi-engine comparison (up to 5) ----------
+MULTI_SUMMARY="$SCRIPT_DIR/../ui/public/summaries/multi_engine_compare.json"
+PAIRWISE_OUT_DIR="$SCRIPT_DIR/../ui/public/summaries"
+mkdir -p "$PAIRWISE_OUT_DIR"
+
+if [[ "${RUN_FALKOR_2:-0}" == "1" && -d "$RESULTS_DIR/${FALKOR_2_NAME:-falkordb-rs}" ]]; then
+  echo "==> Secondary Falkor results available as $RESULTS_DIR/${FALKOR_2_NAME:-falkordb-rs}"
+fi
+
+echo "==> Aggregating multi-engine comparison into $MULTI_SUMMARY"
+if cargo run --release --bin benchmark -- aggregate-aws-tests \
+  --aws-tests-dir "$RESULTS_DIR" \
+  --out-path "$MULTI_SUMMARY"; then
+  echo "==> Multi-engine summary written"
+else
+  echo "Multi-engine labeled aggregate failed; falling back to pairwise aggregate" >&2
+fi
+
+# Pairwise summaries for dedicated UI pages (neo4j/memgraph/postgres vs falkor).
+# Primary Falkor may have been renamed to $FALKOR_NAME; restore a falkor/ view for the pairwise aggregator.
+if [[ ! -d "$RESULTS_DIR/falkor" ]]; then
+  for cand in "${FALKOR_NAME:-falkordb-c}" falkordb falkordb1; do
+    if [[ -d "$RESULTS_DIR/$cand" ]]; then
+      ln -sfn "$cand" "$RESULTS_DIR/falkor"
+      echo "==> Linked $RESULTS_DIR/falkor -> $cand for pairwise aggregate"
+      break
+    fi
+  done
+fi
+if [[ -d "$RESULTS_DIR/falkor" ]]; then
+  echo "==> Aggregating pairwise vendor summaries into $PAIRWISE_OUT_DIR"
+  cargo run --release --bin benchmark -- aggregate \
+    --results-dir "$RESULTS_DIR" \
+    --out-dir "$PAIRWISE_OUT_DIR" || true
 fi
 
 echo "==> Done"

--- a/scripts/run_small_benchmark.sh
+++ b/scripts/run_small_benchmark.sh
@@ -78,6 +78,12 @@ RUN_FALKOR_2=${RUN_FALKOR_2:-1}
 RUN_NEO4J=${RUN_NEO4J:-0}
 RUN_MEMGRAPH=${RUN_MEMGRAPH:-0}
 
+POSTGRES_ENDPOINT=${POSTGRES_ENDPOINT:-"postgres://postgres:postgres@127.0.0.1:5432/postgres"}
+RUN_POSTGRES=${RUN_POSTGRES:-0}
+
+MONGO_ENDPOINT=${MONGO_ENDPOINT:-"mongodb://127.0.0.1:27017"}
+RUN_MONGO=${RUN_MONGO:-0}
+
 BATCH_SIZE=${BATCH_SIZE:-5000}
 PARALLEL=${PARALLEL:-20}
 MPS=${MPS:-5000}
@@ -111,6 +117,8 @@ QUERIES_FILE_BASE="${QUERIES_FILE}"
 FALKOR_QUERIES_FILE="${QUERIES_FILE_BASE}-falkor"
 NEO4J_QUERIES_FILE="${QUERIES_FILE_BASE}-neo4j"
 MEMGRAPH_QUERIES_FILE="${QUERIES_FILE_BASE}-memgraph"
+POSTGRES_QUERIES_FILE="${QUERIES_FILE}-postgres"
+MONGO_QUERIES_FILE="${QUERIES_FILE}-mongo"
 
 # Use a single shared results directory for all vendors so `benchmark aggregate` can
 # generate neo4j-vs-falkordb and memgraph-vs-falkordb UI summaries from one run.
@@ -308,6 +316,95 @@ else
   fi
   echo "==> Aggregating UI summaries to $SCRIPT_DIR/../ui/public/summaries"
   cargo run --release --bin benchmark -- aggregate --results-dir "$RESULTS_DIR" --out-dir "$SCRIPT_DIR/../ui/public/summaries"
+fi
+
+
+# ---------- Postgres ----------
+if [[ "${RUN_POSTGRES:-0}" == "1" ]]; then
+  echo "==> Preparing Postgres (small)"
+  cargo run --release --bin benchmark -- load --vendor postgres --size small \
+    --endpoint "$POSTGRES_ENDPOINT" -b "$BATCH_SIZE" --force --query-profile "$QUERY_PROFILE" || {
+      echo "Postgres load failed; continuing without Postgres results" >&2
+    }
+  echo "==> Generating Postgres query file"
+  cargo run --release --bin benchmark -- generate-queries \
+    --vendor postgres \
+    --dataset small \
+    --size "$QUERIES_COUNT" \
+    --name "$POSTGRES_QUERIES_FILE" \
+    --write-ratio "$WRITE_RATIO" \
+    --query-profile "$QUERY_PROFILE" || true
+  echo "==> Running Postgres workload"
+  cargo run --release --bin benchmark -- run \
+    --vendor postgres \
+    --name "$POSTGRES_QUERIES_FILE" \
+    --parallel "$PARALLEL" \
+    --mps "$MPS" \
+    --endpoint "$POSTGRES_ENDPOINT" \
+    --results-dir "$RESULTS_DIR" || true
+fi
+
+
+# ---------- MongoDB ----------
+if [[ "${RUN_MONGO:-0}" == "1" ]]; then
+  echo "==> Preparing MongoDB (small)"
+  cargo run --release --bin benchmark -- load --vendor mongo --size small \
+    --endpoint "$MONGO_ENDPOINT" -b "$BATCH_SIZE" --force --query-profile "$QUERY_PROFILE" || {
+      echo "MongoDB load failed; continuing without Mongo results" >&2
+    }
+  echo "==> Generating MongoDB query file"
+  cargo run --release --bin benchmark -- generate-queries \
+    --vendor mongo \
+    --dataset small \
+    --size "$QUERIES_COUNT" \
+    --name "$MONGO_QUERIES_FILE" \
+    --write-ratio "$WRITE_RATIO" \
+    --query-profile "$QUERY_PROFILE" || true
+  echo "==> Running MongoDB workload"
+  cargo run --release --bin benchmark -- run \
+    --vendor mongo \
+    --name "$MONGO_QUERIES_FILE" \
+    --parallel "$PARALLEL" \
+    --mps "$MPS" \
+    --endpoint "$MONGO_ENDPOINT" \
+    --results-dir "$RESULTS_DIR" || true
+fi
+
+
+# ---------- Aggregate multi-engine comparison (up to 5) ----------
+MULTI_SUMMARY="$SCRIPT_DIR/../ui/public/summaries/multi_engine_compare.json"
+PAIRWISE_OUT_DIR="$SCRIPT_DIR/../ui/public/summaries"
+mkdir -p "$PAIRWISE_OUT_DIR"
+
+if [[ "${RUN_FALKOR_2:-0}" == "1" && -d "$RESULTS_DIR/${FALKOR_2_NAME:-falkordb-rs}" ]]; then
+  echo "==> Secondary Falkor results available as $RESULTS_DIR/${FALKOR_2_NAME:-falkordb-rs}"
+fi
+
+echo "==> Aggregating multi-engine comparison into $MULTI_SUMMARY"
+if cargo run --release --bin benchmark -- aggregate-aws-tests \
+  --aws-tests-dir "$RESULTS_DIR" \
+  --out-path "$MULTI_SUMMARY"; then
+  echo "==> Multi-engine summary written"
+else
+  echo "Multi-engine labeled aggregate failed; falling back to pairwise aggregate" >&2
+fi
+
+# Pairwise summaries for dedicated UI pages (neo4j/memgraph/postgres vs falkor).
+# Primary Falkor may have been renamed to $FALKOR_NAME; restore a falkor/ view for the pairwise aggregator.
+if [[ ! -d "$RESULTS_DIR/falkor" ]]; then
+  for cand in "${FALKOR_NAME:-falkordb-c}" falkordb falkordb1; do
+    if [[ -d "$RESULTS_DIR/$cand" ]]; then
+      ln -sfn "$cand" "$RESULTS_DIR/falkor"
+      echo "==> Linked $RESULTS_DIR/falkor -> $cand for pairwise aggregate"
+      break
+    fi
+  done
+fi
+if [[ -d "$RESULTS_DIR/falkor" ]]; then
+  echo "==> Aggregating pairwise vendor summaries into $PAIRWISE_OUT_DIR"
+  cargo run --release --bin benchmark -- aggregate \
+    --results-dir "$RESULTS_DIR" \
+    --out-dir "$PAIRWISE_OUT_DIR" || true
 fi
 
 echo "==> Done"

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -205,39 +205,58 @@ pub fn aggregate_results(
         ))
     })?;
 
-    // Required baseline vendor
-    let falkor = load_vendor(&results_dir, Vendor::Falkor)?;
-
-    // neo4j vs falkor
-    if let Ok(neo4j) = load_vendor(&results_dir, Vendor::Neo4j) {
-        let summary = make_summary(&[falkor.clone(), neo4j])?;
-        let out_path = out_dir.join("neo4j_vs_falkordb.json");
-        write_summary(&out_path, &summary)?;
+    // Load every known vendor that has artifacts under results-dir.
+    // Pairwise vs Falkor is preserved for existing UI pages; multi-engine
+    // comparison (up to 5) is written for the all-engines dashboard.
+    let mut present: Vec<VendorArtifacts> = Vec::new();
+    for vendor in [
+        Vendor::Falkor,
+        Vendor::Neo4j,
+        Vendor::Memgraph,
+        Vendor::Postgres,
+        Vendor::Mongo,
+    ] {
+        if let Ok(v) = load_vendor(&results_dir, vendor) {
+            present.push(v);
+        }
     }
 
-    // memgraph vs falkor
-    if let Ok(memgraph) = load_vendor(&results_dir, Vendor::Memgraph) {
-        let summary = make_summary(&[falkor.clone(), memgraph])?;
-        let out_path = out_dir.join("memgraph_vs_falkordb.json");
-        write_summary(&out_path, &summary)?;
+    if present.is_empty() {
+        return Err(OtherError(format!(
+            "No vendor result folders found under {}",
+            results_dir.display()
+        )));
     }
 
-    // postgres vs falkor
-    if let Ok(postgres) = load_vendor(&results_dir, Vendor::Postgres) {
-        let summary = make_summary(&[falkor.clone(), postgres])?;
-        let out_path = out_dir.join("postgres_vs_falkordb.json");
-        write_summary(&out_path, &summary)?;
+    let falkor = present.iter().find(|v| matches!(v.vendor, Vendor::Falkor)).cloned();
+
+    // Pairwise pages (legacy UI routes)
+    if let Some(ref falkor) = falkor {
+        for other in present.iter().filter(|v| !matches!(v.vendor, Vendor::Falkor)) {
+            let summary = make_summary(&[falkor.clone(), other.clone()])?;
+            let out_name = match other.vendor {
+                Vendor::Neo4j => "neo4j_vs_falkordb.json",
+                Vendor::Memgraph => "memgraph_vs_falkordb.json",
+                Vendor::Postgres => "postgres_vs_falkordb.json",
+                Vendor::Mongo => "mongo_vs_falkordb.json",
+                Vendor::Falkor => continue,
+            };
+            write_summary(&out_dir.join(out_name), &summary)?;
+        }
     }
 
-    // mongo vs falkor
-    if let Ok(mongo) = load_vendor(&results_dir, Vendor::Mongo) {
-        let summary = make_summary(&[falkor, mongo])?;
-        let out_path = out_dir.join("mongo_vs_falkordb.json");
-        write_summary(&out_path, &summary)?;
+    // Multi-engine comparison (all present vendors, capped at 5).
+    let multi: Vec<VendorArtifacts> = present.into_iter().take(MAX_MULTI_ENGINE_RUNS).collect();
+    if multi.len() >= 2 {
+        let summary = make_summary(&multi)?;
+        write_summary(&out_dir.join("multi_engine_compare.json"), &summary)?;
     }
 
     Ok(())
 }
+
+/// Maximum number of engine/run series shown side-by-side in multi-engine dashboards.
+const MAX_MULTI_ENGINE_RUNS: usize = 5;
 
 #[derive(Debug, Clone)]
 struct VendorArtifacts {
@@ -402,13 +421,14 @@ struct CustomRunArtifacts {
     metrics_text: String,
 }
 
-/// Aggregate `aws-tests/` style folders into a single UI summary JSON.
+/// Aggregate labeled result folders into a single multi-engine UI summary JSON.
 ///
 /// Expected layout:
 ///   <aws_tests_dir>/<run_name>/{meta.json,metrics.prom}
 ///
-/// This is meant for comparing two FalkorDB runs on different AWS instance families
-/// (e.g. Graviton vs Intel) side-by-side in the UI.
+/// Supports up to [`MAX_MULTI_ENGINE_RUNS`] engines/runs side-by-side, including:
+/// - multiple FalkorDB variants / AWS instance families
+/// - heterogeneous engines (FalkorDB, Neo4j, Memgraph, Postgres)
 pub fn aggregate_aws_tests(
     aws_tests_dir: &str,
     out_path: &str,
@@ -449,17 +469,17 @@ pub fn aggregate_aws_tests(
         let meta: RunResultsMeta = serde_json::from_str(&meta_raw)
             .map_err(|e| OtherError(format!("Failed parsing {}: {}", meta_path.display(), e)))?;
 
-        // We're intentionally aggregating Falkor runs.
-        let vendor = Vendor::Falkor;
-
-        let metrics_text = fs::read_to_string(&metrics_path)
-            .map_err(|e| OtherError(format!("Failed reading {}: {}", metrics_path.display(), e)))?;
-
         let dir_name = path
             .file_name()
             .and_then(|s| s.to_str())
             .unwrap_or("run")
             .to_string();
+
+        // Infer engine from folder name / meta so multi-engine runs can live side-by-side.
+        let vendor = infer_vendor_from_name(&dir_name, &meta.vendor);
+
+        let metrics_text = fs::read_to_string(&metrics_path)
+            .map_err(|e| OtherError(format!("Failed reading {}: {}", metrics_path.display(), e)))?;
 
         fn normalize_instance_type(name: &str) -> Option<String> {
             // Accept already-normalized forms like "r7i.2xlarge".
@@ -541,14 +561,38 @@ pub fn aggregate_aws_tests(
             || lower.contains("x86")
         {
             "intel".to_string()
-        } else if lower.contains("falkordb-c") || lower.contains("falkordb-rs") {
+        } else if lower.contains("falkordb-c")
+            || lower.contains("falkordb-rs")
+            || lower.contains("neo4j")
+            || lower.contains("memgraph")
+            || lower.contains("postgres")
+            || lower.contains("mongo")
+        {
             detected_platform()
         } else {
             // Fallback: use the raw directory name as the platform/hardware identifier
             dir_name.clone()
         };
 
-        let ui_vendor = instance;
+        // For multi-engine compare folders (neo4j/, postgres/, ...), prefer stable UI ids.
+        // For instance-family folders keep the AWS-like instance label.
+        let ui_vendor = match vendor {
+            Vendor::Neo4j => "neo4j".to_string(),
+            Vendor::Memgraph => "memgraph".to_string(),
+            Vendor::Postgres => "postgres".to_string(),
+            Vendor::Mongo => "mongo".to_string(),
+            Vendor::Falkor => {
+                if lower.contains("falkordb-c") {
+                    "falkordb-c".to_string()
+                } else if lower.contains("falkordb-rs") || lower.contains("falkordb2") {
+                    "falkordb-rs".to_string()
+                } else if lower == "falkor" || lower == "falkordb" {
+                    "falkordb".to_string()
+                } else {
+                    instance
+                }
+            }
+        };
 
         candidates.push(CustomRunArtifacts {
             vendor,
@@ -567,25 +611,44 @@ pub fn aggregate_aws_tests(
         )));
     }
 
-    // Prefer r7i* (Intel) and r8g* (Graviton) when present; otherwise take first two.
+    // Prefer known labels when present; otherwise take remaining candidates in sorted order.
+    // Cap at MAX_MULTI_ENGINE_RUNS so dashboards can compare up to 5 engines/runs.
     candidates.sort_by(|a, b| a.ui_vendor.cmp(&b.ui_vendor));
 
     let mut picked: Vec<CustomRunArtifacts> = Vec::new();
-    for want_prefix in ["falkordb1", "falkordb2", "r7i", "r8g"] {
-        if let Some(idx) = candidates
-            .iter()
-            .position(|c| c.ui_vendor.to_lowercase().starts_with(want_prefix))
-        {
+    for want_prefix in [
+        "falkordb1",
+        "falkordb2",
+        "falkordb-c",
+        "falkordb-rs",
+        "falkordb",
+        "neo4j",
+        "memgraph",
+        "postgres",
+        "mongo",
+        "r7i",
+        "r8g",
+        "r7g",
+        "r6g",
+        "r6i",
+    ] {
+        if picked.len() >= MAX_MULTI_ENGINE_RUNS {
+            break;
+        }
+        if let Some(idx) = candidates.iter().position(|c| {
+            let v = c.ui_vendor.to_lowercase();
+            v == want_prefix || v.starts_with(want_prefix)
+        }) {
             picked.push(candidates.remove(idx));
         }
     }
 
-    // Fill up to 2.
-    while picked.len() < 2 && !candidates.is_empty() {
+    // Fill remaining slots from leftover candidates.
+    while picked.len() < MAX_MULTI_ENGINE_RUNS && !candidates.is_empty() {
         picked.push(candidates.remove(0));
     }
 
-    picked.truncate(2);
+    picked.truncate(MAX_MULTI_ENGINE_RUNS);
 
     let mut runs = Vec::new();
     for v in &picked {
@@ -800,6 +863,22 @@ fn vendor_id(vendor: Vendor) -> String {
         Vendor::Memgraph => "memgraph".to_string(),
         Vendor::Postgres => "postgres".to_string(),
         Vendor::Mongo => "mongo".to_string(),
+    }
+}
+
+fn infer_vendor_from_name(dir_name: &str, meta_vendor: &str) -> Vendor {
+    let lower = dir_name.to_lowercase();
+    let meta = meta_vendor.to_lowercase();
+    if lower.contains("postgres") || lower.contains("postgresql") || meta.contains("postgres") {
+        Vendor::Postgres
+    } else if lower.contains("mongo") || meta.contains("mongo") {
+        Vendor::Mongo
+    } else if lower.contains("neo4j") || meta.contains("neo4j") {
+        Vendor::Neo4j
+    } else if lower.contains("memgraph") || meta.contains("memgraph") {
+        Vendor::Memgraph
+    } else {
+        Vendor::Falkor
     }
 }
 

--- a/ui/app/components/dashboard.tsx
+++ b/ui/app/components/dashboard.tsx
@@ -66,7 +66,7 @@ type DashboardProps = {
 
 const DEFAULT_SELECTED_OPTIONS: Record<string, string[]> = {
   "Workload Type": ["concurrent"],
-  Vendors: ["falkordb", "neo4j"],
+  Vendors: ["falkordb", "neo4j", "memgraph", "postgres", "mongo"],
   Clients: ["40"],
   Throughput: ["2500"],
   Hardware: ["arm"],
@@ -332,7 +332,7 @@ export default function DashBoard({
       const groupSelections = prev[groupTitle] || [];
 
       if (groupTitle === "Vendors") {
-        // If this page is restricted to a specific vendor pair, ignore toggles outside it.
+        // If this page is restricted to a specific vendor set, ignore toggles outside it.
         if (
           allowedVendors?.length &&
           !allowedVendors.includes(optionId.toLowerCase())

--- a/ui/app/data/sideBarData.ts
+++ b/ui/app/data/sideBarData.ts
@@ -33,6 +33,8 @@ export const sidebarConfig: {
       icon: Layers,
       options: [
         { id: "falkordb", label: "FalkorDB" },
+        { id: "falkordb-c", label: "FalkorDB (Standard)" },
+        { id: "falkordb-rs", label: "FalkorDB (Rust)" },
         { id: "neo4j", label: "Neo4j" },
         { id: "memgraph", label: "Memgraph" },
         { id: "postgres", label: "Postgres" },

--- a/ui/app/multi-engine/page.tsx
+++ b/ui/app/multi-engine/page.tsx
@@ -1,0 +1,61 @@
+import DashBoard from "../components/dashboard";
+import { Header } from "../components/header";
+import BenchmarkMetricsCrawlerTable from "../components/BenchmarkMetricsCrawlerTable";
+import { loadBenchmarkSummary, loadRunsManifest } from "../lib/benchmark-data.server";
+
+export const dynamic = "force-dynamic";
+
+/** All engines present in a multi-run summary (up to 5). */
+const MULTI_ENGINE_VENDORS = [
+  "falkordb",
+  "falkordb-c",
+  "falkordb-rs",
+  "falkordb1",
+  "falkordb2",
+  "neo4j",
+  "memgraph",
+  "postgres",
+  "mongo",
+];
+
+export default async function MultiEngineCompare() {
+  const dataUrl = "/summaries/multi_engine_compare.json";
+  const [initialData, initialManifest] = await Promise.all([
+    loadBenchmarkSummary(dataUrl),
+    loadRunsManifest(),
+  ]);
+
+  // Prefer vendors actually present in the summary so charts stay dense.
+  const present = Array.from(
+    new Set(
+      (initialData?.runs ?? [])
+        .map((r) => r.vendor?.toString().toLowerCase())
+        .filter(Boolean)
+    )
+  );
+  const comparisonVendors = present.length
+    ? present.slice(0, 5)
+    : MULTI_ENGINE_VENDORS.slice(0, 5);
+
+  return (
+    <main className="min-h-screen md:h-screen flex flex-col">
+      <Header />
+      <DashBoard
+        dataUrl={dataUrl}
+        initialData={initialData}
+        initialManifest={initialManifest}
+        comparisonVendors={comparisonVendors}
+        hideHardware
+        initialSelectedOptions={{
+          "Workload Type": ["concurrent"],
+          Vendors: comparisonVendors,
+        }}
+      />
+      <BenchmarkMetricsCrawlerTable
+        data={initialData}
+        dataUrl={dataUrl}
+        title="Multi-engine comparison (up to 5)"
+      />
+    </main>
+  );
+}

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,15 +1,37 @@
 
+import { redirect } from "next/navigation";
 import DashBoard from "./components/dashboard";
 import { Header } from "./components/header";
 import BenchmarkMetricsCrawlerTable from "./components/BenchmarkMetricsCrawlerTable";
 import { loadBenchmarkSummary, loadRunsManifest } from "./lib/benchmark-data.server";
 
+export const dynamic = "force-dynamic";
+
+const PAIRWISE_DEFAULT_URL = "/summaries/neo4j_vs_falkordb.json";
+const MULTI_ENGINE_URL = "/summaries/multi_engine_compare.json";
+
 export default async function Home() {
-  const dataUrl = "/summaries/neo4j_vs_falkordb.json";
-  const [initialData, initialManifest] = await Promise.all([
-    loadBenchmarkSummary(dataUrl),
+  const [multiData, pairwiseData, initialManifest] = await Promise.all([
+    loadBenchmarkSummary(MULTI_ENGINE_URL),
+    loadBenchmarkSummary(PAIRWISE_DEFAULT_URL),
     loadRunsManifest(),
   ]);
+
+  const multiVendors = Array.from(
+    new Set(
+      (multiData?.runs ?? [])
+        .map((r) => r.vendor?.toString().toLowerCase())
+        .filter(Boolean)
+    )
+  );
+
+  // If at least 3 engines were run, multi-engine is the default view.
+  if (multiVendors.length >= 3) {
+    redirect("/multi-engine");
+  }
+
+  const dataUrl = PAIRWISE_DEFAULT_URL;
+  const initialData = pairwiseData;
   return (
     <main className="min-h-screen md:h-screen flex flex-col">
       <Header />

--- a/ui/public/summaries/multi_engine_compare.json
+++ b/ui/public/summaries/multi_engine_compare.json
@@ -1,0 +1,1 @@
+{"runs":[],"unrealstic":[],"platforms":[]}


### PR DESCRIPTION
## Summary
- Extend small/medium/large benchmark scripts to run Postgres and MongoDB alongside FalkorDB/Neo4j/Memgraph (opt-in via `RUN_*` flags).
- Update aggregation to emit a multi-engine summary (`multi_engine_compare.json`) with up to 5 side-by-side series, while keeping pairwise pages.
- Add `/multi-engine` UI page and make home redirect there when 3+ engines are present in the summary.

## Test plan
- [ ] `cargo check --bin benchmark`
- [ ] `cargo test --lib`
- [ ] `bash -n scripts/run_{small,medium,large}_benchmark.sh`
- [ ] Run a multi-engine small benchmark, e.g.
  `RUN_FALKOR=1 RUN_NEO4J=1 RUN_MEMGRAPH=1 RUN_POSTGRES=0 RUN_MONGO=0 ./scripts/run_small_benchmark.sh`
  and confirm `ui/public/summaries/multi_engine_compare.json` is written
- [ ] Open `/multi-engine` and verify charts show all present engines
- [ ] With ≥3 engines in the summary, open `/` and confirm redirect to `/multi-engine`
- [ ] Pairwise routes (`/neo4j`, `/memgraph`, `/postgres`, `/mongo`) still load

Co-Authored-By: Warp <agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-engine benchmark comparisons supporting up to five engines.
  * Added optional PostgreSQL and MongoDB benchmark runs.
  * Added a dedicated multi-engine comparison dashboard with vendor and workload metrics.
  * Added FalkorDB Standard and FalkorDB Rust vendor options.
  * The dashboard now automatically opens multi-engine comparisons when enough benchmark results are available.
* **Documentation**
  * Added guidance for generating and viewing multi-engine benchmark summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->